### PR TITLE
Fix UTF-8 BOM encoding

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.10.12
+### 0.10.15
 
 **:cactus:Feature**
 
@@ -10,6 +10,7 @@
 
 **:butterfly:Optimization**
 
+- Update third-party packages to the latest version
 
 **:beetle:Bug fix**
 
@@ -17,9 +18,11 @@
 - fix: reset modification indicator after successfully saved changes
 - fix: disable tab focus
 - Bugfix: strong and em parse error #116
-- Fix horizontal line style (#120)
-- Fix user preferences (#122)
+- fix horizontal line style #120
+- fix user preferences #122
 - Bugfix: style error when export PDF/HTML with hr @Jocs
+- fix recently used documents on Linux and Windows #130
+- fix UTF-8 BOM encoding
 
 ### 0.9.25
 

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -70,11 +70,22 @@ const createWindow = (pathname, options = {}) => {
       addRecentlyUsedDocuments(pathname)
       const filename = path.basename(pathname)
       fs.readFile(path.resolve(pathname), 'utf-8', (err, file) => {
-        if (err) return console.log(err)
+        if (err) {
+          console.log(err)
+          return
+        }
+
+        // check UTF-8 BOM (EF BB BF) encoding
+        let isUtf8BomEncoded = file.length >= 1 && file.charCodeAt(0) === 0xFEFF
+        if (isUtf8BomEncoded) {
+          file = file.slice(1)
+        }
+
         win.webContents.send('AGANI::file-loaded', {
           file,
           filename,
-          pathname
+          pathname,
+          isUtf8BomEncoded
         })
       })
     }

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -5,7 +5,7 @@ import path from 'path'
 import { BrowserWindow, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
 import { addRecentlyUsedDocuments } from './menu'
-import { isMarkdownFile } from './utils'
+import { isMarkdownFile, log } from './utils'
 
 export const windows = new Map()
 
@@ -71,7 +71,7 @@ const createWindow = (pathname, options = {}) => {
       const filename = path.basename(pathname)
       fs.readFile(path.resolve(pathname), 'utf-8', (err, file) => {
         if (err) {
-          console.log(err)
+          log(err)
           return
         }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

This fix is not very efficient because we copy the whole text and insert a single character, but node.js don't have such a feature.

@Jocs  Do you have any other ideas? Maybe we can replace the `markdown` string with another "high performance" string class later. I don't know js very well, but in c++ you can set spans, so you can ignore index 0 and work on remaining string and preallocated buffers etc, so you don't have to reallocated the string each time.