### PR TITLE
bugfix: fixed md file last block is 'li' or 'ul' #448

### DIFF
--- a/src/muya/lib/config.js
+++ b/src/muya/lib/config.js
@@ -6,7 +6,7 @@ import voidHtmlTags from 'html-tags/void'
 // Electron 2.0.2 not support yet! So give a default value 4
 export const DEVICE_MEMORY = navigator.deviceMemory || 4 // Get the divice memory number(Chrome >= 63)
 export const UNDO_DEPTH = DEVICE_MEMORY >= 4 ? 100 : 50
-export const HAS_TEXT_BLOCK_REG = /^(h\d|span|th|td|hr|pre)/i
+export const HAS_TEXT_BLOCK_REG = /^(h\d|span|th|td|hr|pre|li|ul)/i
 export const VOID_HTML_TAGS = voidHtmlTags
 export const HTML_TAGS = htmlTags
 // TYPE1 ~ TYPE7 according to https://github.github.com/gfm/#html-blocks


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #448 
| License          | MIT

### Description

Fix bug when markdown file end with 'li' or 'ul' list item.