### PR TITLE
Support of cross-platform home path

### DIFF
--- a/src/main/actions/file.js
+++ b/src/main/actions/file.js
@@ -6,7 +6,7 @@ import path from 'path'
 import { app, dialog, ipcMain, BrowserWindow } from 'electron'
 import createWindow, { windows } from '../createWindow'
 import { EXTENSIONS, EXTENSION_HASN } from '../config'
-import { getUserPreference, setUserPreference } from '../utils'
+import { getPath, getUserPreference, setUserPreference } from '../utils'
 
 const watchAndReload = (pathname, win) => { // when i build, and failed.
   // const watcher = chokidar.watch(pathname, {
@@ -51,7 +51,7 @@ const forceClose = win => {
 const handleResponseForExport = (e, { type, content, filename, pathname }) => {
   const win = BrowserWindow.fromWebContents(e.sender)
   const extension = EXTENSION_HASN[type]
-  const dirname = pathname ? path.dirname(pathname) : '~'
+  const dirname = pathname ? path.dirname(pathname) : getPath('documents')
   const nakedFilename = pathname ? path.basename(pathname, '.md') : 'untitled'
   const defaultPath = `${dirname}/${nakedFilename}${extension}`
   const filePath = dialog.showSaveDialog(win, {
@@ -76,7 +76,7 @@ const handleResponseForSave = (e, { markdown, pathname }) => {
     })
   } else {
     const filePath = dialog.showSaveDialog(win, {
-      defaultPath: '~/Untitled.md'
+      defaultPath: getPath('documents') + '/Untitled.md'
     })
     writeFile(filePath, markdown, '.md', win, e)
   }
@@ -85,7 +85,7 @@ const handleResponseForSave = (e, { markdown, pathname }) => {
 ipcMain.on('AGANI::response-file-save-as', (e, { markdown, pathname }) => {
   const win = BrowserWindow.fromWebContents(e.sender)
   let filePath = dialog.showSaveDialog(win, {
-    defaultPath: pathname || '~/Untitled.md'
+    defaultPath: pathname || getPath('documents') + '/Untitled.md'
   })
   writeFile(filePath, markdown, '.md', win, e)
 })

--- a/src/main/actions/marktext.js
+++ b/src/main/actions/marktext.js
@@ -47,7 +47,7 @@ autoUpdater.on('update-downloaded', () => {
 })
 
 export const userSetting = (menuItem, browserWindow) => {
-  const settingPath = path.join(__static, '/preference.md')
+  const settingPath = path.join(__static, 'preference.md')
   createWindow(settingPath)
 }
 

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { Menu } from 'electron'
+import { app, Menu } from 'electron'
 
 const JSON_REG = /```json(.+)```/g
 const preferencePath = path.join(__static, 'preference.md')
@@ -44,4 +44,8 @@ export const setUserPreference = (key, value) => {
       else resolve(newUserSetting)
     })
   })
+}
+
+export const getPath = directory => {
+  return app.getPath(directory)
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description

This PR adds a cross-platform solution of getting the home directory/path.

Maybe I should remove `getHomePath()` from `utils.js`, but I think it's better for later use.

