### PR TITLE
Revert electron-builder AppImage name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run release:mac ; fi
 
   # calculate checksums
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x64.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x86_64.AppImage ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/Mark\ Text-*-mac.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/Mark\ Text-*.dmg ; fi

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "linux": {
       "category": "Office;TextEditor;Utility",
       "icon": "resources/icons",
+      "artifactName": "marktext-${version}-${arch}.${ext}",
       "target": [
         {
           "target": "AppImage"
@@ -182,11 +183,11 @@
     "del": "^3.0.0",
     "devtron": "^1.4.0",
     "electron": "^3.0.10",
-    "electron-builder": "^20.36.2",
+    "electron-builder": "^20.38.1",
     "electron-debug": "^2.0.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-rebuild": "^1.8.2",
-    "electron-updater": "^4.0.4",
+    "electron-updater": "^4.0.5",
     "electron-window-state": "^5.0.2",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

`electron-builder` changed the AppImage name to the `productName`. This PR revert to the old name (`marktext-%version%-%architecture%.AppImage`).
