### PR TITLE
Reset modification indicator after successfully saved changes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,12 +9,13 @@
 **:beetle:Bug fix**
 
 - fix: update outdated preferences on startup #100
+- fix: reset modification indicator after successfully saved changes
 
 ### 0.9.25
 
 **:cactus:Feature**
 
-- display and inline math surport #36
+- display and inline math support #36
 - Image path auto complement #96
 - Feature: Toggle loose list item in paragraph menu #103
 - Add loose and tight list compatibility #74

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -96,6 +96,7 @@
       dispatch('LISTEN_FOR_ABOUT_DIALOG')
       dispatch('LISTEN_FOR_RENAME')
       dispatch('LISTEN_FOR_IMAGE_PATH')
+      dispatch('LISTEN_FOR_FILE_SAVED_SUCCESSFULLY')
     }
   }
 </script>

--- a/src/renderer/components/editor.vue
+++ b/src/renderer/components/editor.vue
@@ -191,7 +191,7 @@
         })
 
         this.editor.on('change', (markdown, wordCount, cursor) => {
-          this.$store.dispatch('SAVE_FILE', { markdown, wordCount, cursor })
+          this.$store.dispatch('LISTEN_FOR_CONTENT_CHANGE', { markdown, wordCount, cursor })
         })
 
         this.editor.on('selectionChange', changes => {

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -219,22 +219,27 @@ const actions = {
     ipcRenderer.send('AGANI::response-export', { type, content, filename, pathname })
   },
 
-  SAVE_FILE ({ commit, state }, { markdown, wordCount, cursor }) {
+  LISTEN_FOR_CONTENT_CHANGE ({ commit, state }, { markdown, wordCount, cursor }) {
     const { pathname, autoSave, markdown: oldMarkdown } = state
     commit('SET_MARKDOWN', markdown)
     // set word count
     if (wordCount) commit('SET_WORD_COUNT', wordCount)
     // set cursor
     if (cursor) commit('SET_CURSOR', cursor)
-    // save to file only when the markdown changed!
+    // change save status/save to file only when the markdown changed!
     if (markdown !== oldMarkdown) {
       if (pathname && autoSave) {
-        commit('SET_SAVE_STATUS', true)
         ipcRenderer.send('AGANI::response-file-save', { pathname, markdown })
       } else {
         commit('SET_SAVE_STATUS', false)
       }
     }
+  },
+
+  LISTEN_FOR_FILE_SAVED_SUCCESSFULLY ({ commit }) {
+    ipcRenderer.on('AGANI::file-saved-successfully', e => {
+      commit('SET_SAVE_STATUS', true)
+    })
   },
 
   SELECTION_CHANGE ({ commit }, changes) {
@@ -312,7 +317,6 @@ const actions = {
       const { isSaved, markdown, pathname, filename } = state
       if (!isSaved && /[^\n]/.test(markdown)) {
         ipcRenderer.send('AGANI::response-close-confirm', { filename, pathname, markdown })
-        commit('SET_SAVE_STATUS', true)
       } else {
         ipcRenderer.send('AGANI::close-window')
       }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

- Reset modification indicator after successfully saved changes
- If you want to exit with modifications and click on `Save`, the window will be closed
- Change quit message button text from `Delete` to `Exit and don't save`

@Jocs Should I open a issue for the TODO?