### PR TITLE
Workaround: Ctrl+Alt shortcut on Windows

### DIFF
--- a/src/main/menus/edit.js
+++ b/src/main/menus/edit.js
@@ -2,6 +2,7 @@ import * as actions from '../actions/edit'
 import userPreference from '../preference'
 
 const { aidou } = userPreference.getAll()
+const isWindows = process.platform === 'win32'
 
 export default {
   label: 'Edit',
@@ -66,7 +67,7 @@ export default {
     }
   }, {
     label: 'Find Next',
-    accelerator: 'Alt+CmdOrCtrl+U',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+U', //  WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.edit(browserWindow, 'fineNext')
     }
@@ -78,7 +79,7 @@ export default {
     }
   }, {
     label: 'Replace',
-    accelerator: 'Alt+CmdOrCtrl+F',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+F', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.edit(browserWindow, 'replace')
     }

--- a/src/main/menus/paragraph.js
+++ b/src/main/menus/paragraph.js
@@ -1,5 +1,7 @@
 import * as actions from '../actions/paragraph'
 
+const isWindows = process.platform === 'win32'
+
 export default {
   id: 'paragraphMenuEntry',
   label: 'Paragraph',
@@ -81,7 +83,7 @@ export default {
     id: 'codeFencesMenuItem',
     label: 'Code Fences',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+C',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+C', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'pre')
     }
@@ -89,7 +91,7 @@ export default {
     id: 'quoteBlockMenuItem',
     label: 'Quote Block',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+Q',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+Q', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'blockquote')
     }
@@ -97,7 +99,7 @@ export default {
     id: 'mathBlockMenuItem',
     label: 'Math Block',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+M',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+M', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'mathblock')
     }
@@ -105,7 +107,7 @@ export default {
     id: 'htmlBlockMenuItem',
     label: 'Html Block',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+L',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+L', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'html')
     }
@@ -115,7 +117,7 @@ export default {
     id: 'orderListMenuItem',
     label: 'Order List',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+O',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+O', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'ol-order')
     }
@@ -123,7 +125,7 @@ export default {
     id: 'bulletListMenuItem',
     label: 'Bullet List',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+U',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+U', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'ul-bullet')
     }
@@ -131,7 +133,7 @@ export default {
     id: 'taskListMenuItem',
     label: 'Task List',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+X',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+X', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'ul-task')
     }
@@ -141,7 +143,7 @@ export default {
     id: 'looseListItemMenuItem',
     label: 'Loose List Item',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+L',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+L', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'loose-list-item')
     }
@@ -159,7 +161,7 @@ export default {
     id: 'horizontalLineMenuItem',
     label: 'Horizontal Line',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+-',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+-', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'hr')
     }
@@ -167,7 +169,7 @@ export default {
     id: 'frontMatterMenuItem',
     label: 'YAML Front Matter',
     type: 'checkbox',
-    accelerator: 'Alt+CmdOrCtrl+Y',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+Y', // WORKAROUND: #523
     click (menuItem, browserWindow) {
       actions.paragraph(browserWindow, 'front-matter')
     }

--- a/src/main/menus/view.js
+++ b/src/main/menus/view.js
@@ -1,5 +1,7 @@
 import * as actions from '../actions/view'
 
+const isWindows = process.platform === 'win32'
+
 let viewMenu = {
   label: 'View',
   submenu: [{
@@ -29,7 +31,7 @@ let viewMenu = {
   }, {
     id: 'sourceCodeModeMenuItem',
     label: 'Source Code Mode',
-    accelerator: 'Alt+CmdOrCtrl+S',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+S', // WORKAROUND: #523
     type: 'checkbox',
     checked: false,
     click (item, browserWindow) {
@@ -38,7 +40,7 @@ let viewMenu = {
   }, {
     id: 'typewriterModeMenuItem',
     label: 'Typewriter Mode',
-    accelerator: 'Alt+CmdOrCtrl+T',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+T', // WORKAROUND: #523
     type: 'checkbox',
     checked: false,
     click (item, browserWindow) {
@@ -67,7 +69,7 @@ let viewMenu = {
   }, {
     label: 'Toggle Tab Bar',
     id: 'tabBarMenuItem',
-    accelerator: 'Alt+CmdOrCtrl+B',
+    accelerator: (isWindows ? 'Alt+AltGr+CmdOrCtrl' : 'Alt+CmdOrCtrl') + '+B', // WORKAROUND: #523
     type: 'checkbox',
     checked: false,
     click (item, browserWindow) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | workaround
| Fixed tickets    | #523 - not fixed; just a workaround
| License          | MIT

### Description

This is a workaround for the `Ctrl+Alt` shortcut issue on Windows. As soon as electron release a fix for the issue, we need to revert the patch. The problem is that Chromium handle `Alt` and `AltGr` as `Alt+AltGr` since `v66` (electron `v3`) on Windows.
