### PR TITLE
bugfix: #387, if new markdown and old markdown are empty, no need to …

### DIFF
--- a/src/editor/utils/exportMarkdown.js
+++ b/src/editor/utils/exportMarkdown.js
@@ -115,6 +115,7 @@ class ExportMarkdown {
           break
       }
     }
+
     return result.join('')
   }
 

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -394,6 +394,8 @@ const actions = {
     if (cursor) commit('SET_CURSOR', cursor)
     // set history
     if (history) commit('SET_HISTORY', history)
+    // if new markdown and old markdown are empty, no need to save or change status
+    if (!/\S/.test(markdown) && !/\S/.test(oldMarkdown)) return
     // change save status/save to file only when the markdown changed!
     if (markdown !== oldMarkdown) {
       if (pathname && autoSave) {


### PR DESCRIPTION
…save or change status

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    |  #387
| License          | MIT

### Description

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
