### PR TITLE
Improve watcher RegEx

### DIFF
--- a/src/main/watcher.js
+++ b/src/main/watcher.js
@@ -92,7 +92,7 @@ class Watcher {
   watch (win, watchPath, type = 'dir'/* file or dir */) {
     const id = getUniqueId()
     const watcher = chokidar.watch(watchPath, {
-      ignored: /node_modules|\.git/,
+      ignored: /(^|[/\\])(\..|node_modules)/,
       ignoreInitial: type === 'file',
       persistent: true
     })


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Improved RegEx and ignored all dotfiles. 

@Jocs Maybe we should ignore all other file extensions except markdown extensions.
