### PR TITLE
fix: whole selection can not be canceled

### DIFF
--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -156,7 +156,9 @@ const backspaceCtrl = ContentState => {
     // 2. select table from the first cell to the last cell, press backsapce.
     if (/th/.test(startBlock.type) && start.offset === 0 && !startBlock.preSibling) {
       if (
-        end.offset === endBlock.text.length && startOutmostBlock === endOutmostBlock && !endBlock.nextSibling && !maybeLastRow.nextSibling ||
+        end.offset === endBlock.text.length &&
+        startOutmostBlock === endOutmostBlock &&
+        !endBlock.nextSibling && !maybeLastRow.nextSibling ||
         startOutmostBlock !== endOutmostBlock
       ) {
         event.preventDefault()

--- a/src/muya/lib/contentState/clickCtrl.js
+++ b/src/muya/lib/contentState/clickCtrl.js
@@ -107,19 +107,6 @@ const clickCtrl = ContentState => {
       eventCenter.dispatch('muya-format-picker', { reference, formats })
     }
 
-    // bugfix: figure block click
-    if (block.type === 'figure' && block.functionType === 'table') {
-      // first cell in thead
-      const cursorBlock = block.children[1].children[0].children[0].children[0]
-      const offset = cursorBlock.text.length
-      const key = cursorBlock.key
-      this.cursor = {
-        start: { key, offset },
-        end: { key, offset }
-      }
-      needRender = true
-    }
-
     // update '```xxx' to code block when you click other place or use press arrow key.
     if (block && start.key !== this.cursor.start.key) {
       const oldBlock = this.getBlock(this.cursor.start.key)
@@ -137,9 +124,18 @@ const clickCtrl = ContentState => {
     }
 
     const needMarkedUpdate = this.checkNeedRender(this.cursor) || this.checkNeedRender({ start, end })
-    this.cursor = { start, end }
-    if (needMarkedUpdate || needRender) {
+
+    if (needRender) {
+      this.cursor = { start, end }
       return this.partialRender()
+    } else if (needMarkedUpdate) {
+      // Fix: whole select can not be canceled #613
+      requestAnimationFrame(() => {
+        this.cursor = selection.getCursorRange()
+        return this.partialRender()
+      })
+    } else {
+      this.cursor = { start, end }
     }
   }
 }

--- a/src/muya/lib/contentState/clickCtrl.js
+++ b/src/muya/lib/contentState/clickCtrl.js
@@ -131,7 +131,11 @@ const clickCtrl = ContentState => {
     } else if (needMarkedUpdate) {
       // Fix: whole select can not be canceled #613
       requestAnimationFrame(() => {
-        this.cursor = selection.getCursorRange()
+        const cursor = selection.getCursorRange()
+        if (!cursor.start || !cursor.end) {
+          return
+        }
+        this.cursor = cursor
         return this.partialRender()
       })
     } else {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #613 
| License          | MIT

### Description

Because of Mark Text render immediately after click event. so can not canceled the selection.

--

#### Please, don't submit `/dist` files with your PR!
