### PR TITLE
Add swift syntax highlighting

### DIFF
--- a/src/editor/codeMirror/modes.js
+++ b/src/editor/codeMirror/modes.js
@@ -3,6 +3,10 @@ const languages = [{
   'mode': 'clike',
   'mime': 'text/x-objectivec'
 }, {
+  'name': 'swift',
+  'mode': 'swift',
+  'mime': 'text/x-swift'
+}, {
   'name': 'c_cpp',
   'mode': 'clike',
   'mime': 'text/x-csrc'


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes

### Description

I want swift syntax highlighting!
Code Mirror supports Swift syntax. so I added Swift to modes.js.

![image](https://user-images.githubusercontent.com/8188636/37780043-375077c6-2e31-11e8-84c7-c8a66de83473.png)

![image](https://user-images.githubusercontent.com/8188636/37780171-8ad5d9d6-2e31-11e8-97cc-46d000ec5c21.png)

