### PR TITLE
feature: Support `setext` heading but the default heading style is `atx`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feature: Support for CRLF and LF line endings
 - feature: Click filename to `rename` or `save` in title bar(**macOS ONLY**).
 - feature: Support YAML Front Matter
+- feature: Support `setext` heading but the default heading style is `atx`
 
 **:butterfly:Optimization**
 

--- a/src/editor/config.js
+++ b/src/editor/config.js
@@ -115,7 +115,8 @@ export const CLASS_OR_ID = genUpper2LowerKeyHash([
   'AG_TIGHT_LIST_ITEM',
   'AG_HTML_TAG',
   'AG_LINK',
-  'AG_HARD_LINE_BREAK'
+  'AG_HARD_LINE_BREAK',
+  'AG_SOFT_LINE_BREAK'
 ])
 
 export const codeMirrorConfig = {

--- a/src/editor/config.js
+++ b/src/editor/config.js
@@ -162,12 +162,22 @@ export const htmlBeautifyConfig = {
 export const CURSOR_DNA = getLongUniqueId()
 
 export const turndownConfig = {
-  headingStyle: 'atx',
-  bulletListMarker: '*',
-  codeBlockStyle: 'fenced',
-  emDelimiter: '_',
-  strongDelimiter: '**'
+  headingStyle: 'atx', // setext or atx
+  bulletListMarker: '*', // -, +, or *
+  codeBlockStyle: 'fenced', // fenced or indented
+  fence: '```', // ``` or ~~~
+  emDelimiter: '*', // _ or *
+  strongDelimiter: '**' // ** or __
 }
+
+export const FORMAT_MARKER_MAP = {
+  'em': '*',
+  'inline_code': '`',
+  'strong': '**',
+  'del': '~~'
+}
+
+export const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image']
 
 export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
 
@@ -188,6 +198,11 @@ export const TABLE_TOOLS = [{
   icon: 'icon-del'
 }]
 
+export const HTML_TOOLS = [{
+  label: 'delete',
+  icon: 'icon-del'
+}]
+
 export const LINE_BREAK = '\n'
 
 export const DOMPURIFY_CONFIG = {
@@ -200,8 +215,3 @@ export const DOMPURIFY_CONFIG = {
     mathMl: true
   }
 }
-
-export const HTML_TOOLS = [{
-  label: 'delete',
-  icon: 'icon-del'
-}]

--- a/src/editor/contentState/codeBlockCtrl.js
+++ b/src/editor/contentState/codeBlockCtrl.js
@@ -91,6 +91,9 @@ const codeBlockCtrl = ContentState => {
     const pres = document.querySelectorAll(selector)
 
     Array.from(pres).forEach(pre => {
+      // If pre element has children, means that this code block is not editing,
+      // and don't need to update to codeMirror.
+      if (pre.children.length) return
       const id = pre.id
       const block = this.getBlock(id)
       const value = block.text

--- a/src/editor/contentState/formatCtrl.js
+++ b/src/editor/contentState/formatCtrl.js
@@ -1,7 +1,6 @@
 import selection from '../selection'
 import { tokenizer, generator } from '../parser/parse'
-
-const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image']
+import { FORMAT_MARKER_MAP, FORMAT_TYPES } from '../config'
 
 const getOffset = (offset, { range: { start, end }, type, anchor, title }) => {
   const dis = offset - start
@@ -65,18 +64,12 @@ const clearFormat = (token, { start, end }) => {
 
 const addFormat = (type, block, { start, end }) => {
   if (block.type === 'pre') return false
-  const MARKER_MAP = {
-    'em': '*',
-    'inline_code': '`',
-    'strong': '**',
-    'del': '~~'
-  }
   switch (type) {
     case 'em':
     case 'del':
     case 'inline_code':
     case 'strong': {
-      const MARKER = MARKER_MAP[type]
+      const MARKER = FORMAT_MARKER_MAP[type]
       const oldText = block.text
       block.text = oldText.substring(0, start.offset) +
         MARKER + oldText.substring(start.offset, end.offset) +

--- a/src/editor/contentState/paragraphCtrl.js
+++ b/src/editor/contentState/paragraphCtrl.js
@@ -1,5 +1,5 @@
 import selection from '../selection'
-import { PARAGRAPH_TYPES } from '../config'
+import { PARAGRAPH_TYPES, turndownConfig } from '../config'
 import ExportMarkdown from '../utils/exportMarkdown'
 
 const LINE_BREAKS_REG = /\n/
@@ -378,6 +378,7 @@ const paragraphCtrl = ContentState => {
         const newText = '#'.repeat(newLevel) + ` ${partText}`
         if (block.type === 'span' && newType !== 'p') {
           const header = this.createBlock(newType, newText)
+          header.headingStyle = turndownConfig.headingStyle
           key = header.key
           const parent = this.getParent(block)
           if (this.isOnlyChild(block)) {
@@ -409,6 +410,7 @@ const paragraphCtrl = ContentState => {
           this.removeBlock(block)
         } else {
           const newHeader = this.createBlock(newType, newText)
+          newHeader.headingStyle = turndownConfig.headingStyle
           key = newHeader.key
           this.insertAfter(newHeader, block)
           this.removeBlock(block)

--- a/src/editor/contentState/updateCtrl.js
+++ b/src/editor/contentState/updateCtrl.js
@@ -2,7 +2,7 @@ import selection from '../selection'
 import { tokenizer } from '../parser/parse'
 import { conflict, isMetaKey } from '../utils'
 import { getTextContent } from '../utils/domManipulate'
-import { CLASS_OR_ID, EVENT_KEYS } from '../config'
+import { CLASS_OR_ID, EVENT_KEYS, turndownConfig } from '../config'
 
 const INLINE_UPDATE_FREGMENTS = [
   '^([*+-]\\s)', // Bullet list
@@ -234,6 +234,7 @@ const updateCtrl = ContentState => {
   ContentState.prototype.updateHeader = function (block, header, text) {
     const newType = `h${header.length}`
     if (block.type !== newType) {
+      block.headingStyle = turndownConfig.headingStyle
       block.type = newType
       block.text = text
       block.children.length = 0

--- a/src/editor/index.css
+++ b/src/editor/index.css
@@ -42,9 +42,14 @@ h6.ag-active::before {
   display: block;
 }
 
-.ag-hard-line-break::after {
+/* .ag-soft-line-break::after {
   content: '↓';
-  opacity: .3;
+  opacity: .5;
+} */
+
+.ag-hard-line-break::after {
+  content: '↩';
+  opacity: .5;
 }
 
 *::selection, .ag-selection {

--- a/src/editor/index.css
+++ b/src/editor/index.css
@@ -357,6 +357,26 @@ pre.ag-code-block {
   width: 100%;
 }
 
+pre.ag-code-block {
+  margin: 1rem 0;
+}
+
+pre.ag-active.ag-code-block::before,
+pre.ag-active.ag-code-block::after {
+  content: '```';
+  color: #909399;
+  position: absolute;
+  left: 0;
+}
+
+pre.ag-active.ag-code-block::before {
+  top: -20px;
+}
+
+pre.ag-active.ag-code-block::after {
+  bottom: -25px;
+}
+
 div.ag-html-preview {
   pointer-events: none;
   width: 100%;
@@ -403,16 +423,18 @@ span.ag-emoji-marked-text {
 }
 
 .ag-language-input {
+  outline: none;
   display: none;
   min-width: 80px;
   position: absolute;
   font-size: .85em;
-  top: 5px;
-  right: 5px;
-  color: #606266;
+  top: -20px;
+  left: 30px;
+  font-size: 14px;
+  font-family: monospace;
+  color: #909399;
   background: transparent;
   border: none;
-  text-align: center;
   z-index: 10;
 }
 

--- a/src/editor/parser/StateRender.js
+++ b/src/editor/parser/StateRender.js
@@ -79,7 +79,7 @@ class StateRender {
     let selector = this.getSelector(block, cursor, activeBlocks)
     // highlight search key in block
     const highlights = matches.filter(m => m.key === block.key)
-    const { text, type, align, htmlContent, icon, checked, key, lang, functionType, codeBlockStyle } = block
+    const { text, type, headingStyle, align, htmlContent, icon, checked, key, lang, functionType, codeBlockStyle } = block
     const data = {
       attrs: {},
       dataset: {}
@@ -117,6 +117,7 @@ class StateRender {
         Object.assign(data.dataset, {
           head: type
         })
+        selector += `.${headingStyle}`
       }
       Object.assign(data.dataset, {
         role: type

--- a/src/editor/parser/StateRender.js
+++ b/src/editor/parser/StateRender.js
@@ -135,20 +135,29 @@ class StateRender {
       }
       children = ''
     } else if (type === 'pre') {
+      selector += `.${CLASS_OR_ID['AG_CODEMIRROR_BLOCK']}`
+      selector += PRE_BLOCK_HASH[functionType]
+      data.hook = {
+        prepatch (oldvnode, vnode) {
+          // cheat snabbdom that the pre block is not changed!!!
+          vnode.children = oldvnode.children
+        }
+      }
       if (lang) {
         Object.assign(data.dataset, {
           lang
         })
       }
+
       if (codeBlockStyle) {
         Object.assign(data.dataset, {
           codeBlockStyle
         })
       }
-      selector += `.${CLASS_OR_ID['AG_CODEMIRROR_BLOCK']}`
-      selector += PRE_BLOCK_HASH[functionType]
+
       if (functionType !== 'frontmatter') {
-        children = ''
+        // do not set it to '' (empty string)
+        children = []
       }
     } else if (type === 'span' && functionType === 'frontmatter') {
       selector += `.${CLASS_OR_ID['AG_FRONT_MATTER_LINE']}`

--- a/src/editor/parser/marked.js
+++ b/src/editor/parser/marked.js
@@ -211,6 +211,7 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       this.tokens.push({
         type: 'heading',
+        headingStyle: 'atx',
         depth: cap[1].length,
         text: cap[2]
       });
@@ -254,6 +255,7 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       this.tokens.push({
         type: 'heading',
+        headingStyle: 'setext',
         depth: cap[2] === '=' ? 1 : 2,
         text: cap[1]
       });
@@ -846,12 +848,14 @@ Renderer.prototype.html = function(html) {
   return html;
 };
 
-Renderer.prototype.heading = function(text, level, raw) {
+Renderer.prototype.heading = function(text, level, raw, headingStyle) {
   return '<h' +
     level +
     ' id="' +
     this.options.headerPrefix +
     raw.toLowerCase().replace(/[^\w]+/g, '-') +
+    '" class="' +
+    headingStyle +
     '">' +
     text +
     '</h' +
@@ -1071,7 +1075,9 @@ Parser.prototype.tok = function() {
         return this.renderer.heading(
           this.inline.output(this.token.text),
           this.token.depth,
-          this.token.text)
+          this.token.text,
+          this.token.headingStyle
+        )
       }
     case 'code':
       {

--- a/src/editor/utils/exportMarkdown.js
+++ b/src/editor/utils/exportMarkdown.js
@@ -126,9 +126,18 @@ class ExportMarkdown {
   }
 
   normalizeHeaderText (block, indent) {
+    const { headingStyle } = block
     const match = block.text.match(/(#{1,6})(.*)/)
-    const text = `${match[1]} ${match[2].trim()}`
-    return `${indent}${text}\n`
+    if (headingStyle === 'atx') {
+      const text = `${match[1]} ${match[2].trim()}`
+      return `${indent}${text}\n`
+    } else if (headingStyle === 'setext') {
+      const level = match[1].length
+      if (level !== 1 && level !== 2) {
+        console.error(`setext heading only have h1 or h2 but we got a heading h${level}`)
+      }
+      return `${indent}${match[2].trim()}\n${indent}${level === 1 ? '===' : '---'}\n`
+    }
   }
 
   normalizeBlockquote (block, indent) {

--- a/src/editor/utils/importMarkdown.js
+++ b/src/editor/utils/importMarkdown.js
@@ -83,9 +83,9 @@ const importRegister = ContentState => {
 
     const htmlText = marked(markdown, { disableInline: true })
     const domAst = parse5.parseFragment(htmlText)
-    // console.log(markdown)
-    // console.log(htmlText)
-    // console.log(domAst)
+    console.log(markdown)
+    console.log(htmlText)
+    console.log(domAst)
     const childNodes = domAst.childNodes
 
     const getLangAndType = node => {
@@ -140,6 +140,13 @@ const importRegister = ContentState => {
             const match = /\d/.exec(child.nodeName)
             value = match ? '#'.repeat(+match[0]) + ` ${textValue}` : textValue
             block = this.createBlock(child.nodeName, value)
+            // handle heading
+            if (match) {
+              const headingStyle = child.attrs.find(attr => attr.name === 'class').value
+              if (typeof headingStyle === 'string' && /atx|setext/.test(headingStyle)) {
+                block.headingStyle = headingStyle
+              }
+            }
             // handle `th` and `td`
             if (child.nodeName === 'th' || child.nodeName === 'td') {
               const column = childNodes.filter(child => /th|td/.test(child.nodeName)).indexOf(child)

--- a/src/editor/utils/importMarkdown.js
+++ b/src/editor/utils/importMarkdown.js
@@ -83,9 +83,9 @@ const importRegister = ContentState => {
 
     const htmlText = marked(markdown, { disableInline: true })
     const domAst = parse5.parseFragment(htmlText)
-    console.log(markdown)
-    console.log(htmlText)
-    console.log(domAst)
+    // console.log(markdown)
+    // console.log(htmlText)
+    // console.log(domAst)
     const childNodes = domAst.childNodes
 
     const getLangAndType = node => {

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -371,15 +371,18 @@ code {
   color: #efefef;
 }
 
+#ag-editor-id pre.ag-html-block {
+    padding: .4rem 1rem;
+    margin-top: 0;
+}
+
 #ag-editor-id pre.ag-code-block,
 #ag-editor-id pre.ag-html-block {
-  padding: .4rem 1rem;
   font-size: 90%;
   line-height: 1.6;
   border: 1px solid #606266;
   border-radius: 3px;
   color: #777777;
-  margin-top: 0;
 }
 
 .fg-color-dark {

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -345,18 +345,18 @@ code {
 
 #ag-editor-id pre.ag-code-block,
 #ag-editor-id pre.ag-html-block {
-  padding: .4rem 1rem;
   font-size: 90%;
   line-height: 1.6;
   background: #f6f8fa;
   border: 0;
   border-radius: 3px;
   color: #777777;
-  margin-top: 0;
 }
 
 #ag-editor-id pre.ag-html-block {
   background: transparent;
+  padding: .4rem 1rem;
+  margin-top: 0;
 }
 
 #ag-editor-id pre.ag-active.ag-html-block {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #220 
| License          | MIT

### Description

Mark Text support setext heading now. but the default heading style is still `atx`, and user can not change it.

* [x] If a markdown file use setext heading, and it will be save as setext heading if not changed.
* [x] open `setext` heading markdown file
* [x] If YOU change the heading level, and `setext` heading will be change to `atx` heading.
* [x] Copy a `setext` heading will also convert to `atx` heading.
* [x] Newly created heading is `atx`.
* [x] If heading is `setext`, and will be saved to `setext` heading.

Why we don't allow user to select heading style or code block style (fenced or indented) ?

Because setext heading only has `h1` and `h2`, and atx heading has `h1~6`.

fenced code block has language setting, but indented code block does not have.

So we set default heading is atx, and default code block style is fenced. and can not be changed.

--

#### Please, don't submit `/dist` files with your PR!
