### PR TITLE
Adjust titlebar title when using native window

### DIFF
--- a/src/renderer/components/titleBar.vue
+++ b/src/renderer/components/titleBar.vue
@@ -167,8 +167,9 @@
     watch: {
       filename: function (value) {
         // Set filename when hover on dock
-        const title = this.project && this.project.name ? `${value} - ${this.project.name}` : value
-        document.querySelector('title').textContent = title
+        const title = this.project && this.project.name ?
+          `${value} - ${this.project.name}` : `${value} - Mark Text`
+        document.title = title
       }
     },
     methods: {

--- a/test/e2e/specs/Launch.spec.js
+++ b/test/e2e/specs/Launch.spec.js
@@ -7,7 +7,7 @@ describe('Launch', function () {
   it('shows the proper application title', function () {
     return this.app.client.getTitle()
       .then(title => {
-        const result = /^Mark Text|Untitled-1$/.test(title)
+        const result = /^Mark Text|Untitled-1 - Mark Text$/.test(title)
         if (!result) {
           console.error(`AssertionError: expected '${title}' to equal 'Mark Text' or 'Untitled-1'`)
           expect(false).to.equal(true)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Fixed tickets    | #1123
| License          | MIT

### Description

Added `- Mark Text` to untitled tabs to remove the  redundant title but also to be more consistent to the title when a directory is opened (`filename - directory`). This applies to all OSs.

![mt_titlebar_text](https://user-images.githubusercontent.com/22716132/60620025-62f27900-9dda-11e9-8aa0-caf8a050a4c2.png)


---

fixes #1123
