### PR TITLE
 fix: #1128 recommend title exception when heading contains spaces only

### DIFF
--- a/src/main/utils/index.js
+++ b/src/main/utils/index.js
@@ -7,9 +7,12 @@ export const getUniqueId = () => {
   return `${ID_PREFIX}${id++}`
 }
 
-// TODO: We should map all heading into the MarkdownDocument.
+// TODO: Remove this function and load the recommend title from the editor (renderer) when
+// requesting the document to save/export.
 export const getRecommendTitleFromMarkdownString = markdown => {
-  const tokens = markdown.match(/#{1,6} {1,}(.+)(?:\n|$)/g)
+  // NOTE: We should read the title from the renderer cache because this regex matches in
+  // code blocks too.
+  const tokens = markdown.match(/#{1,6} {1,}(.*\S.*)(?:\n|$)/g)
   if (!tokens) return ''
   const headers = tokens.map(t => {
     const matches = t.trim().match(/(#{1,6}) {1,}(.+)/)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1128
| License          | MIT

### Description

Fixed an exception in main process due invalid regex. `getRecommendTitleFromMarkdownString` should be replaced later by the top tree heading from the renderer process cache when requesting file save/export etc.
