### PR TITLE
Add an exception handler

### DIFF
--- a/src/main/config.js
+++ b/src/main/config.js
@@ -74,3 +74,5 @@ export const TITLE_BAR_HEIGHT = isOsx ? 21 : 25
 export const LINE_ENDING_REG = /(?:\r\n|\n)/g
 export const LF_LINE_ENDING_REG = /(?:[^\r]\n)|(?:^\n$)/
 export const CRLF_LINE_ENDING_REG = /\r\n/
+
+export const GITHUB_REPO_URL = 'https://github.com/marktext/marktext'

--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -1,0 +1,96 @@
+// Based on electron-unhandled by sindresorhus:
+//
+// MIT License
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import { app, clipboard, dialog, ipcMain } from 'electron'
+import { log } from './utils'
+import { createAndOpenGitHubIssueUrl } from './utils/createGitHubIssue'
+
+const EXIT_ON_ERROR = !!process.env.MARKTEXT_EXIT_ON_ERROR
+const SHOW_ERROR_DIALOG = !process.env.MARKTEXT_ERROR_INTERACTION
+const ERROR_MSG_MAIN = 'An unexpected error occurred in the main process'
+const ERROR_MSG_RENDERER = 'An unexpected error occurred in the renderer process'
+
+// main process error handler
+process.on('uncaughtException', error => {
+  handleError(ERROR_MSG_MAIN, error)
+})
+
+// renderer process error handler
+ipcMain.on('AGANI::handle-renderer-error', (e, error) => {
+  handleError(ERROR_MSG_RENDERER, error)
+})
+
+const bundleException = (error, type) => {
+  const { message, stack } = error
+  return {
+    version: app.getVersion(),
+    type,
+    date: new Date().toGMTString(),
+    message,
+    stack
+  }
+}
+
+const handleError = (title, error) => {
+  const { message, stack } = error
+
+  // log error
+  const info = bundleException(error, 'renderer')
+  console.error(info)
+  log(JSON.stringify(info, null, 2))
+
+  if (EXIT_ON_ERROR) {
+    process.exit(1)
+  } else if (!SHOW_ERROR_DIALOG) {
+    return
+  }
+
+  // show error dialog
+  if (app.isReady()) {
+    const result = dialog.showMessageBox({
+      type: 'error',
+      buttons: [
+        'OK',
+        'Copy Error',
+        'Report...'
+      ],
+      defaultId: 0,
+      noLink: true,
+      message: title,
+      detail: stack
+    })
+
+    switch (result) {
+      case 1:
+        clipboard.writeText(`${title}\n${stack}`)
+        break
+      case 2:
+        const issueTitle = message ? `Unexpected error: ${message}` : `${title}.`
+        createAndOpenGitHubIssueUrl(
+          issueTitle,
+          `### Description
+
+${title}
+
+<!-- Please describe, how the bug occurred (optional) -->
+
+### Stack Trace
+
+\`\`\`\n${stack}\n\`\`\`
+
+### Version
+
+Mark Text: ${app.getVersion()} (${process.platform})`)
+        break
+    }
+  } else {
+    // error during Electron initialization
+    dialog.showErrorBox(title, stack)
+    process.exit(1)
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,5 +1,6 @@
 import './globalSetting'
 import './cli'
+import './exceptionHandler'
 import { checkSystem } from './utils/checkSystem'
 import App from './app'
 

--- a/src/main/utils/createGitHubIssue.js
+++ b/src/main/utils/createGitHubIssue.js
@@ -1,0 +1,17 @@
+import { shell } from 'electron'
+import { GITHUB_REPO_URL } from '../config'
+
+export const createGitHubIssueUrl = (title, msg) => {
+  const issueUrl = new URL(`${GITHUB_REPO_URL}/issues/new`)
+  if (title) {
+    issueUrl.searchParams.set('title', title)
+  }
+  if (msg) {
+    issueUrl.searchParams.set('body', msg)
+  }
+  return issueUrl.toString()
+}
+
+export const createAndOpenGitHubIssueUrl = (title, msg) => {
+  shell.openExternal(createGitHubIssueUrl(title, msg))
+}

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import axios from 'axios'
+import { ipcRenderer } from 'electron'
 import lang from 'element-ui/lib/locale/lang/en'
 import locale from 'element-ui/lib/locale'
 import App from './app'
@@ -10,6 +11,17 @@ import services from './services'
 
 import './assets/styles/index.css'
 import './assets/styles/printService.css'
+
+window.addEventListener('error', event => {
+  const { message, name, stack } = event.error
+  const copy = {
+    message,
+    name,
+    stack
+  }
+  // pass error to error handler
+  ipcRenderer.send('AGANI::handle-renderer-error', copy)
+})
 
 // import notice from './services/notification'
 // In the renderer process:


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| License          | MIT

### Description

- log all unhanded errors in main and renderer process
- possibility to report the error to GitHub (main process only)

@Jocs It it a problem when ` electron-unhandled` catches `unhandledRejection` error in the main process?
