### PR TITLE
Fix broken release configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ install:
 script:
   #- xvfb-maybe node_modules/.bin/karma start test/unit/karma.conf.js
   #- yarn run pack && xvfb-maybe node_modules/.bin/mocha test/e2e
-  - yarn run release
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn run release ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run release:all ; fi
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "license": "MIT",
   "main": "./dist/electron/main.js",
   "scripts": {
-    "release": "node .electron-vue/build.js && electron-builder -mwl",
+    "release": "node .electron-vue/build.js && electron-builder --win --linux",
+    "release:all": "node .electron-vue/build.js && electron-builder -mwl",
+    "release:linux": "node .electron-vue/build.js && electron-builder --linux",
+    "release:mac": "node .electron-vue/build.js && electron-builder --mac",
+    "release:win32": "node .electron-vue/build.js && electron-builder --win --ia32",
+    "release:win64": "node .electron-vue/build.js && electron-builder --win --x64",
     "build": "node .electron-vue/build.js && electron-builder",
     "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fix `npm run release` build failure if we build on OS's other than OSX.

We now have:

- `release`: builds Linux and Windows packages
- `release:all`:  builds Linux, macOS and Windows packages - works only on OSX!
- `release:linux`: ...
- `release:mac`: ... - works only on OSX!
- `release:win32`: ...
- `release:win64`: ...

@Jocs  You can only create `.dmg` on macOS or electron-build will throw exceptions.
