### PR TITLE
feat: support prism language alias

### DIFF
--- a/src/muya/lib/contentState/tabCtrl.js
+++ b/src/muya/lib/contentState/tabCtrl.js
@@ -313,7 +313,7 @@ const tabCtrl = ContentState => {
       start.key === end.key &&
       start.offset === end.offset &&
       startBlock.type === 'span' &&
-      (!startBlock.functionType || startBlock.functionType === 'codeLine' && startBlock.lang === 'markup')
+      (!startBlock.functionType || startBlock.functionType === 'codeLine' && /markup|html|xml|svg|mathml/.test(startBlock.lang))
     ) {
       const { text } = startBlock
       const lastWordBeforeCursor = text.substring(0, start.offset).split(/\s+/).pop()

--- a/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
+++ b/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
@@ -1,6 +1,6 @@
 import katex from 'katex'
 import mermaid from 'mermaid'
-import prism, { loadedCache } from '../../../prism/'
+import prism, { loadedCache, transfromAliasToOrigin } from '../../../prism/'
 import { CLASS_OR_ID, DEVICE_MEMORY, PREVIEW_DOMPURIFY_CONFIG, HAS_TEXT_BLOCK_REG } from '../../../config'
 import { tokenizer } from '../../'
 import { snakeToCamel, sanitize, escapeHtml, getLongUniqueId, getImageInfo } from '../../../utils'
@@ -202,14 +202,16 @@ export default function renderLeafBlock (block, cursor, activeBlocks, selectedBl
       .replace(new RegExp(MARKER_HASK['>'], 'g'), '>')
       .replace(new RegExp(MARKER_HASK['"'], 'g'), '"')
       .replace(new RegExp(MARKER_HASK["'"], 'g'), "'")
+    // transfrom alias to original language
+    const transformedLang = transfromAliasToOrigin([lang])[0]
 
-    if (lang && /\S/.test(code) && loadedCache.has(lang)) {
+    if (transformedLang && /\S/.test(code) && loadedCache.has(transformedLang)) {
       const wrapper = document.createElement('div')
-      wrapper.classList.add(`language-${lang}`)
+      wrapper.classList.add(`language-${transformedLang}`)
       wrapper.innerHTML = code
       prism.highlightElement(wrapper, false, function () {
         const highlightedCode = this.innerHTML
-        selector += `.language-${lang}`
+        selector += `.language-${transformedLang}`
         children = htmlToVNode(highlightedCode)
       })
     } else {

--- a/src/muya/lib/prism/index.js
+++ b/src/muya/lib/prism/index.js
@@ -1,14 +1,35 @@
 import Prism from 'prismjs'
 import { filter } from 'fuzzaldrin'
-import initLoadLanguage, { loadedCache } from './loadLanguage'
+import initLoadLanguage, { loadedCache, transfromAliasToOrigin } from './loadLanguage'
 import languages from './languages'
 
 const prism = Prism
 window.Prism = Prism
 import('prismjs/plugins/keep-markup/prism-keep-markup')
-const langs = Object.keys(languages).map(name => {
-  return Object.assign({}, languages[name], { name })
-})
+
+const langs = []
+
+for (const name of Object.keys(languages)) {
+  const lang = languages[name]
+  langs.push({
+    name,
+    ...lang
+  })
+  if (lang.alias) {
+    if (typeof lang.alias === 'string') {
+      langs.push({
+        name: lang.alias,
+        ...lang
+      })
+    } else if (Array.isArray(lang.alias)) {
+      langs.push(...lang.alias.map(a => ({
+        name: a,
+        ...lang
+      })))
+    }
+  }
+}
+
 const loadLanguage = initLoadLanguage(Prism)
 
 const search = text => {
@@ -23,6 +44,7 @@ export {
   search,
   loadLanguage,
   loadedCache,
+  transfromAliasToOrigin,
   languages
 }
 

--- a/src/muya/lib/prism/loadLanguage.js
+++ b/src/muya/lib/prism/loadLanguage.js
@@ -31,6 +31,32 @@ function getPeerDependents (mainLanguage) {
   return peerDependentsMap[mainLanguage] || []
 }
 
+// Look for the origin languge by alias
+export const transfromAliasToOrigin = arr => {
+  const result = []
+  for (const lang of arr) {
+    if (languages[lang]) {
+      result.push(lang)
+    } else {
+      const language = Object.keys(languages).find(name => {
+        const l = languages[name]
+        if (l.alias) {
+          return l.alias === lang || Array.isArray(l.alias) && l.alias.includes(lang)
+        }
+        return false
+      })
+
+      if (language) {
+        result.push(language)
+      } else {
+        // The lang is not exist, the will handle in `initLoadLanguage`
+        result.push(lang)
+      }
+    }
+  }
+  return result
+}
+
 function initLoadLanguage (Prism) {
   return async function loadLanguages (arr, withoutDependencies) {
     // If no argument is passed, load all components
@@ -48,8 +74,8 @@ function initLoadLanguage (Prism) {
     }
 
     const promises = []
-
-    for (const language of arr) {
+    const transformedLangs = transfromAliasToOrigin(arr)
+    for (const language of transformedLangs) {
       // handle not existed
       if (!languages[language]) {
         promises.push(Promise.resolve({


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes


now you can input language alias like `js`(javascript), `html`(markup).

and Mark Text will highlight it. like bellow:

\```js
const a = 'b'
\```
