### PR TITLE
feature: vscode debug config support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
       "type": "node",
       "request": "launch",
       "name": "Marktext: Main",
-      "program": "${workspaceFolder}/.electron-vue/dev-runner.js"
+      "program": "${workspaceFolder}/.electron-vue/dev-runner.js",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      }
     },
     {
       "name": "Marktext: Renderer",
@@ -16,7 +19,7 @@
       "request": "attach",
       "port": 8315,
       "webRoot": "${workspaceFolder}/src",
-      "timeout": 100000,
+      "timeout": 30000,
       "urlFilter": "localhost:*"
     }
   ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Marktext: Main",
+      "program": "${workspaceFolder}/.electron-vue/dev-runner.js"
+    },
+    {
+      "name": "Marktext: Renderer",
+      "type": "chrome",
+      "request": "attach",
+      "port": 8315,
+      "webRoot": "${workspaceFolder}/src",
+      "timeout": 100000,
+      "urlFilter": "localhost:*"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Marktext: All",
+      "configurations": [
+        "Marktext: Main",
+        "Marktext: Renderer"
+      ]
+    }
+  ]
+}

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -16,6 +16,11 @@ class App {
       app.commandLine.appendSwitch('enable-experimental-web-platform-features', 'true')
     }
 
+    // Enable vscode chrome extension debugger connection
+    if (process.env.NODE_ENV !== 'production' || process.env.NODE_ENV === 'development') {
+      app.commandLine.appendSwitch('remote-debugging-port', '8315')
+    }
+
     app.on('open-file', this.openFile.bind(this))
 
     app.on('ready', this.ready.bind(this))

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -17,7 +17,7 @@ class App {
     }
 
     // Enable vscode chrome extension debugger connection
-    if (process.env.NODE_ENV !== 'production' || process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development') {
       app.commandLine.appendSwitch('remote-debugging-port', '8315')
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #445 
| License          | MIT

### Description

Add vscode debugger config, you need install [Debugger for chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) 

