### PR TITLE
opti: optimization of paste

### DIFF
--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -54,6 +54,13 @@ const pasteCtrl = ContentState => {
   }
 
   ContentState.prototype.standardizeHTML = function (html) {
+    // Only extract the `body.innerHTML` when the `html` is a full HTML Document.
+    if (/<body>[\s\S]*<\/body>/.test(html)) {
+      const match = /<body>([\s\S]*)<\/body>/.exec(html)
+      if (match && typeof match[1] === 'string') {
+        html = match[1]
+      }
+    }
     const sanitizedHtml = sanitize(html, PREVIEW_DOMPURIFY_CONFIG)
     const tempWrapper = document.createElement('div')
     tempWrapper.innerHTML = sanitizedHtml


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

[Description of the bug or feature]

When copy from `Note` on macOS or from `weChat`, the paste html always contains full HTML document, but we only need the body content.

--

#### Please, don't submit `/dist` files with your PR!
