### PR TITLE
fix list indent by tab

### DIFF
--- a/src/muya/lib/contentState/tabCtrl.js
+++ b/src/muya/lib/contentState/tabCtrl.js
@@ -6,7 +6,7 @@ import { HTML_TAGS, VOID_HTML_TAGS } from '../config'
  * div#id.className => {tag: 'div', id: 'id', className: 'className', isVoid: false}
  */
 
-const parseSelector = str => {
+const parseSelector = (str = '') => {
   const REG_EXP = /(#|\.)([^#.]+)/
   let tag = ''
   let id = ''
@@ -201,10 +201,12 @@ const tabCtrl = ContentState => {
       (!startBlock.functionType || startBlock.functionType === 'codeLine' && startBlock.lang === 'markup')
     ) {
       const { text } = startBlock
-      const lastWord = text.split(/\s+/).pop()
-      const preText = text.substring(0, text.length - lastWord.length)
-      if (lastWord !== '') {
-        const { tag, isVoid, id, className } = parseSelector(lastWord)
+      const lastWordBeforeCursor = text.substring(0, start.offset).split(/\s+/).pop()
+      const { tag, isVoid, id, className } = parseSelector(lastWordBeforeCursor)
+
+      if (tag) {
+        const preText = text.substring(0, start.offset - lastWordBeforeCursor.length)
+        const postText = text.substring(end.offset)
         if (!tag) return
         let html = `<${tag}`
         const key = startBlock.key
@@ -242,7 +244,7 @@ const tabCtrl = ContentState => {
         if (!isVoid) {
           html += `</${tag}>`
         }
-        startBlock.text = preText + html
+        startBlock.text = preText + html + postText
         this.cursor = {
           start: { key, offset: startOffset + preText.length },
           end: { key, offset: endOffset + preText.length }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #907 
| License          | MIT

### Description

if the word before the cursor is a HTML tag, auto complete raw html first, then if not, indent the list item.

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
