### PR TITLE
Smaller scrollbars and hover color

### DIFF
--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -18,9 +18,14 @@ body {
 ::-webkit-scrollbar {
   background: rgb(43, 43, 43);
 }
-
+::-webkit-scrollbar:vertical {
+  width: 12px;
+}
 ::-webkit-scrollbar-thumb {
   background: rgb(55, 55, 55);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #3F3F3F;
 }
 
 #ag-editor-id {

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -19,9 +19,14 @@ body {
 ::-webkit-scrollbar {
   background: rgb(252, 252, 252);
 }
-
+::-webkit-scrollbar:vertical {
+  width: 12px;
+}
 ::-webkit-scrollbar-thumb {
   background: #EBEEF5;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #E1E4EA;
 }
 
 #ag-editor-id {


### PR DESCRIPTION
Added scrollbar hover color and made scrollbars smaller because of custom titlebar "conflicts" with hover x-button background.

before/after:

![mt_scrollbars](https://user-images.githubusercontent.com/22716132/39662223-91b324a8-505e-11e8-9000-f6b54018b03c.png)
