### PR TITLE
fix: #190 Delete user settings on uninstall (NSIS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/electron/*
 dist/web/*
 build/*
 !build/icons
+!build/windows
 coverage
 .vscode
 node_modules/

--- a/build/windows/installer.nsh
+++ b/build/windows/installer.nsh
@@ -1,0 +1,6 @@
+!macro customUnInstall
+  MessageBox MB_YESNO "Do you want to delete user settings?" /SD IDNO IDNO SkipRemoval
+    SetShellVarContext current
+    RMDir /r "$APPDATA\marktext"
+  SkipRemoval:
+!macroend

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "nsis": {
       "perMachine": true,
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "include": "build/windows/installer.nsh"
     },
     "linux": {
       "category": "Office;TextEditor;Utility",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #190
| License          | MIT

### Description

User can decide whether he wants to delete user settings (`marktext`) on uninstall. There are still two folders `marktext` and `Mark Text`, but `Mark Text` is used by NSIS setup.
