### PR TITLE
Publish artifacts to GitHub

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,11 @@
-### 0.13.61
+### 0.13.62
 
 **:butterfly:Optimization**
 
 - Show tab bar when opening a new tab
 - Use default bold (`CmdOrCtrl+B`) and italics (`CmdOrCtrl+I`) key binding (#346)
 - Don't show save dialog for an empty document (#422)
+- Sidebar and tab redesign
 
 **:beetle:Bug fix**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ clone_folder: c:\projects\marktext
 branches:
   only:
     - master
-    - PublishArtifactsToGithub
 skip_tags: true
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,18 @@ version: 0.1.{build}
 image: Visual Studio 2017
 platform:
   - x64
-  - x86
 
 clone_folder: c:\projects\marktext
 
 branches:
   only:
     - master
+    - PublishArtifactsToGithub
 skip_tags: true
+
+environment:
+  GH_TOKEN:
+    secure: Ki5AJWygDYhzMJxl0b0rDx3bhAYmar2aPdwVHiai9IigqsvZpWHLeI3qpTiiaOWL
 
 init:
   - git config --global core.autocrlf input
@@ -27,9 +31,9 @@ install:
 
 cache:
   - node_modules
-  - '%APPDATA%\npm-cache'
-  - '%USERPROFILE%\.electron'
-  - '%USERPROFILE%\AppData\Local\Yarn\cache'
+  - '%LOCALAPPDATA%\electron\Cache'
+  - '%LOCALAPPDATA%\electron-builder\cache'
+  - '%LOCALAPPDATA%\Yarn\cache'
 
 build_script:
   - yarn run lint

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "main": "./dist/electron/main.js",
   "scripts": {
-    "release:win:linux": "node .electron-vue/build.js && electron-builder --win --linux",
-    "release": "node .electron-vue/build.js && electron-builder -mwl",
+    "release": "echo 'Please run \"build\" or \"release:{linux,mac,win}\"' && exit 1",
     "release:linux": "node .electron-vue/build.js && electron-builder build --linux --publish always",
     "release:mac": "node .electron-vue/build.js && electron-builder build --mac --publish always",
     "release:win": "node .electron-vue/build.js && electron-builder build --win --publish always",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

- AppVeyor
  - Publishing artifacts from AppVeyor to GitHub as draft release
  - Removed duplicate `x86` build because we build 32-/64-Bit on the `x64` worker
  - Updated cache directories
- Removed cross-platform support because of native dependencies
- Updated changelog from PR #555

I don't know why we can't set the `GH_TOKEN` variable via web interface but it is protected and only decrypted during `master` builds but not during PRs.

