### PR TITLE
Arrow key up/down navigation in a table

### DIFF
--- a/src/muya/lib/contentState/arrowCtrl.js
+++ b/src/muya/lib/contentState/arrowCtrl.js
@@ -50,7 +50,14 @@ const arrowCtrl = ContentState => {
 
   ContentState.prototype.getTable = function (cell) {
     const parents = this.getParents(cell)
-    return parents[parents.length - 1]
+    const len = parents.length
+    let i
+    for (i = 0; i < len; i++) {
+      if (parents[i].type === 'table') {
+        return parents[i]
+      }
+    }
+    return null
   }
 
   ContentState.prototype.arrowHandler = function (event) {

--- a/src/muya/lib/contentState/arrowCtrl.js
+++ b/src/muya/lib/contentState/arrowCtrl.js
@@ -47,6 +47,11 @@ const arrowCtrl = ContentState => {
     }
     return null
   }
+  
+  ContentState.prototype.getTable = function (cell) {
+    const parents = this.getParents(cell)
+    return parents[parents.length - 1]
+  }
 
   ContentState.prototype.arrowHandler = function (event) {
     // when the float box is show, use up and down to select item.
@@ -166,12 +171,20 @@ const arrowCtrl = ContentState => {
       const cellInNextRow = this.findNextRowCell(block)
       const cellInPrevRow = this.findPrevRowCell(block)
 
-      if (event.key === EVENT_KEYS.ArrowUp && cellInPrevRow) {
-        activeBlock = cellInPrevRow
+      if (event.key === EVENT_KEYS.ArrowUp) {
+        if (cellInPrevRow) {
+          activeBlock = cellInPrevRow
+        } else {
+          activeBlock = this.findPreBlockInLocation(this.getTable(block))
+        }
       }
 
-      if (event.key === EVENT_KEYS.ArrowDown && cellInNextRow) {
-        activeBlock = cellInNextRow
+      if (event.key === EVENT_KEYS.ArrowDown) {
+        if (cellInNextRow) {
+          activeBlock = cellInNextRow
+        } else {
+          activeBlock = this.findNextBlockInLocation(this.getTable(block))
+        }
       }
 
       if (activeBlock) {

--- a/src/muya/lib/contentState/arrowCtrl.js
+++ b/src/muya/lib/contentState/arrowCtrl.js
@@ -48,18 +48,6 @@ const arrowCtrl = ContentState => {
     return null
   }
 
-  ContentState.prototype.getTable = function (cell) {
-    const parents = this.getParents(cell)
-    const len = parents.length
-    let i
-    for (i = 0; i < len; i++) {
-      if (parents[i].type === 'table') {
-        return parents[i]
-      }
-    }
-    return null
-  }
-
   ContentState.prototype.arrowHandler = function (event) {
     // when the float box is show, use up and down to select item.
     const { floatBox } = this
@@ -182,7 +170,7 @@ const arrowCtrl = ContentState => {
         if (cellInPrevRow) {
           activeBlock = cellInPrevRow
         } else {
-          activeBlock = this.findPreBlockInLocation(this.getTable(block))
+          activeBlock = this.findPreBlockInLocation(this.getTableBlock())
         }
       }
 
@@ -190,7 +178,7 @@ const arrowCtrl = ContentState => {
         if (cellInNextRow) {
           activeBlock = cellInNextRow
         } else {
-          activeBlock = this.findNextBlockInLocation(this.getTable(block))
+          activeBlock = this.findNextBlockInLocation(this.getTableBlock())
         }
       }
 

--- a/src/muya/lib/contentState/arrowCtrl.js
+++ b/src/muya/lib/contentState/arrowCtrl.js
@@ -47,7 +47,7 @@ const arrowCtrl = ContentState => {
     }
     return null
   }
-  
+
   ContentState.prototype.getTable = function (cell) {
     const parents = this.getParents(cell)
     return parents[parents.length - 1]


### PR DESCRIPTION
When the cursor is active and pressing up/down key in the table, the cursor should leave the table.

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no ticket
| License          | MIT

### Description

When the user inside the table pressing the down/up key on the last/first row, that it should leave the table instead of jumping to the next/prev column.

**Behaviour before:**

![screencast 2018-08-17 21-24-47](https://user-images.githubusercontent.com/3466287/44285817-24f27200-a267-11e8-9744-0459e4667a6c.gif)

**Behaviour after:**

![screencast 2018-08-17 21-29-02](https://user-images.githubusercontent.com/3466287/44285830-2cb21680-a267-11e8-96dc-f12e72bd4dca.gif)

