### PR TITLE
Fix dark theme format box style

### DIFF
--- a/src/muya/lib/ui/formatPicker/index.css
+++ b/src/muya/lib/ui/formatPicker/index.css
@@ -26,7 +26,7 @@
 }
 
 .ag-format-picker li.item:hover {
-  background: rgb(243, 243, 243);;
+  background: rgb(243, 243, 243);
 }
 
 .ag-format-picker li.item:last-of-type {
@@ -54,4 +54,13 @@
 .ag-format-picker li.item .icon-wrapper {
   width: 16px;
   height: 16px;
+}
+
+/* dark theme */
+.ag-format-picker.dark li.item:hover {
+  background: rgb(60, 60, 60);
+}
+
+.ag-format-picker.dark li.item:last-of-type:before {
+  background: rgb(71, 71, 71);
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

The dark format box hover color and separator was not styled.

**Before:**

![mt_before_format_box](https://user-images.githubusercontent.com/22716132/48342178-4baa2400-e66f-11e8-9ee9-264a518d479e.png)

**After:**

![mt_format_box](https://user-images.githubusercontent.com/22716132/48342187-4ea51480-e66f-11e8-8e97-03285da3aea3.png)

