### PR TITLE
fix: remove separators from help menu in OSX

### DIFF
--- a/src/main/menus/help.js
+++ b/src/main/menus/help.js
@@ -2,7 +2,7 @@ import { shell } from 'electron'
 import * as actions from '../actions/help'
 import { checkUpdates } from '../actions/marktext'
 
-let helpMenu = {
+const helpMenu = {
   label: 'Help',
   role: 'help',
   submenu: [{

--- a/src/main/menus/help.js
+++ b/src/main/menus/help.js
@@ -2,10 +2,7 @@ import { shell } from 'electron'
 import * as actions from '../actions/help'
 import { checkUpdates } from '../actions/marktext'
 
-const notOsx = process.platform !== 'darwin'
-const updateMenuVisibility = process.platform === 'win32' || !!process.env.APPIMAGE
-
-export default {
+let helpMenu = {
   label: 'Help',
   role: 'help',
   submenu: [{
@@ -47,23 +44,29 @@ export default {
     click () {
       shell.openExternal('https://github.com/Jocs')
     }
-  }, {
-    type: 'separator',
-    visible: updateMenuVisibility
+  }]
+}
+
+if (process.platform === 'win32' || !!process.env.APPIMAGE) {
+  helpMenu.submenu.push({
+    type: 'separator'
   }, {
     label: 'Check for updates...',
-    visible: updateMenuVisibility,
     click (menuItem, browserWindow) {
       checkUpdates(menuItem, browserWindow)
     }
-  }, {
-    type: 'separator',
-    visible: notOsx
+  })
+}
+
+if (process.platform !== 'darwin') {
+  helpMenu.submenu.push({
+    type: 'separator'
   }, {
     label: 'About Mark Text',
-    visible: notOsx,
     click (menuItem, browserWindow) {
       actions.showAboutDialog(browserWindow)
     }
-  }]
+  })
 }
+
+export default helpMenu


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no ticket
| License          | MIT

### Description
Help menu in OSX has two unnecessary separators because Electron doesn't support ```visible: false``` for separators [electron/issues/3494](https://github.com/electron/electron/issues/3494#issuecomment-231951984).
<img width="362" alt="screen shot 2018-08-23 at 20 56 30" src="https://user-images.githubusercontent.com/3466287/44546045-0e409500-a717-11e8-9df0-7fa87e9eec64.png">

After fix, it looks:

<img width="358" alt="screen shot 2018-08-23 at 21 03 03" src="https://user-images.githubusercontent.com/3466287/44546376-ffa6ad80-a717-11e8-9692-dab1f8e520af.png">

