### PR TITLE
Add Inline Math to formatting menus

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **:cactus:Feature**
 
-- Added an error handler
+- Improve exception and error handling
 
 **:butterfly:Optimization**
 
@@ -10,6 +10,8 @@
 - Separate font and font size for code blocks and source code mode (#373, #467)
 - Opened files and opened directories/files can now be folded (#475, #602)
 - You can now hide the quick insert hint (#621)
+- Adjusted quote inline math color (#592)
+- Fix inline math text align (#593)
 
 **:beetle:Bug fix**
 

--- a/doc/i18n/zh_cn.md
+++ b/doc/i18n/zh_cn.md
@@ -86,9 +86,9 @@
 
 ### 特性
 
-- Mark Text 所输及所见，摒弃了众多 markdown 编辑器左边写作右边预览的写作方式，巧妙的将编辑和预览融为一体。
+- Mark Text 所输及所见，摒弃了众多 Markdown 编辑器左边写作右边预览的写作方式，巧妙的将编辑和预览融为一体。
 - [snabbdom](https://github.com/snabbdom/snabbdom) 作为 Mark Text 的渲染引擎，保证了极速渲染编辑页面，带来流畅的书写体验。
-- 支持 [CommonMark Spec](https://spec.commonmark.org/0.28/) 和 [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) 语法格式，生成的 Markdown 可以复制到任何支持 markdown 格式的社区、网站。
+- 支持 [CommonMark Spec](https://spec.commonmark.org/0.28/) 和 [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) 语法格式，生成的 Markdown 可以复制到任何支持 Markdown 格式的社区、网站。
 - 段落及行内样式快捷键提升您的编辑效率。
 - 输出 HTML 和 PDF 格式文件，方便在浏览器中预览。
 - 黑、白两款主题，自由切换。
@@ -96,13 +96,13 @@
 
 <h4 align="center">:crescent_moon:Dark and Light themes:high_brightness:</h4>
 
-|                     Dark :crescent_moon:                     |                    Light:high_brightness:                    |
+|                     黑色主题 :crescent_moon:                     |                    白色主题 :high_brightness:                    |
 | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | ![](https://github.com/marktext/marktext/blob/master/doc/dark.jpg) | ![](https://github.com/marktext/marktext/blob/master/doc/light.jpg) |
 
 <h4 align="center">:smile_cat:​Edit modes:dog:​</h4>
 
-|                         Source Code                          |                          Typewriter                          |                            Focus                             |
+|                         源代码模式                          |                          打字机模式                          |                            专注模式                             |
 | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | ![](https://github.com/marktext/marktext/blob/master/doc/source.gif) | ![](https://github.com/marktext/marktext/blob/master/doc/typewriter.gif) | ![](https://github.com/marktext/marktext/blob/master/doc/focus.gif) |
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     },
     "linux": {
       "category": "Office;TextEditor;Utility",
+      "mimeTypes": [ "text/markdown" ],
       "icon": "resources/icons",
       "artifactName": "marktext-${version}-${arch}.${ext}",
       "target": [

--- a/resources/linux/marktext.desktop
+++ b/resources/linux/marktext.desktop
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 Icon=marktext
 Categories=Office;TextEditor;Utility;
+MimeType=text/markdown;

--- a/src/main/actions/format.js
+++ b/src/main/actions/format.js
@@ -7,7 +7,8 @@ const MENU_ID_FORMAT_MAP = {
   'inlineCodeMenuItem': 'inline_code',
   'strikeMenuItem': 'del',
   'hyperlinkMenuItem': 'link',
-  'imageMenuItem': 'image'
+  'imageMenuItem': 'image',
+  'mathMenuItem': 'inline_math'
 }
 
 const selectFormat = formats => {

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -44,6 +44,22 @@ class App {
         this.ready()
       }
     })
+
+    // Prevent to load webview and opening links or new windows via HTML/JS.
+    app.on('web-contents-created', (event, contents) => {
+      contents.on('will-attach-webview', (event, webPreferences, params) => {
+        console.warn('Prevented webview creation.')
+        event.preventDefault()
+      })
+      contents.on('will-navigate', event => {
+        console.warn('Prevented opening a link.')
+        event.preventDefault();
+      });
+      contents.on('new-window', (event, url) => {
+        console.warn('Prevented opening a new window.')
+        event.preventDefault()
+      })
+    })
   }
 
   ready () {

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -9,6 +9,7 @@ export const defaultWinOptions = {
   minWidth: 450,
   minHeight: 220,
   webPreferences: {
+    nodeIntegration: true,
     webSecurity: false
   },
   useContentSize: true,

--- a/src/main/menus/format.js
+++ b/src/main/menus/format.js
@@ -29,6 +29,14 @@ export default {
       actions.format(browserWindow, 'inline_code')
     }
   }, {
+    id: 'inlineMathMenuItem',
+    label: 'Inline Math',
+    type: 'checkbox',
+    accelerator: keybindings.getAccelerator('formatInlineMath'),
+    click (menuItem, browserWindow) {
+      actions.format(browserWindow, 'inline_math')
+    }
+  }, {
     type: 'separator'
   }, {
     id: 'strikeMenuItem',

--- a/src/main/shortcutHandler.js
+++ b/src/main/shortcutHandler.js
@@ -73,13 +73,14 @@ class Keybindings {
       ['formatStrong', 'CmdOrCtrl+B'],
       ['formatEmphasis', 'CmdOrCtrl+I'],
       ['formatInlineCode', 'CmdOrCtrl+`'],
+      ['formatInlineMath', 'CmdOrCtrl+M'],
       ['formatStrike', 'CmdOrCtrl+D'],
       ['formatHyperlink', 'CmdOrCtrl+L'],
       ['formatImage', 'CmdOrCtrl+Shift+I'],
       ['formatClearFormat', 'Shift+CmdOrCtrl+R'],
 
       // window menu
-      ['windowMinimize', 'CmdOrCtrl+M'],
+      // ['windowMinimize', 'CmdOrCtrl+M'], deprecated for math.
       ['windowCloseWindow', 'CmdOrCtrl+Shift+W'],
 
       // view menu

--- a/src/main/shortcutHandler.js
+++ b/src/main/shortcutHandler.js
@@ -73,7 +73,7 @@ class Keybindings {
       ['formatStrong', 'CmdOrCtrl+B'],
       ['formatEmphasis', 'CmdOrCtrl+I'],
       ['formatInlineCode', 'CmdOrCtrl+`'],
-      ['formatInlineMath', 'CmdOrCtrl+M'],
+      ['formatInlineMath', 'Ctrl+M'],
       ['formatStrike', 'CmdOrCtrl+D'],
       ['formatHyperlink', 'CmdOrCtrl+L'],
       ['formatImage', 'CmdOrCtrl+Shift+I'],

--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -192,11 +192,15 @@ span.ag-math > .ag-math-render.ag-math-error {
   font-family: monospace;
 }
 
+/* (Preview) math block */
+/* TODO: DOM path should be wrong. Correct path should be: 'ag-container-preview > .katex-display'. */
 .ag-math > .ag-math-render .katex-display {
   margin: 0;
 }
 
+/* Inline math */
 .ag-math > .ag-math-render .katex {
+  vertical-align: middle;
   white-space: nowrap;
 }
 

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -155,10 +155,11 @@ export const FORMAT_MARKER_MAP = {
   'em': '*',
   'inline_code': '`',
   'strong': '**',
-  'del': '~~'
+  'del': '~~',
+  'inline_math': '$'
 }
 
-export const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image']
+export const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image', 'inline_math']
 
 export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
 

--- a/src/muya/lib/contentState/formatCtrl.js
+++ b/src/muya/lib/contentState/formatCtrl.js
@@ -9,7 +9,8 @@ const getOffset = (offset, { range: { start, end }, type, anchor, alt }) => {
     case 'strong':
     case 'del':
     case 'em':
-    case 'inline_code': {
+    case 'inline_code': 
+    case 'inline_math': {
       const MARKER_LEN = (type === 'strong' || type === 'del') ? 2 : 1
       if (dis < 0) return 0
       if (dis >= 0 && dis < MARKER_LEN) return -dis
@@ -62,6 +63,7 @@ const clearFormat = (token, { start, end }) => {
       delete token.src
       break
     }
+    case 'inline_math':
     case 'inline_code': {
       token.type = 'text'
       token.raw = token.content
@@ -77,7 +79,8 @@ const addFormat = (type, block, { start, end }) => {
     case 'em':
     case 'del':
     case 'inline_code':
-    case 'strong': {
+    case 'strong': 
+    case 'inline_math': {
       const MARKER = FORMAT_MARKER_MAP[type]
       const oldText = block.text
       block.text = oldText.substring(0, start.offset) +

--- a/src/muya/lib/contentState/formatCtrl.js
+++ b/src/muya/lib/contentState/formatCtrl.js
@@ -9,7 +9,7 @@ const getOffset = (offset, { range: { start, end }, type, anchor, alt }) => {
     case 'strong':
     case 'del':
     case 'em':
-    case 'inline_code': 
+    case 'inline_code':
     case 'inline_math': {
       const MARKER_LEN = (type === 'strong' || type === 'del') ? 2 : 1
       if (dis < 0) return 0
@@ -79,7 +79,7 @@ const addFormat = (type, block, { start, end }) => {
     case 'em':
     case 'del':
     case 'inline_code':
-    case 'strong': 
+    case 'strong':
     case 'inline_math': {
       const MARKER = FORMAT_MARKER_MAP[type]
       const oldText = block.text

--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -58,7 +58,7 @@ const inputCtrl = ContentState => {
             (autoPairQuote && /[']{1}/.test(inputChar)) ||
             (autoPairQuote && /["]{1}/.test(inputChar)) ||
             (autoPairBracket && /[\}\]\)]{1}/.test(inputChar)) ||
-            (autoPairMarkdownSyntax && /[*$_]{1}/.test(inputChar))
+            (autoPairMarkdownSyntax && /[*$`~_]{1}/.test(inputChar))
           )
         ) {
           text = text.substring(0, offset) + text.substring(offset + 1)

--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -58,7 +58,7 @@ const inputCtrl = ContentState => {
             (autoPairQuote && /[']{1}/.test(inputChar)) ||
             (autoPairQuote && /["]{1}/.test(inputChar)) ||
             (autoPairBracket && /[\}\]\)]{1}/.test(inputChar)) ||
-            (autoPairMarkdownSyntax && /[*_]{1}/.test(inputChar))
+            (autoPairMarkdownSyntax && /[*$_]{1}/.test(inputChar))
           )
         ) {
           text = text.substring(0, offset) + text.substring(offset + 1)

--- a/src/muya/lib/ui/formatPicker/config.js
+++ b/src/muya/lib/ui/formatPicker/config.js
@@ -26,6 +26,9 @@ const icons = [
     type: 'image',
     icon: imageIcon
   }, {
+    type: 'inline_math',
+    iconText: '𝑥'
+  }, {
     type: 'clear',
     icon: clearIcon
   }

--- a/src/muya/lib/ui/formatPicker/index.css
+++ b/src/muya/lib/ui/formatPicker/index.css
@@ -56,6 +56,15 @@
   height: 16px;
 }
 
+.ag-format-picker li.item .icon-wrapper.icon-is-text {
+  color: #666;
+  font-size: 22px;
+  font-weight: bold;
+  /* For vertical centering. Is this consistent/sane? User zoom?. */
+  line-height: 0px;
+  margin-top: 7px; 
+}
+
 /* dark theme */
 .ag-format-picker.dark li.item:hover {
   background: rgb(60, 60, 60);

--- a/src/muya/lib/ui/formatPicker/index.css
+++ b/src/muya/lib/ui/formatPicker/index.css
@@ -65,6 +65,10 @@
   margin-top: 7px; 
 }
 
+.ag-format-picker li.item.active .icon-wrapper.icon-is-text {
+  color: var(--activeColor);
+}
+
 /* dark theme */
 .ag-format-picker.dark li.item:hover {
   background: rgb(60, 60, 60);

--- a/src/muya/lib/ui/formatPicker/index.css
+++ b/src/muya/lib/ui/formatPicker/index.css
@@ -62,7 +62,7 @@
   font-weight: bold;
   /* For vertical centering. Is this consistent/sane? User zoom?. */
   line-height: 0px;
-  margin-top: 7px; 
+  margin-top: 7px;
 }
 
 .ag-format-picker li.item.active .icon-wrapper.icon-is-text {

--- a/src/muya/lib/ui/formatPicker/index.js
+++ b/src/muya/lib/ui/formatPicker/index.js
@@ -45,21 +45,37 @@ class FormatPicker extends BaseFloat {
     })
   }
 
-  render () {
+  render() {
     const { icons, oldVnode, formatContainer, formats } = this
     const children = icons.map(i => {
-      const icon = h('svg', {
-        attrs: {
-          'viewBox': i.icon.viewBox,
-          'aria-hidden': 'true'
-        }
-      }, [h('use', {
-        attrs: {
-          'xlink:href': `.${i.icon.url}`
-        }
-      })]
-      )
-      const iconWrapper = h('div.icon-wrapper', icon)
+      let icon;
+      if (i.icon) {
+        // SVG icon Asset
+        icon = h('svg', {
+          attrs: {
+            'viewBox': i.icon.viewBox,
+            'aria-hidden': 'true'
+          }
+        }, [h('use', {
+          attrs: {
+            'xlink:href': `.${i.icon.url}`
+          }
+        })]
+        )
+      } else if (i.iconText) {
+        // Unicode icon in source
+        icon = h('span', {
+          attrs: {
+            'aria-hidden': 'true'
+          }
+        }, [i.iconText]
+        )
+      }
+      let iconWrapperSelector = 'div.icon-wrapper'
+      if (i.iconText) {
+        iconWrapperSelector += '.icon-is-text'
+      }
+      const iconWrapper = h(iconWrapperSelector, icon)
       let itemSelector = `li.item.${i.type}`
       if (formats.some(f => f.type === i.type)) {
         itemSelector += '.active'

--- a/src/muya/lib/ui/formatPicker/index.js
+++ b/src/muya/lib/ui/formatPicker/index.js
@@ -45,12 +45,14 @@ class FormatPicker extends BaseFloat {
     })
   }
 
-  render() {
+  render () {
     const { icons, oldVnode, formatContainer, formats } = this
     const children = icons.map(i => {
       let icon;
+      let iconWrapperSelector;
       if (i.icon) {
         // SVG icon Asset
+        iconWrapperSelector = 'div.icon-wrapper'
         icon = h('svg', {
           attrs: {
             'viewBox': i.icon.viewBox,
@@ -64,16 +66,13 @@ class FormatPicker extends BaseFloat {
         )
       } else if (i.iconText) {
         // Unicode icon in source
+        iconWrapperSelector = 'div.icon-wrapper.icon-is-text'
         icon = h('span', {
           attrs: {
             'aria-hidden': 'true'
           }
         }, [i.iconText]
         )
-      }
-      let iconWrapperSelector = 'div.icon-wrapper'
-      if (i.iconText) {
-        iconWrapperSelector += '.icon-is-text'
       }
       const iconWrapper = h(iconWrapperSelector, icon)
       let itemSelector = `li.item.${i.type}`

--- a/src/muya/lib/utils/domManipulate.js
+++ b/src/muya/lib/utils/domManipulate.js
@@ -1,3 +1,4 @@
+
 /**
  * [description `add` or `remove` className of element
  */

--- a/src/muya/themes/dark.css
+++ b/src/muya/themes/dark.css
@@ -455,6 +455,10 @@ td code {
   color: #efefef;
 }
 
+blockquote .ag-hide.ag-math > .ag-math-render {
+  color: #999999;
+}
+
 .ag-gray.ag-math > .ag-math-render {
   color: #333333;
   background: #f6f8fa;

--- a/src/muya/themes/light.css
+++ b/src/muya/themes/light.css
@@ -434,6 +434,10 @@ pre[class*="language-"] {
   color: #333333;
 }
 
+blockquote .ag-hide.ag-math > .ag-math-render {
+  color: #777777;
+}
+
 .ag-gray.ag-math > .ag-math-render {
   color: #f6f8fa;
   background: #333333;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | yes - CmdOrCtrl-M altered to default inline_math, no longer minimises.
| New tests added? | no - not sure how to test, open to learning
| Fixed tickets    | none
| License          | MIT

### Description

Enables inline math with:
CmdOrCtrl-M
Inline Menu
Format dropdown menu

Also makes sure that formatting can be removed.

![2019-01-15 12 44 36](https://user-images.githubusercontent.com/8830910/51181670-ae17de80-18c3-11e9-9270-c5fc959677ef.gif)
--