### PR TITLE
Add compile time version information

### DIFF
--- a/.electron-vue/marktextEnvironment.js
+++ b/.electron-vue/marktextEnvironment.js
@@ -1,0 +1,32 @@
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { version } = require('../package.json')
+
+const getEnvironmentDefinitions = function () {
+  const gitRevisionPlugin = new GitRevisionPlugin()
+  const isOfficialRelease = !!process.env.MARKTEXT_IS_OFFICIAL_RELEASE
+  const shortHash = gitRevisionPlugin.version()
+  const fullHash = gitRevisionPlugin.commithash()
+  const versionSuffix = isOfficialRelease ? '' : ` (${shortHash})`
+  
+  return {
+    'global.MARKTEXT_GIT_SHORT_HASH': JSON.stringify(shortHash),
+    'global.MARKTEXT_GIT_HASH': JSON.stringify(fullHash),
+  
+    'global.MARKTEXT_VERSION': JSON.stringify(version),
+    'global.MARKTEXT_VERSION_STRING': JSON.stringify(`v${version}${versionSuffix}`),
+    'global.MARKTEXT_IS_OFFICIAL_RELEASE': JSON.stringify(isOfficialRelease)
+  }
+}
+
+const getRendererEnvironmentDefinitions = function () {
+  const env = getEnvironmentDefinitions()
+  return {
+    'process.versions.MARKTEXT_VERSION': env['global.MARKTEXT_VERSION'],
+    'process.versions.MARKTEXT_VERSION_STRING': env['global.MARKTEXT_VERSION_STRING'], 
+  }
+}
+
+module.exports = {
+  getEnvironmentDefinitions: getEnvironmentDefinitions,
+  getRendererEnvironmentDefinitions: getRendererEnvironmentDefinitions
+}

--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -3,11 +3,10 @@
 process.env.BABEL_ENV = 'main'
 
 const path = require('path')
+const { getEnvironmentDefinitions } = require('./marktextEnvironment')
 const { dependencies } = require('../package.json')
 const webpack = require('webpack')
-const GitRevisionPlugin = require('git-revision-webpack-plugin')
 const proMode = process.env.NODE_ENV === 'production'
-const isOfficialRelease = !!process.env.MARKTEXT_IS_OFFICIAL_RELEASE
 
 const mainConfig = {
   mode: 'development',
@@ -53,7 +52,9 @@ const mainConfig = {
     path: path.join(__dirname, '../dist/electron')
   },
   plugins: [
-    new webpack.NoEmitOnErrorsPlugin()
+    new webpack.NoEmitOnErrorsPlugin(),
+    // Add global environment definitions.
+    new webpack.DefinePlugin(getEnvironmentDefinitions())
   ],
   resolve: {
     extensions: ['.js', '.json', '.node']
@@ -78,21 +79,6 @@ if (!proMode) {
 if (proMode) {
   mainConfig.devtool = '#nosources-source-map'
   mainConfig.mode = 'production'
-  mainConfig.plugins.push(
-    // new BabiliWebpackPlugin()
-  )
 }
-
-/**
- * Add git information
- */
-const gitRevisionPlugin = new GitRevisionPlugin()
-mainConfig.plugins.push(
-  new webpack.DefinePlugin({
-    'global.MARKTEXT_GIT_INFO': JSON.stringify(gitRevisionPlugin.version()),
-    'global.MARKTEXT_GIT_HASH': JSON.stringify(gitRevisionPlugin.commithash()),
-    'global.MARKTEXT_IS_OFFICIAL_RELEASE': isOfficialRelease
-  })
-)
 
 module.exports = mainConfig

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -12,6 +12,7 @@ const SpritePlugin = require('svg-sprite-loader/plugin')
 const postcssPresetEnv = require('postcss-preset-env')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
+const { getRendererEnvironmentDefinitions } = require('./marktextEnvironment')
 const { dependencies } = require('../package.json')
 const proMode = process.env.NODE_ENV === 'production'
 /**
@@ -152,6 +153,7 @@ const rendererConfig = {
         : false
     }),
     new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.DefinePlugin(getRendererEnvironmentDefinitions()),
     new VueLoaderPlugin()
   ],
   output: {

--- a/src/main/cli.js
+++ b/src/main/cli.js
@@ -1,4 +1,3 @@
-import { app } from 'electron'
 import { dumpKeyboardInformation } from './keyboardUtils'
 
 for (const arg of process.argv) {
@@ -12,8 +11,7 @@ for (const arg of process.argv) {
     global.MARKTEXT_SAFE_MODE = true
     continue
   } else if (arg === '--version') {
-    const gitInfo = global.MARKTEXT_IS_OFFICIAL_RELEASE ? '' : `(${global.MARKTEXT_GIT_INFO})`
-    console.log(`Mark Text: ${app.getVersion()} ${gitInfo}
+    console.log(`Mark Text: ${global.MARKTEXT_VERSION_STRING}
 Node.js: ${process.versions.node}
 Electron: ${process.versions.electron}
 Chromium: ${process.versions.chrome}

--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -80,7 +80,6 @@ const handleError = (title, error) => {
       }
       case 2: {
         const issueTitle = message ? `Unexpected error: ${message}` : title
-        const gitInfo = global.MARKTEXT_IS_OFFICIAL_RELEASE ? `(${global.MARKTEXT_GIT_INFO} - git)` : global.MARKTEXT_GIT_INFO
         createAndOpenGitHubIssueUrl(
           issueTitle,
           `### Description
@@ -95,7 +94,7 @@ ${title}.
 
 ### Version
 
-Mark Text: ${app.getVersion()} (${gitInfo})
+Mark Text: ${global.MARKTEXT_VERSION_STRING}
 Operating system: ${process.platform}`)
         break
       }

--- a/src/main/globalSetting.js
+++ b/src/main/globalSetting.js
@@ -7,5 +7,5 @@ if (process.env.NODE_ENV !== 'development') {
   global.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
 }
 
-global.MARKTEXT_DEBUG = process.env.NODE_ENV !== 'production'
+global.MARKTEXT_DEBUG = process.env.MARKTEXT_DEBUG || process.env.NODE_ENV !== 'production'
 global.MARKTEXT_SAFE_MODE = false

--- a/src/renderer/components/about/index.vue
+++ b/src/renderer/components/about/index.vue
@@ -13,7 +13,7 @@
           <h3 class="text fg-color-dark">{{ name }}</h3>
         </el-col>
         <el-col :span="24">
-          <div class="text">{{ `${versionPrefix} ${appVersion}` }}</div>
+          <div class="text">{{ appVersion }}</div>
         </el-col>
         <el-col :span="24">
           <div class="text">{{ copyright }}</div>
@@ -30,7 +30,6 @@
   export default {
     data () {
       this.name = 'Mark Text'
-      this.versionPrefix = 'v'
       this.copyright = `Copyright © 2017-${new Date().getFullYear()} Jocs`
       return {
         showAboutDialog: false

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { ipcRenderer, remote } from 'electron'
+import { ipcRenderer } from 'electron'
 
 import listenForMain from './listenForMain'
 import project from './project'
@@ -17,7 +17,7 @@ Vue.use(Vuex)
 // global states
 const state = {
   platform: process.platform, // platform of system `darwin` | `win32` | `linux`
-  appVersion: remote.app.getVersion(), // electron version in develop and Mark Text version in production
+  appVersion: process.versions.MARKTEXT_VERSION_STRING, // Mark Text version string
   windowActive: true, // weather current window is active or focused
   init: process.env.NODE_ENV === 'development' // weather Mark Text is inited
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

I added the version information to the main and renderer process at compile time to simplify access and also outsourced the environment definitions.
