### PR TITLE
backport: Spellchecker minor bug fixes

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { app } from 'electron'
 import appWindow from './window'
 import { isOsx } from './config'
@@ -52,7 +53,8 @@ class App {
         if (arg.startsWith('--')) {
           continue
         } else if (isDirectory(arg) || isMarkdownFile(arg)) {
-          this.openFilesCache = [arg]
+          // Normalize path into an absolute path.
+          this.openFilesCache = [ path.resolve(arg) ]
           break
         }
       }

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -2,7 +2,7 @@ import { app } from 'electron'
 import appWindow from './window'
 import { isOsx } from './config'
 import { dockMenu } from './menus'
-import { isMarkdownFile } from './utils'
+import { isDirectory, isMarkdownFile } from './utils'
 import { watchers } from './utils/imagePathAutoComplement'
 
 class App {
@@ -51,7 +51,7 @@ class App {
       for (const arg of process.argv) {
         if (arg.startsWith('--')) {
           continue
-        } else if (isMarkdownFile(arg)) {
+        } else if (isDirectory(arg) || isMarkdownFile(arg)) {
           this.openFilesCache = [arg]
           break
         }

--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -6,7 +6,7 @@
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { app, clipboard, dialog, ipcMain } from 'electron'
+import { app, clipboard, crashReporter, dialog, ipcMain } from 'electron'
 import { log } from './utils'
 import { createAndOpenGitHubIssueUrl } from './utils/createGitHubIssue'
 
@@ -23,6 +23,14 @@ process.on('uncaughtException', error => {
 // renderer process error handler
 ipcMain.on('AGANI::handle-renderer-error', (e, error) => {
   handleError(ERROR_MSG_RENDERER, error)
+})
+
+// start crashReporter to save core dumps to temporary folder
+crashReporter.start({
+  companyName: 'marktext',
+  productName: 'marktext',
+  submitURL: 'http://0.0.0.0/',
+  uploadToServer: false
 })
 
 const bundleException = (error, type) => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,6 +4,12 @@ import './exceptionHandler'
 import { checkSystem } from './utils/checkSystem'
 import App from './app'
 
+// NOTE: We only support Linux, macOS and Windows but not BSD nor SunOS.
+if (!/^(darwin|win32|linux)$/i.test(process.platform)) {
+  console.error(`Operating system "${process.platform}" is not supported! Please open an issue at "https://github.com/marktext/marktext".`)
+  process.exit(1)
+}
+
 checkSystem()
 
 const app = new App()

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -8,6 +8,7 @@ import { wordCount } from './utils'
 import ExportMarkdown from './utils/exportMarkdown'
 import ExportHtml from './utils/exportHtml'
 import ToolTip from './ui/tooltip'
+import selection from './selection'
 import './assets/styles/index.css'
 
 class Muya {
@@ -45,7 +46,18 @@ class Muya {
     eventCenter.attachDOMEvent(container, 'contextmenu', event => {
       event.preventDefault()
       event.stopPropagation()
-      const sectionChanges = this.contentState.selectionChange(this.contentState.cursor)
+
+      // Hide format box
+      this.eventCenter.dispatch('muya-format-picker', { reference: null })
+
+      // Commit native cursor position because right-clicking doesn't update the cursor postion.
+      const cursor = selection.getCursorRange()
+      this.contentState.cursor = cursor
+
+      // TODO: Should we render to update the cursor or is this not necessary because we'll render
+      //       when leaving or clicking on the context menu?
+
+      const sectionChanges = this.contentState.selectionChange(cursor)
       eventCenter.dispatch('contextmenu', event, sectionChanges)
     })
     contentState.listenForPathChange()

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -12,6 +12,7 @@ import services from './services'
 import './assets/styles/index.css'
 import './assets/styles/printService.css'
 
+// Decode source map in production - must be registered first
 import sourceMapSupport from 'source-map-support'
 sourceMapSupport.install({
   environment: 'node',
@@ -19,6 +20,7 @@ sourceMapSupport.install({
   hookRequire: false
 })
 
+// Register renderer error handler
 window.addEventListener('error', event => {
   const { message, name, stack } = event.error
   const copy = {
@@ -30,15 +32,7 @@ window.addEventListener('error', event => {
   ipcRenderer.send('AGANI::handle-renderer-error', copy)
 })
 
-// import notice from './services/notification'
-// In the renderer process:
-// var webFrame = require('electron').webFrame
-// var SpellCheckProvider = require('electron-spell-check-provider')
-
-// webFrame.setSpellCheckProvider('en-US', true, new SpellCheckProvider('en-US').on('misspelling', function (suggestions) {
-//   console.log(suggestions)
-// }))
-
+// Configure Vue
 locale.use(lang)
 
 Vue.use(Dialog)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Backporting minor bug fixes from the experimental spellchecker branch.

- Allow opening directories via CLI
- Launch Chromiums crash handler to log process crashes (core dumps)
- Muya:
  - Hide format box when right-clicking
  - Update cursor position when right-clicking
