### PR TITLE
fix: cut not work on mobile devices

### DIFF
--- a/src/muya/lib/contentState/copyCutCtrl.js
+++ b/src/muya/lib/contentState/copyCutCtrl.js
@@ -6,7 +6,10 @@ import marked from '../parser/marked'
 
 const copyCutCtrl = ContentState => {
   ContentState.prototype.cutHandler = function () {
-    const { start, end } = this.cursor
+    const { start, end } = selection.getCursorRange()
+    if (!start || !end) {
+      return
+    }
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)
     startBlock.text = startBlock.text.substring(0, start.offset) + endBlock.text.substring(end.offset)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Because select text will not emit click event on mobile phone, so we didn't update the cursor after user select some text, So we need to get the current cursor range when we cut some text.

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
