### PR TITLE
Fix titlebar null property during initialization

### DIFF
--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -32,6 +32,7 @@
         @click.stop="handleMenuClick"
       >&#9776;</div>
       <el-tooltip
+        v-if="wordCount"
         class="item"
         effect="dark"
         :content="`${wordCount[show]} ${HASH[show].full + (wordCount[show] > 1 ? 's' : '')}`"


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fixed multiple exceptions during titlebar template initialization because `wordCount` is not defined.