### PR TITLE
Fix hr and dark background style when export HTML

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -430,7 +430,7 @@ class Aganippe {
   }
 
   async exportStyledHTML () {
-    const html = await new ExportStyledHTML().generate()
+    const html = await new ExportStyledHTML().generate(this.theme)
     return html
   }
 

--- a/src/editor/parser/parse.js
+++ b/src/editor/parser/parse.js
@@ -22,7 +22,6 @@ const getSrcAlt = text => {
 }
 
 const validateEmphasize = (src, offset, marker, pending) => {
-  console.log(src, offset, marker)
   /**
    * Intraword emphasis is disallowed for _
    */
@@ -127,7 +126,6 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top) => {
   while (src.length) {
     // backlash
     const backTo = inlineRules.backlash.exec(src)
-    console.log(backTo)
     if (backTo) {
       pushPending()
       tokens.push({

--- a/src/editor/utils/exportStyledHTML.js
+++ b/src/editor/utils/exportStyledHTML.js
@@ -5,7 +5,7 @@ import { CLASS_OR_ID, DAED_REMOVE_SELECTOR } from '../config'
 import { collectImportantComments, unescapeHtml } from './index'
 
 class ExportHTML {
-  async generate () {
+  async generate (themeName) {
     const html = this.getHtml()
     const style = await this.getStyle()
     const outputHtml = `<!DOCTYPE html>
@@ -15,17 +15,29 @@ class ExportHTML {
         <title>Mark Text</title>
         <style>
         ${style}
+        html, body, body.fillscreen {
+          display: block;
+          position: relative;
+          height: 100%;
+        }
         a {
           pointer-events: auto;
         }
         hr {
-          height: 5px;
-          background: gainsboro;
-          border: none;
+          height: 4px;
+          padding: 0;
+          margin: 16px 0;
+          background-color: #e7e7e7;
+          border: 0 none;
+          overflow: hidden;
+          box-sizing: content-box;
+        }
+        .dark hr {
+          background-color: #545454;
         }
         </style>
       </head>
-      <body>
+      <body class="editor-wrapper fillscreen ${themeName}">
         ${html}
       </body>
     </html>`

--- a/src/renderer/components/sourceCode.vue
+++ b/src/renderer/components/sourceCode.vue
@@ -91,7 +91,6 @@
           const preLine = cm.getLine(cursor.line - 1)
           const nextLine = cm.getLine(cursor.line + 1)
           cursor = adjustCursor(cursor, preLine, line, nextLine)
-          console.log(cursor)
           bus.$emit('content-in-source-mode', { markdown, cursor, renderCursor: false })
         })
 

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -195,11 +195,14 @@ hr {
   height: 4px;
   padding: 0;
   margin: 16px 0;
-  background-color: #e7e7e7;
+  background-color: #545454;
   border: 0 none;
   overflow: hidden;
   box-sizing: content-box;
-  border-bottom: 1px solid #ddd;
+}
+
+p:not(.ag-active)[data-role="hr"]::before {
+  background-color: #545454;
 }
 
 body>h2:first-child {
@@ -368,10 +371,6 @@ code {
   border-radius: 3px;
   color: #777777;
   margin-top: 0;
-}
-
-p:not(.ag-active)[data-role="hr"]::before {
-  background: #545454;
 }
 
 .fg-color-dark {

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -172,7 +172,10 @@ hr {
   border: 0 none;
   overflow: hidden;
   box-sizing: content-box;
-  border-bottom: 1px solid #ddd;
+}
+
+p:not(.ag-active)[data-role="hr"]::before {
+  background: gainsboro;
 }
 
 body>h2:first-child {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

This PR fixes hr and dark background style when export HTML, but still no PDF problems because PDF "prints" the browser content. Maybe use a node extension to export PDF with styled HTML content (in another PR)?