### PR TITLE
fix: source code mode tab switching

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,6 +41,7 @@ foo<section>bar</section>zar
 - Add new themes: Ulysses Light, Graphite Light, Material Dark and One Dark.
 - Watch file changed in tabs and show a notice(autoSave is `false`) or update the file(autoSave is `true`)
 - Support input inline Ruby charactors as raw html (#257)
+- Added unsaved tab indicator
 
 **:butterfly:Optimization**
 
@@ -109,6 +110,8 @@ foo<section>bar</section>zar
 - Fixed bug when combine pre list and next list into one when inline update #707
 - Fix renderer error when selection in sidebar (#625)
 - Fixed list parse error [more info](https://github.com/marktext/marktext/issues/831#issuecomment-477719256)
+- Fixed source code mode tab switching
+- Fixed source code mode to preview switching
 
 ### 0.13.65
 

--- a/src/main/window.js
+++ b/src/main/window.js
@@ -218,6 +218,7 @@ class AppWindow {
   newTab (win, filePath) {
     this.watcher.watch(win, filePath, 'file')
     loadMarkdownFile(filePath).then(rawDocument => {
+      appMenu.addRecentlyUsedDocument(filePath)
       newTab(win, rawDocument)
     }).catch(err => {
       // TODO: Handle error --> create a end-user error handler.

--- a/src/muya/lib/ui/emojis/index.js
+++ b/src/muya/lib/ui/emojis/index.js
@@ -28,7 +28,7 @@ export const validEmoji = text => {
  */
 
 export const checkEditEmoji = node => {
-  if (node.classList.contains(CLASS_OR_ID['AG_EMOJI_MARKED_TEXT'])) {
+  if (node && node.classList.contains(CLASS_OR_ID['AG_EMOJI_MARKED_TEXT'])) {
     return node
   }
   return false

--- a/src/renderer/assets/themes/one-dark.theme.css
+++ b/src/renderer/assets/themes/one-dark.theme.css
@@ -59,6 +59,10 @@
   background: #4d78cc !important;
 }
 
+.drop-container.active {
+  border: 1px dashed #4d78cc !important;
+}
+
 .title-bar .frameless-titlebar-button > div > svg {
   fill: #ffffff;
 }
@@ -84,12 +88,19 @@
 .side-bar-toc .no-data svg {
   fill: #4d78cc !important;
 }
+
+.recent-files-projects a,
 .open-project a {
   color: #9da5b4 !important;
   border: 1px solid #181a1f !important;
   background-color: #353b45 !important;
   background-image: linear-gradient(#3a3f4b, #353b45) !important;
   box-shadow: none !important;
+}
+.recent-files-projects a:hover,
+.open-project a:hover {
+  color: #d7dae0 !important;
+  background-image: linear-gradient(#3e4451, #3a3f4b) !important;
 }
 
 .editor-tabs {
@@ -110,6 +121,9 @@
   width: 2px !important;
   height: auto !important;
   background: #4d78cc !important;
+}
+.tabs-container svg.close-icon #unsaved-circle-icon {
+  fill: #4d78cc;
 }
 
 :not(pre) > code[class*="language-"],

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -261,7 +261,8 @@
         })
 
         this.editor.on('change', changes => {
-          this.$store.dispatch('LISTEN_FOR_CONTENT_CHANGE', changes)
+          // WORKAROUND: "id: 'muya'"
+          this.$store.dispatch('LISTEN_FOR_CONTENT_CHANGE', Object.assign(changes, { id: 'muya' }))
         })
 
         this.editor.on('format-click', ({ event, formatType, data }) => {
@@ -445,7 +446,7 @@
       },
 
       // listen for `open-single-file` event, it will call this method only when open a new file.
-      setMarkdownToEditor (markdown) {
+      setMarkdownToEditor ({id, markdown}) {
         const { editor } = this
         if (editor) {
           editor.clearHistory()
@@ -455,7 +456,7 @@
       },
 
       // listen for markdown change form source mode or change tabs etc
-      handleMarkdownChange ({ markdown, cursor, renderCursor, history }) {
+      handleMarkdownChange ({ id, markdown, cursor, renderCursor, history }) {
         const { editor } = this
         if (editor) {
           if (history) {
@@ -488,12 +489,15 @@
       bus.$off('undo', this.handleUndo)
       bus.$off('redo', this.handleRedo)
       bus.$off('export', this.handleExport)
+      bus.$off('print-service-clearup', this.handlePrintServiceClearup)
       bus.$off('paragraph', this.handleEditParagraph)
       bus.$off('format', this.handleInlineFormat)
       bus.$off('searchValue', this.handleSearch)
       bus.$off('replaceValue', this.handReplace)
       bus.$off('find', this.handleFind)
-      bus.$off('dotu-select', this.handleSelect)
+      bus.$off('insert-image', this.handleSelect)
+      bus.$off('image-uploaded', this.handleUploadedImage)
+      bus.$off('file-changed', this.handleMarkdownChange)
       bus.$off('editor-blur', this.blurEditor)
       bus.$off('image-auto-path', this.handleImagePath)
       bus.$off('copyAsMarkdown', this.handleCopyPaste)

--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -11,10 +11,11 @@
           @click.stop="selectFile(file)"
         >
           <span>{{ file.filename }}</span>
-          <svg class="icon" aria-hidden="true"
+          <svg class="close-icon icon" aria-hidden="true"
             @click.stop="removeFileInTab(file)"
           >
-            <use xlink:href="#icon-close-small"></use>
+            <circle id="unsaved-circle-icon" cx="6" cy="6" r="3"></circle>
+            <use id="default-close-icon" xlink:href="#icon-close-small"></use>
           </svg>
         </li>
         <li class="new-file">
@@ -49,6 +50,9 @@
 </script>
 
 <style scoped>
+  svg.close-icon #unsaved-circle-icon {
+    fill: var(--themeColor);
+  }
   .editor-tabs {
     width: 100%;
     height: 35px;
@@ -82,11 +86,28 @@
       &:hover > svg {
         opacity: 1;
       }
+      &:hover > svg.close-icon #default-close-icon {
+        display: block !important;
+      }
+      &:hover > svg.close-icon #unsaved-circle-icon {
+        display: none !important;
+      }
       & > span {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
         margin-right: 3px;
+      }
+    }
+    & > li.unsaved:not(.active) {
+      & > svg.close-icon {
+        opacity: 1;
+      }
+      & > svg.close-icon #unsaved-circle-icon {
+        display: block;
+      }
+      & > svg.close-icon #default-close-icon {
+        display: none;
       }
     }
     & > li.active {
@@ -102,6 +123,9 @@
       }
       & > svg {
         opacity: 1;
+      }
+      & > svg.close-icon #unsaved-circle-icon {
+        display: none;
       }
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #858
| License          | MIT

### Description

I guess I fixed #858 and found a few other issues:

- Fixed tab switching in source-code mode. Changes are not applied because the current tab is switched before changes are applied. I added the tab id to both `file-loaded` and `file-changed` events to set markdown content after switching tabs. NOTE: The tab id is only used in source code mode. `editor.vue`/muya uses `muya` as id and the source code mode workaround is not applied.
- Fixed source-code-/preview mode switching because source-code changes were not applied.
- Fixed exception because `checkEditEmoji` parameter was `null` 
- Free all vue events in `editor.vue` and `sourceCode.vue`
- A few One-Dark theme improvements
- Added unsaved tab indicator
- Fixed recently used document on Linux and Windows

fixes #858