### PR TITLE
fix: commonmark example 475 and related failed examples

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -184,8 +184,6 @@ export const FORMAT_MARKER_MAP = {
 
 export const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image', 'inline_math']
 
-export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
-
 export const LINE_BREAK = '\n'
 
 export const PREVIEW_DOMPURIFY_CONFIG = {
@@ -237,10 +235,3 @@ export const isInElectron = window && window.process && window.process.type === 
 export const isOsx = window && window.navigator && /Mac/.test(window.navigator.platform)
 // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
 export const URL_REG = /^http(s)?:\/\/([a-z0-9\-._~]+\.[a-z]{2,}|[0-9.]+|localhost|\[[a-f0-9.:]+\])(:[0-9]{1,5})?\/[\S]+/i
-
-// selected from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-export const WHITELIST_ATTRIBUTES = [
-  'align', 'alt', 'checked', 'class', 'color', 'dir', 'disabled', 'for', 'height', 'hidden',
-  'href', 'id', 'lang', 'lazyload', 'rel', 'spellcheck', 'src', 'srcset', 'start', 'style',
-  'target', 'title', 'type', 'value', 'width'
-]

--- a/src/muya/lib/parser/index.js
+++ b/src/muya/lib/parser/index.js
@@ -114,7 +114,6 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
     for (const rule of emRules) {
       const to = inlineRules[rule].exec(src)
       if (to && isLengthEven(to[3])) {
-        console.log(to)
         const isValid = validateEmphasize(src, to[0].length, to[1], pending, validateRules)
         if (isValid) {
           inChunk = true

--- a/src/muya/lib/parser/index.js
+++ b/src/muya/lib/parser/index.js
@@ -1,6 +1,6 @@
 import { beginRules, inlineRules } from './rules'
 import { isLengthEven, union } from '../utils'
-import { punctuation, WHITELIST_ATTRIBUTES } from '../config'
+import { getAttributes, parseSrcAndTitle, validateEmphasize, lowerPriority } from './utils'
 
 // const CAN_NEST_RULES = ['strong', 'em', 'link', 'del', 'a_link', 'reference_link', 'html_tag']
 // disallowed html tags in https://github.github.com/gfm/#raw-html
@@ -10,100 +10,6 @@ delete validateRules.em
 delete validateRules.strong
 delete validateRules['tail_header']
 delete validateRules['backlash']
-
-const validWidthAndHeight = value => {
-  if (!/^\d{1,}$/.test(value)) return ''
-  value = parseInt(value)
-  return value >= 0 ? value : ''
-}
-
-const getAttributes = html => {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(html, 'text/html')
-  const target = doc.querySelector('body').firstElementChild
-  if (!target) return null
-  const attrs = {}
-  for (const attr of target.getAttributeNames()) {
-    if (!WHITELIST_ATTRIBUTES.includes(attr)) continue
-    if (/width|height/.test(attr)) {
-      attrs[attr] = validWidthAndHeight(target.getAttribute(attr))
-    } else {
-      attrs[attr] = target.getAttribute(attr)
-    }
-  }
-
-  return attrs
-}
-
-const parseSrcAndTitle = (text = '') => {
-  const parts = text.split(/\s+/)
-  const src = parts[0]
-  const rawTitle = text.substring(src.length).trim()
-  const TITLE_REG = /^('|")(.*?)\1$/ // we only support use `'` and `"` to indicate a title now.
-  let title = ''
-  if (rawTitle && TITLE_REG.test(rawTitle)) {
-    title = rawTitle.replace(TITLE_REG, '$2')
-  }
-  return { src, title }
-}
-
-const lowerPriority = (src, offset) => {
-  let i
-  for (i = 0; i < offset; i++) {
-    const text = src.substring(i)
-    for (const rule of Object.keys(validateRules)) {
-      const to = validateRules[rule].exec(text)
-      if (to && to[0].length > offset - i) {
-        return false
-      }
-    }
-  }
-  return true
-}
-
-const validateEmphasize = (src, offset, marker, pending) => {
-  /**
-   * Intraword emphasis is disallowed for _
-   */
-  const lastChar = pending.charAt(pending.length - 1)
-  const followedChar = src[offset]
-  const ALPHA_REG = /[a-zA-Z]{1}/
-  if (/_/.test(marker)) {
-    if (ALPHA_REG.test(lastChar)) return false
-    if (followedChar && ALPHA_REG.test(followedChar)) return false
-  }
-  /**
-   * 1. This is not emphasis, because the second * is preceded by punctuation and followed by an alphanumeric
-   * (hence it is not part of a right-flanking delimiter run:
-   * 2. This is not emphasis, because the opening * is preceded by an alphanumeric and followed by punctuation,
-   * and hence not part of a left-flanking delimiter run:
-   */
-  if (ALPHA_REG.test(lastChar) && punctuation.indexOf(src[marker.length]) > -1) {
-    return false
-  }
-
-  if (followedChar && ALPHA_REG.test(followedChar) && punctuation.indexOf(src[offset - marker.length - 1]) > -1) {
-    return false
-  }
-  /**
-   * When there are two potential emphasis or strong emphasis spans with the same closing delimiter,
-   * the shorter one (the one that opens later) takes precedence. Thus, for example, **foo **bar baz**
-   * is parsed as **foo <strong>bar baz</strong> rather than <strong>foo **bar baz</strong>.
-   */
-  const mLen = marker.length
-  const emphasizeText = src.substring(mLen, offset - mLen)
-  const index = emphasizeText.indexOf(marker)
-  if (index > -1 && /\S/.test(emphasizeText[index + mLen])) {
-    return false
-  }
-  /**
-   * Inline code spans, links, images, and HTML tags group more tightly than emphasis.
-   * So, when there is a choice between an interpretation that contains one of these elements
-   * and one that does not, the former always wins. Thus, for example, *[foo*](bar) is parsed
-   * as *<a href="bar">foo*</a> rather than as <em>[foo</em>](bar).
-   */
-  return lowerPriority(src, offset)
-}
 
 const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
   const tokens = []
@@ -208,7 +114,8 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
     for (const rule of emRules) {
       const to = inlineRules[rule].exec(src)
       if (to && isLengthEven(to[3])) {
-        const isValid = validateEmphasize(src, to[0].length, to[1], pending)
+        console.log(to)
+        const isValid = validateEmphasize(src, to[0].length, to[1], pending, validateRules)
         if (isValid) {
           inChunk = true
           pushPending()
@@ -239,7 +146,7 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
     for (const rule of chunks) {
       const to = inlineRules[rule].exec(src)
       if (to && isLengthEven(to[3])) {
-        if (rule === 'emoji' && !lowerPriority(src, to[0].length)) break
+        if (rule === 'emoji' && !lowerPriority(src, to[0].length, validateRules)) break
         inChunk = true
         pushPending()
         const range = {

--- a/src/muya/lib/parser/marked/blockRules.js
+++ b/src/muya/lib/parser/marked/blockRules.js
@@ -11,7 +11,7 @@ export const block = {
   code: /^( {4}[^\n]+\n*)+/,
   fences: noop,
   hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
-  heading: /^ *(#{1,6}) *([^\n]+?) *(?:#+ *)?(?:\n+|$)/,
+  heading: /^ {0,3}(#{1,6})(?: +([^\n]*?)( *#+ *)?(?:\n+|$)|(?:\n+|$))/,
   nptable: noop,
   blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
   list: /^( {0,3})(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
@@ -94,8 +94,7 @@ export const normal = Object.assign({}, block)
 
 export const gfm = Object.assign({}, normal, {
   fences: /^ {0,3}(`{3,}|~{3,})([^`\n]*)\n(?:|([\s\S]*?)\n)(?: {0,3}\1[~`]* *(?:\n+|$)|$)/,
-  paragraph: /^/,
-  heading: /^ *(#{1,6}) +([^\n]+?) *#* *(?:\n+|$)/
+  paragraph: /^/
 })
 
 gfm.paragraph = edit(block.paragraph)

--- a/src/muya/lib/parser/marked/inlineLexer.js
+++ b/src/muya/lib/parser/marked/inlineLexer.js
@@ -2,6 +2,7 @@ import Renderer from './renderer'
 import { normal, breaks, gfm, pedantic } from './inlineRules'
 import defaultOptions from './options'
 import { escape, findClosingBracket } from './utils'
+import { validateEmphasize } from '../utils'
 
 /**
  * Inline Lexer & Compiler
@@ -27,6 +28,12 @@ function InlineLexer (links, options) {
       this.rules = gfm
     }
   }
+  this.highPriorityRules = {}
+  for (const key of Object.keys(this.rules)) {
+    if (/^(?:link|code|tag)$/.test(key) && this.rules[key] instanceof RegExp) {
+      this.highPriorityRules[key] = this.rules[key]
+    }
+  } 
 }
 
 /**
@@ -46,12 +53,14 @@ InlineLexer.prototype.output = function (src) {
   let title
   let cap
   let prevCapZero
+  let lastChar = ''
 
   while (src) {
     // escape
     cap = this.rules.escape.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += escape(cap[1])
       continue
     }
@@ -71,6 +80,7 @@ InlineLexer.prototype.output = function (src) {
       }
 
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += this.options.sanitize
         ? this.options.sanitizer
           ? this.options.sanitizer(cap[0])
@@ -90,6 +100,7 @@ InlineLexer.prototype.output = function (src) {
         cap[3] = ''
       }
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       this.inLink = true
       href = cap[2]
       if (this.options.pedantic) {
@@ -117,6 +128,7 @@ InlineLexer.prototype.output = function (src) {
     cap = this.rules.reflink.exec(src) || this.rules.nolink.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       link = (cap[2] || cap[1]).replace(/\s+/g, ' ')
       link = this.links[link.toLowerCase()]
       if (!link || !link.href) {
@@ -135,6 +147,7 @@ InlineLexer.prototype.output = function (src) {
       cap = this.rules.math.exec(src)
       if (cap) {
         src = src.substring(cap[0].length)
+        lastChar = cap[0].charAt(cap[0].length - 1)
         text = cap[1]
         out += this.renderer.inlineMath(text)
       }
@@ -145,6 +158,7 @@ InlineLexer.prototype.output = function (src) {
       cap = this.rules.emoji.exec(src)
       if (cap) {
         src = src.substring(cap[0].length)
+        lastChar = cap[0].charAt(cap[0].length - 1)
         text = cap[0]
         out += this.renderer.emoji(text, cap[2])
       }
@@ -153,23 +167,34 @@ InlineLexer.prototype.output = function (src) {
     // strong
     cap = this.rules.strong.exec(src)
     if (cap) {
-      src = src.substring(cap[0].length)
-      out += this.renderer.strong(this.output(cap[4] || cap[3] || cap[2] || cap[1]))
-      continue
+      const marker = cap[0].match(/^(?:_{1,2}|\*{1,2})/)[0]
+      const isValid = validateEmphasize(src, cap[0].length, marker, lastChar, this.highPriorityRules)
+      if (isValid) {
+        src = src.substring(cap[0].length)
+        lastChar = cap[0].charAt(cap[0].length - 1)
+        out += this.renderer.strong(this.output(cap[4] || cap[3] || cap[2] || cap[1]))
+        continue
+      }
     }
 
     // em
     cap = this.rules.em.exec(src)
     if (cap) {
-      src = src.substring(cap[0].length)
-      out += this.renderer.em(this.output(cap[6] || cap[5] || cap[4] || cap[3] || cap[2] || cap[1]))
-      continue
+      const marker = cap[0].match(/^(?:_{1,2}|\*{1,2})/)[0]
+      const isValid = validateEmphasize(src, cap[0].length, marker, lastChar, this.highPriorityRules)
+      if (isValid) {
+        src = src.substring(cap[0].length)
+        lastChar = cap[0].charAt(cap[0].length - 1)
+        out += this.renderer.em(this.output(cap[6] || cap[5] || cap[4] || cap[3] || cap[2] || cap[1]))
+        continue
+      }
     }
 
     // code
     cap = this.rules.code.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += this.renderer.codespan(escape(cap[2].trim(), true))
       continue
     }
@@ -178,6 +203,7 @@ InlineLexer.prototype.output = function (src) {
     cap = this.rules.br.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += this.renderer.br()
       continue
     }
@@ -186,6 +212,7 @@ InlineLexer.prototype.output = function (src) {
     cap = this.rules.del.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += this.renderer.del(this.output(cap[1]))
       continue
     }
@@ -194,6 +221,7 @@ InlineLexer.prototype.output = function (src) {
     cap = this.rules.autolink.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       if (cap[2] === '@') {
         text = escape(this.mangle(cap[1]))
         href = 'mailto:' + text
@@ -225,6 +253,7 @@ InlineLexer.prototype.output = function (src) {
         }
       }
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       out += this.renderer.link(href, null, text)
       continue
     }
@@ -233,6 +262,7 @@ InlineLexer.prototype.output = function (src) {
     cap = this.rules.text.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      lastChar = cap[0].charAt(cap[0].length - 1)
       if (this.inRawBlock) {
         out += this.renderer.text(cap[0])
       } else {

--- a/src/muya/lib/parser/marked/inlineLexer.js
+++ b/src/muya/lib/parser/marked/inlineLexer.js
@@ -30,7 +30,7 @@ function InlineLexer (links, options) {
   }
   this.highPriorityRules = {}
   for (const key of Object.keys(this.rules)) {
-    if (/^(?:link|code|tag)$/.test(key) && this.rules[key] instanceof RegExp) {
+    if (/^(?:autolink|link|code|tag)$/.test(key) && this.rules[key] instanceof RegExp) {
       this.highPriorityRules[key] = this.rules[key]
     }
   } 
@@ -41,6 +41,8 @@ function InlineLexer (links, options) {
  */
 
 InlineLexer.prototype.output = function (src) {
+  src = src
+    .replace(/\u00a0/g, ' ')
   const { disableInline, emoji, math } = this.options
   if (disableInline) {
     return escape(src)

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -134,11 +134,15 @@ Lexer.prototype.token = function (src, top) {
     cap = this.rules.heading.exec(src)
     if (cap) {
       src = src.substring(cap[0].length)
+      let text = cap[2] || ''
+      if (cap[3] && !cap[3].startsWith(' ') && !/ +#+ *(?:\n+|$)/.test(cap[0])) {
+        text = (text + cap[3]).trim()
+      }
       this.tokens.push({
         type: 'heading',
         headingStyle: 'atx',
         depth: cap[1].length,
-        text: cap[2]
+        text
       })
       continue
     }

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -32,7 +32,7 @@ Lexer.prototype.lex = function (src) {
     .replace(/\r\n|\r/g, '\n')
     // replace `\t` to four space.
     .replace(/\t/g, '    ')
-    .replace(/\u00a0/g, ' ')
+    // .replace(/\u00a0/g, ' ')
     .replace(/\u2424/g, '\n')
   this.checkFrontmatter = true
   return this.token(src, true)

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -453,16 +453,29 @@ Lexer.prototype.token = function (src, top) {
     // lheading
     cap = this.rules.lheading.exec(src)
     if (cap) {
+      const precededToken = this.tokens[this.tokens.length - 1]
       const chops = cap[0].trim().split(/\n/)
       const marker = chops[chops.length - 1]
       src = src.substring(cap[0].length)
-      this.tokens.push({
-        type: 'heading',
-        headingStyle: 'setext',
-        depth: cap[2] === '=' ? 1 : 2,
-        text: cap[1],
-        marker
-      })
+
+      if (precededToken && precededToken.type === 'paragraph') {
+        this.tokens.pop()
+        this.tokens.push({
+          type: 'heading',
+          headingStyle: 'setext',
+          depth: cap[2] === '=' ? 1 : 2,
+          text: precededToken.text + '\n' + cap[1],
+          marker
+        })
+      } else {
+        this.tokens.push({
+          type: 'heading',
+          headingStyle: 'setext',
+          depth: cap[2] === '=' ? 1 : 2,
+          text: cap[1],
+          marker
+        })
+      }
       continue
     }
 

--- a/src/muya/lib/parser/marked/renderer.js
+++ b/src/muya/lib/parser/marked/renderer.js
@@ -179,7 +179,7 @@ Renderer.prototype.image = function (href, title, text) {
     return text
   }
 
-  let out = '<img src="' + href + '" alt="' + text + '"'
+  let out = '<img src="' + href + '" alt="' + text.replace(/\*/g, '') + '"'
   if (title) {
     out += ' title="' + title + '"'
   }

--- a/src/muya/lib/parser/rules.js
+++ b/src/muya/lib/parser/rules.js
@@ -4,7 +4,7 @@ import { escapeCharacters } from './escapeCharacter'
 export const beginRules = {
   'hr': /^(\*{3,}$|^\-{3,}$|^\_{3,}$)/,
   'code_fense': /^(`{3,})([^`]*)$/,
-  'header': /(^\s{0,3}#{1,6}(\s{1,}|$))/,
+  'header': /(^ {0,3}#{1,6}(\s{1,}|$))/,
   'reference_definition': /^( {0,3}\[)([^\]]+?)(\\*)(\]: *)(<?)([^\s>]+)(>?)(?:( +)(["'(]?)([^\n"'\(\)]+)\9)?( *)$/,
 
   // extra syntax (not belogs to GFM)

--- a/src/muya/lib/parser/rules.js
+++ b/src/muya/lib/parser/rules.js
@@ -23,7 +23,7 @@ export const inlineRules = {
   'reference_link': /^\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   'reference_image': /^\!\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   'tail_header': /^(\s{1,}#{1,})(\s*)$/,
-  'html_tag': /^(<!--[\s\S]*?-->|(<([a-zA-Z]{1}[a-zA-Z\d-]*) *[_\.\-/:a-zA-Z\d='";\? ]* *(?:\/)?>)(?:([\s\S]*?)(<\/\3 *>))?)/, // row html
+  'html_tag': /^(<!--[\s\S]*?-->|(<([a-zA-Z]{1}[a-zA-Z\d-]*) *[_\.\-/:a-zA-Z\d='";\? *]* *(?:\/)?>)(?:([\s\S]*?)(<\/\3 *>))?)/, // row html
   'html_escape': new RegExp(`^(${escapeCharacters.join('|')})`, 'i'),
   'hard_line_break': /^(\s{2,})$/,
 

--- a/src/muya/lib/parser/utils.js
+++ b/src/muya/lib/parser/utils.js
@@ -1,0 +1,104 @@
+// These utils only used for this folder.
+// Move punctuation and WHITELIST_ATTRIBUTES here just to prevent `navigator is not defined` error when run test.
+export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
+// selected from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
+export const WHITELIST_ATTRIBUTES = [
+  'align', 'alt', 'checked', 'class', 'color', 'dir', 'disabled', 'for', 'height', 'hidden',
+  'href', 'id', 'lang', 'lazyload', 'rel', 'spellcheck', 'src', 'srcset', 'start', 'style',
+  'target', 'title', 'type', 'value', 'width'
+]
+
+const validWidthAndHeight = value => {
+  if (!/^\d{1,}$/.test(value)) return ''
+  value = parseInt(value)
+  return value >= 0 ? value : ''
+}
+
+export const lowerPriority = (src, offset, rules) => {
+  let i
+  for (i = 0; i < offset; i++) {
+    const text = src.substring(i)
+    for (const rule of Object.keys(rules)) {
+      const to = rules[rule].exec(text)
+      if (to && to[0].length > offset - i) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+export const getAttributes = html => {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  const target = doc.querySelector('body').firstElementChild
+  if (!target) return null
+  const attrs = {}
+  for (const attr of target.getAttributeNames()) {
+    if (!WHITELIST_ATTRIBUTES.includes(attr)) continue
+    if (/width|height/.test(attr)) {
+      attrs[attr] = validWidthAndHeight(target.getAttribute(attr))
+    } else {
+      attrs[attr] = target.getAttribute(attr)
+    }
+  }
+
+  return attrs
+}
+
+export const parseSrcAndTitle = (text = '') => {
+  const parts = text.split(/\s+/)
+  const src = parts[0]
+  const rawTitle = text.substring(src.length).trim()
+  const TITLE_REG = /^('|")(.*?)\1$/ // we only support use `'` and `"` to indicate a title now.
+  let title = ''
+  if (rawTitle && TITLE_REG.test(rawTitle)) {
+    title = rawTitle.replace(TITLE_REG, '$2')
+  }
+  return { src, title }
+}
+
+export const validateEmphasize = (src, offset, marker, pending, rules) => {
+  /**
+   * Intraword emphasis is disallowed for _
+   */
+  const lastChar = pending.charAt(pending.length - 1) || ''
+  const followedChar = src[offset]
+  const ALPHA_REG = /[a-zA-Z]{1}/
+  if (/_/.test(marker)) {
+    if (ALPHA_REG.test(lastChar)) return false
+    if (followedChar && ALPHA_REG.test(followedChar)) return false
+  }
+  /**
+   * 1. This is not emphasis, because the second * is preceded by punctuation and followed by an alphanumeric
+   * (hence it is not part of a right-flanking delimiter run:
+   * 2. This is not emphasis, because the opening * is preceded by an alphanumeric and followed by punctuation,
+   * and hence not part of a left-flanking delimiter run:
+   */
+  if (ALPHA_REG.test(lastChar) && punctuation.indexOf(src[marker.length]) > -1) {
+    return false
+  }
+
+  if (followedChar && ALPHA_REG.test(followedChar) && punctuation.indexOf(src[offset - marker.length - 1]) > -1) {
+    return false
+  }
+  /**
+   * When there are two potential emphasis or strong emphasis spans with the same closing delimiter,
+   * the shorter one (the one that opens later) takes precedence. Thus, for example, **foo **bar baz**
+   * is parsed as **foo <strong>bar baz</strong> rather than <strong>foo **bar baz</strong>.
+   */
+  const mLen = marker.length
+  const emphasizeText = src.substring(mLen, offset - mLen)
+  const SHORTER_REG = new RegExp(` \\${marker.split('').join('\\')}[^\\${marker.charAt(0)}]`)
+  const CLOSE_REG = new RegExp(`[^\\${marker.charAt(0)}]\\${marker.split('').join('\\')}`)
+  if (emphasizeText.match(SHORTER_REG) && !emphasizeText.match(CLOSE_REG)) {
+    return false
+  }
+  /**
+   * Inline code spans, links, images, and HTML tags group more tightly than emphasis.
+   * So, when there is a choice between an interpretation that contains one of these elements
+   * and one that does not, the former always wins. Thus, for example, *[foo*](bar) is parsed
+   * as *<a href="bar">foo*</a> rather than as <em>[foo</em>](bar).
+   */
+  return lowerPriority(src, offset, rules)
+}

--- a/src/muya/lib/parser/utils.js
+++ b/src/muya/lib/parser/utils.js
@@ -103,7 +103,7 @@ const canOpenEmphasis = (src, marker, pending) => {
   return true
 }
 
-const canCloseEmphasis = (src, offset, marker, pending) => {
+const canCloseEmphasis = (src, offset, marker) => {
   const precededChar = src[offset - marker.length - 1]
   const followedChar = src[offset] || ''
   // not preceded by Unicode whitespace, 
@@ -125,7 +125,7 @@ export const validateEmphasize = (src, offset, marker, pending, rules) => {
   if (!canOpenEmphasis(src, marker, pending)) {
     return false
   }
-  if (!canCloseEmphasis(src, offset, marker, pending)) {
+  if (!canCloseEmphasis(src, offset, marker)) {
     return false
   }
 

--- a/src/muya/lib/parser/utils.js
+++ b/src/muya/lib/parser/utils.js
@@ -1,7 +1,8 @@
-// These utils only used for this folder.
-// Move punctuation and WHITELIST_ATTRIBUTES here just to prevent `navigator is not defined` error when run test.
 // ASCII PUNCTUATION character
-export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
+// export const punctuation = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~']
+/* eslint-disable no-useless-escape */
+export const PUNCTUATION_REG = new RegExp(/[!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDF3C-\uDF3E]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]/)
+/* eslint-enable no-useless-escape */
 // selected from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
 export const WHITELIST_ATTRIBUTES = [
   'align', 'alt', 'checked', 'class', 'color', 'dir', 'disabled', 'for', 'height', 'hidden',
@@ -9,30 +10,32 @@ export const WHITELIST_ATTRIBUTES = [
   'target', 'title', 'type', 'value', 'width'
 ]
 
-export const unicodeZsCategory = [
-  '\u0020', '\u00A0', '\u1680', '\u2000', '\u2001', '\u2001',
-  '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007',
-  '\u2008', '\u2009', '\u200A', '\u202F', '\u205F', '\u3000'
-]
+// export const unicodeZsCategory = [
+//   '\u0020', '\u00A0', '\u1680', '\u2000', '\u2001', '\u2001',
+//   '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007',
+//   '\u2008', '\u2009', '\u200A', '\u202F', '\u205F', '\u3000'
+// ]
 
-export const space = ['\u0020'] // space
+// export const space = ['\u0020'] // space
 
-export const whitespaceCharacter = [
-  ...space, // space
-  '\u0009', // tab
-  '\u000A', // newline
-  '\u000B', // tabulation
-  '\u000C', // form feed
-  '\u000D' // carriage return
-]
+// export const whitespaceCharacter = [
+//   ...space, // space
+//   '\u0009', // tab
+//   '\u000A', // newline
+//   '\u000B', // tabulation
+//   '\u000C', // form feed
+//   '\u000D' // carriage return
+// ]
 
-export const unicodeWhitespaceCharacter = [
-  ...unicodeZsCategory,
-  '\u0009', // tab
-  '\u000D', // carriage return
-  '\u000A', // newline
-  '\u000C' // form feed
-]
+// export const unicodeWhitespaceCharacter = [
+//   ...unicodeZsCategory,
+//   '\u0009', // tab
+//   '\u000D', // carriage return
+//   '\u000A', // newline
+//   '\u000C' // form feed
+// ]
+
+const UNICODE_WHITESPACE_REG = /^\s/
 
 const validWidthAndHeight = value => {
   if (!/^\d{1,}$/.test(value)) return ''
@@ -85,19 +88,19 @@ export const parseSrcAndTitle = (text = '') => {
 }
 
 const canOpenEmphasis = (src, marker, pending) => {
-  const precededChar = pending.charAt(pending.length - 1) || ''
+  const precededChar = pending.charAt(pending.length - 1) || '\n'
   const followedChar = src[marker.length]
   // not followed by Unicode whitespace, 
-  if (unicodeWhitespaceCharacter.includes(followedChar)) {
+  if (UNICODE_WHITESPACE_REG.test(followedChar)) {
     return false
   }
   // and either (2a) not followed by a punctuation character,
   // or (2b) followed by a punctuation character and preceded by Unicode whitespace or a punctuation character.
   // For purposes of this definition, the beginning and the end of the line count as Unicode whitespace.
-  if (punctuation.includes(followedChar) && !(!precededChar || unicodeWhitespaceCharacter.includes(precededChar) || punctuation.includes(precededChar))) {
+  if (PUNCTUATION_REG.test(followedChar) && !(UNICODE_WHITESPACE_REG.test(precededChar) || PUNCTUATION_REG.test(precededChar))) {
     return false
   }
-  if (/_/.test(marker) && !(!precededChar || unicodeWhitespaceCharacter.includes(precededChar) || punctuation.includes(precededChar))) {
+  if (/_/.test(marker) && !(UNICODE_WHITESPACE_REG.test(precededChar) || PUNCTUATION_REG.test(precededChar))) {
     return false
   }
   return true
@@ -105,17 +108,17 @@ const canOpenEmphasis = (src, marker, pending) => {
 
 const canCloseEmphasis = (src, offset, marker) => {
   const precededChar = src[offset - marker.length - 1]
-  const followedChar = src[offset] || ''
+  const followedChar = src[offset] || '\n'
   // not preceded by Unicode whitespace, 
-  if (unicodeWhitespaceCharacter.includes(precededChar)) {
+  if (UNICODE_WHITESPACE_REG.test(precededChar)) {
     return false
   }
   // either (2a) not preceded by a punctuation character,
   // or (2b) preceded by a punctuation character and followed by Unicode whitespace or a punctuation character.
-  if (punctuation.includes(precededChar) && !(!followedChar || unicodeWhitespaceCharacter.includes(followedChar) || punctuation.includes(followedChar))) {
+  if (PUNCTUATION_REG.test(precededChar) && !(UNICODE_WHITESPACE_REG.test(followedChar) || PUNCTUATION_REG.test(followedChar))) {
     return false
   }
-  if (/_/.test(marker) && !(!followedChar || unicodeWhitespaceCharacter.includes(followedChar) || punctuation.includes(followedChar))) {
+  if (/_/.test(marker) && !(UNICODE_WHITESPACE_REG.test(followedChar) || PUNCTUATION_REG.test(followedChar))) {
     return false
   }
   return true

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -27,6 +27,7 @@ const importRegister = ContentState => {
       children: []
     }
     const tokens = new Lexer({ disableInline: true }).lex(markdown)
+
     let token
     let block
     let value

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -2865,8 +2865,7 @@
     "example": 353,
     "start_line": 6322,
     "end_line": 6326,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "foo*bar*\n",
@@ -3912,8 +3911,7 @@
     "example": 479,
     "start_line": 7413,
     "end_line": 7417,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "__a<http://foo.bar/?q=__>\n",
@@ -3921,8 +3919,7 @@
     "example": 480,
     "start_line": 7420,
     "end_line": 7424,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "[link](/uri \"title\")\n",

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -357,8 +357,7 @@
     "example": 45,
     "start_line": 915,
     "end_line": 919,
-    "section": "ATX headings",
-    "shouldFail": true
+    "section": "ATX headings"
   },
   {
     "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
@@ -366,8 +365,7 @@
     "example": 46,
     "start_line": 925,
     "end_line": 933,
-    "section": "ATX headings",
-    "shouldFail": true
+    "section": "ATX headings"
   },
   {
     "markdown": "****\n## foo\n****\n",
@@ -391,8 +389,7 @@
     "example": 49,
     "start_line": 963,
     "end_line": 971,
-    "section": "ATX headings",
-    "shouldFail": true
+    "section": "ATX headings"
   },
   {
     "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -2929,8 +2929,7 @@
     "example": 361,
     "start_line": 6390,
     "end_line": 6394,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "aa_\"bb\"_cc\n",
@@ -3140,8 +3139,7 @@
     "example": 387,
     "start_line": 6641,
     "end_line": 6645,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "__foo, __bar__, baz__\n",
@@ -3247,8 +3245,7 @@
     "example": 400,
     "start_line": 6768,
     "end_line": 6772,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "__foo__bar__baz__\n",

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -2768,8 +2768,7 @@
     "example": 341,
     "start_line": 6003,
     "end_line": 6007,
-    "section": "Code spans",
-    "shouldFail": true
+    "section": "Code spans"
   },
   {
     "markdown": "[not a `link](/foo`)\n",
@@ -2980,8 +2979,7 @@
     "example": 367,
     "start_line": 6455,
     "end_line": 6459,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "*(*foo*)*\n",
@@ -3014,8 +3012,7 @@
     "example": 371,
     "start_line": 6497,
     "end_line": 6501,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "_(_foo_)_\n",
@@ -3080,8 +3077,7 @@
     "example": 379,
     "start_line": 6570,
     "end_line": 6574,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "foo**bar**\n",
@@ -3180,8 +3176,7 @@
     "example": 391,
     "start_line": 6685,
     "end_line": 6689,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "*(**foo**)*\n",
@@ -3229,8 +3224,7 @@
     "example": 397,
     "start_line": 6742,
     "end_line": 6746,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "_(__foo__)_\n",
@@ -3246,8 +3240,7 @@
     "example": 399,
     "start_line": 6761,
     "end_line": 6765,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "__пристаням__стремятся\n",
@@ -3886,8 +3879,7 @@
     "example": 475,
     "start_line": 7385,
     "end_line": 7389,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "__<a href=\"__\">\n",
@@ -3895,8 +3887,7 @@
     "example": 476,
     "start_line": 7392,
     "end_line": 7396,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "*a `*`*\n",

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -405,8 +405,7 @@
     "example": 51,
     "start_line": 1020,
     "end_line": 1027,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "  Foo *bar\nbaz*\t\n====\n",
@@ -414,8 +413,7 @@
     "example": 52,
     "start_line": 1034,
     "end_line": 1041,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
@@ -521,8 +519,7 @@
     "example": 65,
     "start_line": 1214,
     "end_line": 1221,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
@@ -4644,8 +4641,7 @@
     "example": 569,
     "start_line": 8490,
     "end_line": 8496,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo ![bar](/url)](/url2)\n",
@@ -4671,8 +4667,7 @@
     "example": 572,
     "start_line": 8520,
     "end_line": 8526,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
@@ -4680,8 +4675,7 @@
     "example": 573,
     "start_line": 8529,
     "end_line": 8535,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo](train.jpg)\n",
@@ -4745,8 +4739,7 @@
     "example": 581,
     "start_line": 8597,
     "end_line": 8603,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
@@ -4778,8 +4771,7 @@
     "example": 585,
     "start_line": 8642,
     "end_line": 8648,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",

--- a/test/specs/commonMark/commonmark.0.29.json
+++ b/test/specs/commonMark/commonmark.0.29.json
@@ -4240,8 +4240,7 @@
     "example": 520,
     "start_line": 7880,
     "end_line": 7884,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo`](/uri)`\n",
@@ -4249,8 +4248,7 @@
     "example": 521,
     "start_line": 7887,
     "end_line": 7891,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo<http://example.com/?search=](uri)>\n",
@@ -4258,8 +4256,7 @@
     "example": 522,
     "start_line": 7894,
     "end_line": 7898,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,6 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 100 examples:
+Total test 649 examples, and failed 97 examples:
 
 **Example53**
 
@@ -1657,48 +1657,6 @@ Expected Html
 
 Actural Html
 <p>![<a href="uri2"><a href="uri1">foo</a></a>](uri3)</p>
-
-```
-
-**Example520**
-
-```markdown
-Markdown content
-[foo <bar attr="](baz)">
-
-Expected Html
-<p>[foo <bar attr="](baz)"></p>
-
-Actural Html
-<p><a href="baz">foo &lt;bar attr=&quot;</a>&quot;&gt;</p>
-
-```
-
-**Example521**
-
-```markdown
-Markdown content
-[foo\`](/uri)\`
-
-Expected Html
-<p>[foo<code>](/uri)</code></p>
-
-Actural Html
-<p><a href="/uri">foo`</a>`</p>
-
-```
-
-**Example522**
-
-```markdown
-Markdown content
-[foo<http://example.com/?search=](uri)>
-
-Expected Html
-<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
-
-Actural Html
-<p><a href="uri">foo&lt;http://example.com/?search=</a>&gt;</p>
 
 ```
 

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,6 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 114 examples:
+Total test 649 examples, and failed 111 examples:
 
 **Example45**
 
@@ -1129,20 +1129,6 @@ Actural Html
 
 ```
 
-**Example361**
-
-```markdown
-Markdown content
-пристаням_стремятся_
-
-Expected Html
-<p>пристаням_стремятся_</p>
-
-Actural Html
-<p>пристаням<em>стремятся</em></p>
-
-```
-
 **Example368**
 
 ```markdown
@@ -1171,20 +1157,6 @@ Actural Html
 
 ```
 
-**Example387**
-
-```markdown
-Markdown content
-пристаням__стремятся__
-
-Expected Html
-<p>пристаням__стремятся__</p>
-
-Actural Html
-<p>пристаням<strong>стремятся</strong></p>
-
-```
-
 **Example388**
 
 ```markdown
@@ -1210,20 +1182,6 @@ Expected Html
 
 Actural Html
 <p>*<em>foo bar *</em></p>
-
-```
-
-**Example400**
-
-```markdown
-Markdown content
-__пристаням__стремятся
-
-Expected Html
-<p>__пристаням__стремятся</p>
-
-Actural Html
-<p><strong>пристаням</strong>стремятся</p>
 
 ```
 
@@ -1349,7 +1307,7 @@ Expected Html
 <p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
 
 Actural Html
-<p><em>foo **bar *baz</em> bim<em>* bop</em></p>
+<p><em>foo **bar *baz</em> bim** bop*</p>
 
 ```
 

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,6 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 126 examples:
+Total test 649 examples, and failed 117 examples:
 
 **Example45**
 
@@ -1115,20 +1115,6 @@ Actural Html
 
 ```
 
-**Example341**
-
-```markdown
-Markdown content
-*foo\`*\`
-
-Expected Html
-<p>*foo<code>*</code></p>
-
-Actural Html
-<p><em>foo`</em>`</p>
-
-```
-
 **Example342**
 
 ```markdown
@@ -1173,20 +1159,6 @@ Actural Html
 
 ```
 
-**Example367**
-
-```markdown
-Markdown content
-*(*foo)
-
-Expected Html
-<p>*(*foo)</p>
-
-Actural Html
-<p><em>(</em>foo)</p>
-
-```
-
 **Example368**
 
 ```markdown
@@ -1197,21 +1169,7 @@ Expected Html
 <p><em>(<em>foo</em>)</em></p>
 
 Actural Html
-<p><em>(</em>foo<em>)</em></p>
-
-```
-
-**Example371**
-
-```markdown
-Markdown content
-_(_foo)
-
-Expected Html
-<p>_(_foo)</p>
-
-Actural Html
-<p><em>(</em>foo)</p>
+<p>*(<em>foo</em>)*</p>
 
 ```
 
@@ -1225,21 +1183,7 @@ Expected Html
 <p><em>(<em>foo</em>)</em></p>
 
 Actural Html
-<p><em>(</em>foo_)_</p>
-
-```
-
-**Example379**
-
-```markdown
-Markdown content
-a**"foo"**
-
-Expected Html
-<p>a**&quot;foo&quot;**</p>
-
-Actural Html
-<p>a<strong>&quot;foo&quot;</strong></p>
+<p>_(<em>foo</em>)_</p>
 
 ```
 
@@ -1285,48 +1229,6 @@ Actural Html
 
 ```
 
-**Example391**
-
-```markdown
-Markdown content
-**(**foo)
-
-Expected Html
-<p>**(**foo)</p>
-
-Actural Html
-<p><strong>(</strong>foo)</p>
-
-```
-
-**Example397**
-
-```markdown
-Markdown content
-__(__foo)
-
-Expected Html
-<p>__(__foo)</p>
-
-Actural Html
-<p><strong>(</strong>foo)</p>
-
-```
-
-**Example399**
-
-```markdown
-Markdown content
-__foo__bar
-
-Expected Html
-<p>__foo__bar</p>
-
-Actural Html
-<p><strong>foo</strong>bar</p>
-
-```
-
 **Example400**
 
 ```markdown
@@ -1351,7 +1253,7 @@ Expected Html
 <p><strong>foo__bar__baz</strong></p>
 
 Actural Html
-<p><strong>foo</strong>bar__baz__</p>
+<p>__foo__bar__baz__</p>
 
 ```
 
@@ -1407,7 +1309,7 @@ Expected Html
 <p><em>foo <strong>bar</strong></em></p>
 
 Actural Html
-<p><em>foo *</em>bar***</p>
+<p>*foo <strong>bar*</strong></p>
 
 ```
 
@@ -1421,7 +1323,7 @@ Expected Html
 <p><em>foo<strong>bar</strong></em></p>
 
 Actural Html
-<p><em>foo*</em>bar***</p>
+<p>*foo<strong>bar*</strong></p>
 
 ```
 
@@ -1435,7 +1337,7 @@ Expected Html
 <p>foo<em><strong>bar</strong></em>baz</p>
 
 Actural Html
-<p>foo<strong><em>bar</em></strong>baz</p>
+<p>foo***bar***baz</p>
 
 ```
 
@@ -1449,7 +1351,7 @@ Expected Html
 <p>foo<strong><strong><strong>bar</strong></strong></strong>***baz</p>
 
 Actural Html
-<p>foo<strong>**</strong>bar<strong>*****</strong>baz</p>
+<p>foo******bar*********baz</p>
 
 ```
 
@@ -1477,7 +1379,7 @@ Expected Html
 <p><em>foo <a href="/url"><em>bar</em></a></em></p>
 
 Actural Html
-<p><em>foo [</em>bar<em>](/url)</em></p>
+<p>*foo <a href="/url"><em>bar</em></a>*</p>
 
 ```
 
@@ -1521,7 +1423,7 @@ Expected Html
 bim</em> bop</strong></p>
 
 Actural Html
-<p><strong>foo <em>bar *</em>baz</strong>
+<p><strong>foo *bar **baz</strong>
 bim* bop**</p>
 
 ```
@@ -1704,7 +1606,7 @@ Expected Html
 <p><strong><strong><strong>foo</strong></strong></strong></p>
 
 Actural Html
-<p><strong>**</strong>foo<strong>**</strong></p>
+<p>*<strong><strong><em>foo*</em></strong></strong></p>
 
 ```
 
@@ -1764,34 +1666,6 @@ Actural Html
 
 ```
 
-**Example475**
-
-```markdown
-Markdown content
-**<a href="**">
-
-Expected Html
-<p>**<a href="**"></p>
-
-Actural Html
-<p><strong>&lt;a href=&quot;</strong>&quot;&gt;</p>
-
-```
-
-**Example476**
-
-```markdown
-Markdown content
-__<a href="__">
-
-Expected Html
-<p>__<a href="__"></p>
-
-Actural Html
-<p><strong>&lt;a href=&quot;</strong>&quot;&gt;</p>
-
-```
-
 **Example477**
 
 ```markdown
@@ -1802,7 +1676,7 @@ Expected Html
 <p><em>a <code>*</code></em></p>
 
 Actural Html
-<p><em>a `</em>`*</p>
+<p>*a <code>*</code>*</p>
 
 ```
 

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,6 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 117 examples:
+Total test 649 examples, and failed 114 examples:
 
 **Example45**
 
@@ -1129,22 +1129,6 @@ Actural Html
 
 ```
 
-**Example353**
-
-```markdown
-Markdown content
-* a *
-
-Expected Html
-<p>* a *</p>
-
-Actural Html
-<ul>
-<li>a *</li>
-</ul>
-
-```
-
 **Example361**
 
 ```markdown
@@ -1677,34 +1661,6 @@ Expected Html
 
 Actural Html
 <p>*a <code>*</code>*</p>
-
-```
-
-**Example479**
-
-```markdown
-Markdown content
-**a<http://foo.bar/?q=**>
-
-Expected Html
-<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
-
-Actural Html
-<p><strong>a&lt;<a href="http://foo.bar/?q=">http://foo.bar/?q=</a></strong>&gt;</p>
-
-```
-
-**Example480**
-
-```markdown
-Markdown content
-__a<http://foo.bar/?q=__>
-
-Expected Html
-<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
-
-Actural Html
-<p><strong>a&lt;<a href="http://foo.bar/?q=">http://foo.bar/?q=</a></strong>&gt;</p>
 
 ```
 

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,60 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 111 examples:
-
-**Example45**
-
-```markdown
-Markdown content
-# foo#
-
-Expected Html
-<h1>foo#</h1>
-
-Actural Html
-<h1>foo</h1>
-
-```
-
-**Example46**
-
-```markdown
-Markdown content
-### foo \###
-## foo #\##
-# foo \#
-
-Expected Html
-<h3>foo ###</h3>
-<h2>foo ###</h2>
-<h1>foo #</h1>
-
-Actural Html
-<h3>foo \</h3>
-<h2>foo #\</h2>
-<h1>foo \</h1>
-
-```
-
-**Example49**
-
-```markdown
-Markdown content
-## 
-#
-### ###
-
-Expected Html
-<h2></h2>
-<h1></h1>
-<h3></h3>
-
-Actural Html
-<p>## 
-#</p>
-<h3>#</h3>
-
-```
+Total test 649 examples, and failed 108 examples:
 
 **Example51**
 

--- a/test/specs/commonMark/commonmark.0.29.md
+++ b/test/specs/commonMark/commonmark.0.29.md
@@ -1,42 +1,6 @@
 ## Test Result
 
-Total test 649 examples, and failed 108 examples:
-
-**Example51**
-
-```markdown
-Markdown content
-Foo *bar
-baz*
-====
-
-Expected Html
-<h1>Foo <em>bar
-baz</em></h1>
-
-Actural Html
-<p>Foo *bar</p>
-<h1>baz*</h1>
-
-```
-
-**Example52**
-
-```markdown
-Markdown content
-  Foo *bar
-baz*	
-====
-
-Expected Html
-<h1>Foo <em>bar
-baz</em></h1>
-
-Actural Html
-<p>  Foo *bar</p>
-<h1>baz*    </h1>
-
-```
+Total test 649 examples, and failed 100 examples:
 
 **Example53**
 
@@ -79,24 +43,6 @@ Actural Html
 <p>foo</p>
 </blockquote>
 <h1>bar</h1>
-
-```
-
-**Example65**
-
-```markdown
-Markdown content
-Foo
-Bar
----
-
-Expected Html
-<h2>Foo
-Bar</h2>
-
-Actural Html
-<p>Foo</p>
-<h2>Bar</h2>
 
 ```
 
@@ -1852,22 +1798,6 @@ Actural Html
 
 ```
 
-**Example569**
-
-```markdown
-Markdown content
-![foo *bar*]
-
-[foo *bar*]: train.jpg "train & tracks"
-
-Expected Html
-<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
-
-Actural Html
-<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
-
-```
-
 **Example570**
 
 ```markdown
@@ -1893,70 +1823,6 @@ Expected Html
 
 Actural Html
 <p><img src="/url2" alt="foo [bar](/url)"></p>
-
-```
-
-**Example572**
-
-```markdown
-Markdown content
-![foo *bar*][]
-
-[foo *bar*]: train.jpg "train & tracks"
-
-Expected Html
-<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
-
-Actural Html
-<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
-
-```
-
-**Example573**
-
-```markdown
-Markdown content
-![foo *bar*][foobar]
-
-[FOOBAR]: train.jpg "train & tracks"
-
-Expected Html
-<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
-
-Actural Html
-<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
-
-```
-
-**Example581**
-
-```markdown
-Markdown content
-![*foo* bar][]
-
-[*foo* bar]: /url "title"
-
-Expected Html
-<p><img src="/url" alt="foo bar" title="title" /></p>
-
-Actural Html
-<p><img src="/url" alt="*foo* bar" title="title"></p>
-
-```
-
-**Example585**
-
-```markdown
-Markdown content
-![*foo* bar]
-
-[*foo* bar]: /url "title"
-
-Expected Html
-<p><img src="/url" alt="foo bar" title="title" /></p>
-
-Actural Html
-<p><img src="/url" alt="*foo* bar" title="title"></p>
 
 ```
 

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
-Marked.js failed examples count: 133
-Mark Text failed examples count: 108
+Marked.js failed examples count: 131
+Mark Text failed examples count: 100
 
 **Example7**
 
@@ -31,28 +31,6 @@ marked.js html
 <li>foo</li>
 </ul>
 
-```
-
-**Example40**
-
-Mark Text success and marked.js fail
-
-```markdown
-Markdown content
-foo
-    # bar
-
-Expected Html
-<p>foo
-# bar</p>
-
-Actural Html
-<p>foo
-    # bar</p>
-
-marked.js html
-<p>foo</p>
-<pre><code># bar</code></pre>
 ```
 
 **Example45**
@@ -128,25 +106,75 @@ marked.js html
 
 ```
 
-**Example57**
+**Example51**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+Foo *bar
+baz*
+====
+
+Expected Html
+<h1>Foo <em>bar
+baz</em></h1>
+
+Actural Html
+<h1>Foo <em>bar
+baz</em></h1>
+
+marked.js html
+<p>Foo *bar</p>
+<h1>baz*</h1>
+
+```
+
+**Example52**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+  Foo *bar
+baz*	
+====
+
+Expected Html
+<h1>Foo <em>bar
+baz</em></h1>
+
+Actural Html
+<h1>  Foo <em>bar
+baz</em>    </h1>
+
+marked.js html
+<p>  Foo *bar</p>
+<h1>baz*    </h1>
+
+```
+
+**Example65**
 
 Mark Text success and marked.js fail
 
 ```markdown
 Markdown content
 Foo
-    ---
+Bar
+---
 
 Expected Html
-<p>Foo
----</p>
+<h2>Foo
+Bar</h2>
 
 Actural Html
-<p>Foo
-    ---</p>
+<h2>Foo
+Bar</h2>
 
 marked.js html
-<h2>Foo</h2>
+<p>Foo</p>
+<h2>Bar</h2>
 
 ```
 
@@ -632,4 +660,109 @@ marked.js html
 
 ```
 
-There are 27 examples are different with marked.js.
+**Example569**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+![foo *bar*]
+
+[foo *bar*]: train.jpg "train & tracks"
+
+Expected Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+
+Actural Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks"></p>
+
+marked.js html
+<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
+
+```
+
+**Example572**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+![foo *bar*][]
+
+[foo *bar*]: train.jpg "train & tracks"
+
+Expected Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+
+Actural Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks"></p>
+
+marked.js html
+<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
+
+```
+
+**Example573**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+![foo *bar*][foobar]
+
+[FOOBAR]: train.jpg "train & tracks"
+
+Expected Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+
+Actural Html
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks"></p>
+
+marked.js html
+<p><img src="train.jpg" alt="foo *bar*" title="train &amp; tracks"></p>
+
+```
+
+**Example581**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+![*foo* bar][]
+
+[*foo* bar]: /url "title"
+
+Expected Html
+<p><img src="/url" alt="foo bar" title="title" /></p>
+
+Actural Html
+<p><img src="/url" alt="foo bar" title="title"></p>
+
+marked.js html
+<p><img src="/url" alt="*foo* bar" title="title"></p>
+
+```
+
+**Example585**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+![*foo* bar]
+
+[*foo* bar]: /url "title"
+
+Expected Html
+<p><img src="/url" alt="foo bar" title="title" /></p>
+
+Actural Html
+<p><img src="/url" alt="foo bar" title="title"></p>
+
+marked.js html
+<p><img src="/url" alt="*foo* bar" title="title"></p>
+
+```
+
+There are 33 examples are different with marked.js.

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 133
-Mark Text failed examples count: 117
+Mark Text failed examples count: 114
 
 **Example7**
 
@@ -291,6 +291,27 @@ marked.js html
 
 ```
 
+**Example353**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+* a *
+
+Expected Html
+<p>* a *</p>
+
+Actural Html
+<p>* a *</p>
+
+marked.js html
+<ul>
+<li>a *</li>
+</ul>
+
+```
+
 **Example367**
 
 Mark Text success and marked.js fail
@@ -443,4 +464,42 @@ marked.js html
 
 ```
 
-There are 18 examples are different with marked.js.
+**Example479**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+**a<http://foo.bar/?q=**>
+
+Expected Html
+<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
+
+Actural Html
+<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
+
+marked.js html
+<p><strong>a&lt;<a href="http://foo.bar/?q=">http://foo.bar/?q=</a></strong>&gt;</p>
+
+```
+
+**Example480**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+__a<http://foo.bar/?q=__>
+
+Expected Html
+<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
+
+Actural Html
+<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
+
+marked.js html
+<p><strong>a&lt;<a href="http://foo.bar/?q=">http://foo.bar/?q=</a></strong>&gt;</p>
+
+```
+
+There are 21 examples are different with marked.js.

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 133
-Mark Text failed examples count: 114
+Mark Text failed examples count: 111
 
 **Example7**
 
@@ -312,6 +312,25 @@ marked.js html
 
 ```
 
+**Example361**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+пристаням_стремятся_
+
+Expected Html
+<p>пристаням_стремятся_</p>
+
+Actural Html
+<p>пристаням_стремятся_</p>
+
+marked.js html
+<p>пристаням<em>стремятся</em></p>
+
+```
+
 **Example367**
 
 Mark Text success and marked.js fail
@@ -369,6 +388,25 @@ marked.js html
 
 ```
 
+**Example387**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+пристаням__стремятся__
+
+Expected Html
+<p>пристаням__стремятся__</p>
+
+Actural Html
+<p>пристаням__стремятся__</p>
+
+marked.js html
+<p>пристаням<strong>стремятся</strong></p>
+
+```
+
 **Example391**
 
 Mark Text success and marked.js fail
@@ -423,6 +461,25 @@ Actural Html
 
 marked.js html
 <p><strong>foo</strong>bar</p>
+
+```
+
+**Example400**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+__пристаням__стремятся
+
+Expected Html
+<p>__пристаням__стремятся</p>
+
+Actural Html
+<p>__пристаням__стремятся</p>
+
+marked.js html
+<p><strong>пристаням</strong>стремятся</p>
 
 ```
 
@@ -502,4 +559,4 @@ marked.js html
 
 ```
 
-There are 21 examples are different with marked.js.
+There are 24 examples are different with marked.js.

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 131
-Mark Text failed examples count: 100
+Mark Text failed examples count: 97
 
 **Example7**
 
@@ -404,7 +404,7 @@ Expected Html
 <p>* a *</p>
 
 Actural Html
-<p>* a *</p>
+<p>* a *</p>
 
 marked.js html
 <ul>
@@ -660,6 +660,63 @@ marked.js html
 
 ```
 
+**Example520**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+[foo <bar attr="](baz)">
+
+Expected Html
+<p>[foo <bar attr="](baz)"></p>
+
+Actural Html
+<p>[foo <bar attr="](baz)"></p>
+
+marked.js html
+<p><a href="baz">foo &lt;bar attr=&quot;</a>&quot;&gt;</p>
+
+```
+
+**Example521**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+[foo\`](/uri)\`
+
+Expected Html
+<p>[foo<code>](/uri)</code></p>
+
+Actural Html
+<p>[foo<code>](/uri)</code></p>
+
+marked.js html
+<p><a href="/uri">foo`</a>`</p>
+
+```
+
+**Example522**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+[foo<http://example.com/?search=](uri)>
+
+Expected Html
+<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
+
+Actural Html
+<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
+
+marked.js html
+<p><a href="uri">foo&lt;http://example.com/?search=</a>&gt;</p>
+
+```
+
 **Example569**
 
 Mark Text success and marked.js fail
@@ -765,4 +822,4 @@ marked.js html
 
 ```
 
-There are 33 examples are different with marked.js.
+There are 36 examples are different with marked.js.

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 133
-Mark Text failed examples count: 111
+Mark Text failed examples count: 108
 
 **Example7**
 
@@ -53,6 +53,79 @@ Actural Html
 marked.js html
 <p>foo</p>
 <pre><code># bar</code></pre>
+```
+
+**Example45**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+# foo#
+
+Expected Html
+<h1>foo#</h1>
+
+Actural Html
+<h1>foo#</h1>
+
+marked.js html
+<h1>foo</h1>
+
+```
+
+**Example46**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+### foo \###
+## foo #\##
+# foo \#
+
+Expected Html
+<h3>foo ###</h3>
+<h2>foo ###</h2>
+<h1>foo #</h1>
+
+Actural Html
+<h3>foo ###</h3>
+<h2>foo ###</h2>
+<h1>foo #</h1>
+
+marked.js html
+<h3>foo \</h3>
+<h2>foo #\</h2>
+<h1>foo \</h1>
+
+```
+
+**Example49**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+## 
+#
+### ###
+
+Expected Html
+<h2></h2>
+<h1></h1>
+<h3></h3>
+
+Actural Html
+<h2></h2>
+<h1></h1>
+<h3></h3>
+
+marked.js html
+<p>## 
+#</p>
+<h3>#</h3>
+
 ```
 
 **Example57**
@@ -559,4 +632,4 @@ marked.js html
 
 ```
 
-There are 24 examples are different with marked.js.
+There are 27 examples are different with marked.js.

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,7 +1,7 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 133
-Mark Text failed examples count: 126
+Mark Text failed examples count: 117
 
 **Example7**
 
@@ -272,4 +272,175 @@ marked.js html
 
 ```
 
-There are 9 examples are different with marked.js.
+**Example341**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+*foo\`*\`
+
+Expected Html
+<p>*foo<code>*</code></p>
+
+Actural Html
+<p>*foo<code>*</code></p>
+
+marked.js html
+<p><em>foo`</em>`</p>
+
+```
+
+**Example367**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+*(*foo)
+
+Expected Html
+<p>*(*foo)</p>
+
+Actural Html
+<p>*(*foo)</p>
+
+marked.js html
+<p><em>(</em>foo)</p>
+
+```
+
+**Example371**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+_(_foo)
+
+Expected Html
+<p>_(_foo)</p>
+
+Actural Html
+<p>_(_foo)</p>
+
+marked.js html
+<p><em>(</em>foo)</p>
+
+```
+
+**Example379**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+a**"foo"**
+
+Expected Html
+<p>a**&quot;foo&quot;**</p>
+
+Actural Html
+<p>a**&quot;foo&quot;**</p>
+
+marked.js html
+<p>a<strong>&quot;foo&quot;</strong></p>
+
+```
+
+**Example391**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+**(**foo)
+
+Expected Html
+<p>**(**foo)</p>
+
+Actural Html
+<p>**(**foo)</p>
+
+marked.js html
+<p><strong>(</strong>foo)</p>
+
+```
+
+**Example397**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+__(__foo)
+
+Expected Html
+<p>__(__foo)</p>
+
+Actural Html
+<p>__(__foo)</p>
+
+marked.js html
+<p><strong>(</strong>foo)</p>
+
+```
+
+**Example399**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+__foo__bar
+
+Expected Html
+<p>__foo__bar</p>
+
+Actural Html
+<p>__foo__bar</p>
+
+marked.js html
+<p><strong>foo</strong>bar</p>
+
+```
+
+**Example475**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+**<a href="**">
+
+Expected Html
+<p>**<a href="**"></p>
+
+Actural Html
+<p>**<a href="**"></p>
+
+marked.js html
+<p><strong>&lt;a href=&quot;</strong>&quot;&gt;</p>
+
+```
+
+**Example476**
+
+Mark Text success and marked.js fail
+
+```markdown
+Markdown content
+__<a href="__">
+
+Expected Html
+<p>__<a href="__"></p>
+
+Actural Html
+<p>__<a href="__"></p>
+
+marked.js html
+<p><strong>&lt;a href=&quot;</strong>&quot;&gt;</p>
+
+```
+
+There are 18 examples are different with marked.js.


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #958 
| License          | MIT

### Description



```md
markdown:
**<a href="**">

expect html
<p>**<a href="**"></p>
```

- [X] fix in preview render.
- [x] the forked marked still has this issue, fixed in export HTML.
- [ ] Reduce failed test cases to less than 100

**Fixed commonmark examples:**

    "example": 45,

    "example": 46,

    "example": 49,

    "example": 51,
  
    "example": 52,
   
    "example": 65,
   
    "example": 341,
  
    "example": 353,
   
    "example": 361,
    
    "example": 367,
    
    "example": 371,
   
    "example": 379,
  
    "example": 387,
   
    "example": 391,
 
    "example": 397,
  
    "example": 399,
   
    "example": 400,
   
    "example": 475,
  
    "example": 476,
    
    "example": 479,

    "example": 480,
   
    "example": 520,
 
    "example": 521,
   
    "example": 522,
   
    "example": 569,
   
    "example": 572,
  
    "example": 573,
 
    "example": 581,
  
    "example": 585,

Reduce the failed commonmark examples count from 126 to 97 now.