### PR TITLE
Update package.json

### DIFF
--- a/doc/linux.md
+++ b/doc/linux.md
@@ -1,0 +1,40 @@
+# Mark Text on Linux
+
+## AppImage
+
+Download the AppImage and type the following:
+
+1. `chmod +x marktext-%version%-x86_64.AppImage`
+2. `./marktext-%version%-x86_64.AppImage`
+3. Now you can decide whether you want to install Mark Text (yes) or just execute it (no).
+
+### Installation
+
+You cannot really install a AppImage. It's just a file which can be integrated with your desktop environment. The only thing you have to do is to execute Mark Text and click `Yes` on dialog.
+
+### Uninstall
+
+1. Delete AppImage file
+2. Delete `~/.local/share/applications/appimagekit-marktext.desktop`
+3. Delete your user settings: `~/.config/marktext`
+
+### Extract application
+
+1. `./marktext-%version%-x86_64.AppImage --appimage-extract`
+2. Move Mark Text into another location: `mkdir ~/bin/marktext && mv squashfs-root/app/* ~/bin/marktext`
+3. Delete `squashfs-root` folder
+
+### Known issues
+
+Some error output during application update. Just ignore it if everything is ok.
+
+## Snappy
+
+Downlaod snap file and execute `sudo snap install --classic --dangerous marktext_%version%_amd64.snap`.
+
+Please note that snappy packages may not work on not Debian-based distros and SELinux distros.
+
+### Known issues
+
+- Library problems on SELinux distros (even if SELinux is disabled) and not Debian-based distros.
+- User directories (like documents and downloads) are always saved under the english name.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "build": {
     "productName": "Mark Text",
-    "appId": "org.simulatedgreg.electron-marktext",
+    "appId": "com.github.marktext.marktext",
     "asar": true,
     "directories": {
       "output": "build"
@@ -84,7 +84,26 @@
       "allowToChangeInstallationDirectory": true
     },
     "linux": {
-      "icon": "build/icons"
+      "category": "Office;TextEditor;Utility",
+      "icon": "build/icons",
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "snap"
+        }
+      ]
+    },
+    "snap": {
+      "confinement": "classic",
+      "grade": "stable",
+      "plugs": [
+        "default",
+        "classic-support",
+        "wayland"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| License          | MIT

### Description

- changed `appId` to `com.github.marktext.marktext`
- changed linux categories to: Office, TextEditor and Utility

## snappy

- add wayland support
- allow Mark Text access files outside from user home directory

**What's still not working:**

- Library problems on SELinux distros (even if SELinux is disabled) and not Debian-based distros - many libraries are not found.
- User directories (like documents and downloads) are always saved under the english name. E.g. "Dokumente" (documents) will be saved under `~/Documents/file` and not `~/Dokumente/file`

 
My suggestion is that we remove snappy build/support and use Flatpak after v1.0 release. At the moment snappy should only work on Debian based distros like Ubuntu with AppArmor.

@Jocs If you want to continue supporting snappy we have to disable automaticaly update in snappy packages. And also this leads to another problem: if we want to support "cross-distro" compatibility, then we can only build snappy on Ubuntu (or other Debian distros ???), because of native libraries. I will not fix that, but I can send you log files. Missing libraries are at least: `libtinfo`, `libdl`, `libc` and `libselinux`.
