### PR TITLE
Fix package filenames due electron-builder change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ script:
   # Calculate checksums
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x64.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x86_64.AppImage ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/Mark\ Text-*-mac.zip ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/Mark\ Text-*.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-*-mac.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-*.dmg ; fi
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,8 +47,8 @@ build_script:
   - yarn run release:win
 
   # calculate checksums
-  - ps: get-filehash -Algorithm SHA256 "build\Mark Text *.exe"
-  - ps: get-filehash -Algorithm SHA256 "build\Mark Text-*-win.zip"
+  - ps: get-filehash -Algorithm SHA256 "build\marktext-*.exe"
+  - ps: get-filehash -Algorithm SHA256 "build\marktext-*-win.zip"
 
 test: off
 # test_script:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "build": {
     "productName": "Mark Text",
     "appId": "com.github.marktext.marktext",
+    "artifactName": "marktext-${version}-${arch}.${ext}",
     "asar": true,
     "directories": {
       "output": "build"
@@ -120,7 +121,6 @@
         "StartupWMClass": "marktext",
         "Keywords": "marktext;"
       },
-      "artifactName": "marktext-${version}-${arch}.${ext}",
       "target": [
         {
           "target": "AppImage"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "build": {
     "productName": "Mark Text",
     "appId": "com.github.marktext.marktext",
-    "artifactName": "marktext-${version}-${arch}.${ext}",
     "asar": true,
     "directories": {
       "output": "build"
@@ -67,6 +66,7 @@
       }
     ],
     "dmg": {
+      "artifactName": "marktext-${version}.${ext}",
       "contents": [
         {
           "x": 410,
@@ -82,10 +82,12 @@
       ]
     },
     "mac": {
+      "artifactName": "marktext-${version}-mac.${ext}",
       "icon": "resources/icons/icon.icns",
       "darkModeSupport": true
     },
     "win": {
+      "artifactName": "marktext-${version}-${arch}-win.${ext}",
       "icon": "resources/icons/icon.ico",
       "target": [
         {
@@ -113,6 +115,7 @@
       "include": "resources/windows/installer.nsh"
     },
     "linux": {
+      "artifactName": "marktext-${version}-${arch}.${ext}",
       "category": "Office;TextEditor;Utility",
       "mimeTypes": [
         "text/markdown"

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
       "requestedExecutionLevel": "asInvoker"
     },
     "nsis": {
+      "artifactName": "marktext-setup-${version}.${ext}",
       "perMachine": false,
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

This change should fix the wrong package filenames due an electron-builder breaking change.

**Tested on:**

- [x] Linux
- [x] macOS (maybe we must remove the `${arch}` on macOS)
- [x] Windows

