### PR TITLE
fix: #481 add missing dot to parse markdown files only

### DIFF
--- a/src/main/utils/index.js
+++ b/src/main/utils/index.js
@@ -56,7 +56,7 @@ export const log = data => {
 // returns true if the filename matches one of the markdown extensions
 export const hasMarkdownExtension = filename => {
   if (!filename || typeof filename !== 'string') return false
-  return EXTENSIONS.some(ext => filename.endsWith(ext))
+  return EXTENSIONS.some(ext => filename.endsWith(`.${ext}`))
 }
 
 export const hasSameKeys = (a, b) => {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Fixed tickets    | #481
| License          | MIT

### Description

Add missing dot to parse markdown files only. See #481 for more information.