### PR TITLE
enable frameless window on Linux

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -2,7 +2,7 @@
 
 import fs from 'fs'
 import path from 'path'
-import { BrowserWindow, app } from 'electron'
+import { BrowserWindow, app, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
 import { isMarkdownFile } from './utils'
 
@@ -15,7 +15,7 @@ const createWindow = (pathname, options = {}) => {
     defaultHeight: 800
   })
 
-  const { x, y, width, height } = mainWindowState
+  const { x, y, width, height } = ensureWindowPosition(mainWindowState)
   const winOpt = Object.assign({ x, y, width, height }, {
     icon: path.join(__static, 'logo-96px.png'),
     minWidth: 450,
@@ -25,10 +25,11 @@ const createWindow = (pathname, options = {}) => {
     },
     useContentSize: true,
     show: false,
-    frame: process.platform === 'linux',
+    frame: false,
     titleBarStyle: 'hidden'
   }, options)
   let win = new BrowserWindow(winOpt)
+  mainWindowState.manage(win)
 
   const winURL = process.env.NODE_ENV === 'development'
     ? `http://localhost:9080`
@@ -68,6 +69,31 @@ const createWindow = (pathname, options = {}) => {
 
   windows.set(win.id, win)
   return win
+}
+
+const ensureWindowPosition = mainWindowState => {
+  let { x, y, width, height } = mainWindowState
+  let center = false
+  if (x === undefined || y === undefined) {
+    center = true
+  } else {
+    center = !screen.getAllDisplays().map(display =>
+      x >= display.bounds.x && x <= display.bounds.x + display.bounds.width &&
+      y >= display.bounds.y && y <= display.bounds.y + display.bounds.height)
+      .some(display => display)
+  }
+  if (center) {
+    // win.center() and "workArea" doesn't work on Linux
+    const screenArea = process.platform === 'linux' ? screen.getPrimaryDisplay().bounds : screen.getPrimaryDisplay().workArea
+    x = Math.ceil(screenArea.x + (screenArea.width - width) / 2)
+    y = Math.ceil(screenArea.y + (screenArea.height - height) / 2)
+  }
+  return {
+    x,
+    y,
+    width,
+    height
+  }
 }
 
 export default createWindow

--- a/src/renderer/assets/window-controls.js
+++ b/src/renderer/assets/window-controls.js
@@ -1,0 +1,30 @@
+/*
+Copyright (c) GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// These paths are all drawn to a 10x10 view box and replicate the symbols
+// seen on Windows 10 window controls.
+export const closePath =
+  'M 0,0 0,0.7 4.3,5 0,9.3 0,10 0.7,10 5,5.7 9.3,10 10,10 10,9.3 5.7,5 10,0.7 10,0 9.3,0 5,4.3 0.7,0 Z'
+export const restorePath =
+  'm 2,1e-5 0,2 -2,0 0,8 8,0 0,-2 2,0 0,-8 z m 1,1 6,0 0,6 -1,0 0,-5 -5,0 z m -2,2 6,0 0,6 -6,0 z'
+export const maximizePath = 'M 0,0 0,10 10,10 10,0 Z M 1,1 9,1 9,9 1,9 Z'
+export const minimizePath = 'M 0,5 10,5 10,6 0,6 Z'


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| BC breaks?       | yes/no
| License          | MIT

### Description

- enabled frameless window on Linux
- changed frameless window control icons and added restore icon
- enabled `windowStateKeeper`
  - if window is out of bounds or `undefined` center window on screen
  - fix problem where window is between two monitor (50% on first and on second monitor) if window has no frame on Linux

Before:

![0c441b4b2d2d](https://user-images.githubusercontent.com/17591936/37636866-9b21f174-2c58-11e8-9b8e-0c441b4b2d2d.png)

After:

![mt_window_controls_new](https://user-images.githubusercontent.com/22716132/38262338-402e682c-376d-11e8-9a55-8a44e98d525d.png)

![mt_window_controls_new_2](https://user-images.githubusercontent.com/22716132/38262339-405c7730-376d-11e8-8e48-43a5c7e4cab2.png)
