### PR TITLE
fix: #1158

### DIFF
--- a/src/muya/lib/contentState/enterCtrl.js
+++ b/src/muya/lib/contentState/enterCtrl.js
@@ -471,12 +471,13 @@ const enterCtrl = ContentState => {
     }
 
     cursorBlock = getParagraphBlock(cursorBlock)
-    const key = cursorBlock.type === 'p' ? cursorBlock.children[0].key : cursorBlock.key
+    const key = cursorBlock.type === 'p' || cursorBlock.type === 'pre' ? cursorBlock.children[0].key : cursorBlock.key
     const offset = 0
     this.cursor = {
       start: { key, offset },
       end: { key, offset }
     }
+
     this.partialRender()
   }
 }

--- a/src/muya/lib/parser/render/renderBlock/renderContainerBlock.js
+++ b/src/muya/lib/parser/render/renderBlock/renderContainerBlock.js
@@ -39,7 +39,7 @@ export default function renderContainerBlock (block, activeBlocks, matches, useC
   }
 
   if (/code|pre/.test(type) && typeof lang === 'string' && !!lang) {
-    selector += `.language-${lang}`
+    selector += `.language-${lang.replace(/[#.]{1}/g, '')}`
   }
 
   if (/^h/.test(type)) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1158 
| License          | MIT

### Description

[Description of the bug or feature]

Because the `#` and `.` will be recognized as id selector and class selector when render.

--

#### Please, don't submit `/dist` files with your PR!
