### PR TITLE
fix: Enter multiple lines in Chinese

### DIFF
--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -82,7 +82,6 @@ const inputCtrl = ContentState => {
     if (!start || !end) {
       return
     }
-
     const { start: oldStart, end: oldEnd } = this.cursor
     const key = start.key
     const block = this.getBlock(key)
@@ -201,7 +200,7 @@ const inputCtrl = ContentState => {
       if (
         block.text.endsWith('\n') &&
         start.offset === text.length &&
-        event.inputType === 'insertText'
+        (event.inputType === 'insertText' || event.type === 'compositionend')
       ) {
         block.text += event.data
         start.offset++

--- a/src/muya/lib/parser/index.js
+++ b/src/muya/lib/parser/index.js
@@ -404,8 +404,8 @@ const tokenizerFac = (src, beginRules, inlineRules, pos = 0, top, labels) => {
       tokens.push({
         type: 'hard_line_break',
         raw: hardTo[0],
-        spaces: hardTo[1],
-        lineBreak: hardTo[2],
+        spaces: hardTo[1], // The space in hard line break
+        lineBreak: hardTo[2], // \n
         isAtEnd: hardTo.input.length === hardTo[0].length,
         parent: tokens,
         range: {


### PR DESCRIPTION
##### How to reproduce this issue:

1. write markdown bellow:

```md
中国
<Cursor>
```

2. Cursor just in another line, not a new paragraph. Write some other Chinese, The new characters will append to the end of first line, the second line removed.