### PR TITLE
Add production source maps

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -11,6 +11,7 @@ const isOfficialRelease = !!process.env.MARKTEXT_IS_OFFICIAL_RELEASE
 
 const mainConfig = {
   mode: 'development',
+  devtool: '#cheap-module-eval-source-map',
   entry: {
     main: path.join(__dirname, '../src/main/index.js')
   },
@@ -26,7 +27,8 @@ const mainConfig = {
         use: {
           loader: 'eslint-loader',
           options: {
-            formatter: require('eslint-friendly-formatter')
+            formatter: require('eslint-friendly-formatter'),
+            failOnError: true
           }
         }
       },
@@ -74,6 +76,7 @@ if (!proMode) {
  * Adjust mainConfig for production settings
  */
 if (proMode) {
+  mainConfig.devtool = '#nosources-source-map'
   mainConfig.mode = 'production'
   mainConfig.plugins.push(
     // new BabiliWebpackPlugin()

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -40,7 +40,8 @@ const rendererConfig = {
         use: {
           loader: 'eslint-loader',
           options: {
-            formatter: require('eslint-friendly-formatter')
+            formatter: require('eslint-friendly-formatter'),
+            failOnError: true
           }
         }
       },
@@ -83,7 +84,10 @@ const rendererConfig = {
       {
         test: /\.vue$/,
         use: {
-          loader: 'vue-loader'
+          loader: 'vue-loader',
+          options: {
+            sourceMap: true
+          }
         }
       },
       {
@@ -130,8 +134,8 @@ const rendererConfig = {
     ]
   },
   node: {
-    __dirname: process.env.NODE_ENV !== 'production',
-    __filename: process.env.NODE_ENV !== 'production'
+    __dirname: !proMode,
+    __filename: !proMode
   },
   plugins: [
     new SpritePlugin(),
@@ -169,7 +173,7 @@ const rendererConfig = {
 /**
  * Adjust rendererConfig for development settings
  */
-if (process.env.NODE_ENV !== 'production') {
+if (!proMode) {
   rendererConfig.plugins.push(
     new webpack.DefinePlugin({
       '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`
@@ -188,7 +192,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
  * Adjust rendererConfig for production settings
  */
 if (proMode) {
-  rendererConfig.devtool = ''
+  rendererConfig.devtool = '#nosources-source-map'
   rendererConfig.mode = 'production'
   rendererConfig.plugins.push(
     new MiniCssExtractPlugin({

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -71,7 +71,10 @@ const webConfig = {
       {
         test: /\.vue$/,
         use: {
-          loader: 'vue-loader'
+          loader: 'vue-loader',
+          options: {
+            sourceMap: true
+          }
         }
       },
       {
@@ -146,7 +149,7 @@ const webConfig = {
  * Adjust webConfig for production settings
  */
 if (proMode) {
-  webConfig.devtool = ''
+  webConfig.devtool = '#nosources-source-map'
   webConfig.mode ='production'
 
   webConfig.plugins.push(

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "snabbdom": "^0.7.2",
     "snabbdom-to-html": "^5.1.1",
     "snapsvg": "^0.5.1",
+    "source-map-support": "^0.5.9",
     "turndown": "^5.0.1",
     "turndown-plugin-gfm": "^1.0.2",
     "underscore": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:dev": "node .electron-vue/build.js",
     "build:web": "cross-env BUILD_TARGET=web node .electron-vue/build.js",
     "dev": "node .electron-vue/dev-runner.js",
-    "e2e": "npm run pack && mocha test/e2e",
+    "e2e": "npm run pack && mocha --timeout 10000 test/e2e",
     "lint": "eslint --ext .js,.vue -f ./node_modules/eslint-friendly-formatter src test",
     "lint:fix": "eslint --ext .js,.vue -f ./node_modules/eslint-friendly-formatter --fix src test",
     "pack": "npm run pack:main && npm run pack:renderer",

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -12,6 +12,13 @@ import services from './services'
 import './assets/styles/index.css'
 import './assets/styles/printService.css'
 
+import sourceMapSupport from 'source-map-support'
+sourceMapSupport.install({
+  environment: 'node',
+  handleUncaughtExceptions: false,
+  hookRequire: false
+})
+
 window.addEventListener('error', event => {
   const { message, name, stack } = event.error
   const copy = {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

I added source map also for the production build to better reproduce errors reported by the new error handler. For the renderer we have to use `source-map-support` to map stack traces.

```
nosources-source-map - A SourceMap is created without the sourcesContent in it.
It can be used to map stack traces on the client without exposing all of the
source code. You can deploy the Source Map file to the webserver.
```

**Main error stack trace example:**

```
An unexpected error occurred in the main process
Error: Test
    at ./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/src/main/actions/file.js:338:9
    at actions (./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/src/main/menus/file.js:17:9)
    at MenuItem.click (./build/linux-unpacked/resources/electron.asar/browser/api/menu-item.js:55:9)
    at Function.executeCommand (./build/linux-unpacked/resources/electron.asar/browser/api/menu.js:30:13)
```

**Renderer error stack trace example:**

```
An unexpected error occurred in the renderer process
Error: Test
    at i.handleCloseClick (file://./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/src/renderer/components/titleBar.vue:128:1)
    at handleCloseClick (file://./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/src/renderer/components/titleBar.vue?10ff:1:1607)
    at apply (file://./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/node_modules/vue/dist/vue.esm.js:2128:1)
    at HTMLDivElement.apply (file://./build/linux-unpacked/resources/app.asar/dist/electron/webpack:/node_modules/vue/dist/vue.esm.js:1913:1)
```

