### PR TITLE
fix: #870 list parse error

### DIFF
--- a/src/main/app.js
+++ b/src/main/app.js
@@ -50,8 +50,8 @@ class App {
       })
       contents.on('will-navigate', event => {
         console.warn('Prevented opening a link.')
-        event.preventDefault();
-      });
+        event.preventDefault()
+      })
       contents.on('new-window', (event, url) => {
         console.warn('Prevented opening a new window.')
         event.preventDefault()

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -254,11 +254,6 @@ Lexer.prototype.token = function (src, top) {
           return ''
         })
 
-        // Changing the bullet or ordered list delimiter starts a new list (CommonMark 264 and 265)
-        // Changing to/from task list item from/to bullet, starts a new lit(work for marktext)
-        //   - unordered, unordered --> bull !== newBull --> new list (e.g "-" --> "*")
-        //   - ordered, ordered --> lastChar !== lastChar --> new list (e.g "." --> ")")
-        //   - else --> new list (e.g. ordered --> unordered)
         const newIsOrdered = bull.length > 1 && /\d{1,9}/.test(newBull)
 
         if (!newIsOrdered && this.options.gfm) {
@@ -271,14 +266,23 @@ Lexer.prototype.token = function (src, top) {
             checked = undefined
           }
         }
+
         if (i === 0) {
           isTaskListItem = newIsTaskListItem
         } else if (
+          // Changing the bullet or ordered list delimiter starts a new list (CommonMark 264 and 265)
+          //   - unordered, unordered --> bull !== newBull --> new list (e.g "-" --> "*")
+          //   - ordered, ordered --> lastChar !== lastChar --> new list (e.g "." --> ")")
+          //   - else --> new list (e.g. ordered --> unordered)
           i !== 0 &&
           (
             (!isOrdered && !newIsOrdered && bull !== newBull) ||
             (isOrdered && newIsOrdered && bull.slice(-1) !== newBull.slice(-1)) ||
             (isOrdered !== newIsOrdered) ||
+            // Changing to/from task list item from/to bullet, starts a new list(work for marktext issue #870)
+            // Because we distinguish between task list and bullet list in Mark Text,
+            // the parsing here is somewhat different from the commonmark Spec,
+            // and the task list needs to be a separate list.
             (isTaskListItem !== newIsTaskListItem)
           )
         ) {

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -233,7 +233,7 @@ Lexer.prototype.token = function (src, top) {
       let next = false
       let prevNext = true
       let listItemIndices = []
-      let isTaskListItem = false
+      let isTaskList = false
 
       // Get each top-level item.
       cap = cap[0].match(this.rules.item)
@@ -268,7 +268,7 @@ Lexer.prototype.token = function (src, top) {
         }
 
         if (i === 0) {
-          isTaskListItem = newIsTaskListItem
+          isTaskList = newIsTaskListItem
         } else if (
           // Changing the bullet or ordered list delimiter starts a new list (CommonMark 264 and 265)
           //   - unordered, unordered --> bull !== newBull --> new list (e.g "-" --> "*")
@@ -283,7 +283,7 @@ Lexer.prototype.token = function (src, top) {
             // Because we distinguish between task list and bullet list in Mark Text,
             // the parsing here is somewhat different from the commonmark Spec,
             // and the task list needs to be a separate list.
-            (isTaskListItem !== newIsTaskListItem)
+            (isTaskList !== newIsTaskListItem)
           )
         ) {
           this.tokens.push({
@@ -293,7 +293,7 @@ Lexer.prototype.token = function (src, top) {
           // Start a new list
           bull = newBull
           isOrdered = newIsOrdered
-          isTaskListItem = newIsTaskListItem
+          isTaskList = newIsTaskListItem
           this.tokens.push({
             type: 'list_start',
             ordered: isOrdered,
@@ -355,7 +355,7 @@ Lexer.prototype.token = function (src, top) {
         const isOrderedListItem = /\d/.test(bull)
         this.tokens.push({
           checked: checked,
-          listItemType: bull.length > 1 ? 'order' : (isTaskListItem ? 'task' : 'bullet'),
+          listItemType: bull.length > 1 ? 'order' : (isTaskList ? 'task' : 'bullet'),
           bulletMarkerOrDelimiter: isOrderedListItem ? bull.slice(-1) : bull.charAt(0),
           type: loose ? 'loose_item_start' : 'list_item_start'
         })

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -233,6 +233,7 @@ Lexer.prototype.token = function (src, top) {
       let next = false
       let prevNext = true
       let listItemIndices = []
+      let isTaskListItem = false
 
       // Get each top-level item.
       cap = cap[0].match(this.rules.item)
@@ -241,9 +242,8 @@ Lexer.prototype.token = function (src, top) {
 
       for (; i < l; i++) {
         const itemWithBullet = cap[i]
-        let isTaskListItem = false
         item = itemWithBullet
-
+        let newIsTaskListItem = false
         // Remove the list item's bullet
         // so it is seen as the next token.
         space = item.length
@@ -255,14 +255,33 @@ Lexer.prototype.token = function (src, top) {
         })
 
         // Changing the bullet or ordered list delimiter starts a new list (CommonMark 264 and 265)
+        // Changing to/from task list item from/to bullet, starts a new lit(work for marktext)
         //   - unordered, unordered --> bull !== newBull --> new list (e.g "-" --> "*")
         //   - ordered, ordered --> lastChar !== lastChar --> new list (e.g "." --> ")")
         //   - else --> new list (e.g. ordered --> unordered)
         const newIsOrdered = bull.length > 1 && /\d{1,9}/.test(newBull)
-        if (i !== 0 &&
-          ((!isOrdered && !newIsOrdered && bull !== newBull) ||
-          (isOrdered && newIsOrdered && bull.slice(-1) !== newBull.slice(-1)) ||
-          ((isOrdered && !newIsOrdered) || (!isOrdered && newIsOrdered)))) {
+
+        if (!newIsOrdered && this.options.gfm) {
+          checked = this.rules.checkbox.exec(item)
+          if (checked) {
+            checked = checked[1] === 'x' || checked[1] === 'X'
+            item = item.replace(this.rules.checkbox, '')
+            newIsTaskListItem = true
+          } else {
+            checked = undefined
+          }
+        }
+        if (i === 0) {
+          isTaskListItem = newIsTaskListItem
+        } else if (
+          i !== 0 &&
+          (
+            (!isOrdered && !newIsOrdered && bull !== newBull) ||
+            (isOrdered && newIsOrdered && bull.slice(-1) !== newBull.slice(-1)) ||
+            (isOrdered !== newIsOrdered) ||
+            (isTaskListItem !== newIsTaskListItem)
+          )
+        ) {
           this.tokens.push({
             type: 'list_end'
           })
@@ -270,23 +289,13 @@ Lexer.prototype.token = function (src, top) {
           // Start a new list
           bull = newBull
           isOrdered = newIsOrdered
+          isTaskListItem = newIsTaskListItem
           this.tokens.push({
             type: 'list_start',
             ordered: isOrdered,
             listType: bull.length > 1 ? 'order' : (/^( {0,3})([-*+]) \[[xX ]\]/.test(itemWithBullet) ? 'task' : 'bullet'),
             start: isOrdered ? +(bull.slice(0, -1)) : ''
           })
-        }
-
-        if (!isOrdered && this.options.gfm) {
-          checked = this.rules.checkbox.exec(item)
-          if (checked) {
-            checked = checked[1] === 'x' || checked[1] === 'X'
-            item = item.replace(this.rules.checkbox, '')
-            isTaskListItem = true
-          } else {
-            checked = undefined
-          }
         }
 
         // Outdent whatever the


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #870 
| License          | MIT

### Description

Because we distinguish between task list and bullet list in Mark Text, the parsing here is somewhat different from the `commonmark Spec`, and the task list needs to be a separate list.
