### PR TITLE
fix: runtime error when click bellow the last paragraph

### DIFF
--- a/src/muya/lib/contentState/clickCtrl.js
+++ b/src/muya/lib/contentState/clickCtrl.js
@@ -27,6 +27,7 @@ const clickCtrl = ContentState => {
         }
 
         if (needToInsertNewParagraph) {
+          event.preventDefault()
           const paragraphBlock = this.createBlockP()
           this.insertAfter(paragraphBlock, archor)
           const key = paragraphBlock.children[0].key
@@ -36,7 +37,7 @@ const clickCtrl = ContentState => {
             end: { key, offset }
           }
 
-          return this.partialRender()
+          return this.render()
         }
       }
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

### Description

![屏幕快照 2019-07-25 下午1 49 34](https://user-images.githubusercontent.com/9712830/61849260-429e7180-aee3-11e9-9586-f923f1963485.png)


### Steps to reproduce:

1. write some paragraphs.
2. put the cursor at the first paragraph.
3. click bellow the last paragraph.

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
