### PR TITLE
Unpack all node modules during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "productName": "Mark Text",
     "appId": "com.github.marktext.marktext",
     "asar": true,
+    "asarUnpack": [
+      "**/*.node"
+    ],
     "directories": {
       "output": "build"
     },


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1164
| License          | MIT

### Description

This PR fixes issues with restricted execution permissions on Linux. All node modules will be unpacked during build and not at runtime. It should also improve startup time a bit.
