### PR TITLE
Fixed issue https://github.com/marktext/marktext/issues/150

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@
 ### Features
 
 - Realtime preview and use [snabbdom](https://github.com/snabbdom/snabbdom) as its render engine.
-- Support [CommonMark Spec](http://spec.commonmark.org/0.28/) and [GitHub Flavored Markdown Spec](http://spec.commonmark.org/0.28/).
+- Support [CommonMark Spec](http://spec.commonmark.org/0.28/) and [GitHub Flavored Markdown Spec](https://github.github.com/gfm/).
 - Support paragraphs and inline style shortcuts to improve your writing efficiency.
 - Output **HTML** and **PDF** file.
 - Dark and Light themes.


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 150
| License          | MIT

### Description

The link to GFM originally pointed to CommonMark spec. Fixed the link to point to the GitHub Flavored Markdown Spec instead as it should be.