### PR TITLE
fix: unexpected delete all content when input Chinese

### DIFF
--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -715,7 +715,8 @@ const paragraphCtrl = ContentState => {
     return firstTextBlock.key === start.key &&
       start.offset === 0 &&
       lastTextBlock.key === end.key &&
-      end.offset === lastTextBlock.text.length
+      end.offset === lastTextBlock.text.length &&
+      !this.muya.keyboard.isComposed
   }
 
   ContentState.prototype.selectAll = function () {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

[Description of the bug or feature]

Input Chinese like bellow：
<img width="475" alt="屏幕快照 2019-07-25 上午2 35 14" src="https://user-images.githubusercontent.com/9712830/61819105-e73d9680-ae84-11e9-937a-906e66aa891b.png">

press `backspace` key will delete all the content, but it's not the expected behavior. I only want to delete the last character.

--

#### Please, don't submit `/dist` files with your PR!
