### PR TITLE
fix: title bar resizing in north direction

### DIFF
--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -19,7 +19,7 @@
         <span class="save-dot" :class="{'show': !isSaved}"></span>
       </span>
     </div>
-    <div :class="platform !== 'darwin' ? 'left-toolbar' : 'right-toolbar'">
+    <div :class="platform !== 'darwin' ? 'left-toolbar title-no-drag' : 'right-toolbar'">
       <div
         v-if="platform !== 'darwin'"
         class="frameless-titlebar-menu title-no-drag"
@@ -195,6 +195,15 @@
     transition: all .25s ease-in-out;
     & .filename {
       transition: all .25s ease-in-out;
+    }
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      height: 1px;
+      width: 100%;
+      z-index: 1;
+      -webkit-app-region: no-drag;
     }
   }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no ticket
| License          | MIT

### Description

Fixing window resizing in north direction on top of title bar.
![2018-08-09_14-11-13](https://user-images.githubusercontent.com/3466287/43898567-8092def8-9bdf-11e8-9932-f895a5228e19.gif)

Added title-no-drag to left-toolbar for non darwin systems
