### PR TITLE
fix: Linux rename syscall when using side bar

### DIFF
--- a/src/main/watcher.js
+++ b/src/main/watcher.js
@@ -109,7 +109,7 @@ class Watcher {
         }
 
         // rename syscall on Linux (chokidar#591)
-        if (isLinux && event === 'rename') {
+        if (isLinux && type === 'file' && event === 'rename') {
           const { watchedPath } = details
           // Use the same watcher and re-watch the file.
           watcher.unwatch(watchedPath)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Only re-listen for files but not directories - fixed side bar on Linux when deleting files/directories.
