### PR TITLE
fix: avoid pack summary.gif to app bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **MarkText** is an **open source** Markdown editor for OS X, released under the **MIT license**. It is inspired by outstanding markdown editor **Typora**.
 
-![](https://github.com/marktext/marktext/blob/master/static/summary.gif)
+![](https://github.com/marktext/marktext/blob/master/summary.gif)
 
 ### Why write another Markdown editor ?
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes

### Description

Webpack packs summary.gif into final app's bundle accidently.

When move summary.gif out of static/, the size changes: 75.4M -> 54.7M
