### PR TITLE
fix unecessary cache token

### DIFF
--- a/src/muya/lib/parser/parse.js
+++ b/src/muya/lib/parser/parse.js
@@ -340,7 +340,7 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
     }
 
     const rImageTo = inlineRules['reference_image'].exec(src)
-    if (rImageTo && isLengthEven(rImageTo[2]) && isLengthEven(rImageTo[4])) {
+    if (rImageTo && labels.has(rImageTo[3] || rImageTo[1]) && isLengthEven(rImageTo[2]) && isLengthEven(rImageTo[4])) {
       pushPending()
 
       tokens.push({

--- a/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
+++ b/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
@@ -45,6 +45,23 @@ const getHighlightHtml = (text, highlights, escape = false) => {
   return code
 }
 
+const hasReferenceToken = tokens => {
+  let result = false
+  const travel = tokens => {
+    for (const token of tokens) {
+      if (/reference_image|reference_link/.test(token.type)) {
+        result = true
+        break
+      }
+      if (Array.isArray(token.children) && token.children.length) {
+        travel(token.children)
+      }
+    }
+  }
+  travel(tokens)
+  return result
+}
+
 export default function renderLeafBlock (block, cursor, activeBlocks, matches, useCache = false) {
   const { loadMathMap } = this
   let selector = this.getSelector(block, cursor, activeBlocks)
@@ -80,7 +97,8 @@ export default function renderLeafBlock (block, cursor, activeBlocks, matches, u
     ) {
       const hasBeginRules = /^(h\d|span|hr)/.test(type)
       tokens = tokenizer(text, highlights, hasBeginRules, this.labels)
-      if (highlights.length === 0 && useCache && DEVICE_MEMORY >= 4) {
+      const hasReferenceTokens = hasReferenceToken(tokens)
+      if (highlights.length === 0 && useCache && DEVICE_MEMORY >= 4 && !hasReferenceTokens) {
         this.tokenCache.set(text, tokens)
       }
     }

--- a/src/muya/lib/parser/render/renderInlines/referenceLink.js
+++ b/src/muya/lib/parser/render/renderInlines/referenceLink.js
@@ -24,6 +24,7 @@ export default function referenceLink (h, cursor, block, token, outerClass) {
     }, []),
     ...this.backlashInToken(h, backlash.first, className, backlashStart, token)
   ]
+
   const { href, title } = this.labels.get(key)
   const startMarker = this.highlight(
     h,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
 Fixed tickets    | #882
| License          | MIT

### Description

if tokens after `tokenizer` has reference link or reference image, no need to cache them. Because the `reference_definition` maybe removed later.