### PR TITLE
Build Windows zip binaries

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,21 +4,23 @@
 
 - `preference.md` is deprecated and no longer supported. Please use the GUI or edit `preferences.json` manually.
 - Removed portable Windows executable. NSIS installer can now be used to install per-user (without administrator privileges) or machine wide.
+- Added portable zip archive for both x86 and x64 Windows.
 - Changed `viewToggleFullScreen` and `windowCloseWindow` key bindings to `windowToggleFullScreen` and `fileCloseWindow`.
 - Removed `viewChangeFont` key binding.
 - Mark Text is now single-instance application on Linux and Windows too.
 
 **:cactus:Feature**
 
-- GUI settings (#1028)
+- Added GUI settings (#1028)
 - The cursor jump to the end of format or to the next brackets when press `tab`(#976)
 - Tab drag & drop inside the window
 - Scrollable tabs
 - Support to replace the root folder in a window
 - Second-instance files and directories via command-line are opened in the best window
 - Mark Text can use a default directory that is automatically opened during startup (#711)
-- New CLI flags: `--disable-gpu` and `-n,--new-window`
+- New CLI flags: `--disable-gpu`, `-n,--new-window` and `--user-data-dir`
 - Find in files use ripgrep as searcher.
+- You can know automatically save your document after a predefined intervall.
 
 **:butterfly:Optimization**
 
@@ -27,12 +29,14 @@
 - Improved startup time
 - Replace empty untitled tabs (#830)
 - Editor window is shown immediately while loading
+- Adjust titlebar title when using native window to not show a duplicate title
+- Added `Noto Color Emoji` as default emoji fallback font on Linux to display emojis properly.
 
 **:beetle:Bug fix**
 
-- Fixed some commonmark failed examples and add test case (#943)
+- Fixed some CommonMark failed examples and add test cases (#943)
 - Fixed some bugs after press `backspace` (#934, #938)
-- Change `inline math` vertical align to `top` (#977)
+- Changed `inline math` vertical align to `top` (#977)
 - Prevent to open the same file twice, instead select the existing tab (#878)
 - Fixed some minor filesystem watcher issues
 - Fixed rename filesystem watcher bug which lead to multiple issues because the parent directory was watched after deleting a file on Linux using `rename`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 
   # calculate checksums
   - ps: get-filehash -Algorithm SHA256 "build\Mark Text *.exe"
-  - ps: get-filehash -Algorithm SHA256 "build\Mark Text Setup *.exe"
+  - ps: get-filehash -Algorithm SHA256 "build\Mark Text-*-win.zip"
 
 test: off
 # test_script:

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -6,16 +6,16 @@ Download the AppImage and type the following:
 
 1. `chmod +x marktext-%version%-x86_64.AppImage`
 2. `./marktext-%version%-x86_64.AppImage`
-3. Now you can decide whether you want to install Mark Text (yes) or just execute it (no).
+3. Now you can execute Mark Text.
 
 ### Installation
 
-You cannot really install an AppImage. It's just a file which can be integrated with your desktop environment. The only thing you have to do is to execute Mark Text and click `Yes` on dialog.
+You cannot really install an AppImage. It's just a file which can be integrated with your desktop environment. The only thing you have to do is to create a desktop file that link to Mark Text (like `~/.local/share/applications/appimage-marktext.desktop`).
 
 ### Uninstallation
 
-1. Delete AppImage file
-2. Delete `~/.local/share/applications/appimagekit-marktext.desktop`
+1. Delete AppImage file.
+2. Delete your desktop file if exists.
 3. Delete your user settings: `~/.config/marktext`
 
 ### Custom launch script

--- a/docs/PORTABLE.md
+++ b/docs/PORTABLE.md
@@ -8,7 +8,9 @@ On Linux and Window you can also create a directory called `marktext-user-data` 
 
 ```
 marktext-portable/
- ├── marktext/Mark Text.exe
+ ├── marktext (Linux) or Mark Text.exe (Windows)
  ├── marktext-user-data/
+ ├── resources/
+ ├── THIRD-PARTY-LICENSES.txt
  └── ...
 ```

--- a/package.json
+++ b/package.json
@@ -93,6 +93,13 @@
             "ia32",
             "x64"
           ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "ia32",
+            "x64"
+          ]
         }
       ],
       "requestedExecutionLevel": "asInvoker"


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Added Windows binary as ZIP-archive for both x86 and x64. We still need to test the automatically update feature for ZIP packages or disable this feature later.
