### PR TITLE
fix: tab switch exception due invalid cursor

### DIFF
--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -409,10 +409,11 @@
 
       // listen for `open-single-file` event, it will call this method only when open a new file.
       setMarkdownToEditor (markdown) {
-        const { cursor, editor } = this
+        const { editor } = this
         if (editor) {
           editor.clearHistory()
-          editor.setMarkdown(markdown, cursor)
+          // NOTE: Don't set the cursor because we load a new file - no tab switch.
+          editor.setMarkdown(markdown)
         }
       },
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fixed an exception when creating a new tab/loading a file because the old cursor (from the last tab) is used.
