### PR TITLE
fix: paragraphCtrl cursor may be null

### DIFF
--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -18,6 +18,10 @@ const getCurrentLevel = type => {
 const paragraphCtrl = ContentState => {
   ContentState.prototype.selectionChange = function (cursor) {
     const { start, end } = cursor || selection.getCursorRange()
+    if (!start || !end) {
+      // TODO: Throw an exception and try to fix this later (GH#848).
+      throw new Error('selectionChange: expected cursor but cursor is null.')
+    }
     const cursorCoords = selection.getCursorCoords()
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #848
| License          | MIT

### Description

@Jocs I think we should renderer with the old/last valid cursor position, right? This would apply for #799 as well.
