### PR TITLE
Line ending

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - feature: add editorFont setting in user preference. (#175) - Anderson
 - feature: line break, support event and import and export markdown - Jocs
-- feat: unindent list item - Jocs
+- feature: unindent list item - Jocs
+- feature: Support for CRLF and LF line endings
 
 **:butterfly:Optimization**
 

--- a/src/main/actions/edit.js
+++ b/src/main/actions/edit.js
@@ -41,6 +41,10 @@ export const edit = (win, type) => {
   win.webContents.send('AGANI::edit', { type })
 }
 
+export const lineEnding = (win, lineEnding) => {
+  win.webContents.send('AGANI::set-line-ending', { lineEnding })
+}
+
 export const insertImage = (win, type) => {
   if (type === 'absolute' || type === 'relative') {
     getAndSendImagePath(win, type)

--- a/src/main/actions/edit.js
+++ b/src/main/actions/edit.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { dialog, ipcMain, BrowserWindow } from 'electron'
 import { IMAGE_EXTENSIONS } from '../config'
 import { searchFilesAndDir } from '../imagePathAutoComplement'
+import { updateLineEndingnMenu } from '../menu'
 import { log } from '../utils'
 
 const getAndSendImagePath = (win, type) => {
@@ -35,6 +36,10 @@ ipcMain.on('AGANI::ask-for-image-auto-path', (e, { pathname, src }) => {
       win.webContents.send('AGANI::image-auto-path', files)
     })
     .catch(log)
+})
+
+ipcMain.on('AGANI::update-line-ending-menu', (e, lineEnding) => {
+  updateLineEndingnMenu(lineEnding)
 })
 
 export const edit = (win, type) => {

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -37,5 +37,5 @@ export const VIEW_MENU_ITEM = {
 }
 
 export const LINE_ENDING_REG = /(?:\r\n|\n)/g
-export const LF_LINE_ENDING_REG = /([^\r]\n)|(^\n$)/
-export const CRLF_LINE_ENDING_REG = /(\r\n)/
+export const LF_LINE_ENDING_REG = /(?:[^\r]\n)|(?:^\n$)/
+export const CRLF_LINE_ENDING_REG = /\r\n/

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -36,6 +36,6 @@ export const VIEW_MENU_ITEM = {
   'Focus Mode': false
 }
 
-export const LINE_ENDING_REG = /(\r\n|\n)/g
-export const LF_LINE_ENDING_REG = /([^\r]\n)/
+export const LINE_ENDING_REG = /(?:\r\n|\n)/g
+export const LF_LINE_ENDING_REG = /([^\r]\n)|(^\n$)/
 export const CRLF_LINE_ENDING_REG = /(\r\n)/

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -35,3 +35,7 @@ export const VIEW_MENU_ITEM = {
   'Typewriter Mode': false,
   'Focus Mode': false
 }
+
+export const LINE_ENDING_REG = /(\r\n|\n)/g
+export const LF_LINE_ENDING_REG = /([^\r]\n)/
+export const CRLF_LINE_ENDING_REG = /(\r\n)/

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -3,7 +3,7 @@
 import path from 'path'
 import { app, BrowserWindow, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
-import { loadMarkdownFile } from './filesystem'
+import { getOsLineEndingName, loadMarkdownFile } from './filesystem'
 import { addRecentlyUsedDocuments } from './menu'
 import { isMarkdownFile } from './utils'
 
@@ -67,6 +67,11 @@ const createWindow = (pathname, options = {}) => {
     if (pathname && isMarkdownFile(pathname)) {
       addRecentlyUsedDocuments(pathname)
       loadMarkdownFile(win, pathname)
+    } else {
+      win.webContents.send('AGANI::set-line-ending', {
+        lineEnding: getOsLineEndingName(),
+        ignoreSaveStatus: true
+      })
     }
   })
 

--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -1,11 +1,11 @@
 'use strict'
 
-import fs from 'fs'
 import path from 'path'
-import { BrowserWindow, screen } from 'electron'
+import { app, BrowserWindow, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
+import { loadMarkdownFile } from './filesystem'
 import { addRecentlyUsedDocuments } from './menu'
-import { isMarkdownFile, log } from './utils'
+import { isMarkdownFile } from './utils'
 
 export const windows = new Map()
 
@@ -66,26 +66,7 @@ const createWindow = (pathname, options = {}) => {
 
     if (pathname && isMarkdownFile(pathname)) {
       addRecentlyUsedDocuments(pathname)
-      const filename = path.basename(pathname)
-      fs.readFile(path.resolve(pathname), 'utf-8', (err, file) => {
-        if (err) {
-          log(err)
-          return
-        }
-
-        // check UTF-8 BOM (EF BB BF) encoding
-        let isUtf8BomEncoded = file.length >= 1 && file.charCodeAt(0) === 0xFEFF
-        if (isUtf8BomEncoded) {
-          file = file.slice(1)
-        }
-
-        win.webContents.send('AGANI::file-loaded', {
-          file,
-          filename,
-          pathname,
-          isUtf8BomEncoded
-        })
-      })
+      loadMarkdownFile(win, pathname)
     }
   })
 
@@ -111,6 +92,17 @@ const createWindow = (pathname, options = {}) => {
 
   windows.set(win.id, win)
   return win
+}
+
+export const forceClose = win => {
+  if (!win) return
+  if (windows.has(win.id)) {
+    windows.delete(win.id)
+  }
+  win.destroy() // if use win.close(), it will cause a endless loop.
+  if (windows.size === 0) {
+    app.quit()
+  }
 }
 
 export default createWindow

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -11,7 +11,7 @@ const convertLineEndings = (text, lineEnding) => {
   return text.replace(LINE_ENDING_REG, getLineEnding(lineEnding))
 }
 
-const getOsLineEndingName = () => {
+export const getOsLineEndingName = () => {
   const { endOfLine } = userPreference.getAll()
   if (endOfLine === 'lf') {
     return 'lf'

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -1,0 +1,57 @@
+import fs from 'fs'
+import path from 'path'
+import { forceClose } from './createWindow'
+import { log } from './utils'
+
+export const writeFile = (pathname, content, extension, e, callback = null) => {
+  if (pathname) {
+    pathname = !extension || pathname.endsWith(extension) ? pathname : `${pathname}${extension}`
+    fs.writeFile(pathname, content, 'utf-8', err => {
+      if (err) log(err)
+      if (callback) callback(err, pathname)
+    })
+  } else {
+    log('[ERROR] Cannot save file without path.')
+  }
+}
+
+export const writeMarkdownFile = (pathname, content, extension, options, win, e, quitAfterSave = false) => {
+  if (options.isUtf8BomEncoded) {
+    content = '\uFEFF' + content
+  }
+
+  writeFile(pathname, content, extension, e, (err, filePath) => {
+    if (!err) e.sender.send('AGANI::file-saved-successfully')
+    const filename = path.basename(filePath)
+    if (e && filePath) e.sender.send('AGANI::set-pathname', { pathname: filePath, filename })
+    if (!err && quitAfterSave) forceClose(win)
+  })
+}
+
+export const loadMarkdownFile = (win, pathname) => {
+  fs.readFile(path.resolve(pathname), 'utf-8', (err, file) => {
+    if (err) {
+      log(err)
+      return
+    }
+
+    // check UTF-8 BOM (EF BB BF) encoding
+    let isUtf8BomEncoded = file.length >= 1 && file.charCodeAt(0) === 0xFEFF
+    if (isUtf8BomEncoded) {
+      file = file.slice(1)
+    }
+
+    // TODO: Detect line ending
+
+    const filename = path.basename(pathname)
+    win.webContents.send('AGANI::file-loaded', {
+      file,
+      filename,
+      pathname,
+      options: {
+        isUtf8BomEncoded,
+        lineEnding: 'lf'
+      }
+    })
+  })
+}

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -1,7 +1,24 @@
 import fs from 'fs'
 import path from 'path'
+import { LF_LINE_ENDING_REG, CRLF_LINE_ENDING_REG } from './config'
 import { forceClose } from './createWindow'
 import { log } from './utils'
+
+const isWin = process.platform === 'win32'
+
+const getOsLineEndingName = () => {
+  // TODO: check settings option
+  return isWin ? 'crlf' : 'lf'
+}
+
+// const getLineEnding = lineEnding => {
+//   if (lineEnding === 'lf') {
+//     return '\n'
+//   } else if (lineEnding === 'crlf') {
+//     return '\r\n'
+//   }
+//   return isWin ? '\r\n' : '\n'
+// }
 
 export const writeFile = (pathname, content, extension, e, callback = null) => {
   if (pathname) {
@@ -20,6 +37,10 @@ export const writeMarkdownFile = (pathname, content, extension, options, win, e,
     content = '\uFEFF' + content
   }
 
+  if (options.adjustLineEndingOnSave) {
+    // TODO: Change document line ending if needed
+  }
+
   writeFile(pathname, content, extension, e, (err, filePath) => {
     if (!err) e.sender.send('AGANI::file-saved-successfully')
     const filename = path.basename(filePath)
@@ -35,13 +56,28 @@ export const loadMarkdownFile = (win, pathname) => {
       return
     }
 
-    // check UTF-8 BOM (EF BB BF) encoding
-    let isUtf8BomEncoded = file.length >= 1 && file.charCodeAt(0) === 0xFEFF
+    // Check UTF-8 BOM (EF BB BF) encoding
+    const isUtf8BomEncoded = file.length >= 1 && file.charCodeAt(0) === 0xFEFF
     if (isUtf8BomEncoded) {
       file = file.slice(1)
     }
 
-    // TODO: Detect line ending
+    // Detect line ending
+    const isLf = LF_LINE_ENDING_REG.test(file)
+    const isCrlf = CRLF_LINE_ENDING_REG.test(file)
+    const isMixed = isLf && isCrlf
+    let lineEnding = getOsLineEndingName()
+    if (isLf) {
+      lineEnding = 'lf'
+    } else if (isCrlf) {
+      lineEnding = 'crlf'
+    }
+
+    let adjustLineEndingOnSave = false
+    if (lineEnding !== 'lf') {
+      adjustLineEndingOnSave = true
+      // TODO: Convert CRLF to LF for internal use and change it back on save.
+    }
 
     const filename = path.basename(pathname)
     win.webContents.send('AGANI::file-loaded', {
@@ -50,8 +86,13 @@ export const loadMarkdownFile = (win, pathname) => {
       pathname,
       options: {
         isUtf8BomEncoded,
-        lineEnding: 'lf'
+        lineEnding,
+        adjustLineEndingOnSave
       }
     })
+
+    if (isMixed) {
+      // TODO: Notify user about mixed endings
+    }
   })
 }

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -25,7 +25,7 @@ const getLineEnding = lineEnding => {
   } else if (lineEnding === 'crlf') {
     return '\r\n'
   }
-  return isWin ? '\r\n' : '\n'
+  return getOsLineEndingName() === 'crlf' ? '\r\n' : '\n'
 }
 
 export const writeFile = (pathname, content, extension, e, callback = null) => {
@@ -100,8 +100,12 @@ export const loadMarkdownFile = (win, pathname) => {
       }
     })
 
+    // Notify user about mixed endings
     if (isMixed) {
-      // TODO: Notify user about mixed endings
+      win.webContents.send('AGANI::show-info-notification', {
+        msg: `The document has mixed line endings which are automatically normalized to ${lineEnding.toUpperCase()}.`,
+        timeout: 20000
+      })
     }
   })
 }

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -41,12 +41,13 @@ export const writeFile = (pathname, content, extension, e, callback = null) => {
 }
 
 export const writeMarkdownFile = (pathname, content, extension, options, win, e, quitAfterSave = false) => {
-  if (options.isUtf8BomEncoded) {
+  const { adjustLineEndingOnSave, isUtf8BomEncoded, lineEnding } = options
+  if (isUtf8BomEncoded) {
     content = '\uFEFF' + content
   }
 
-  if (options.adjustLineEndingOnSave) {
-    content = convertLineEndings(content, options.lineEnding)
+  if (adjustLineEndingOnSave) {
+    content = convertLineEndings(content, lineEnding)
   }
 
   writeFile(pathname, content, extension, e, (err, filePath) => {
@@ -74,6 +75,7 @@ export const loadMarkdownFile = (win, pathname) => {
     const isLf = LF_LINE_ENDING_REG.test(file)
     const isCrlf = CRLF_LINE_ENDING_REG.test(file)
     const isMixed = isLf && isCrlf
+    const isUnknownEnding = !isLf && !isCrlf
     let lineEnding = getOsLineEndingName()
     if (isLf && !isCrlf) {
       lineEnding = 'lf'
@@ -82,9 +84,9 @@ export const loadMarkdownFile = (win, pathname) => {
     }
 
     let adjustLineEndingOnSave = false
-    if (isMixed || lineEnding !== 'lf') {
+    if (isMixed || isUnknownEnding || lineEnding !== 'lf') {
       adjustLineEndingOnSave = lineEnding !== 'lf'
-      // Convert CRLF to LF for internal use.
+      // Convert to LF for internal use.
       file = convertLineEndings(file, 'lf')
     }
 

--- a/src/main/filesystem.js
+++ b/src/main/filesystem.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { LINE_ENDING_REG, LF_LINE_ENDING_REG, CRLF_LINE_ENDING_REG } from './config'
 import { forceClose } from './createWindow'
+import userPreference from './preference'
 import { log } from './utils'
 
 const isWin = process.platform === 'win32'
@@ -11,8 +12,11 @@ const convertLineEndings = (text, lineEnding) => {
 }
 
 const getOsLineEndingName = () => {
-  // TODO: check settings option
-  return isWin ? 'crlf' : 'lf'
+  const { endOfLine } = userPreference.getAll()
+  if (endOfLine === 'lf') {
+    return 'lf'
+  }
+  return endOfLine === 'crlf' || isWin ? 'crlf' : 'lf'
 }
 
 const getLineEnding = lineEnding => {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -84,3 +84,14 @@ export const updateApplicationMenu = (recentUsedDocuments) => {
   }
   initMacDock = true
 }
+
+export const updateLineEndingnMenu = lineEnding => {
+  const menus = Menu.getApplicationMenu()
+  const crlfMenu = menus.getMenuItemById('crlfLineEndingMenuEntry')
+  const lfMenu = menus.getMenuItemById('lfLineEndingMenuEntry')
+  if (lineEnding === 'crlf') {
+    crlfMenu.checked = true
+  } else {
+    lfMenu.checked = true
+  }
+}

--- a/src/main/menus/edit.js
+++ b/src/main/menus/edit.js
@@ -93,12 +93,16 @@ export default {
   }, {
     label: 'Line Ending',
     submenu: [{
+      id: 'crlfLineEndingMenuEntry',
       label: 'Carriage return and line feed (CRLF)',
+      type: 'radio',
       click (menuItem, browserWindow) {
         actions.lineEnding(browserWindow, 'crlf')
       }
     }, {
+      id: 'lfLineEndingMenuEntry',
       label: 'Line feed (LF)',
+      type: 'radio',
       click (menuItem, browserWindow) {
         actions.lineEnding(browserWindow, 'lf')
       }

--- a/src/main/menus/edit.js
+++ b/src/main/menus/edit.js
@@ -71,6 +71,8 @@ export default {
       actions.edit(browserWindow, 'aidou')
     }
   }, {
+    type: 'separator'
+  }, {
     label: 'Insert Image',
     submenu: [{
       label: 'Absolute Path',
@@ -86,6 +88,21 @@ export default {
       label: 'Upload to Cloud (EXP)',
       click (menuItem, browserWindow) {
         actions.insertImage(browserWindow, 'upload')
+      }
+    }]
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Line Ending',
+    submenu: [{
+      label: 'Carriage return and line feed (CRLF)',
+      click (menuItem, browserWindow) {
+        actions.lineEnding(browserWindow, 'crlf')
+      }
+    }, {
+      label: 'Line feed (LF)',
+      click (menuItem, browserWindow) {
+        actions.lineEnding(browserWindow, 'lf')
       }
     }]
   }]

--- a/src/main/menus/edit.js
+++ b/src/main/menus/edit.js
@@ -71,8 +71,6 @@ export default {
       actions.edit(browserWindow, 'aidou')
     }
   }, {
-    type: 'separator'
-  }, {
     label: 'Insert Image',
     submenu: [{
       label: 'Absolute Path',

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -20,6 +20,8 @@ export const getPath = directory => {
 }
 
 export const getMenuItem = menuName => {
+  // TODO(fxha): Please use menu id attribute to find menu entries. This will
+  //             cause problems with internationalization later!
   const menus = Menu.getApplicationMenu()
   return menus.items.find(menu => menu.label === menuName)
 }

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -98,6 +98,7 @@
       dispatch('LISTEN_FOR_RENAME')
       dispatch('LISTEN_FOR_IMAGE_PATH')
       dispatch('LISTEN_FOR_FILE_SAVED_SUCCESSFULLY')
+      dispatch('LINTEN_FOR_SET_LINE_ENDING')
     }
   }
 </script>

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -99,6 +99,7 @@
       dispatch('LISTEN_FOR_IMAGE_PATH')
       dispatch('LISTEN_FOR_FILE_SAVED_SUCCESSFULLY')
       dispatch('LINTEN_FOR_SET_LINE_ENDING')
+      dispatch('LISTEN_FOR_NOTIFICATION')
     }
   }
 </script>

--- a/src/renderer/components/status.vue
+++ b/src/renderer/components/status.vue
@@ -26,7 +26,6 @@
       }
     },
     created () {
-      const self = this
       this.$nextTick(() => {
         bus.$on('status-error', msg => {
           this.showStatus = true
@@ -39,7 +38,7 @@
           this.message = msg
           if (timeout) {
             setTimeout(() => {
-              self.close(true)
+              this.close(true)
             }, timeout)
           }
         })

--- a/src/renderer/components/status.vue
+++ b/src/renderer/components/status.vue
@@ -1,10 +1,11 @@
 <template>
-  <div 
+  <div
     class="bottom-status"
+    :class="{'error': error}"
     v-show="showStatus"
   >
     <div class="status-wrapper">
-      <span class="message" :class="{'error': error}">{{ message }}</span>
+      <span class="message" :title="message">{{ message }}</span>
       <span class="yes" v-show="showYes" @click="handleYesClick">[ Y ]</span>
       <span class="no" @click="close(true)">[ X ]</span>
     </div>
@@ -25,16 +26,22 @@
       }
     },
     created () {
+      const self = this
       this.$nextTick(() => {
         bus.$on('status-error', msg => {
           this.showStatus = true
           this.error = true
           this.message = msg
         })
-        bus.$on('status-message', msg => {
+        bus.$on('status-message', (msg, timeout) => {
           this.showStatus = true
           this.error = false
           this.message = msg
+          if (timeout) {
+            setTimeout(() => {
+              self.close(true)
+            }, timeout)
+          }
         })
         bus.$on('status-promote', (msg, eventId) => {
           this.showStatus = true
@@ -72,12 +79,17 @@
   .bottom-status {
     width: 100%;
     height: 25px;
+    background-color: #2196F3;
+    color: #fff;
+  }
+  .bottom-status.error {
+    background-color: #F44336;
   }
   .status-wrapper {
     text-align: center;
     line-height: 25px;
     font-size: 13px;
-    color: rgb(136, 170, 204);
+    color: #fff;
   }
   .message {
     max-width: 70%;
@@ -89,12 +101,9 @@
   .message, .yes {
     margin-right: 5px;
   }
-  .message.error {
-    color: #E6A23C;
-  }
   .yes, .no {
     vertical-align: top;
-    color: rgb(79, 183, 221);
+    color: #fff;
     cursor: pointer;
   }
 </style>

--- a/src/renderer/notice/index.js
+++ b/src/renderer/notice/index.js
@@ -5,8 +5,8 @@ export const error = msg => {
   bus.$emit('status-error', msg)
 }
 
-export const message = msg => {
-  bus.$emit('status-message', msg)
+export const message = (msg, timeout) => {
+  bus.$emit('status-message', msg, timeout)
 }
 
 export const promote = msg => {

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -350,11 +350,12 @@ const actions = {
   },
 
   LINTEN_FOR_SET_LINE_ENDING ({ commit, state }) {
-    ipcRenderer.on('AGANI::set-line-ending', (e, { lineEnding }) => {
+    ipcRenderer.on('AGANI::set-line-ending', (e, { lineEnding, ignoreSaveStatus }) => {
       const { lineEnding: oldLineEnding } = state
       if (lineEnding !== oldLineEnding) {
         commit('SET_LINE_ENDING', lineEnding)
         commit('SET_ADJUST_LINE_ENDING_ON_SAVE', lineEnding !== 'lf')
+        commit('SET_SAVE_STATUS', !!ignoreSaveStatus)
       }
     })
   }

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -31,7 +31,8 @@ const state = {
   isSaved: true,
   markdown: '',
   isUtf8BomEncoded: false,
-  lineEnding: 'lf', // lf, crlf or mixed
+  lineEnding: 'lf', // lf or crlf
+  adjustLineEndingOnSave: false,
   cursor: null,
   windowActive: true,
   wordCount: {
@@ -71,6 +72,9 @@ const mutations = {
   },
   SET_LINE_ENDING (state, lineEnding) {
     state.lineEnding = lineEnding
+  },
+  SET_ADJUST_LINE_ENDING_ON_SAVE (state, adjustLineEndingOnSave) {
+    state.adjustLineEndingOnSave = adjustLineEndingOnSave
   },
   SET_WORD_COUNT (state, wordCount) {
     state.wordCount = wordCount
@@ -216,6 +220,7 @@ const actions = {
       commit('SET_SAVE_STATUS', true)
       commit('SET_IS_UTF8_BOM_ENCODED', options.isUtf8BomEncoded)
       commit('SET_LINE_ENDING', options.lineEnding)
+      commit('SET_ADJUST_LINE_ENDING_ON_SAVE', options.adjustLineEndingOnSave)
       bus.$emit('file-loaded', file)
     })
   },
@@ -349,6 +354,7 @@ const actions = {
       const { lineEnding: oldLineEnding } = state
       if (lineEnding !== oldLineEnding) {
         commit('SET_LINE_ENDING', lineEnding)
+        commit('SET_ADJUST_LINE_ENDING_ON_SAVE', lineEnding !== 'lf')
       }
     })
   }

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -355,7 +355,9 @@ const actions = {
       if (lineEnding !== oldLineEnding) {
         commit('SET_LINE_ENDING', lineEnding)
         commit('SET_ADJUST_LINE_ENDING_ON_SAVE', lineEnding !== 'lf')
-        commit('SET_SAVE_STATUS', !!ignoreSaveStatus)
+        if (!ignoreSaveStatus) {
+          commit('SET_SAVE_STATUS', false)
+        }
       }
     })
   }

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -4,13 +4,15 @@ import Vuex from 'vuex'
 import editorStore from './editor'
 import aidouStore from './aidou'
 import autoUpdates from './autoUpdates'
+import notification from './notification'
 
 Vue.use(Vuex)
 
 const storeArray = [
   editorStore,
   aidouStore,
-  autoUpdates
+  autoUpdates,
+  notification
 ]
 
 const { actions, mutations, state } = storeArray.reduce((acc, s) => {

--- a/src/renderer/store/notification.js
+++ b/src/renderer/store/notification.js
@@ -1,0 +1,21 @@
+import { ipcRenderer } from 'electron'
+import { error, message } from '../notice'
+
+const state = {
+}
+
+const mutations = {
+}
+
+const actions = {
+  LISTEN_FOR_NOTIFICATION ({ commit }) {
+    ipcRenderer.on('AGANI::show-error-notification', (e, msg) => {
+      error(msg)
+    })
+    ipcRenderer.on('AGANI::show-info-notification', (e, { msg, timeout }) => {
+      message(msg, timeout)
+    })
+  }
+}
+
+export default { state, mutations, actions }

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -168,8 +168,3 @@ export const animatedScrollTo = function (element, to, duration, callback) {
   }
   requestAnimationFrame(animateScroll)
 }
-
-export const getOptionsFromState = state => {
-  const { isUtf8BomEncoded, lineEnding, adjustLineEndingOnSave } = state
-  return { isUtf8BomEncoded, lineEnding, adjustLineEndingOnSave }
-}

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -172,6 +172,7 @@ export const animatedScrollTo = function (element, to, duration, callback) {
 export const getOptionsFromState = state => {
   return {
     isUtf8BomEncoded: state.isUtf8BomEncoded,
-    lineEnding: state.lineEnding
+    lineEnding: state.lineEnding,
+    adjustLineEndingOnSave: state.adjustLineEndingOnSave
   }
 }

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -168,3 +168,10 @@ export const animatedScrollTo = function (element, to, duration, callback) {
   }
   requestAnimationFrame(animateScroll)
 }
+
+export const getOptionsFromState = state => {
+  return {
+    isUtf8BomEncoded: state.isUtf8BomEncoded,
+    lineEnding: state.lineEnding
+  }
+}

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -170,9 +170,6 @@ export const animatedScrollTo = function (element, to, duration, callback) {
 }
 
 export const getOptionsFromState = state => {
-  return {
-    isUtf8BomEncoded: state.isUtf8BomEncoded,
-    lineEnding: state.lineEnding,
-    adjustLineEndingOnSave: state.adjustLineEndingOnSave
-  }
+  const { isUtf8BomEncoded, lineEnding, adjustLineEndingOnSave } = state
+  return { isUtf8BomEncoded, lineEnding, adjustLineEndingOnSave }
 }

--- a/static/preference.md
+++ b/static/preference.md
@@ -1,10 +1,12 @@
 ### :bust_in_silhouette:User Preferences
 
-Edit and save to update preferences.  You can only change the JSON below!
+Edit and save to update preferences. You can only change the JSON below!
 
 - **theme**: *String* `dark` or `light`
 
 - **autoSave**: *Boolean* `true` or `false`
+
+- **endOfLine**: *String* `lf`, `crlf` or `default`
 
 ```json
 {
@@ -19,7 +21,8 @@ Edit and save to update preferences.  You can only change the JSON below!
   "preferLooseListItem": true,
   "autoPairBracket": true,
   "autoPairMarkdownSyntax": true,
-  "autoPairQuote": true
+  "autoPairQuote": true,
+  "endOfLine": "default"
 }
 ```
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| Fixed tickets    | #48
| License          | MIT

## TODO's:

- [x] Prepare line ending feature
- [x] Detect document line ending
- [x] Always convert text to `LF` for internal use and change it back on save
- [x] Add menu entry: `LF: Line feed` and `CRLF: Carriage return and line feed`
- [x] Notify user about mixed endings via auto. update statusbar
- [x] Settings option: `EndOfLine: <string> { LF, CRLF }` (overrides platform ending)