### PR TITLE
Add last commit hash to error handler

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -5,7 +5,9 @@ process.env.BABEL_ENV = 'main'
 const path = require('path')
 const { dependencies } = require('../package.json')
 const webpack = require('webpack')
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
 const proMode = process.env.NODE_ENV === 'production'
+const isOfficialRelease = !!process.env.MARKTEXT_IS_OFFICIAL_RELEASE
 
 const mainConfig = {
   mode: 'development',
@@ -77,5 +79,17 @@ if (proMode) {
     // new BabiliWebpackPlugin()
   )
 }
+
+/**
+ * Add git information
+ */
+const gitRevisionPlugin = new GitRevisionPlugin()
+mainConfig.plugins.push(
+  new webpack.DefinePlugin({
+    'global.MARKTEXT_GIT_INFO': JSON.stringify(gitRevisionPlugin.version()),
+    'global.MARKTEXT_GIT_HASH': JSON.stringify(gitRevisionPlugin.commithash()),
+    'global.MARKTEXT_IS_OFFICIAL_RELEASE': isOfficialRelease
+  })
+)
 
 module.exports = mainConfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ node_js:
 matrix:
   include:
   - os: osx
-    env: CC=clang CXX=clang++ npm_config_clang=1
+    env: CC=clang CXX=clang++ npm_config_clang=1 MARKTEXT_IS_OFFICIAL_RELEASE=1
     compiler: clang
   - os: linux
-    env: CC=clang CXX=clang++ npm_config_clang=1
+    env: CC=clang CXX=clang++ npm_config_clang=1 MARKTEXT_IS_OFFICIAL_RELEASE=1
     compiler: clang
 
 cache:
@@ -76,3 +76,4 @@ script:
 branches:
   only:
   - master
+  - /^release-v[0-9.]+$/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,11 @@ clone_folder: c:\projects\marktext
 branches:
   only:
     - master
+    - /^release-v[0-9.]+$/
 skip_tags: true
 
 environment:
+  MARKTEXT_IS_OFFICIAL_RELEASE: 1
   GH_TOKEN:
     secure: Ki5AJWygDYhzMJxl0b0rDx3bhAYmar2aPdwVHiai9IigqsvZpWHLeI3qpTiiaOWL
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -1,0 +1,28 @@
+# Steps to release Mark Text
+
+- Create a release candidate
+  - Create branch `release-v%version%`
+  - Set environment variable `MARKTEXT_IS_OFFICIAL_RELEASE` to `1` (default on AppVeyor and Travis CI)
+  - Ensure [changelog](https://github.com/marktext/marktext/blob/master/.github/CHANGELOG.md) is up-to-date
+  - Bump version in `package.json` and changelog
+  - Update all `README.md` files
+  - Bump Flathub version ([marktext.appdata.xml](https://github.com/marktext/marktext/blob/master/resources/linux/marktext.appdata.xml))
+  - Create commit `release version %version%`
+  - Ensure all tests pass
+  - A new draft release should be available or create one
+- Publish GitHub release
+  - Add git tag `v%version%`
+  - Add changelog
+  - Add SHA256 checksums
+- Update website and documentation
+- Publish [Flathub package](https://github.com/flathub/com.github.marktext.marktext)
+  - Ensure native dependencies
+  - Update `runtime` and `SDK` if needed
+  - Bump version and update URLs
+  - Test the package (`scripts/build-bundle.sh && scripts/test-marktext.sh`)
+  - Create commit `Update to v%version%`
+
+## Work after releasing
+
+- Ensure all issues in the changelog are closed
+- :relaxed: :tada:

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "file-loader": "^2.0.0",
+    "git-revision-webpack-plugin": "^3.0.3",
     "html-webpack-plugin": "^3.2.0",
     "inject-loader": "^4.0.1",
     "karma": "^1.3.0",

--- a/src/main/cli.js
+++ b/src/main/cli.js
@@ -12,7 +12,8 @@ for (const arg of process.argv) {
     global.MARKTEXT_SAFE_MODE = true
     continue
   } else if (arg === '--version') {
-    console.log(`Mark Text: ${app.getVersion()}
+    const gitInfo = global.MARKTEXT_IS_OFFICIAL_RELEASE ? '' : `(${global.MARKTEXT_GIT_INFO})`
+    console.log(`Mark Text: ${app.getVersion()} ${gitInfo}
 Node.js: ${process.versions.node}
 Electron: ${process.versions.electron}
 Chromium: ${process.versions.chrome}

--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -70,14 +70,15 @@ const handleError = (title, error) => {
         clipboard.writeText(`${title}\n${stack}`)
         break
       case 2:
-        const issueTitle = message ? `Unexpected error: ${message}` : `${title}.`
+        const issueTitle = message ? `Unexpected error: ${message}` : title
+        const gitInfo = global.MARKTEXT_IS_OFFICIAL_RELEASE ? `(${global.MARKTEXT_GIT_INFO} - git)` : global.MARKTEXT_GIT_INFO
         createAndOpenGitHubIssueUrl(
           issueTitle,
           `### Description
 
-${title}
+${title}.
 
-<!-- Please describe, how the bug occurred (optional) -->
+<!-- Please describe, how the bug occurred -->
 
 ### Stack Trace
 
@@ -85,7 +86,8 @@ ${title}
 
 ### Version
 
-Mark Text: ${app.getVersion()} (${process.platform})`)
+Mark Text: ${app.getVersion()} (${gitInfo})
+Operating system: ${process.platform}`)
         break
     }
   } else {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Add the last commit hash to the error handler report and `--version` command if not build by us. I also added a release guide.

@Jocs Do we need to add `brew` instructions?
