### PR TITLE
fix: #705

### DIFF
--- a/src/muya/lib/contentState/copyCutCtrl.js
+++ b/src/muya/lib/contentState/copyCutCtrl.js
@@ -79,8 +79,10 @@ const copyCutCtrl = ContentState => {
 
     const tightListItem = wrapper.querySelectorAll(`.ag-tight-list-item`)
     ;[...tightListItem].forEach(li => {
-      if (li.childElementCount === 1) {
-        li.innerHTML = li.firstElementChild.innerHTML
+      for (const item of li.childNodes) {
+        if (item.tagName === 'P' && item.childElementCount === 1 && item.classList.contains('ag-paragraph')) {
+          li.replaceChild(item.firstElementChild, item)
+        }
       }
     })
 

--- a/src/muya/lib/contentState/copyCutCtrl.js
+++ b/src/muya/lib/contentState/copyCutCtrl.js
@@ -30,8 +30,8 @@ const copyCutCtrl = ContentState => {
       .${CLASS_OR_ID['AG_MATH_PREVIEW']},
       .${CLASS_OR_ID['AG_COPY_REMOVE']},
       .${CLASS_OR_ID['AG_LANGUAGE_INPUT']}`
-
     )
+
     ;[...removedElements].forEach(e => e.remove())
 
     const hrs = wrapper.querySelectorAll(`[data-role=hr]`)
@@ -75,6 +75,13 @@ const copyCutCtrl = ContentState => {
       const selectedCodeLines = cf.querySelectorAll('.ag-code-line')
       const value = [...selectedCodeLines].map(codeLine => codeLine.textContent).join('\n')
       cf.innerHTML = `<code class="language-${language}">${value}</code>`
+    })
+
+    const tightListItem = wrapper.querySelectorAll(`.ag-tight-list-item`)
+    ;[...tightListItem].forEach(li => {
+      if (li.childElementCount === 1) {
+        li.innerHTML = li.firstElementChild.innerHTML
+      }
     })
 
     const htmlBlock = wrapper.querySelectorAll(`figure[data-role='HTML']`)

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -236,7 +236,6 @@ const importRegister = ContentState => {
     // fix #752, but I don't know why the &nbsp; vanlished.
     html = html.replace(/&nbsp;/g, ' ')
     const markdown = turndownService.turndown(html) // .replace(/(\\)\\/g, '$1')
-    console.log(html, markdown)
     return markdown
   }
 

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -236,6 +236,7 @@ const importRegister = ContentState => {
     // fix #752, but I don't know why the &nbsp; vanlished.
     html = html.replace(/&nbsp;/g, ' ')
     const markdown = turndownService.turndown(html) // .replace(/(\\)\\/g, '$1')
+    console.log(html, markdown)
     return markdown
   }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #705 
| License          | MIT

I have a question:

```md
- foo
- bar

  zar
- war
```

Do you think it is a loose list or tight list? According to GFM, it's a loose list. But in Mark Text, we use the style to distinguish loose list and tight list, both loose and tight list item has a `P` paragraph in preview. So the above `loose list` looks like `tight` list.

So I think it a problem with tight list implement. if one tight list item has two paragraph, we need to automatically change it into loose list?


### Description

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
