### PR TITLE
fix: TOC level error

### DIFF
--- a/src/renderer/components/sideBar/toc.vue
+++ b/src/renderer/components/sideBar/toc.vue
@@ -4,6 +4,7 @@
     <el-tree
       v-if="toc.length"
       :data="toc"
+      :default-expand-all="true"
       :props="defaultProps"
       @node-click="handleClick"
       :expand-on-click-node="false"

--- a/src/renderer/util/listToTree.js
+++ b/src/renderer/util/listToTree.js
@@ -1,30 +1,47 @@
-const listToTree = list => {
-  const result = []
-  let parent = null
-  let child = null
-  let tempLvl = 7 // any number great than 6
+class Node {
+  constructor (item) {
+    const { parent, lvl, content, slug } = item
+    this.parent = parent
+    this.lvl = lvl
+    this.label = content
+    this.slug = slug
+    this.children = []
+  }
+  // Add child node.
+  addChild (node) {
+    this.children.push(node)
+  }
+}
 
-  for (const { lvl, content, slug } of list) {
-    const item = {
-      lvl, label: content, slug, children: []
-    }
-    if (lvl < tempLvl) {
-      tempLvl = lvl
-      result.push(item)
-      parent = { children: result }
-      child = item
-    } else if (lvl === tempLvl) {
-      parent.children.push(item)
-      child = item
-    } else if (lvl > tempLvl) {
-      tempLvl = lvl
-      child.children.push(item)
-      parent = child
-      child = item
-    }
+const findParent = (item, lastNode, rootNode) => {
+  if (!lastNode) {
+    return rootNode
+  }
+  const { lvl: lastLvl } = lastNode
+  const { lvl } = item
+
+  if (lvl < lastLvl) {
+    return findParent(item, lastNode.parent, rootNode)
+  } else if (lvl === lastLvl) {
+    return lastNode.parent
+  } else {
+    return lastNode
+  }
+}
+
+const listToTree = list => {
+  const rootNode = new Node({ parent: null, lvl: null, content: null, slug: null })
+  let lastNode = null
+
+  for (const item of list) {
+    const parent = findParent(item, lastNode, rootNode)
+
+    const node = new Node({ parent, ...item })
+    parent.addChild(node)
+    lastNode = node
   }
 
-  return result
+  return rootNode.children
 }
 
 export default listToTree


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Fixed tickets    | #966 
| License          | MIT

The TOC is expanded by default, and it is not possible to remember which nodes were expanded before. When the content is modified, the TOC will expand all.