### PR TITLE
Portable Windows application

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat: quick insert paragraph
 - feat: inline format float box
 - feat: import files: TEX\ WIKI\ DOCX etc
+- feat: portable Windows application (#369)
 
 **:butterfly:Optimization**
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,13 @@
             "ia32",
             "x64"
           ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "ia32",
+            "x64"
+          ]
         }
       ],
       "requestedExecutionLevel": "asInvoker"

--- a/src/main/menus/help.js
+++ b/src/main/menus/help.js
@@ -1,6 +1,8 @@
+import path from 'path'
 import { shell } from 'electron'
 import * as actions from '../actions/help'
 import { checkUpdates } from '../actions/marktext'
+import { isFile } from '../utils'
 
 const helpMenu = {
   label: 'Help',
@@ -47,7 +49,8 @@ const helpMenu = {
   }]
 }
 
-if (process.platform === 'win32' || !!process.env.APPIMAGE) {
+if (isFile(path.join(process.resourcesPath, 'app-update.yml')) &&
+  (process.platform === 'win32' || !!process.env.APPIMAGE)) {
   helpMenu.submenu.push({
     type: 'separator'
   }, {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #369
| License          | MIT

### Description

Added portable single executable Windows application (`Mark Text %version.exe`). The application still uses the default operating system application data storage path like `~/.config/martext/` on Linux.