### PR TITLE
add: auto save with delay

### DIFF
--- a/docs/PREFERENCE.md
+++ b/docs/PREFERENCE.md
@@ -5,7 +5,7 @@
 | Key                    | Type    | Default Value | Description                                                                                                                                                |
 | ---------------------- | ------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | autoSave               | Boolean | false         | Automatically save the content being edited. option value: true, false                                                                                     |
-| autoSaveDelay          | Number  | 5000          | The delay in milliseconds after a changed file is saved automatically? 3000 ~10000                                                                         |
+| autoSaveDelay          | Number  | 5000          | The delay in milliseconds after a changed file is saved automatically? 1000 ~10000                                                                         |
 | titleBarStyle          | String  | custom        | The title bar style on Linux and Window: `custom` or `native`                                                                                              |
 | openFilesInNewWindow   | Boolean | false         | true, false                                                                                                                                                |
 | openFolderInNewWindow  | Boolean | false         | true, false                                                                                                                                                |

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -469,7 +469,7 @@ export const saveAs = win => {
 
 export const autoSave = (menuItem, browserWindow) => {
   const { checked } = menuItem
-  ipcMain.emit('mt::set-user-preference', { autoSave: checked })
+  ipcMain.emit('set-user-preference', { autoSave: checked })
 }
 
 export const moveTo = win => {

--- a/src/main/menu/actions/theme.js
+++ b/src/main/menu/actions/theme.js
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
 
 export const selectTheme = theme => {
-  ipcMain.emit('mt::set-user-preference', undefined, { theme })
+  ipcMain.emit('set-user-preference', { theme })
 }

--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -144,6 +144,10 @@ class Preference extends EventEmitter {
     ipcMain.on('mt::set-user-preference', (e, settings) => {
       this.setItems(settings)
     })
+
+    ipcMain.on('set-user-preference', settings => {
+      this.setItems(settings)
+    })
   }
 }
 

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -6,7 +6,7 @@
   "autoSaveDelay": {
     "description": "General--How long do you want to save your document(ms)?",
     "type": "number",
-    "minimum": 500
+    "minimum": 1000
   },
   "titleBarStyle": {
     "description": "General--The title bar style (Windows and Linux system only).",

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -9,12 +9,11 @@
     <range
       description="How long do you want to save your document?"
       :value="autoSaveDelay"
-      :min="3000"
+      :min="1000"
       :max="10000"
       unit="ms"
       :step="100"
       :onChange="value => onSelectChange('autoSaveDelay', value)"
-      :disable="true"
     ></range>
     <cur-select
       v-if="!isOsx"

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -1,5 +1,4 @@
 import { ipcRenderer } from 'electron'
-import { getOptionsFromState } from './help'
 
 // user preference
 const state = {
@@ -80,19 +79,8 @@ const actions = {
     ipcRenderer.send('mt::ask-for-user-preference')
     ipcRenderer.send('mt::ask-for-user-data')
 
-    ipcRenderer.on('AGANI::user-preference', (e, preference) => {
-      const { autoSave } = preference
-      commit('SET_USER_PREFERENCE', preference)
-
-      // handle autoSave @todo
-      if (autoSave) {
-        const { pathname, markdown } = state
-        const options = getOptionsFromState(rootState.editor)
-        if (pathname) {
-          commit('SET_SAVE_STATUS', true)
-          ipcRenderer.send('AGANI::response-file-save', { pathname, markdown, options })
-        }
-      }
+    ipcRenderer.on('AGANI::user-preference', (e, preferences) => {
+      commit('SET_USER_PREFERENCE', preferences)
     })
   },
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #971
| License          | MIT

### Description

Implemented auto save with delay. There are still some issues with file changes on disk and auto save. With this PR we automatically load changes only if the file is saved, otherwise show a notification but the file on disk may be overwritten due further text editor changes.

@Jocs BTW I don't really know where to store `autoSaveTimers` because it's not UI relevant and I don't wanted to `commit` to make changes.
