### PR TITLE
fix: shortcuts and menus without id not longer work

### DIFF
--- a/src/main/shortcutHandler.js
+++ b/src/main/shortcutHandler.js
@@ -303,7 +303,8 @@ const callMenuCallback = (menuInfo, win) => {
       const menus = Menu.getApplicationMenu()
       menuItem = menus.getMenuItemById(id)
     }
-    if (menuItem && menuItem.enabled !== false) {
+    // Allow all shortcuts/menus without id and only enabled menus with id (GH#980).
+    if (!menuItem || menuItem.enabled !== false) {
       click(menuItem, win)
     }
   } else {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Fixes regression from PR #981 that not shortcuts and menus without id work anymore.