### PR TITLE
fix: should not nest math block into other math block

### DIFF
--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -392,16 +392,21 @@ const paragraphCtrl = ContentState => {
   }
 
   ContentState.prototype.insertContainerBlock = function (functionType, block) {
-    if (block.type === 'span') {
-      block = this.getParent(block)
+    const anchor = this.getAnchor(block)
+    if (!anchor) {
+      console.error('Can not find the anchor paragraph to insert paragraph')
+      return
     }
-    const value = block.type === 'p'
-      ? block.children.map(child => child.text).join('\n').trim()
-      : block.text
+
+    const value = anchor.type === 'p'
+      ? anchor.children.map(child => child.text).join('\n').trim()
+      : ''
 
     const containerBlock = this.createContainerBlock(functionType, value)
-    this.insertAfter(containerBlock, block)
-    this.removeBlock(block)
+    this.insertAfter(containerBlock, anchor)
+    if (anchor.type === 'p') {
+      this.removeBlock(anchor)
+    }
 
     const cursorBlock = containerBlock.children[0].children[0].children[0]
     const { key } = cursorBlock


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

If the cursor is in math block, we can not create a new math block in the outer math block, we need to create a new math block after the previous math block.

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
