### PR TITLE
fix: emoji picker icon color

### DIFF
--- a/src/muya/lib/ui/emojiPicker/index.css
+++ b/src/muya/lib/ui/emojiPicker/index.css
@@ -53,6 +53,7 @@
   font-size: 26px;
   text-align: center;
   line-height: 42px;
+  color: var(--editorColor);
   transition: transform .2s ease-in;
   transform-origin: center;
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fixed emoji picker icon color because the color was barely readable in dark themes.