### PR TITLE
Fixes screen not going 100% height.

### DIFF
--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -465,7 +465,6 @@
 
 <style>
   .editor-wrapper {
-    height: 100%;
     position: relative;
     flex: 1;
   }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

When exporting to html, if the text is longer than 100% of the browser height, the background color was not applied to the rest of the document. This merge should fix that.