### PR TITLE
Fix framless titlebar height

### DIFF
--- a/src/main/config.js
+++ b/src/main/config.js
@@ -55,7 +55,7 @@ export const EXTENSION_HASN = {
   pdf: '.pdf'
 }
 
-export const TITLE_BAR_HEIGHT = 21
+export const TITLE_BAR_HEIGHT = isOsx ? 21 : 25
 export const LINE_ENDING_REG = /(?:\r\n|\n)/g
 export const LF_LINE_ENDING_REG = /(?:[^\r]\n)|(?:^\n$)/
 export const CRLF_LINE_ENDING_REG = /\r\n/

--- a/src/main/menus/view.js
+++ b/src/main/menus/view.js
@@ -56,7 +56,7 @@ let viewMenu = {
   }, {
     type: 'separator'
   }, {
-    label: 'Side Bar',
+    label: 'Toggle Side Bar',
     id: 'sideBarMenuItem',
     type: 'checkbox',
     checked: false,
@@ -64,7 +64,7 @@ let viewMenu = {
       actions.layout(item, browserWindow, 'showSideBar')
     }
   }, {
-    label: 'Tab Bar',
+    label: 'Toggle Tab Bar',
     id: 'tabBarMenuItem',
     type: 'checkbox',
     checked: false,

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="editor-container">
+  <div
+    class="editor-container"
+    :class="[{ 'frameless': platform !== 'darwin' }]"
+  >
     <title-bar
       :pathname="pathname"
       :filename="filename"
@@ -136,6 +139,9 @@
 <style scoped>
   .editor-container {
     padding-top: 22px;
+  }
+  .editor-container.frameless {
+    padding-top: 25px;
   }
   .editor-container .hide {
     z-index: -1;

--- a/src/renderer/components/editorWithTabs/index.vue
+++ b/src/renderer/components/editorWithTabs/index.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="editor-with-tabs">
+    <div
+      class="editor-with-tabs"
+      :class="[{ 'frameless': platform !== 'darwin' }]"
+    >
       <tabs v-show="showTabBar"></tabs>
       <editor
         :theme="theme"
@@ -19,6 +22,7 @@
   import Tabs from './tabs.vue'
   import Editor from './editor.vue'
   import SourceCode from './sourceCode.vue'
+  import { mapState } from 'vuex'
 
   export default {
     props: {
@@ -45,6 +49,11 @@
         required: true
       }
     },
+    computed: {
+      ...mapState([
+        'platform'
+      ])
+    },
     components: {
       Tabs,
       Editor,
@@ -60,5 +69,8 @@
     flex-direction: column;
     height: calc(100vh - 22px);
     overflow: hidden;
+  }
+  .editor-with-tabs.frameless {
+    height: calc(100vh - 25px);
   }
 </style>

--- a/src/renderer/components/editorWithTabs/sourceCode.vue
+++ b/src/renderer/components/editorWithTabs/sourceCode.vue
@@ -2,7 +2,7 @@
   <div
     class="source-code"
     ref="sourceCode"
-    :class="[theme]"
+    :class="[theme, { 'frameless': platform !== 'darwin' }]"
   >
   </div>
 </template>
@@ -12,6 +12,7 @@
   import { wordCount as getWordCount } from '../../../editor/utils'
   import { adjustCursor } from '../../util'
   import bus from '../../bus'
+  import { mapState } from 'vuex'
 
   export default {
     props: {
@@ -21,6 +22,12 @@
       },
       markdown: String,
       cursor: Object
+    },
+
+    computed: {
+      ...mapState([
+        'platform'
+      ])
     },
 
     data () {
@@ -125,6 +132,9 @@
     height: calc(100vh - 22px);
     box-sizing: border-box;
     overflow: auto;
+  }
+  .source-code.frameless {
+    height: calc(100vh - 25px);
   }
   .source-code .CodeMirror {
     margin: 50px auto;

--- a/src/renderer/components/sideBar/index.vue
+++ b/src/renderer/components/sideBar/index.vue
@@ -2,7 +2,7 @@
   <div
     v-show="showSideBar"
     class="side-bar"
-    :class="[theme]"
+    :class="[theme, { 'frameless': platform !== 'darwin' }]"
     ref="sideBar"
     :style="{ 'width': `${finalSideBarWidth}px` }"
   >
@@ -80,6 +80,9 @@
         'sideBarWidth': state => state.project.sideBarWidth,
         'tabs': state => state.editor.tabs
       }),
+      ...mapState([
+        'platform'
+      ]),
       ...mapGetters(['fileList']),
       finalSideBarWidth () {
         const { showSideBar, rightColumn, sideBarViewWidth } = this
@@ -144,6 +147,9 @@
     height: calc(100vh - 22px);
     position: relative;
     color: var(--secondaryColor);
+  }
+  .side-bar.frameless {
+    height: calc(100vh - 25px);
   }
   .side-bar.dark {
     background: var(--darkBgColor);

--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="title-bar"
-    :class="[{ 'active': active }, theme]"
+    :class="[{ 'active': active }, theme, { 'frameless': platform !== 'darwin' }]"
   >
     <div class="title">
       <span v-if="!filename">Mark Text</span>
@@ -176,6 +176,9 @@
     z-index: 1;
     transition: color .4s ease-in-out;
     cursor: default;
+  }
+  .title-bar.frameless {
+    height: 25px;
   }
   .active {
     color: #909399;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Adjusted titlebar height to 25px on Linux and Windows, because of window-control icon size and improve toggle side-bar/tabs description.