### PR TITLE
Fix unable duplicate html and deprecate the html delete icon button

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -195,12 +195,6 @@ export const TABLE_TOOLS = [{
   icon: 'icon-del'
 }]
 
-export const HTML_TOOLS = [{
-  label: 'delete',
-  title: 'Delete HTML',
-  icon: 'icon-del'
-}]
-
 export const LINE_BREAK = '\n'
 
 export const PREVIEW_DOMPURIFY_CONFIG = {

--- a/src/muya/lib/contentState/htmlBlock.js
+++ b/src/muya/lib/contentState/htmlBlock.js
@@ -1,28 +1,10 @@
-import { VOID_HTML_TAGS, HTML_TAGS, HTML_TOOLS } from '../config'
+import { VOID_HTML_TAGS, HTML_TAGS } from '../config'
 import { inlineRules } from '../parser/rules'
 
 const HTML_BLOCK_REG = /^<([a-zA-Z\d-]+)(?=\s|>)[^<>]*?>$/
 const LINE_BREAKS = /\n/
 
 const htmlBlock = ContentState => {
-  ContentState.prototype.createToolBar = function (tools, toolBarType) {
-    const toolBar = this.createBlock('div', '', false)
-    toolBar.toolBarType = toolBarType
-    const ul = this.createBlock('ul')
-
-    tools.forEach(tool => {
-      const toolBlock = this.createBlock('li')
-      const svgBlock = this.createBlock('svg')
-      svgBlock.icon = tool.icon
-      toolBlock.label = tool.label
-      toolBlock.title = tool.title
-      this.appendChild(toolBlock, svgBlock)
-      this.appendChild(ul, toolBlock)
-    })
-    this.appendChild(toolBar, ul)
-    return toolBar
-  }
-
   ContentState.prototype.createCodeInHtml = function (code) {
     const codeContainer = this.createBlock('div')
     codeContainer.functionType = 'html'
@@ -89,9 +71,7 @@ const htmlBlock = ContentState => {
   ContentState.prototype.createHtmlBlock = function (code) {
     const block = this.createBlock('figure')
     block.functionType = 'html'
-    const toolBar = this.createToolBar(HTML_TOOLS, 'html')
     const htmlBlock = this.createCodeInHtml(code)
-    this.appendChild(block, toolBar)
     this.appendChild(block, htmlBlock)
     return block
   }
@@ -130,9 +110,7 @@ const htmlBlock = ContentState => {
     block.functionType = 'html'
     block.text = htmlContent
     block.children = []
-    const toolBar = this.createToolBar(HTML_TOOLS, 'html')
     const codeContainer = this.createCodeInHtml(htmlContent)
-    this.appendChild(block, toolBar)
     this.appendChild(block, codeContainer)
     return codeContainer.children[0] // preBlock
   }

--- a/src/muya/lib/contentState/htmlBlock.js
+++ b/src/muya/lib/contentState/htmlBlock.js
@@ -29,33 +29,6 @@ const htmlBlock = ContentState => {
     return codeContainer
   }
 
-  ContentState.prototype.htmlToolBarClick = function (type) {
-    const { start: { key } } = this.cursor
-    const codeLine = this.getBlock(key)
-    const codeBlock = this.getParent(codeLine)
-    const preBlock = this.getParent(codeBlock)
-    const codeBlockContainer = this.getParent(preBlock)
-    const htmlBlock = this.getParent(codeBlockContainer)
-
-    switch (type) {
-      case 'delete': {
-        htmlBlock.type = 'p'
-        htmlBlock.text = ''
-        htmlBlock.children = []
-        const emptyLine = this.createBlock('span')
-        this.appendChild(htmlBlock, emptyLine)
-        const key = emptyLine.key
-        const offset = 0
-        this.cursor = {
-          start: { key, offset },
-          end: { key, offset }
-        }
-        this.partialRender()
-        break
-      }
-    }
-  }
-
   ContentState.prototype.handleHtmlBlockClick = function (codeWrapper) {
     const id = codeWrapper.id
     const codeBlock = this.getBlock(id).children[0]

--- a/src/muya/lib/contentState/tableBlockCtrl.js
+++ b/src/muya/lib/contentState/tableBlockCtrl.js
@@ -4,6 +4,24 @@ import { TABLE_TOOLS } from '../config'
 const TABLE_BLOCK_REG = /^\|.*?(\\*)\|.*?(\\*)\|/
 
 const tableBlockCtrl = ContentState => {
+  ContentState.prototype.createToolBar = function (tools, toolBarType) {
+    const toolBar = this.createBlock('div', '', false)
+    toolBar.toolBarType = toolBarType
+    const ul = this.createBlock('ul')
+
+    tools.forEach(tool => {
+      const toolBlock = this.createBlock('li')
+      const svgBlock = this.createBlock('svg')
+      svgBlock.icon = tool.icon
+      toolBlock.label = tool.label
+      toolBlock.title = tool.title
+      this.appendChild(toolBlock, svgBlock)
+      this.appendChild(ul, toolBlock)
+    })
+    this.appendChild(toolBar, ul)
+    return toolBar
+  }
+
   ContentState.prototype.createTableInFigure = function ({ rows, columns }, headerTexts) {
     const table = this.createBlock('table')
     const tHead = this.createBlock('thead')

--- a/src/muya/lib/eventHandler/clickEvent.js
+++ b/src/muya/lib/eventHandler/clickEvent.js
@@ -41,7 +41,7 @@ class ClickEvent {
     const { container, eventCenter, contentState } = this.muya
     const handler = event => {
       const { target } = event
-      // handler table | html toolbar click
+      // handler table click
       const toolItem = getToolItem(target)
       if (toolItem) {
         event.preventDefault()
@@ -50,8 +50,6 @@ class ClickEvent {
         const grandPa = toolItem.parentNode.parentNode
         if (grandPa.classList.contains('ag-tool-table')) {
           contentState.tableToolBarClick(type)
-        } else if (grandPa.classList.contains('ag-tool-html')) {
-          contentState.htmlToolBarClick(type)
         }
       }
       // handler image and inline math preview click

--- a/src/muya/lib/ui/baseFloat/index.css
+++ b/src/muya/lib/ui/baseFloat/index.css
@@ -7,7 +7,7 @@
   top: -1000px;
   right: -1000px;
   border-radius: 8px;
-  box-shadow: 0 3px 11px 0 var(--floatShadow);
+  box-shadow: 0 4px 8px 0 var(--floatShadow);
   border: 1px solid var(--floatBorderColor);
   background-color: var(--floatBgColor);
   transition: opacity .25s ease-in-out;

--- a/src/muya/lib/utils/exportMarkdown.js
+++ b/src/muya/lib/utils/exportMarkdown.js
@@ -249,7 +249,7 @@ class ExportMarkdown {
 
   normalizeHTML (block, indent) { // figure
     const result = []
-    const codeLines = block.children[1].children[0].children[0].children
+    const codeLines = block.children[0].children[0].children[0].children
     for (const line of codeLines) {
       result.push(`${indent}${line.text}\n`)
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Deprecations?    | html delete icon
| New tests added? | yes/not needed
| Fixed tickets    | #909 
| License          | MIT

### Description

Because I didn't set the code of html to `contentState.codeBlocks`, so it can not find the html code after duplicated.

--

#### Please, don't submit `/dist` files with your PR!
