### PR TITLE
Fix remove content bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 thumbs.db
 !.gitkeep
 .idea
+.env

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "css-loader": "^2.1.1",
     "del": "^4.1.0",
     "devtron": "^1.4.0",
+    "dotenv": "^7.0.0",
     "electron": "^4.1.4",
     "electron-builder": "^20.39.0",
     "electron-debug": "^2.1.0",

--- a/src/main/index.dev.js
+++ b/src/main/index.dev.js
@@ -6,7 +6,7 @@
  */
 
 /* eslint-disable */
-
+require('dotenv').config()
 // Install `electron-debug` with `devtron`
 require('electron-debug')({ showDevTools: false })
 

--- a/src/main/menus/edit.js
+++ b/src/main/menus/edit.js
@@ -56,7 +56,9 @@ export default {
   }, {
     label: 'Select All',
     accelerator: keybindings.getAccelerator('editSelectAll'),
-    role: 'selectall'
+    click (menuItem, browserWindow) {
+      actions.edit(browserWindow, 'selectAll')
+    }
   }, {
     type: 'separator'
   }, {

--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -159,14 +159,25 @@ const backspaceCtrl = ContentState => {
         end.offset === endBlock.text.length && startOutmostBlock === endOutmostBlock && !endBlock.nextSibling && !maybeLastRow.nextSibling ||
         startOutmostBlock !== endOutmostBlock
       ) {
+        event.preventDefault()
         // need remove the figure block.
         const figureBlock = this.getBlock(this.findFigure(startBlock))
         // if table is the only block, need create a p block.
-        if (!figureBlock.nextSibling && !figureBlock.preSibling && !figureBlock.parent) {
-          const p = this.createBlockP()
-          this.insertBefore(p, figureBlock)
+        const p = this.createBlockP(endBlock.text.substring(end.offset))
+        this.insertBefore(p, figureBlock)
+        const cursorBlock = p.children[0]
+        if (startOutmostBlock !== endOutmostBlock) {
+          this.removeBlocks(figureBlock, endBlock)
         }
+
         this.removeBlock(figureBlock)
+        const { key } = cursorBlock
+        const offset = 0
+        this.cursor = {
+          start: { key, offset },
+          end: { key, offset }
+        }
+        return this.render()
       }
     }
 

--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -181,8 +181,6 @@ const backspaceCtrl = ContentState => {
       }
     }
 
-
-
     // If select multiple paragraph or multiple characters in one paragraph, just let
     // inputCtrl to handle this case.
     if (start.key !== end.key || start.offset !== end.offset) {

--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -108,6 +108,9 @@ const backspaceCtrl = ContentState => {
     }
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)
+    const maybeLastRow = this.getParent(endBlock)
+    const startOutmostBlock = this.findOutMostBlock(startBlock)
+    const endOutmostBlock = this.findOutMostBlock(endBlock)
     // fix: #897
     const { text } = startBlock
     const tokens = tokenizer(text)
@@ -148,27 +151,26 @@ const backspaceCtrl = ContentState => {
       return this.partialRender()
     }
 
-    // fix: unexpect remove all editor html. #67 problem 4
-    if (startBlock.type === 'figure' && !startBlock.preSibling) {
-      event.preventDefault()
-      this.removeBlock(startBlock)
-      if (start.key !== end.key) {
-        this.removeBlocks(startBlock, endBlock)
+    // fix bug when the first block is table, these two ways will cause bugs.
+    // 1. one paragraph bollow table, selectAll, press backspace.
+    // 2. select table from the first cell to the last cell, press backsapce.
+    if (/th/.test(startBlock.type) && start.offset === 0 && !startBlock.preSibling) {
+      if (
+        end.offset === endBlock.text.length && startOutmostBlock === endOutmostBlock && !endBlock.nextSibling && !maybeLastRow.nextSibling ||
+        startOutmostBlock !== endOutmostBlock
+      ) {
+        // need remove the figure block.
+        const figureBlock = this.getBlock(this.findFigure(startBlock))
+        // if table is the only block, need create a p block.
+        if (!figureBlock.nextSibling && !figureBlock.preSibling && !figureBlock.parent) {
+          const p = this.createBlockP()
+          this.insertBefore(p, figureBlock)
+        }
+        this.removeBlock(figureBlock)
       }
-      let newBlock = this.findNextBlockInLocation(startBlock)
-      if (!newBlock) {
-        this.blocks = [this.createBlockP()]
-        newBlock = this.blocks[0].children[0]
-      }
-      const key = newBlock.key
-      const offset = 0
-
-      this.cursor = {
-        start: { key, offset },
-        end: { key, offset }
-      }
-      return this.render()
     }
+
+
 
     // If select multiple paragraph or multiple characters in one paragraph, just let
     // inputCtrl to handle this case.

--- a/src/muya/lib/contentState/index.js
+++ b/src/muya/lib/contentState/index.js
@@ -631,6 +631,10 @@ class ContentState {
     }
   }
 
+  getFirstBlock () {
+    return this.firstInDescendant(this.blocks[0])
+  }
+
   getLastBlock () {
     const { blocks } = this
     const len = blocks.length

--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -90,7 +90,6 @@ const inputCtrl = ContentState => {
     let text = getTextContent(paragraph, [ CLASS_OR_ID['AG_MATH_RENDER'], CLASS_OR_ID['AG_RUBY_RENDER'] ])
     let needRender = false
     let needRenderAll = false
-
     if (oldStart.key !== oldEnd.key) {
       const startBlock = this.getBlock(oldStart.key)
       const startOutmostBlock = this.findOutMostBlock(startBlock)
@@ -98,12 +97,22 @@ const inputCtrl = ContentState => {
       const endOutmostBlock = this.findOutMostBlock(endBlock)
       if (
         // fix #918.
-        startBlock.functionType === 'languageInput' &&
-        startOutmostBlock === endOutmostBlock &&
-        !endBlock.nextSibling
+        startBlock.functionType === 'languageInput'
       ) {
-        this.removeBlocks(startBlock, endBlock, false)
-        endBlock.text = ''
+        if (startOutmostBlock === endOutmostBlock && !endBlock.nextSibling) {
+          this.removeBlocks(startBlock, endBlock, false)
+          endBlock.text = ''
+        } else if (startOutmostBlock !== endOutmostBlock) {
+          const preBlock = this.getParent(startBlock)
+          const pBlock = this.createBlock('p')
+          this.removeBlocks(startBlock, endBlock)
+          delete startBlock.functionType
+          this.appendChild(pBlock, startBlock)
+          this.insertBefore(pBlock, preBlock)
+          this.removeBlock(preBlock)
+        } else {
+          this.removeBlocks(startBlock, endBlock)
+        }
       } else {
         this.removeBlocks(startBlock, endBlock)
       }

--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -682,6 +682,73 @@ const paragraphCtrl = ContentState => {
     this.partialRender()
     return this.muya.eventCenter.dispatch('stateChange')
   }
+
+  ContentState.prototype.selectAll = function () {
+    const { start } = this.cursor
+    const startBlock = this.getBlock(start.key)
+    // const endBlock = this.getBlock(end.key)
+    // handle selectAll in table. only select the startBlock cell...
+    if (/th|td/.test(startBlock.type)) {
+      const { key } = start
+      const textLength = startBlock.text.length
+      this.cursor = {
+        start: {
+          key,
+          offset: 0
+        },
+        end: {
+          key,
+          offset: textLength
+        }
+      }
+      return this.partialRender()
+    }
+    // Handler selectAll in code block. only select all the code block conent.
+    // `code block` here is Math, HTML, BLOCK CODE, Mermaid, vega-lite, flowchart, front-matter etc...
+    if (startBlock.type === 'span' && startBlock.functionType === 'codeLine') {
+      const codeBlock = this.getParent(startBlock)
+      const firstCodeLine = this.firstInDescendant(codeBlock)
+      const lastCodeLine = this.lastInDescendant(codeBlock)
+      this.cursor = {
+        start: {
+          key: firstCodeLine.key,
+          offset: 0
+        },
+        end: {
+          key: lastCodeLine.key,
+          offset: lastCodeLine.text.length
+        }
+      }
+      return this.partialRender()
+    }
+    // Handler language input, only select language info only...
+    if (startBlock.type === 'span' && startBlock.functionType === 'languageInput') {
+      this.cursor = {
+        start: {
+          key: startBlock.key,
+          offset: 0
+        },
+        end: {
+          key: startBlock.key,
+          offset: startBlock.text.length
+        }
+      }
+      return this.partialRender()
+    }
+    const firstTextBlock = this.getFirstBlock()
+    const lastTextBlock = this.getLastBlock()
+    this.cursor = {
+      start: {
+        key: firstTextBlock.key,
+        offset: 0
+      },
+      end: {
+        key: lastTextBlock.key,
+        offset: lastTextBlock.text.length
+      }
+    }
+    this.render()
+  }
 }
 
 export default paragraphCtrl

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -45,6 +45,43 @@ class Muya {
     const { focusMode, markdown } = this
     this.setMarkdown(markdown)
     this.setFocusMode(focusMode)
+    this.mutationObserver()
+  }
+
+  mutationObserver () {
+    // Select the node that will be observed for mutations
+    const { container } = this
+
+    // Options for the observer (which mutations to observe)
+    const config = { childList: true, subtree: true }
+
+    // Callback function to execute when mutations are observed
+    const callback = function(mutationsList, observer) {
+      for(const mutation of mutationsList) {
+        if (mutation.type == 'childList') {
+          const { removedNodes, target } = mutation
+          // If the code executes any of the following `if` statements, the editor has gone wrong.
+          // need to report bugs.
+          if (removedNodes && removedNodes.length) {
+            const hasTable = Array.from(removedNodes).some(node => node.nodeType === 1 && node.closest('table.ag-paragraph'))
+            if (hasTable) {
+              console.warn('There was a problem with the table deletion.')
+            }
+          }
+
+          if (target.getAttribute('id') === 'ag-editor-id' && target.childElementCount === 0) {
+            // TODO: the editor can not be input any more. report bugs and recoveryr...
+            console.warn('editor crashed, and can not be input any more.')
+          }
+        }
+      }
+    }
+
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(callback)
+
+    // Start observing the target node for configured mutations
+    observer.observe(container, config)
   }
 
   dispatchChange = () => {
@@ -245,6 +282,10 @@ class Muya {
 
   redo () {
     this.contentState.history.redo()
+  }
+
+  selectAll () {
+    this.contentState.selectAll()
   }
 
   copyAsMarkdown () {

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -58,7 +58,7 @@ class Muya {
     // Callback function to execute when mutations are observed
     const callback = function(mutationsList, observer) {
       for(const mutation of mutationsList) {
-        if (mutation.type == 'childList') {
+        if (mutation.type === 'childList') {
           const { removedNodes, target } = mutation
           // If the code executes any of the following `if` statements, the editor has gone wrong.
           // need to report bugs.

--- a/src/muya/lib/selection/index.js
+++ b/src/muya/lib/selection/index.js
@@ -441,6 +441,7 @@ class Selection {
     let { anchorNode, anchorOffset, focusNode, focusOffset } = this.doc.getSelection()
     // when the first paragraph is task list, press ctrl + a, then press backspace will cause bug
     // use code bellow to fix the bug
+    console.log(anchorNode, anchorOffset, focusNode, focusOffset)
     const findFirstTextNode = anchor => {
       if (anchor.nodeType === 3) return anchor
       // if it's a empty line, just return the span element.

--- a/src/muya/lib/selection/index.js
+++ b/src/muya/lib/selection/index.js
@@ -437,52 +437,42 @@ class Selection {
     this.select(startNode, startOffset, endNode, endOffset)
   }
 
+  isValidCursorNode (node) {
+    if (!node) return false
+    if (node.nodeType === 3) {
+      node = node.parentNode
+    }
+    return node.closest('p[data-role=hr]') ||
+      node.closest('span.ag-paragraph.ag-line') ||
+      node.closest('th.ag-paragraph') ||
+      node.closest('td.ag-paragraph') ||
+      node.closest('.ag-paragraph[data-head]')
+  }
+
   getCursorRange () {
     let { anchorNode, anchorOffset, focusNode, focusOffset } = this.doc.getSelection()
-    // when the first paragraph is task list, press ctrl + a, then press backspace will cause bug
-    // use code bellow to fix the bug
-    console.log(anchorNode, anchorOffset, focusNode, focusOffset)
-    const findFirstTextNode = anchor => {
-      if (anchor.nodeType === 3) return anchor
-      // if it's a empty line, just return the span element.
-      if (
-        anchor.nodeType === 1 &&
-        anchor.nodeName === 'SPAN' &&
-        anchor.textContent === '' &&
-        anchor.classList.contains('ag-line')
-      ) {
-        return anchor
-      }
-      const children = anchor.childNodes
-      for (const node of children) {
-        if (
-          /input/i.test(node.nodeName) ||
-          node.nodeType === 1 && node.getAttribute('contenteditable') === 'false'
-        ) {
-          continue
-        }
-        return findFirstTextNode(node)
-      }
-    }
+    const isAnchorValid = this.isValidCursorNode(anchorNode)
+    const isFocusValid = this.isValidCursorNode(focusNode)
     let needFix = false
-    if (anchorNode.nodeName === 'LI') {
+    if (!isAnchorValid && isFocusValid) {
       needFix = true
-      anchorNode = findFirstTextNode(anchorNode)
-    }
-
-    if (focusNode.nodeName === 'LI') {
+      anchorNode = focusNode
+      anchorOffset = focusOffset
+    } else if (isAnchorValid && !isFocusValid) {
       needFix = true
-      focusNode = findFirstTextNode(focusNode)
-    }
-
-    let startParagraph = findNearestParagraph(anchorNode)
-    let endParagraph = findNearestParagraph(focusNode)
-    if (!startParagraph || !endParagraph) {
+      focusNode = anchorNode
+      focusOffset = anchorOffset
+    } else if (!isAnchorValid && !isFocusValid) {
+      const editor = document.querySelector('#ag-editor-id').parentNode
+      editor.blur()
       return {
         start: null,
         end: null
       }
     }
+
+    const startParagraph = findNearestParagraph(anchorNode)
+    const endParagraph = findNearestParagraph(focusNode)
 
     const getOffsetOfParagraph = (node, paragraph) => {
       let offset = 0
@@ -530,9 +520,11 @@ class Selection {
         result = { start: rawCursor.end, end: rawCursor.start }
       }
     }
+
     if (needFix) {
       this.setCursorRange(result)
     }
+
     return result
   }
 

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -269,6 +269,7 @@
         bus.$on('file-loaded', this.setMarkdownToEditor)
         bus.$on('undo', this.handleUndo)
         bus.$on('redo', this.handleRedo)
+        bus.$on('selectAll', this.handleSelectAll)
         bus.$on('export', this.handleExport)
         bus.$on('print-service-clearup', this.handlePrintServiceClearup)
         bus.$on('paragraph', this.handleEditParagraph)
@@ -375,6 +376,12 @@
       handleRedo () {
         if (this.editor) {
           this.editor.redo()
+        }
+      },
+
+      handleSelectAll () {
+        if (this.editor) {
+          this.editor.selectAll()
         }
       },
 
@@ -557,6 +564,7 @@
       bus.$off('file-loaded', this.setMarkdownToEditor)
       bus.$off('undo', this.handleUndo)
       bus.$off('redo', this.handleRedo)
+      bus.$on('selectAll', this.handleSelectAll)
       bus.$off('export', this.handleExport)
       bus.$off('print-service-clearup', this.handlePrintServiceClearup)
       bus.$off('paragraph', this.handleEditParagraph)

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -564,7 +564,7 @@
       bus.$off('file-loaded', this.setMarkdownToEditor)
       bus.$off('undo', this.handleUndo)
       bus.$off('redo', this.handleRedo)
-      bus.$on('selectAll', this.handleSelectAll)
+      bus.$off('selectAll', this.handleSelectAll)
       bus.$off('export', this.handleExport)
       bus.$off('print-service-clearup', this.handlePrintServiceClearup)
       bus.$off('paragraph', this.handleEditParagraph)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3646,6 +3646,11 @@ dotenv@^6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
+dotenv@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
+  integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #934 #938 
| License          | MIT

### Description

1. rewrite selectAll in menu.
   * if the cursor is in a cell, select all only select the full cell.
   * if the cursor is in code block, only select the code block content.
   * if the cursor is in language input, only select the language.

2. valid cursor, if the getCursorRange has invalid node, reset it to a valid cursor.

- [x] FIX #938 

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
