### PR TITLE
Set application menu offset without window position

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: prevent open image or file directly when drag and drop over Mark Text #42
 - fix: set theme to all the open window not just the active one.
+- fix: set correct application menu offset on windows #44
 
 ### 0.7.17
 

--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -13,7 +13,7 @@
     </div>
     <div :class="platform === 'win32' ? 'left-toolbar' : 'right-toolbar'">
       <div v-if="platform === 'win32'" class="windows-titlebar-menu title-no-drag" @click.stop="handleMenuClick">&#9776;</div>
-      <div 
+      <div
         class="word-count"
         :class="[{ 'title-no-drag': platform === 'win32' }]"
         @click.stop="handleWordClick"
@@ -81,7 +81,7 @@
       },
       handleMenuClick () {
         const win = remote.getCurrentWindow()
-        remote.Menu.getApplicationMenu().popup({window: win, x: win.getPosition()[0] + 23, y: win.getPosition()[1] + 20})
+        remote.Menu.getApplicationMenu().popup({window: win, x: 23, y: 20})
       }
     }
   }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #44 
| License          | MIT

### Description

This PR aims at fixing the wrong application menu offset on windows. It seems that the menu popup  parameters `x` and `y` are both offsets.
