### PR TITLE
Don't show save dialog for an empty/not changed document

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Show tab bar when opening a new tab
 - Use default bold (`CmdOrCtrl+B`) and italics (`CmdOrCtrl+I`) key binding (#346)
+- Don't show save dialog for an empty document (#422)
 
 **:beetle:Bug fix**
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.13.58
+### 0.13.61
 
 **:butterfly:Optimization**
 
@@ -15,6 +15,7 @@
 - fix: #535 Application menu is not updated when switching windows
 - fix #216 and #311 key binding issues on Linux and Windows
 - fix #546 paste issue in table
+- fix: Blank document was always encoded as `LF`
 
 ### 0.13.50
 

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -241,7 +241,7 @@ const actions = {
 
   LISTEN_FOR_CLOSE ({ commit, state }) {
     ipcRenderer.on('AGANI::ask-for-close', e => {
-      const unSavedFiles = state.tabs.filter(file => !(file.isSaved && /[^\n]/.test(file.markdown)))
+      const unSavedFiles = state.tabs.filter(file => !file.isSaved)
         .map(file => {
           const { id, filename, pathname, markdown } = file
           const options = getOptionsFromState(file)
@@ -421,12 +421,19 @@ const actions = {
     const { pathname, markdown: oldMarkdown, id } = state.currentFile
     const options = getOptionsFromState(state.currentFile)
     commit('SET_MARKDOWN', markdown)
+
+    // ignore new line which is added if the editor text is empty (#422)
+    if (oldMarkdown.length === 0 && markdown.length === 1 && markdown[0] === '\n') {
+      return
+    }
+
     // set word count
     if (wordCount) commit('SET_WORD_COUNT', wordCount)
     // set cursor
     if (cursor) commit('SET_CURSOR', cursor)
     // set history
     if (history) commit('SET_HISTORY', history)
+
     // change save status/save to file only when the markdown changed!
     if (markdown !== oldMarkdown) {
       if (projectTree) {

--- a/src/renderer/store/help.js
+++ b/src/renderer/store/help.js
@@ -7,7 +7,7 @@ export const defaultFileState = {
   markdown: '',
   isUtf8BomEncoded: false,
   lineEnding: 'lf', // lf or crlf
-  adjustLineEndingOnSave: false,
+  adjustLineEndingOnSave: false, // convert editor buffer (LF) to CRLF when saving
   textDirection: 'ltr',
   history: {
     stack: [],
@@ -45,6 +45,8 @@ export const getFileStateFromData = data => {
   } = data
   const id = getUniqueId()
 
+  assertLineEnding(adjustLineEndingOnSave, lineEnding)
+
   return Object.assign(fileState, {
     id,
     markdown,
@@ -71,6 +73,7 @@ export const getBlankFileState = (tabs, lineEnding = 'lf', markdown = '') => {
 
   return Object.assign(fileState, {
     lineEnding,
+    adjustLineEndingOnSave: lineEnding.toLowerCase() === 'crlf',
     id,
     filename: `Untitled-${++untitleId}`,
     markdown
@@ -81,6 +84,8 @@ export const getSingleFileState = ({ id = getUniqueId(), markdown, filename, pat
   const fileState = JSON.parse(JSON.stringify(defaultFileState))
   const { isUtf8BomEncoded, lineEnding, adjustLineEndingOnSave } = options
 
+  assertLineEnding(adjustLineEndingOnSave, lineEnding)
+
   return Object.assign(fileState, {
     id,
     markdown,
@@ -90,4 +95,12 @@ export const getSingleFileState = ({ id = getUniqueId(), markdown, filename, pat
     lineEnding,
     adjustLineEndingOnSave
   })
+}
+
+const assertLineEnding = (adjustLineEndingOnSave, lineEnding) => {
+  lineEnding = lineEnding.toLowerCase()
+  if ((adjustLineEndingOnSave && lineEnding !== 'crlf') ||
+    (!adjustLineEndingOnSave && lineEnding === 'crlf')) {
+    console.error('Assertion failed: Line ending is "CRLF" but document is saved as "LF".')
+  }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Fixed tickets    | #422
| License          | MIT

### Description

Please see #422. The PR also contains a bug fix for the blank document which was always saved as LF.
