### PR TITLE
fix: #535 Application menu is not updated when switching windows 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.14.x
+
+**:butterfly:Optimization**
+
+- Show tab bar when opening a new tab
+
+**:beetle:Bug fix**
+
+- fix: #535 Application menu is not updated when switching windows
+
+
 ### 0.13.54
 
 **:beetle:Bug fix**

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.14.x
+### 0.13.55
 
 **:butterfly:Optimization**
 
@@ -6,17 +6,11 @@
 
 **:beetle:Bug fix**
 
-- fix: #535 Application menu is not updated when switching windows
-
-
-### 0.13.54
-
-**:beetle:Bug fix**
-
 - fix: #451 empty list item error
 - fix: #522 paste bug when paste into empty line
 - fix: #521
 - fix: #534
+- fix: #535 Application menu is not updated when switching windows
 
 ### 0.13.50
 

--- a/src/main/actions/view.js
+++ b/src/main/actions/view.js
@@ -25,6 +25,13 @@ export const layout = (item, win, type) => {
   win.webContents.send('AGANI::listen-for-view-layout', { [type]: item.checked })
 }
 
+export const showTabBar = win => {
+  const tabBarMenuItem = getMenuItemById('tabBarMenuItem')
+  if (tabBarMenuItem && !tabBarMenuItem.checked && tabBarMenuItem.click) {
+    tabBarMenuItem.click(tabBarMenuItem, win)
+  }
+}
+
 ipcMain.on('AGANI::ask-for-mode', e => {
   const sourceCodeModeMenuItem = getMenuItemById(sourceCodeModeMenuItemId)
   const typewriterModeMenuItem = getMenuItemById(typewriterModeMenuItemId)

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,7 +1,7 @@
 import { app } from 'electron'
-import appMenu from './menu'
 import appWindow from './window'
 import { isOsx } from './config'
+import { dockMenu } from './menus'
 import { isMarkdownFile } from './utils'
 import { watchers } from './utils/imagePathAutoComplement'
 
@@ -56,13 +56,17 @@ class App {
       }
     }
 
+    // Set dock on macOS
+    if (process.platform === 'darwin') {
+      app.dock.setMenu(dockMenu)
+    }
+
     if (this.openFilesCache.length) {
       this.openFilesCache.forEach(path => appWindow.createWindow(path))
       this.openFilesCache.length = 0 // empty the open file path cache
     } else {
       appWindow.createWindow()
     }
-    appMenu.updateAppMenu()
   }
 
   openFile (event, path) {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -132,13 +132,7 @@ class AppMenu {
       recentUsedDocuments = this.getRecentlyUsedDocuments()
     }
 
-    // const menuTemplate = configureMenu(recentUsedDocuments)
-    // #DEBUG
-    let menuTemplate = configureMenu(recentUsedDocuments)
-    menuTemplate.push({
-      label: `Window id: ${window.id}`
-    })
-    // END #DEBUG
+    const menuTemplate = configureMenu(recentUsedDocuments)
     const menu = Menu.buildFromTemplate(menuTemplate)
 
     let shortcutMap = null
@@ -164,8 +158,7 @@ class AppMenu {
     // rebuild all window menus
     this.windowMenus.forEach((value, key) => {
       const { menu: oldMenu } = value
-      // const { menu: newMenu } = this.buildDefaultMenu(null, recentUsedDocuments)
-      const { menu: newMenu } = this.buildDefaultMenu({ id: key }, recentUsedDocuments) // #DEBUG show window id
+      const { menu: newMenu } = this.buildDefaultMenu(null, recentUsedDocuments)
 
       // all other menu items are set automatically
       updateMenuItem(oldMenu, newMenu, 'sourceCodeModeMenuItem')

--- a/src/main/menus/file.js
+++ b/src/main/menus/file.js
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 import * as actions from '../actions/file'
 import { userSetting } from '../actions/marktext'
+import { showTabBar } from '../actions/view'
 import userPreference from '../preference'
 
 export default function (recentlyUsedFiles) {
@@ -13,6 +14,7 @@ export default function (recentlyUsedFiles) {
       accelerator: 'Shift+CmdOrCtrl+T',
       click (menuItem, browserWindow) {
         actions.newTab(browserWindow)
+        showTabBar(browserWindow)
       }
     }, {
       label: 'New Window',

--- a/src/main/menus/file.js
+++ b/src/main/menus/file.js
@@ -9,16 +9,16 @@ export default function (recentlyUsedFiles) {
   let fileMenu = {
     label: 'File',
     submenu: [{
-      label: 'New File',
-      accelerator: 'CmdOrCtrl+N',
-      click (menuItem, browserWindow) {
-        actions.newFile()
-      }
-    }, {
       label: 'New Tab',
       accelerator: 'Shift+CmdOrCtrl+T',
       click (menuItem, browserWindow) {
         actions.newTab(browserWindow)
+      }
+    }, {
+      label: 'New Window',
+      accelerator: 'CmdOrCtrl+N',
+      click (menuItem, browserWindow) {
+        actions.newFile()
       }
     }, {
       type: 'separator'

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -62,6 +62,12 @@ class AppWindow {
       watchers: []
     })
 
+    // create a menu for the current window
+    appMenu.addWindowMenuWithListener(win)
+    if (windows.size === 1) {
+      appMenu.setActiveWindow(win.id)
+    }
+
     win.once('ready-to-show', async () => {
       mainWindowState.manage(win)
       win.show()
@@ -130,6 +136,9 @@ class AppWindow {
         win.webContents.send('AGANI::req-update-line-ending-menu')
         win.webContents.send('AGANI::request-for-view-layout')
         win.webContents.send('AGANI::req-update-text-direction-menu')
+
+        // update application menu
+        appMenu.setActiveWindow(win.id)
       }
     })
 
@@ -176,6 +185,7 @@ class AppWindow {
       }
       windows.delete(win.id)
     }
+    appMenu.removeWindowMenu(win.id)
     win.destroy() // if use win.close(), it will cause a endless loop.
     if (windows.size === 0) {
       app.quit()


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #535
| License          | MIT

### Description

Please see #535 for more information.

- [x] Core
- [x] Synchronize menu checkboxes and radio buttons on menu update
- [ ] Remove debug stuff
- [x] UX
  - [x] Rename `New file` to `New window` because we open a new window.
  - [x] Improve new file/tab usability: Show tab bar if we open a new tab.
- [x] Update changelog

@Jocs Can you please test it on macOS and do a code review? I need the patch for the [shortcut fixes](https://github.com/marktext/marktext/projects/6).

---

After merge: Open an issue for `FIXME` and `BUG`.
