### PR TITLE
fix: #974 inline math style optimization

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed some commonmark failed examples and add test case (#943)
 - Fixed some bugs after press `backspace` (#934, #938)
+- Change `inline math` vertical align to `top` (#977)
 
 ### 0.14.0
 

--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -130,7 +130,7 @@ span.ag-math {
   color: var(--editorColor);
   font-family: monospace;
   display: inline-block;
-  vertical-align: bottom;
+  vertical-align: top;
 }
 
 .ag-math > .ag-math-render,


### PR DESCRIPTION
fix: #974

Change inline math vertical align to `top`.
