### PR TITLE
Titlebar workaround for #339

### DIFF
--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -71,6 +71,7 @@
       font-size: 12px;
       line-height: 35px;
       height: 35px;
+      max-width: 280px;
       background: var(--floatBgColor);
       display: flex;
       align-items: center;

--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -256,6 +256,14 @@
       -webkit-app-region: no-drag;
     }
   }
+  div.title > span {
+    /* Workaround for GH#339 */
+    display: block;
+    direction: rtl;
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+  }
 
   .title-bar .title .filename.isOsx:hover {
     color: var(--themeColor);


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Titlebar workaround for #339. BTW the tabs are not scrollable and the titlebar resizes to the tabs width if tab width `>` window width.

![mt_titlebar_workaround](https://user-images.githubusercontent.com/22716132/55017741-a4aca000-4ff1-11e9-90ac-d0e40aba070c.png)



