### PR TITLE
Release 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "vega-embed": "^4.2.1",
     "vega-lite": "^3.3.0",
     "view-image": "^0.0.1",
-    "vscode-ripgrep": "^1.5.5",
+    "vscode-ripgrep": "^1.3.1",
     "vue": "^2.6.10",
     "vue-electron": "^1.0.6",
     "vue-router": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marktext",
-  "version": "0.15.0.rc.01",
+  "version": "0.15.0-rc.1",
   "homepage": "https://marktext.app/",
   "description": "Next generation markdown editor",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12073,9 +12073,9 @@ vow@^0.4.17, vow@^0.4.19, vow@^0.4.7:
   resolved "https://registry.yarnpkg.com/vow/-/vow-0.4.19.tgz#cc5ef4d6bb6972d830830a7c9ecf8ad834a7c525"
   integrity sha512-S+0+CiQlbUhTNWMlJdqo/ARuXOttXdvw5ACGyh1W97NFHUdwt3Fzyaus03Kvdmo733dwnYS9AGJSDg0Zu8mNfA==
 
-vscode-ripgrep@^1.5.5:
+vscode-ripgrep@^1.3.1:
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.5.5.tgz#24c0e9cb356cf889c98e15ecb58f9cf654a1d961"
+  resolved "https://registry.npmjs.org/vscode-ripgrep/-/vscode-ripgrep-1.5.5.tgz#24c0e9cb356cf889c98e15ecb58f9cf654a1d961"
   integrity sha512-OrPrAmcun4+uZAuNcQvE6CCPskh+5AsjANod/Q3zRcJcGNxgoOSGlQN9RPtatkUNmkN8Nn8mZBnS1jMylu/dKg==
 
 vscode-windows-registry@1.0.1:


### PR DESCRIPTION


### Description

degrade vscode-ripgrep to v1.3.1 to test pass travis error.
