### PR TITLE
fix typo in flathub metadata

### DIFF
--- a/resources/linux/marktext.appdata.xml
+++ b/resources/linux/marktext.appdata.xml
@@ -81,7 +81,7 @@
         <content_attribute id="money-gambling">none</content_attribute>
     </content_rating>
     <releases>
-        <release version="0.14.0" date="2018-04-12"/>
+        <release version="0.14.0" date="2019-04-12"/>
         <release version="0.13.65" date="2018-11-21"/>
         <release version="0.13.53" date="2018-10-28"/>
         <release version="0.12.25" date="2018-06-19"/>


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Corrected wrong release date for Flathub page.
