### PR TITLE
fix: #1254 alt accelerator on Linux and Windows

### DIFF
--- a/src/main/menu/templates/edit.js
+++ b/src/main/menu/templates/edit.js
@@ -4,7 +4,7 @@ import { isOsx } from '../../config'
 export default function (keybindings, userPreference) {
   const { aidou } = userPreference.getAll()
   return {
-    label: 'Edit',
+    label: '&Edit',
     submenu: [{
       label: 'Undo',
       accelerator: keybindings.getAccelerator('editUndo'),

--- a/src/main/menu/templates/file.js
+++ b/src/main/menu/templates/file.js
@@ -7,7 +7,7 @@ import { isOsx } from '../../config'
 export default function (keybindings, userPreference, recentlyUsedFiles) {
   const { autoSave } = userPreference.getAll()
   const fileMenu = {
-    label: 'File',
+    label: '&File',
     submenu: [{
       label: 'New Tab',
       accelerator: keybindings.getAccelerator('fileNewFile'),

--- a/src/main/menu/templates/format.js
+++ b/src/main/menu/templates/format.js
@@ -3,7 +3,7 @@ import * as actions from '../actions/format'
 export default function (keybindings) {
   return {
     id: 'formatMenuItem',
-    label: 'Format',
+    label: 'F&ormat',
     submenu: [{
       id: 'strongMenuItem',
       label: 'Strong',

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -29,7 +29,7 @@ const isUpdatable = () => {
 
 export default function () {
   const helpMenu = {
-    label: 'Help',
+    label: '&Help',
     role: 'help',
     submenu: [{
       label: 'Learn More',

--- a/src/main/menu/templates/paragraph.js
+++ b/src/main/menu/templates/paragraph.js
@@ -3,7 +3,7 @@ import * as actions from '../actions/paragraph'
 export default function (keybindings) {
   return {
     id: 'paragraphMenuEntry',
-    label: 'Paragraph',
+    label: '&Paragraph',
     submenu: [{
       id: 'heading1MenuItem',
       label: 'Heading 1',

--- a/src/main/menu/templates/theme.js
+++ b/src/main/menu/templates/theme.js
@@ -3,7 +3,7 @@ import * as actions from '../actions/theme'
 export default function (userPreference) {
   const { theme } = userPreference.getAll()
   return {
-    label: 'Theme',
+    label: '&Theme',
     id: 'themeMenu',
     submenu: [{
       label: 'Cadmium Light',

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -3,7 +3,7 @@ import * as actions from '../actions/view'
 
 export default function (keybindings) {
   const viewMenu = {
-    label: 'View',
+    label: '&View',
     submenu: [{
       id: 'sourceCodeModeMenuItem',
       label: 'Source Code Mode',

--- a/src/main/menu/templates/window.js
+++ b/src/main/menu/templates/window.js
@@ -3,7 +3,7 @@ import { isOsx } from '../../config'
 
 export default function (keybindings) {
   const menu = {
-    label: 'Window',
+    label: '&Window',
     role: 'window',
     submenu: [{
       label: 'Minimize',


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #1254
| License          | MIT

### Description

Added ability to use the `alt` accelerator on Linux and Windows to open the menu.
