### PR TITLE
Add Markdown MimeType

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     },
     "linux": {
       "category": "Office;TextEditor;Utility",
+      "mimeTypes": [ "text/markdown" ],
       "icon": "resources/icons",
       "artifactName": "marktext-${version}-${arch}.${ext}",
       "target": [

--- a/resources/linux/marktext.desktop
+++ b/resources/linux/marktext.desktop
@@ -6,4 +6,4 @@ Terminal=false
 Type=Application
 Icon=marktext
 Categories=Office;TextEditor;Utility;
-MimeType=text/markdown;text/x-markdown;
+MimeType=text/markdown;

--- a/resources/linux/marktext.desktop
+++ b/resources/linux/marktext.desktop
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 Icon=marktext
 Categories=Office;TextEditor;Utility;
+MimeType=text/markdown;text/x-markdown;


### PR DESCRIPTION
XDG Desktop components will identify this program as a Markdown editor

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? |not needed
| Fixed tickets    | 
| License          | MIT

### Description

Linux desktops will identify MarkText as a markdown editor


