### PR TITLE
Exclude hard-line-break from printing.

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -57,7 +57,8 @@
   .ag-table-tool-bar,
   .editor-tabs,
   .side-bar,
-  .CodeMirror-cursors {
+  .CodeMirror-cursors,
+  .ag-hard-line-break {
     display: none !important;
   }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #447
| License          | MIT

### Description

Fix removes hard line break from PDF export and Printing.