### PR TITLE
Hide control buttions in fullscreen

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -34,7 +34,8 @@ This update **fixes a XSS security vulnerability** when exporting a document.
 - Inserting Codeblock should automatically set cursor into language field (#684)
 - Upstream: prismjs highlighting issues (#709)
 - Improvements for "Open Recent" (#616)
-- [feature request] make table of contents in sidebar collapsible (#404)
+- Make table of contents in sidebar collapsible (#404)
+- Hide titlebar control buttons in custom titlebar style
 
 **:beetle:Bug fix**
 

--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -57,7 +57,7 @@
       </el-tooltip>
     </div>
     <div
-      v-if="titleBarStyle === 'custom'"
+      v-if="titleBarStyle === 'custom' && !isFullScreen"
       class="right-toolbar"
       :class="[{ 'title-no-drag': titleBarStyle === 'custom' }]"
     >
@@ -118,6 +118,7 @@
       this.windowIconMaximize = maximizePath
       this.windowIconClose = closePath
       return {
+        isFullScreen: remote.getCurrentWindow().isFullScreen(),
         isMaximized: remote.getCurrentWindow().isMaximized() || remote.getCurrentWindow().isFullScreen(),
         show: 'word'
       }
@@ -192,7 +193,8 @@
       },
 
       handleWindowStateChanged () {
-        this.isMaximized = remote.getCurrentWindow().isMaximized() || remote.getCurrentWindow().isFullScreen()
+        this.isFullScreen = remote.getCurrentWindow().isFullScreen()
+        this.isMaximized = remote.getCurrentWindow().isMaximized() || this.isFullScreen
       },
 
       rename () {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

 Hide titlebar control buttons in custom titlebar style.