### PR TITLE
Update markedjs

### DIFF
--- a/src/muya/lib/parser/marked/README.md
+++ b/src/muya/lib/parser/marked/README.md
@@ -1,6 +1,6 @@
 # Marked
 
-This folder contains a patched [Marked.js](https://github.com/markedjs/marked/) version based on `v0.6.1` commit [6eec528e5d6e08ea751251f9dc195d052caf4a79](https://github.com/markedjs/marked/commit/6eec528e5d6e08ea751251f9dc195d052caf4a79).
+This folder contains a patched [Marked.js](https://github.com/markedjs/marked/) version based on `v0.6.2` commit [529a8d4e185a8aa561e4d8d2891f8556b5717cd4](https://github.com/markedjs/marked/commit/529a8d4e185a8aa561e4d8d2891f8556b5717cd4).
 
 ## Changes
 

--- a/src/muya/lib/parser/marked/inlineRules.js
+++ b/src/muya/lib/parser/marked/inlineRules.js
@@ -29,8 +29,8 @@ const inline = {
   // ------------------------
   // patched
 
-  // allow inline math (text: /^(`+|[^`])[\s\S]*?(?=[\\<!\[`*]|\b_| {2,}\n|$)/,)
-  text: /^(`+|[^`])[\s\S]*?(?=[\\<!\[`*\$]|\b_| {2,}\n|$)/, // emoji is patched in gfm
+  // allow inline math "$" ("?=[\\<!\[`*]" to "?=[\\<!\[`*\$]")
+  text: /^(`+|[^`])(?:[\s\S]*?(?:(?=[\\<!\[`*\$]|\b_|$)|[^ ](?= {2,}\n))|(?= {2,}\n))/, // emoji is patched in gfm
 
   // ------------------------
   // extra
@@ -106,11 +106,12 @@ export const gfm = Object.assign({}, normal, {
   url: /^((?:ftp|https?):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/,
   _backpedal: /(?:[^?!.,:;*_~()&]+|\([^)]*\)|&(?![a-zA-Z0-9]+;$)|[?!.,:;*_~)]+(?!$))+/,
   del: /^~+(?=\S)([\s\S]*?\S)~+/,
-  text: edit(inline.text)
-    .replace(']|', ':]|') // patched: allow emojis
-    .replace(']|', '~]|')
-    .replace('|$', '|https?://|ftp://|www\\.|[a-zA-Z0-9.!#$%&\'*+/=?^_`{\\|}~-]+@|$')
-    .getRegex(),
+
+  // ------------------------
+  // patched
+
+  // allow inline math "$" and emoji ":" ("?=[\\<!\[`*~]|" to "?=[\\<!\[`*~:\$]|")
+  text: /^(`+|[^`])(?:[\s\S]*?(?:(?=[\\<!\[`*~:\$]|\b_|https?:\/\/|ftp:\/\/|www\.|$)|[^ ](?= {2,}\n)|[^a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-](?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@))|(?= {2,}\n|[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@))/,
 
   // ------------------------
   // extra
@@ -128,7 +129,7 @@ gfm.url = edit(gfm.url, 'i').
 
 export const breaks = Object.assign({}, gfm, {
   br: edit(inline.br).replace('{2,}', '*').getRegex(),
-  text: edit(gfm.text).replace('{2,}', '*').getRegex()
+  text: edit(gfm.text).replace(/\{2,\}/g, '*').getRegex()
 })
 
 /* eslint-ensable no-useless-escape */


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

>  Improve worst-case performance of inline.text regex
> 
> The old regex may take quadratic time to scan for potential line
> breaks or email addresses starting at every point.  Fix it to avoid
> scanning from points that would have been in the middle of a previous
> scan.
