### PR TITLE
fix white screen when search in setting window

### DIFF
--- a/src/renderer/prefComponents/sideBar/config.js
+++ b/src/renderer/prefComponents/sideBar/config.js
@@ -50,3 +50,4 @@ export const searchContent = Object.keys(preferences).map(k => {
     preference
   }
 })
+  .filter(({ category: ca }) => category.some(c => c.label === ca.toLowerCase()))


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

### Description

Fix search `watch` key word will cause setting window became white screen.

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
