### PR TITLE
Remove PDF background color

### DIFF
--- a/src/main/actions/file.js
+++ b/src/main/actions/file.js
@@ -29,7 +29,7 @@ const handleResponseForExport = async (e, { type, content, pathname, markdown })
     let data = content
     try {
       if (!content && type === 'pdf') {
-        data = await promisify(win.webContents.printToPDF.bind(win.webContents))({ printBackground: true })
+        data = await promisify(win.webContents.printToPDF.bind(win.webContents))({ printBackground: false })
       }
       if (data) {
         await writeFile(filePath, data, extension)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #583
| License          | MIT

### Description

Removed the background from the PDF document.

@Jocs Was there a reason for `printBackground: true` or because of a previous version with white/dark PDF style?
