### PR TITLE
fix: insert image by image uploader, but can not copy and paste, beca…

### DIFF
--- a/src/muya/lib/contentState/copyCutCtrl.js
+++ b/src/muya/lib/contentState/copyCutCtrl.js
@@ -39,6 +39,22 @@ const copyCutCtrl = ContentState => {
       e.remove()
     }
 
+    const images = wrapper.querySelectorAll('span.ag-inline-image img')
+    for (const image of images) {
+      const src = image.getAttribute('src')
+      let originSrc = null
+      for (const [sSrc, tSrc] of this.stateRender.urlMap.entries()) {
+        if (tSrc === src) {
+          originSrc = sSrc
+          break
+        }
+      }
+
+      if (originSrc) {
+        image.setAttribute('src', originSrc)
+      }
+    }
+
     const hrs = wrapper.querySelectorAll(`[data-role=hr]`)
     for (const hr of hrs) {
       hr.replaceWith(document.createElement('hr'))


### PR DESCRIPTION
We can not copy image after it uploaded, because muya still render the local image. So we need to get the uploaded url when copy and paste.