### PR TITLE
Fix frameless window drag

### DIFF
--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -6,7 +6,6 @@
       <span
         v-for="(path, index) of paths"
         :key="index"
-        :class="{ 'title-no-drag': platform !== 'darwin' }"
       >
         {{ path }}
         <svg class="icon" aria-hidden="true">


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fix an issue that you cannot drag the frameless window on the left side of the  title bar path.
