### PR TITLE
Added drag & drop support for markdown files

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { BrowserWindow, app } from 'electron'
 import windowStateKeeper from 'electron-window-state'
+import { isMarkdownFile } from './utils'
 
 export const windows = new Map()
 
@@ -35,7 +36,7 @@ const createWindow = (pathname, options = {}) => {
   win.once('ready-to-show', () => {
     win.show()
 
-    if (pathname) {
+    if (pathname && isMarkdownFile(pathname)) {
       app.addRecentDocument(pathname)
       const filename = path.basename(pathname)
       fs.readFile(path.resolve(pathname), 'utf-8', (err, file) => {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { app, Menu } from 'electron'
+import { EXTENSIONS } from './config'
 
 const JSON_REG = /```json(.+)```/g
 const preferencePath = path.join(__static, 'preference.md')
@@ -48,4 +49,28 @@ export const setUserPreference = (key, value) => {
 
 export const getPath = directory => {
   return app.getPath(directory)
+}
+
+// returns true if the filename matches one of the markdown extensions
+export const hasMarkdownExtension = filename => {
+  const extension = path.extname(filename).split('.').pop()
+  if (extension) {
+    return EXTENSIONS.indexOf(extension) >= 0
+  }
+  return false
+}
+
+// returns true if the path is a file with read access.
+export const isFile = filepath => {
+  try {
+    return fs.existsSync(filepath) && fs.lstatSync(filepath).isFile()
+  } catch (e) {
+    // No permissions
+    return false
+  }
+}
+
+// returns true if the file is a supported markdown file.
+export const isMarkdownFile = filepath => {
+  return isFile(filepath) && hasMarkdownExtension(filepath)
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import axios from 'axios'
 
+import { ipcRenderer } from 'electron'
+
 import App from './app'
 import store from './store'
 
@@ -16,12 +18,25 @@ import { Dialog, Form, FormItem, InputNumber, Button, Tooltip, Upload } from 'el
 //   console.log(suggestions)
 // }))
 
-// prevent drag image or other file to Mark Text, and open it by Chrome default behavior.
+// prevent Chromium's default behavior and try to open the first file
 window.addEventListener('dragover', function (e) {
   e.preventDefault()
+  if (e.dataTransfer.types.indexOf('Files') >= 0) {
+    e.dataTransfer.dropEffect = 'copy'
+  } else {
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'none'
+  }
 }, false)
 window.addEventListener('drop', function (e) {
   e.preventDefault()
+  if (e.dataTransfer.files) {
+    const fileList = []
+    for (const file of e.dataTransfer.files) {
+      fileList.push(file.path)
+    }
+    ipcRenderer.send('AGANI::window::drop', fileList)
+  }
 }, false)
 
 Vue.use(Dialog)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description

If the user drops a valid markdown file, a new windows is opened.

I added a to-do in `src/main/createWindow.js`. because the path should be verified before passing it to the parser.