### PR TITLE
Improvement math preview styles (#419)

### DIFF
--- a/src/muya/lib/index.css
+++ b/src/muya/lib/index.css
@@ -154,11 +154,7 @@ span.ag-math {
 .ag-math > .ag-math-render {
   display: inline-block;
   padding: .5rem;
-  background: #fff;
-  border: 1px solid var(--lightBorder);
   border-radius: 4px;
-  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, .1);
-  color: var(--primaryColor);
   position: absolute;
   top: 30px;
   left: 0;
@@ -184,6 +180,10 @@ span.ag-math > .ag-math-render.ag-math-error {
   margin: 0;
 }
 
+.ag-math > .ag-math-render .katex {
+  white-space: nowrap;
+}
+
 .ag-hide.ag-math {
   width: auto;
   height: auto;
@@ -203,6 +203,17 @@ span.ag-math > .ag-math-render.ag-math-error {
   border: none;
   box-shadow: none;
   background: transparent;
+}
+
+.ag-gray.ag-math > .ag-math-render::before {
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  content: "";
 }
 
 .ag-hide.ag-math > .ag-math-render::before {

--- a/src/muya/themes/dark.css
+++ b/src/muya/themes/dark.css
@@ -394,6 +394,15 @@ code {
   color: #efefef;
 }
 
+.ag-gray.ag-math > .ag-math-render {
+  color: #333333;
+  background: #f6f8fa;
+  box-shadow: 0 2px 12px 0 rgba(255, 255, 255, 0.3);
+}
+.ag-gray.ag-math > .ag-math-render::before {
+  border-bottom-color: #f6f8fa;
+}
+
 #ag-editor-id pre.ag-html-block {
     padding: 0 .5rem;
     margin-top: 0;

--- a/src/muya/themes/light.css
+++ b/src/muya/themes/light.css
@@ -367,6 +367,15 @@ code {
   color: #333333;
 }
 
+.ag-gray.ag-math > .ag-math-render {
+  color: #f6f8fa;
+  background: #333333;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.3);
+}
+.ag-gray.ag-math > .ag-math-render::before {
+  border-bottom-color: #333333;
+}
+
 #ag-editor-id pre.ag-code-block,
 #ag-editor-id pre.ag-html-block {
   font-size: 90%;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #419 
| License          | MIT

### Description
Fix math inline preview text wrap error in #419.
Also improvement math preview styles in light and dark style. 

### Light style
![kapture 2018-07-17 at 0 05 10](https://user-images.githubusercontent.com/40362568/42769640-5b5d10c8-8955-11e8-9851-45067332741f.gif)

### Dark style
![kapture 2018-07-17 at 0 06 14](https://user-images.githubusercontent.com/40362568/42769651-641031c8-8955-11e8-99ef-a85da92841e3.gif)

Please review.