### PR TITLE
Fix dark preview box background color

### DIFF
--- a/src/muya/themes/dark.css
+++ b/src/muya/themes/dark.css
@@ -89,6 +89,11 @@ body {
   border-bottom: none;
 }
 
+figure.ag-active.ag-container-block > div.ag-container-preview {
+  background: rgb(50, 50, 50);
+  border: 1px solid rgb(43, 43, 43);
+}
+
 .ag-gray {
   color: #909399;
   text-decoration: none;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #587
| License          | MIT

### Description

Fix dark theme background color of preview boxes.

![mt_dark_preview](https://user-images.githubusercontent.com/22716132/49366988-0bc4e280-f6eb-11e8-86cd-9760b8d23e34.png)

![mt_dark_preview_2](https://user-images.githubusercontent.com/22716132/49366989-0bc4e280-f6eb-11e8-8ce9-2b949fe78b78.png)
