### PR TITLE
Fixed changelog URL

### DIFF
--- a/src/main/menus/help.js
+++ b/src/main/menus/help.js
@@ -21,7 +21,7 @@ export default {
   }, {
     label: 'Changelog',
     click: function () {
-      shell.openExternal('https://github.com/marktext/marktext/blob/master/CHANGELOG.md')
+      shell.openExternal('https://github.com/marktext/marktext/blob/master/.github/CHANGELOG.md')
     }
   }, {
     label: 'Markdown syntax',


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no

The URL in the menu Help/Changelog pointed to a 404 page so I assumed that this URL should be the right one.
