### PR TITLE
Temporary workaround for txt/text file associations

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
       "ext": [
         "md",
         "markdown",
-        "txt",
         "mmd",
-        "text",
         "mdown",
         "mdtxt",
         "mdtext"


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes

I suspect that the standard file association with txt/text files breaks the windows context menu for creating empty text files and just hides that option for whatever reason. Opening the files via "Open with..." does not create that behavior. As it is a Markdown Editor I suggest just removing that feature.
(Maybe startup time increased to but I am not sure about that.)
