### PR TITLE
Initialize editor when loading a folder and show default tab

### DIFF
--- a/src/renderer/store/project.js
+++ b/src/renderer/store/project.js
@@ -106,6 +106,9 @@ const mutations = {
 const actions = {
   LISTEN_FOR_LOAD_PROJECT ({ commit, dispatch }) {
     ipcRenderer.on('AGANI::open-project', (e, { pathname, name }) => {
+      // Initialize editor and show empty/new tab
+      dispatch('NEW_BLANK_FILE')
+
       dispatch('INIT_STATUS', true)
       commit('SET_PROJECT_TREE', { pathname, name })
       commit('SET_LAYOUT', {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #696
| License          | MIT

### Description

Fixed an issue with "open folder" that the editor was not initialized - no editor nor custom titlebar was shown. We now show an empty tab to initialize the editor.
