### PR TITLE
fix: #752

### DIFF
--- a/src/muya/lib/eventHandler/clickEvent.js
+++ b/src/muya/lib/eventHandler/clickEvent.js
@@ -90,6 +90,7 @@ class ClickEvent {
         // Handle select image
         const imageInfo = getImageInfo(imageWrapper)
         event.preventDefault()
+        eventCenter.dispatch('select-image', imageInfo)
         return contentState.selectImage(imageInfo)
       }
 

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -346,7 +346,7 @@ const importRegister = ContentState => {
     const turndownService = new TurndownService(turndownConfig)
     usePluginAddRules(turndownService)
     // fix #752, but I don't know why the &nbsp; vanlished.
-    html = html.replace(/&nbsp;/g, ' ')
+    html = html.replace(/<span>&nbsp;<\/span>/g, ' ')
     html = turnSoftBreakToSpan(html)
     const markdown = turndownService.turndown(html)
     return markdown


### PR DESCRIPTION
Because `turndown` treat `<span> </span>` as flankingWhitespace node. So it add a leading and trailing space before and after node content. and `<span> </span>` is also a blank node, `turndown` will remove it's content by `blankReplacement`, So there will be two space before and after link.
