### PR TITLE
Fix multiple print service bugs 

### DIFF
--- a/src/main/actions/file.js
+++ b/src/main/actions/file.js
@@ -128,7 +128,7 @@ const pandocFile = async pathname => {
 
 const removePrintServiceFromWindow = win => {
   // remove print service content and restore GUI
-  win.webContents.send('AGANI::export-clearup')
+  win.webContents.send('AGANI::print-service-clearup')
 }
 
 ipcMain.on('AGANI::save-all', (e, unSavedFiles) => {

--- a/src/main/actions/file.js
+++ b/src/main/actions/file.js
@@ -29,7 +29,9 @@ const handleResponseForExport = async (e, { type, content, pathname, markdown })
     let data = content
     try {
       if (!content && type === 'pdf') {
-        data = await promisify(win.webContents.printToPDF.bind(win.webContents))({ printBackground: false })
+        data = await promisify(win.webContents.printToPDF.bind(win.webContents))({ printBackground: true })
+        // remove print service content and restore GUI
+        win.webContents.send('AGANI::export-clearup')
       }
       if (data) {
         await writeFile(filePath, data, extension)

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -81,9 +81,9 @@ class Muya {
     return this.contentState.history.clearHistory()
   }
 
-  exportStyledHTML (filename) {
+  exportStyledHTML (title = '', printOptimization = false) {
     const { markdown } = this
-    return new ExportHtml(markdown).generate(filename)
+    return new ExportHtml(markdown).generate(title, printOptimization)
   }
 
   exportHtml () {

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -38,20 +38,27 @@ class ExportHtml {
       }
     })
   }
-  // get html with style
-  generate (filename = '') {
+  /**
+   * Get HTML with style
+   *
+   * @param {*} title Page title
+   * @param {*} printOptimization Optimize HTML and CSS for printing
+   */
+  generate (title = '', printOptimization = false) {
+    // WORKAROUND: Hide Prism.js style when exporting or printing. Otherwise the background color is white in the dark theme.
+    const highlightCssStyle = printOptimization ? `@media print { ${highlightCss} }` : highlightCss
     const html = this.renderHtml()
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${filename}</title>
+  <title>${title}</title>
   <style>
   ${githubMarkdownCss}
   </style>
   <style>
-  ${highlightCss}
+  ${highlightCssStyle}
   </style>
   <style>
   ${katexCss}

--- a/src/muya/themes/dark.css
+++ b/src/muya/themes/dark.css
@@ -29,14 +29,11 @@
 }
 
 html, body {
-  font-size: 16px;
-  background: rgb(45, 45, 45);
-}
-
-body {
   font-family: "Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
   color: rgb(217, 217, 217);
   line-height: 1.6;
+  background: rgb(45, 45, 45);
 }
 
 ::-webkit-scrollbar {

--- a/src/muya/themes/light.css
+++ b/src/muya/themes/light.css
@@ -29,14 +29,11 @@
 }
 
 html, body {
-  font-size: 16px;
-  background: rgb(252, 252, 252);
-}
-
-body {
   font-family: "Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
   color: #303133;
   line-height: 1.6;
+  background: rgb(252, 252, 252);
 }
 
 ::-webkit-scrollbar {

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -139,7 +139,7 @@
       dispatch('LINTEN_FOR_SET_LINE_ENDING')
       dispatch('LISTEN_FOR_NEW_TAB')
       dispatch('LISTEN_FOR_CLOSE_TAB')
-      dispatch('LINTEN_FOR_EXPORT_CLEARUP')
+      dispatch('LINTEN_FOR_PRINT_SERVICE_CLEARUP')
       dispatch('LINTEN_FOR_EXPORT_SUCCESS')
       dispatch('LISTEN_FOR_SET_TEXT_DIRECTION')
       dispatch('LISTEN_FOR_TEXT_DIRECTION_MENU')

--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -139,6 +139,7 @@
       dispatch('LINTEN_FOR_SET_LINE_ENDING')
       dispatch('LISTEN_FOR_NEW_TAB')
       dispatch('LISTEN_FOR_CLOSE_TAB')
+      dispatch('LINTEN_FOR_EXPORT_CLEARUP')
       dispatch('LINTEN_FOR_EXPORT_SUCCESS')
       dispatch('LISTEN_FOR_SET_TEXT_DIRECTION')
       dispatch('LISTEN_FOR_TEXT_DIRECTION_MENU')

--- a/src/renderer/assets/styles/printService.css
+++ b/src/renderer/assets/styles/printService.css
@@ -3,8 +3,8 @@ body article.print-container {
 }
 @media print {
   /* General rules for printing. */
-  body {
-    background: transparent none;
+  html, body {
+    background: transparent !important;
   }
 
   body > div {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -215,7 +215,7 @@
         bus.$on('undo', this.handleUndo)
         bus.$on('redo', this.handleRedo)
         bus.$on('export', this.handleExport)
-        bus.$on('export-clearup', this.handleExportClearup)
+        bus.$on('print-service-clearup', this.handlePrintServiceClearup)
         bus.$on('paragraph', this.handleEditParagraph)
         bus.$on('format', this.handleInlineFormat)
         bus.$on('searchValue', this.handleSearch)
@@ -368,8 +368,8 @@
       },
 
       handlePrint () {
-        // generate styled HTML with empty title tag
-        const html = this.editor.exportStyledHTML('')
+        // generate styled HTML with empty title and optimized for printing
+        const html = this.editor.exportStyledHTML('', true)
         this.printer.renderMarkdown(html)
         this.$store.dispatch('PRINT_RESPONSE')
       },
@@ -384,7 +384,8 @@
           }
 
           case 'pdf': {
-            const html = this.editor.exportStyledHTML()
+            // generate styled HTML with empty title and optimized for printing
+            const html = this.editor.exportStyledHTML('', true)
             this.printer.renderMarkdown(html)
             this.$store.dispatch('EXPORT', { type, markdown })
             break
@@ -392,7 +393,7 @@
         }
       },
 
-      handleExportClearup () {
+      handlePrintServiceClearup () {
         this.printer.clearup()
       },
 

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -215,6 +215,7 @@
         bus.$on('undo', this.handleUndo)
         bus.$on('redo', this.handleRedo)
         bus.$on('export', this.handleExport)
+        bus.$on('export-clearup', this.handleExportClearup)
         bus.$on('paragraph', this.handleEditParagraph)
         bus.$on('format', this.handleInlineFormat)
         bus.$on('searchValue', this.handleSearch)
@@ -388,6 +389,10 @@
             break
           }
         }
+      },
+
+      handleExportClearup () {
+        this.printer.clearup()
       },
 
       handleEditParagraph (type) {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -368,9 +368,10 @@
       },
 
       handlePrint () {
-        const html = this.editor.exportHtml()
-        const printer = new Printer(html)
-        printer.print()
+        // generate styled HTML with empty title tag
+        const html = this.editor.exportStyledHTML('')
+        this.printer.renderMarkdown(html)
+        this.$store.dispatch('PRINT_RESPONSE')
       },
 
       handleExport (type) {

--- a/src/renderer/services/printService.js
+++ b/src/renderer/services/printService.js
@@ -9,12 +9,6 @@ class MarkdownPrint {
     printContainer.innerHTML = html
   }
 
-  print (html) {
-    this.renderMarkdown(html)
-    window.print()
-    this.clearup()
-  }
-
   clearup () {
     if (this.container) {
       this.container.remove()

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -481,16 +481,6 @@ const actions = {
     ipcRenderer.send('AGANI::response-export', { type, content, filename, pathname, markdown })
   },
 
-  PRINT_RESPONSE ({ commit }) {
-    ipcRenderer.send('AGANI::response-print')
-  },
-
-  LINTEN_FOR_EXPORT_CLEARUP ({ commit }) {
-    ipcRenderer.on('AGANI::export-clearup', e => {
-      bus.$emit('export-clearup')
-    })
-  },
-
   LINTEN_FOR_EXPORT_SUCCESS ({ commit }) {
     ipcRenderer.on('AGANI::export-success', (e, { type, filePath }) => {
       notice.notify({
@@ -501,6 +491,16 @@ const actions = {
         .then(() => {
           shell.showItemInFolder(filePath)
         })
+    })
+  },
+
+  PRINT_RESPONSE ({ commit }) {
+    ipcRenderer.send('AGANI::response-print')
+  },
+
+  LINTEN_FOR_PRINT_SERVICE_CLEARUP ({ commit }) {
+    ipcRenderer.on('AGANI::print-service-clearup', e => {
+      bus.$emit('print-service-clearup')
     })
   },
 

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -481,6 +481,10 @@ const actions = {
     ipcRenderer.send('AGANI::response-export', { type, content, filename, pathname, markdown })
   },
 
+  PRINT_RESPONSE ({ commit }) {
+    ipcRenderer.send('AGANI::response-print')
+  },
+
   LINTEN_FOR_EXPORT_CLEARUP ({ commit }) {
     ipcRenderer.on('AGANI::export-clearup', e => {
       bus.$emit('export-clearup')

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -481,6 +481,12 @@ const actions = {
     ipcRenderer.send('AGANI::response-export', { type, content, filename, pathname, markdown })
   },
 
+  LINTEN_FOR_EXPORT_CLEARUP ({ commit }) {
+    ipcRenderer.on('AGANI::export-clearup', e => {
+      bus.$emit('export-clearup')
+    })
+  },
+
   LINTEN_FOR_EXPORT_SUCCESS ({ commit }) {
     ipcRenderer.on('AGANI::export-success', (e, { type, filePath }) => {
       notice.notify({


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #583
| License          | MIT

### Description

- Revert #589 because we have to print the background; e.g. for code blocks
  - fixes #583
- Remove print service container after exporting/printing
- Fixed an issue where you cannot print a document because of `undefined` HTML
- Use `win.webContents.print(...)` instead of `window.print()` to print the background
- `MarkdownPrint.print()` is now deprecated; find usages and delete it

**TODO's:**

- [x] `MarkdownPrint.print()` is now deprecated; find usages and delete it
- [x] `file.js` `handleResponseForPrint()` don't remove the print service container
- [x] Fixed exporting/printing issue where code boxes are white in the dark theme during the operation. See image below.

![mt_print_export_svc](https://user-images.githubusercontent.com/22716132/49520365-699c2a80-f8a3-11e8-929c-d939f5b635bd.png)

