### PR TITLE
Fix build failure with latest vue version

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "vega": "^4.3.0",
     "vega-embed": "^3.24.2",
     "vega-lite": "^3.0.0-rc8",
-    "vue": "^2.5.17",
+    "vue": "^2.5.21",
     "vue-electron": "^1.0.6",
     "vuex": "^3.0.1"
   },
@@ -227,7 +227,7 @@
     "vue-html-loader": "^1.2.4",
     "vue-loader": "^15.4.2",
     "vue-style-loader": "^4.1.2",
-    "vue-template-compiler": "^2.5.17",
+    "vue-template-compiler": "^2.5.21",
     "webpack": "^4.26.0",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2",

--- a/src/renderer/components/sideBar/tree.vue
+++ b/src/renderer/components/sideBar/tree.vue
@@ -40,9 +40,10 @@
       </div>
       <div class="opened-files-list">
         <transition-group name="list">
+          <!-- tab.id := mt-1, mt-2, ... -->
           <opened-file
-            v-for="(tab, index) of tabs"
-            :key="index"
+            v-for="tab of tabs"
+            :key="tab.id"
             :file="tab"
           ></opened-file>
         </transition-group>


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #604
| License          | MIT

### Description

This PR fixes the following build failure with the latest `vue` version:

```
Do not use v-for index as key on <transtion-group> children, this is the same as not using keys.
```

@Jocs I don't know why did you use a `key` there but I set it to another value.

fixes #604