### PR TITLE
fix: subsequent list paragraphs

### DIFF
--- a/doc/SETTINGS.md
+++ b/doc/SETTINGS.md
@@ -10,8 +10,7 @@
 - **codeFontFamily**: The code block font family name.
 - **lineHeight**: The line height of the editor.
 - **tabSize**: The number of spaces a tab is equal to.
-- **listIndentation**: The list indentation of list items (`"dfm"`, `"tab"` or number `1-4`)
-  - `tab`: Indent subsequent paragraphs by one tab.
+- **listIndentation**: The list indentation of sub list items or paragraphs (`"dfm"`, `"tab"` or number `1-4`)
   - `dfm`: Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab, we are using 4 spaces (used by Bitbucket and Daring Fireball Markdown Spec).
   - `number`: Dynamic indent subsequent paragraphs by the given number (1-4) plus list marker width (default).
 - **autoPairBracket**: If `true` the editor automatically closes brackets.

--- a/src/main/preference.js
+++ b/src/main/preference.js
@@ -165,7 +165,7 @@ class Preference {
       if (settings.listIndentation < 1 || settings.listIndentation > 4) {
         settings.listIndentation = 1
       }
-    } else if (settings.listIndentation !== 'tab' && settings.listIndentation !== 'dfm') {
+    } else if (settings.listIndentation !== 'dfm') {
       settings.listIndentation = 1
     }
 

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -153,7 +153,7 @@ class Muya {
       if (listIndentation < 1 || listIndentation > 4) {
         listIndentation = 1
       }
-    } else if (listIndentation !== 'tab' && listIndentation !== 'dfm') {
+    } else if (listIndentation !== 'dfm') {
       listIndentation = 1
     }
     this.contentState.listIndentation = listIndentation

--- a/test/unit/specs/markdown-list-indentation.spec.js
+++ b/test/unit/specs/markdown-list-indentation.spec.js
@@ -15,8 +15,9 @@ const createMuyaContext = listIdentation => {
 // Muya parser (Markdown to HTML to Markdown)
 //
 
-const verifyMarkdown = (expectedMarkdown, listIdentation) => {
-  const markdown = `start
+const verifyMarkdown = (expectedMarkdown, listIdentation, markdown = '') => {
+  if (!markdown) {
+    markdown = `start
 
 - foo
 - foo
@@ -41,6 +42,7 @@ sep
        141. foo
             1. foo
 `
+  }
 
   const ctx = createMuyaContext(listIdentation)
   ctx.contentState.importMarkdown(markdown)
@@ -50,7 +52,7 @@ sep
   expect(exportedMarkdown).to.equal(expectedMarkdown)
 }
 
-describe('Muya tab identation', () => {
+describe('Muya list identation', () => {
   it('Indent by 1 space', () => {
     const md = `start
 
@@ -164,7 +166,7 @@ sep
 
     verifyMarkdown(md, 4)
   })
-  it('Indent by one tab', () => {
+/*  it('Indent by one tab', () => {
     const md = `start
 
 - foo
@@ -191,7 +193,7 @@ sep
 \t\t\t1. foo
 `
     verifyMarkdown(md, "tab")
-  })
+  })*/
   it('Indent using Daring Fireball Markdown Spec', () => {
     const md = `start
 
@@ -215,9 +217,10 @@ sep
     3. foo
 3. foo
     20. foo
-        141. foo
+        99. foo
             1. foo
 `
-    verifyMarkdown(md, "dfm")
+
+    verifyMarkdown(md, "dfm", md)
   })
 })


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #887
| License          | MIT

### Description

Fixed subsequent list paragraphs and removed `tab` indentation.

fixes #887
