### PR TITLE
Disable update menu for snap and not supported packages

### DIFF
--- a/src/main/menus/help.js
+++ b/src/main/menus/help.js
@@ -3,6 +3,7 @@ import * as actions from '../actions/help'
 import { checkUpdates } from '../actions/marktext'
 
 const notOsx = process.platform !== 'darwin'
+const updateMenuVisibility = process.platform === 'win32' || !!process.env.APPIMAGE
 
 export default {
   label: 'Help',
@@ -41,10 +42,10 @@ export default {
     }
   }, {
     type: 'separator',
-    visible: notOsx
+    visible: updateMenuVisibility
   }, {
     label: 'Check for updates...',
-    visible: notOsx,
+    visible: updateMenuVisibility,
     click (menuItem, browserWindow) {
       checkUpdates(menuItem, browserWindow)
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Disable update menu for snappy and not supported packages. Otherwise `Check for updates` will crash Mark Text, because it's not supported. macOS use the updater routine defined in `Mark Text` menu.

Supported packages are: macOS (dmg+zip), Windows (NSIS) and AppImage