### PR TITLE
feat: jump cursor to the end to format

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **:cactus:Feature**
 
+- The cursor jump to the end of format or to the next brackets when press `tab`(#976)
+
 **:butterfly:Optimization**
 
 - Rewrite `select all` when press `CtrlOrCmd + A` (#937)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Fixed tickets    | #967 #334 
| License          | MIT

### Description

Support inline formats: 

```javascript
['strong', 'em', 'inline_code', 'image', 'link', 'reference_image', 'reference_link', 'emoji', 'del', 'html_tag', 'inline_math']
```

For example:

\*\*strong\<cursor\>**

after press `tab`

it becomes:

\*\*strong**\<cursor\>

--

#### Please, don't submit `/dist` files with your PR!
