### PR TITLE
fix: #262 select text from selected table cell only

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.11.36
+### 0.11.37
 
 **:cactus:Feature**
 
@@ -10,6 +10,7 @@
 - feature: Support YAML Front Matter
 - feature: Support `setext` heading but the default heading style is `atx`
 - feature: User list item marker setting in preference file.
+- feature: Select text from selected table (cell) only if you press Ctrl+A
 
 **:butterfly:Optimization**
 

--- a/src/editor/contentState/index.js
+++ b/src/editor/contentState/index.js
@@ -8,6 +8,7 @@ import updateCtrl from './updateCtrl'
 import backspaceCtrl from './backspaceCtrl'
 import codeBlockCtrl from './codeBlockCtrl'
 import tableBlockCtrl from './tableBlockCtrl'
+import selectionCtrl from './selectionCtrl'
 import History from './history'
 import arrowCtrl from './arrowCtrl'
 import pasteCtrl from './pasteCtrl'
@@ -24,6 +25,7 @@ import importMarkdown from '../utils/importMarkdown'
 const prototypes = [
   tabCtrl,
   enterCtrl,
+  selectionCtrl,
   updateCtrl,
   backspaceCtrl,
   codeBlockCtrl,
@@ -504,9 +506,11 @@ class ContentState {
   }
 
   getLastChild (block) {
-    const len = block.children.length
-    if (len) {
-      return block.children[len - 1]
+    if (block) {
+      const len = block.children.length
+      if (len) {
+        return block.children[len - 1]
+      }
     }
     return null
   }

--- a/src/editor/contentState/selectionCtrl.js
+++ b/src/editor/contentState/selectionCtrl.js
@@ -1,0 +1,58 @@
+const selectionCtrl = ContentState => {
+  // Returns the table from the table cell:
+  //   table <-- thead or tbody <-- tr <-- th or td (cell)
+  ContentState.prototype.getTableFromTableCell = function (block) {
+    const table = this.getParent(this.getParent(this.getParent(block)))
+    if (table && table.type !== 'table') {
+      return null
+    }
+    return table
+  }
+
+  ContentState.prototype.tableCellHandler = function (event) {
+    const { start, end } = this.cursor
+    const startBlock = this.getBlock(start.key)
+    const endBlock = this.getBlock(end.key)
+    const { type: startType } = startBlock
+    const { type: endType } = endBlock
+    if (/th|td/.test(startType) && /th|td/.test(endType)) {
+      if (start.key === end.key) {
+        const { text, key } = startBlock
+        this.cursor = {
+          start: { key, offset: 0 },
+          end: { key, offset: text.length }
+        }
+      } else {
+        const startTable = this.getTableFromTableCell(startBlock)
+        const endTable = this.getTableFromTableCell(endBlock)
+        // Check whether both blocks are in the same table.
+        if (!startTable || !endTable) {
+          console.error('No table found or invalid type.')
+          return
+        } else if (startTable.key !== endTable.key) {
+          // Select entire document
+          return
+        }
+        const firstTableBlock = this.firstInDescendant(startTable)
+        const lastTableBlock = this.lastInDescendant(startTable)
+        if (!firstTableBlock || !/th|td/.test(firstTableBlock.type) ||
+          !lastTableBlock || !/th|td/.test(lastTableBlock.type)) {
+          console.error('No table cell found or invalid type.')
+          return
+        }
+        const { key: startKey } = firstTableBlock
+        const { key: endKey, text } = lastTableBlock
+        this.cursor = {
+          start: { key: startKey, offset: 0 },
+          end: { key: endKey, offset: text.length }
+        }
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      this.partialRender()
+    }
+  }
+}
+
+export default selectionCtrl

--- a/src/editor/contentState/selectionCtrl.js
+++ b/src/editor/contentState/selectionCtrl.js
@@ -33,15 +33,15 @@ const selectionCtrl = ContentState => {
           // Select entire document
           return
         }
-        const firstTableBlock = this.firstInDescendant(startTable)
-        const lastTableBlock = this.lastInDescendant(startTable)
-        if (!firstTableBlock || !/th|td/.test(firstTableBlock.type) ||
-          !lastTableBlock || !/th|td/.test(lastTableBlock.type)) {
+        const firstTableCell = this.firstInDescendant(startTable)
+        const lastTableCell = this.lastInDescendant(startTable)
+        if (!firstTableCell || !/th|td/.test(firstTableCell.type) ||
+          !lastTableCell || !/th|td/.test(lastTableCell.type)) {
           console.error('No table cell found or invalid type.')
           return
         }
-        const { key: startKey } = firstTableBlock
-        const { key: endKey, text } = lastTableBlock
+        const { key: startKey } = firstTableCell
+        const { key: endKey, text } = lastTableCell
         this.cursor = {
           start: { key: startKey, offset: 0 },
           end: { key: endKey, offset: text.length }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -74,6 +74,7 @@ class Aganippe {
     this.dispatchArrow()
     this.dispatchBackspace()
     this.dispatchEnter()
+    this.dispatchSelection()
     this.dispatchUpdateState()
     this.dispatchCopyCut()
     this.dispatchTableToolBar()
@@ -281,6 +282,17 @@ class Aganippe {
     const handler = event => {
       if (event.key === EVENT_KEYS.Enter && !this._isEditChinese) {
         this.contentState.enterHandler(event)
+      }
+    }
+
+    eventCenter.attachDOMEvent(container, 'keydown', handler)
+  }
+
+  dispatchSelection (event) {
+    const { container, eventCenter } = this
+    const handler = event => {
+      if (event.ctrlKey && event.key === 'a') {
+        this.contentState.tableCellHandler(event)
       }
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #262
| License          | MIT

### Description

@Jocs How can I select a full block? `selection` helper seems not work ([ref](https://github.com/marktext/marktext/pull/273/files#diff-65dc429a509634687baabb2a50c9072cR11)).