### PR TITLE
Bug #365 - Fix "move to trash" typo in sidebar menu

### DIFF
--- a/src/renderer/contextMenu/sideBar/menuItems.js
+++ b/src/renderer/contextMenu/sideBar/menuItems.js
@@ -53,7 +53,7 @@ export const RENAME = {
 }
 
 export const DELETE = {
-  label: 'Move To Trach',
+  label: 'Move To Trash',
   id: 'deleteMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.remove()


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     |no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #365
| License          | MIT

### Description

In the sidebar folder browser, the context menu that's opened by right clicking on either a directory or file in the sidebar has a typo. The menu item for moving a directory or file to the trash is labeled "Move to Trach", when it should be labeled "Move to Trash".

Issue: https://github.com/marktext/marktext/issues/365