### PR TITLE
Fixing issue https://github.com/marktext/marktext/issues/150

### DIFF
--- a/doc/i18n/pl.md
+++ b/doc/i18n/pl.md
@@ -90,7 +90,7 @@
 ### Cechy programu
 
 - Podgląd na żywo - użycie [snabbdom](https://github.com/snabbdom/snabbdom) jako swojego silnika renderującego.
-- Wsparcie specyfikacji [CommonMark](http://spec.commonmark.org/0.28/) i [GitHub Flavored Markdown](http://spec.commonmark.org/0.28/).
+- Wsparcie specyfikacji [CommonMark](http://spec.commonmark.org/0.28/) i [GitHub Flavored Markdown](https://github.github.com/gfm/).
 - Wsparcie paragrafów i skrótów klawiatowych dla stylów wbudowanych w celu zwiększenia twojej wydajności podczas pisania.
 - Zapis do plików **HTML** i **PDF**.
 - Ciemny i jasny motyw.


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 150
| License          | MIT

### Description
The link to GFM originally pointed to CommonMark spec. Fixed the link to point to the GitHub Flavored Markdown Spec instead as it should be.
