### PR TITLE
Add fallback editor font family

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marktext",
-  "version": "0.9.25",
+  "version": "0.10.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/renderer/components/editor.vue
+++ b/src/renderer/components/editor.vue
@@ -2,8 +2,8 @@
   <div
     class="editor-wrapper"
     :class="[{ 'typewriter': typewriter, 'focus': focus, 'source': sourceCode }, theme]"
-    :style="{ 'color': theme === 'dark' ? darkColor : lightColor, 'lineHeight': lineHeight, 'fontSize': fontSize, 
-    'font-family': editorFontFamily ? `${editorFontFamily}, sans-serif`:'sans-serif'}"
+    :style="{ 'color': theme === 'dark' ? darkColor : lightColor, 'lineHeight': lineHeight, 'fontSize': fontSize,
+    'font-family': editorFontFamily ? `${editorFontFamily}, ${defaultFontFamily}` : `${defaultFontFamily}`}"
   >
     <div
       ref="editor"
@@ -104,6 +104,7 @@
       ])
     },
     data () {
+      this.defaultFontFamily = '"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif'
       return {
         selectionChange: null,
         editor: null,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Add fallback editor font family as it's defined in `dark.css`/`light.css`.
