### PR TITLE
Fix tab change in source code mode

### DIFF
--- a/src/renderer/components/editorWithTabs/sourceCode.vue
+++ b/src/renderer/components/editorWithTabs/sourceCode.vue
@@ -77,6 +77,7 @@
         if (theme === 'dark') codeMirrorConfig.theme = 'railscasts'
         const editor = this.editor = codeMirror(container, codeMirrorConfig)
         bus.$on('file-loaded', this.setMarkdown)
+        bus.$on('file-changed', this.handleMarkdownChange)
         bus.$on('dotu-select', this.handleSelectDoutu)
 
         setMode(editor, 'markdown')
@@ -120,12 +121,18 @@
       },
       setMarkdown (markdown) {
         const { editor, cursor } = this
-        this.editor.setValue(markdown)
+        editor.setValue(markdown)
         if (cursor) {
           editor.setCursor(cursor)
         } else {
           setCursorAtLastLine(editor)
         }
+      },
+      // Only listen to get changes. Do not set history or other things.
+      handleMarkdownChange({ markdown, cursor, renderCursor, history }) {
+        const { editor } = this
+        editor.setValue(markdown)
+        editor.setCursor(cursor)
       }
     }
   }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #606
| License          | MIT

### Description

@Jocs I think the issue exists because we don't listen for changes in source code mode but I'm unsure about it. This patch works and don't break other tab and sets the CodeMirror text when changes occur.

fixes #606
