### PR TITLE
Fix undefined language id when exporting a code block (#591)

### DIFF
--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -21,7 +21,17 @@ class ExportHtml {
   renderHtml () {
     return marked(this.markdown, {
       highlight (code, lang) {
-        return Prism.highlight(code, Prism.languages[lang], lang)
+        // Language may be undefined (GH#591)
+        if (!lang) {
+          return code
+        }
+
+        const grammar = Prism.languages[lang]
+        if (!grammar) {
+          console.warn(`Unable to find grammar for "${lang}".`)
+          return code
+        }
+        return Prism.highlight(code, grammar, lang)
       },
       emojiRenderer (emoji) {
         const validate = validEmoji(emoji)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #591
| License          | MIT

### Description

Fixed an error when exporting a code block without language identifier because the code block language may be empty or undefined.

fixes #591