### PR TITLE
add 'Noto Color Emoji' as default emoji fallback font on Linux

### DIFF
--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -1,11 +1,13 @@
 import path from 'path'
 
+export const isLinux = process.platform === 'linux'
+
 export const PATH_SEPARATOR = path.sep
 
 export const THEME_STYLE_ID = 'ag-theme'
 export const COMMON_STYLE_ID = 'ag-common-style'
 
-export const DEFAULT_EDITOR_FONT_FAMILY = '"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif'
+export const DEFAULT_EDITOR_FONT_FAMILY = `"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif ${isLinux ? ', "Noto Color Emoji"' : ''}`
 export const DEFAULT_CODE_FONT_FAMILY = '"DejaVu Sans Mono", "Source Code Pro", "Droid Sans Mono", monospace'
 export const DEFAULT_STYLE = {
   codeFontFamily: DEFAULT_CODE_FONT_FAMILY,

--- a/src/renderer/util/theme.js
+++ b/src/renderer/util/theme.js
@@ -1,8 +1,14 @@
-import { THEME_STYLE_ID, COMMON_STYLE_ID, DEFAULT_CODE_FONT_FAMILY, oneDarkThemes, railscastsThemes } from '../config'
+import { isLinux, THEME_STYLE_ID, COMMON_STYLE_ID, DEFAULT_CODE_FONT_FAMILY, oneDarkThemes, railscastsThemes } from '../config'
 import { dark, graphite, materialDark, oneDark, ulysses } from './themeColor'
 
 const patchTheme = css => {
   return `@media not print {\n${css}\n}`
+}
+
+const getEmojiPickerPatch = () => {
+  return isLinux ? `.ag-emoji-picker section .emoji-wrapper .item span {
+  font-family: sans-serif, "Noto Color Emoji";
+}` : ''
 }
 
 export const addThemeStyle = theme => {
@@ -70,6 +76,7 @@ export const addCommonStyle = style => {
     sheet.id = COMMON_STYLE_ID
     document.head.appendChild(sheet)
   }
+
   sheet.innerHTML = `
 span code,
 td code,
@@ -81,6 +88,8 @@ pre.ag-paragraph {
 font-family: ${codeFontFamily}, ${DEFAULT_CODE_FONT_FAMILY};
 font-size: ${codeFontSize};
 }
+
+${getEmojiPickerPatch()}
 `
 }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Added `Noto Color Emoji` as fallback emoji font on Linux to fix emojis. The user must have `Noto Color Emoji` preinstalled, otherwise the system emoji font is used. `Segoe UI Emoji` is used on Windows (10) and `Apple Color Emoji` on macOS.
