### PR TITLE
Cycle through tabs

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -137,8 +137,9 @@ Here is an example:
 
 **Misc**
 
-| Id                  | Default                                  | Description             |
-| ------------------- | ---------------------------------------- | ----------------------- |
-| `tabsCycle`         | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>      | Cycle through tabs      |
-| `tabsSwitchToLeft`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>   | Switch tab to the left  |
-| `tabsSwitchToRight` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd> | Switch tab to the right |
+| Id                  | Default                                              | Description                  |
+| ------------------- | ---------------------------------------------------- | ---------------------------- |
+| `tabsCycleForward`  | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>                  | Cycle through tabs           |
+| `tabsCycleBackward` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> | Cycle backwards through tabs |
+| `tabsSwitchToLeft`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>               | Switch tab to the left       |
+| `tabsSwitchToRight` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd>             | Switch tab to the right      |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -32,103 +32,113 @@ Here is an example:
 
 **Mark Text menu (macOS only):**
 
-| Id                | Description                             |
-| ----------------- | --------------------------------------- |
-| `mtHide`          | Hide Mark Text                          |
-| `mtHideOthers`    | Hide all other windows except Mark Text |
-| `filePreferences` | Open settings window                    |
-| `fileQuit`        | Quit Mark Text                          |
+| Id                | Default                                        | Description                             |
+| ----------------- | ---------------------------------------------- | --------------------------------------- |
+| `mtHide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide Mark Text                          |
+| `mtHideOthers`    | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
+| `filePreferences` | <kbd>Command</kbd>+<kbd>,</kbd>                | Open settings window                    |
+| `fileQuit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit Mark Text                          |
 
 **File menu:**
 
-| Id                | Description                               |
-|:----------------- | ----------------------------------------- |
-| `fileNewFile`     | New file                                  |
-| `fileNewTab`      | New tab                                   |
-| `fileOpenFile`    | Open markdown file                        |
-| `fileOpenFolder`  | Open folder                               |
-| `fileSave`        | Save                                      |
-| `fileSaveAs`      | Save as...                                |
-| `filePreferences` | Open settings window (Linux/Windows only) |
-| `fileCloseTab`    | Close tab                                 |
-| `fileCloseWindow` | Close window                              |
-| `fileQuit`        | Quit Mark Text (Linux/Windows only)       |
+| Id                | Default                                            | Description                               |
+|:----------------- | -------------------------------------------------- | ----------------------------------------- |
+| `fileNewFile`     | <kbd>CmdOrCtrl</kbd>+<kbd>N</kbd>                  | New file                                  |
+| `fileNewTab`      | <kbd>CmdOrCtrl</kbd>+<kbd>T</kbd>                  | New tab                                   |
+| `fileOpenFile`    | <kbd>CmdOrCtrl</kbd>+<kbd>O</kbd>                  | Open markdown file                        |
+| `fileOpenFolder`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                               |
+| `fileSave`        | <kbd>CmdOrCtrl</kbd>+<kbd>S</kbd>                  | Save                                      |
+| `fileSaveAs`      | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                                |
+| `filePrint`       | <kbd>Ctrl</kbd>+<kbd>P</kbd>                       | Print current tab                         |
+| `filePreferences` | <kbd>Ctrl</kbd>+<kbd>,</kbd>                       | Open settings window (Linux/Windows only) |
+| `fileCloseTab`    | <kbd>CmdOrCtrl</kbd>+<kbd>W</kbd>                  | Close tab                                 |
+| `fileCloseWindow` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                              |
+| `fileQuit`        | <kbd>CmdOrCtrl</kbd>+<kbd>Q</kbd>                  | Quit Mark Text (Linux/Windows only)       |
 
 **Edit menu:**
 
-| Id                    | Description                                     |
-|:--------------------- | ----------------------------------------------- |
-| `editUndo`            | Undo last operation                             |
-| `editRedo`            | Redo last operation                             |
-| `editCut`             | Cut selected text                               |
-| `editCopy`            | Copy selected text                              |
-| `editPaste`           | Paste text                                      |
-| `editCopyAsMarkdown`  | Copy selected text as markdown                  |
-| `editCopyAsPlaintext` | Copy selected text as plaintext                 |
-| `editSelectAll`       | Select all text of the document                 |
-| `editDuplicate`       | Duplicate the current paragraph                 |
-| `editCreateParagraph` | Create a new paragraph after the current one    |
-| `editDeleteParagraph` | Delete current paragraph                        |
-| `editFind`            | Find information in the document                |
-| `editFindNext`        | Continue the search and find the next match     |
-| `editFindPrevious`    | Continue the search and find the previous match |
-| `editReplace`         | Replace the information with a replacement      |
-| `editAidou`           | Show Aidou dialog                               |
-| `editScreenshot`      | Get the screenshot                              |
+| Id                    | Default                                            | Description                                     |
+|:--------------------- | -------------------------------------------------- | ----------------------------------------------- |
+| `editUndo`            | <kbd>CmdOrCtrl</kbd>+<kbd>Z</kbd>                  | Undo last operation                             |
+| `editRedo`            | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> | Redo last operation                             |
+| `editCut`             | <kbd>CmdOrCtrl</kbd>+<kbd>X</kbd>                  | Cut selected text                               |
+| `editCopy`            | <kbd>CmdOrCtrl</kbd>+<kbd>C</kbd>                  | Copy selected text                              |
+| `editPaste`           | <kbd>CmdOrCtrl</kbd>+<kbd>V</kbd>                  | Paste text                                      |
+| `editCopyAsMarkdown`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> | Copy selected text as markdown                  |
+| `editCopyAsPlaintext` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> | Copy selected text as plaintext                 |
+| `editSelectAll`       | <kbd>CmdOrCtrl</kbd>+<kbd>A</kbd>                  | Select all text of the document                 |
+| `editDuplicate`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Duplicate the current paragraph                 |
+| `editCreateParagraph` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> | Create a new paragraph after the current one    |
+| `editDeleteParagraph` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> | Delete current paragraph                        |
+| `editFind`            | <kbd>CmdOrCtrl</kbd>+<kbd>F</kbd>                  | Find information in the document                |
+| `editFindNext`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Continue the search and find the next match     |
+| `editFindPrevious`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Continue the search and find the previous match |
+| `editReplace`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>   | Replace the information with a replacement      |
+| `editAidou`           | <kbd>CmdOrCtrl</kbd>+<kbd>/</kbd>                  | Show Aidou dialog                               |
+| `editScreenshot`      | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>A</kbd>     | Get the screenshot (macOS only)                 |
 
 **Paragraph menu:**
 
-| Id                         | Description                              |
-| -------------------------- | ---------------------------------------- |
-| `paragraphHeading1`        | Set line as heading 1                    |
-| `paragraphHeading2`        | Set line as heading 2                    |
-| `paragraphHeading3`        | Set line as heading 3                    |
-| `paragraphHeading4`        | Set line as heading 4                    |
-| `paragraphHeading5`        | Set line as heading 5                    |
-| `paragraphHeading6`        | Set line as heading 6                    |
-| `paragraphUpgradeHeading`  | Upgrade a heading                        |
-| `paragraphDegradeHeading`  | Degrade a heading                        |
-| `paragraphTable`           | Insert a table                           |
-| `paragraphCodeFence`       | Insert a code block                      |
-| `paragraphQuoteBlock`      | Insert a quote block                     |
-| `paragraphMathBlock`       | Insert a math block                      |
-| `paragraphHtmlBlock`       | Insert a HTML block                      |
-| `paragraphOrderList`       | Insert a ordered list                    |
-| `paragraphBulletList`      | Insert a unordered list                  |
-| `paragraphTaskList`        | Insert a task list                       |
-| `paragraphLooseListItem`   | Convert a list item to a loose list item |
-| `paragraphParagraph`       | Convert a heading to a paragraph         |
-| `paragraphHorizontalLine`  | Add a horizontal line                    |
-| `paragraphYAMLFrontMatter` | Insert a YAML frontmatter block          |
+| Id                         | Default                                            | Description                                       |
+| -------------------------- | -------------------------------------------------- | ------------------------------------------------- |
+| `paragraphHeading1`        | <kbd>CmdOrCtrl</kbd>+<kbd>1</kbd>                  | Set line as heading 1                             |
+| `paragraphHeading2`        | <kbd>CmdOrCtrl</kbd>+<kbd>2</kbd>                  | Set line as heading 2                             |
+| `paragraphHeading3`        | <kbd>CmdOrCtrl</kbd>+<kbd>3</kbd>                  | Set line as heading 3                             |
+| `paragraphHeading4`        | <kbd>CmdOrCtrl</kbd>+<kbd>4</kbd>                  | Set line as heading 4                             |
+| `paragraphHeading5`        | <kbd>CmdOrCtrl</kbd>+<kbd>5</kbd>                  | Set line as heading 5                             |
+| `paragraphHeading6`        | <kbd>CmdOrCtrl</kbd>+<kbd>6</kbd>                  | Set line as heading 6                             |
+| `paragraphUpgradeHeading`  | <kbd>CmdOrCtrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                                 |
+| `paragraphDegradeHeading`  | <kbd>CmdOrCtrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                                 |
+| `paragraphTable`           | <kbd>CmdOrCtrl</kbd>+<kbd>T</kbd>                  | Insert a table                                    |
+| `paragraphCodeFence`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>   | Insert a code block                               |
+| `paragraphQuoteBlock`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd>   | Insert a quote block                              |
+| `paragraphMathBlock`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>   | Insert a math block                               |
+| `paragraphHtmlBlock`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>J/H</kbd> | Insert a HTML block (`J` on macOS, `H` otherwise) |
+| `paragraphOrderList`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>   | Insert a ordered list                             |
+| `paragraphBulletList`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Insert a unordered list                           |
+| `paragraphTaskList`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>   | Insert a task list                                |
+| `paragraphLooseListItem`   | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>   | Convert a list item to a loose list item          |
+| `paragraphParagraph`       | <kbd>CmdOrCtrl</kbd>+<kbd>0</kbd>                  | Convert a heading to a paragraph                  |
+| `paragraphHorizontalLine`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>-</kbd>   | Add a horizontal line                             |
+| `paragraphYAMLFrontMatter` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd>   | Insert a YAML frontmatter block                   |
 
 **Format menu:**
 
-| Id                  | Description                                 |
-| ------------------- | ------------------------------------------- |
-| `formatStrong`      | Set the font of the selected text to bold   |
-| `formatEmphasis`    | Set the font of the selected text to italic |
-| `formatUnderline`   | Change the selected text to underline       |
-| `formatInlineCode`  | Change the selected text to inline code     |
-| `formatStrike`      | Strike through the selected text            |
-| `formatHyperlink`   | Insert a hyperlink                          |
-| `formatImage`       | Insert a image                              |
-| `formatClearFormat` | Clear the formatting of the selected text   |
+| Id                  | Default                                            | Description                                 |
+| ------------------- | -------------------------------------------------- | ------------------------------------------- |
+| `formatStrong`      | <kbd>CmdOrCtrl</kbd>+<kbd>B</kbd>                  | Set the font of the selected text to bold   |
+| `formatEmphasis`    | <kbd>CmdOrCtrl</kbd>+<kbd>I</kbd>                  | Set the font of the selected text to italic |
+| `formatUnderline`   | <kbd>CmdOrCtrl</kbd>+<kbd>U</kbd>                  | Change the selected text to underline       |
+| `formatInlineCode`  | <kbd>CmdOrCtrl</kbd>+<kbd>`</kbd>                  | Change the selected text to inline code     |
+| `formatInlineMath`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> | Change the selected text to inline math     |
+| `formatStrike`      | <kbd>CmdOrCtrl</kbd>+<kbd>D</kbd>                  | Strike through the selected text            |
+| `formatHyperlink`   | <kbd>CmdOrCtrl</kbd>+<kbd>L</kbd>                  | Insert a hyperlink                          |
+| `formatImage`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> | Insert a image                              |
+| `formatClearFormat` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> | Clear the formatting of the selected text   |
 
 **Window menu:**
 
-| Id                       | Description            |
-| ------------------------ | ---------------------- |
-| `windowMinimize`         | Minimize the window    |
-| `windowToggleFullScreen` | Toggle fullscreen mode |
+| Id               | Default                           | Description         |
+| ---------------- | --------------------------------- | ------------------- |
+| `windowMinimize` | <kbd>CmdOrCtrl</kbd>+<kbd>M</kbd> | Minimize the window |
 
 **View menu:**
 
-| Id                            | Description                              |
-| ----------------------------- | ---------------------------------------- |
-| `viewSourceCodeMode`          | Switch to source code mode               |
-| `viewTypewriterMode`          | Enable typewriter mode                   |
-| `viewFocusMode`               | Enable focus mode                        |
-| `viewToggleSideBar`           | Toggle sidebar                           |
-| `viewToggleTabBar`            | Toggle tabbar                            |
-| `viewDevToggleDeveloperTools` | Toggle developer tools (debug mode only) |
-| `viewDevReload`               | Reload window (debug mode only)          |
+| Id                            | Default                                            | Description                                                                          |
+| ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `viewToggleFullScreen`        | <kbd>F11</kbd>                                     | Toggle fullscreen mode (or <kbd>Ctrl</kbd>+<kbd>Command</kbd>+<kbd>F</kbd> on macOS) |
+| `viewSourceCodeMode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode                                                           |
+| `viewTypewriterMode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                                                               |
+| `viewFocusMode`               | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                                                                    |
+| `viewToggleSideBar`           | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                                                                       |
+| `viewToggleTabBar`            | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                                                                        |
+| `viewDevToggleDeveloperTools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only)                                             |
+| `viewDevReload`               | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)                                                      |
+
+**Misc**
+
+| Id                  | Default                                  | Description             |
+| ------------------- | ---------------------------------------- | ----------------------- |
+| `tabsCycle`         | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>      | Cycle through tabs      |
+| `tabsSwitchToLeft`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>   | Switch tab to the left  |
+| `tabsSwitchToRight` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd> | Switch tab to the right |

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -104,7 +104,8 @@ class Keybindings {
       ['viewDevReload', 'CmdOrCtrl+R'],
 
       // Misc
-      ['tabsCycle', 'CmdOrCtrl+Tab'],
+      ['tabsCycleForward', 'CmdOrCtrl+Tab'],
+      ['tabsCycleBackward', 'CmdOrCtrl+Shift+Tab'],
       ['tabsSwitchToLeft', 'CmdOrCtrl+PageUp'],
       ['tabsSwitchToRight', 'CmdOrCtrl+PageDown']
     ])

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -21,11 +21,11 @@ class Keybindings {
     this.configPath = path.join(userDataPath, 'keybindings.json')
 
     this.keys = new Map([
-      // marktext - macOS only
+      // Mark Text - macOS only
       ['mtHide', 'Command+H'],
       ['mtHideOthers', 'Command+Alt+H'],
 
-      // file menu
+      // File menu
       ['fileNewFile', 'CmdOrCtrl+N'],
       ['fileNewTab', 'CmdOrCtrl+Shift+T'],
       ['fileOpenFile', 'CmdOrCtrl+O'],
@@ -38,7 +38,7 @@ class Keybindings {
       ['fileCloseWindow', 'CmdOrCtrl+Shift+W'],
       ['fileQuit', 'CmdOrCtrl+Q'],
 
-      // edit menu
+      // Edit menu
       ['editUndo', 'CmdOrCtrl+Z'],
       ['editRedo', 'CmdOrCtrl+Shift+Z'],
       ['editCut', 'CmdOrCtrl+X'],
@@ -57,7 +57,7 @@ class Keybindings {
       ['editAidou', 'CmdOrCtrl+/'],
       ['editScreenshot', 'CmdOrCtrl+Alt+A'],
 
-      // paragraph menu
+      // Paragraph menu
       ['paragraphHeading1', 'CmdOrCtrl+1'],
       ['paragraphHeading2', 'CmdOrCtrl+2'],
       ['paragraphHeading3', 'CmdOrCtrl+3'],
@@ -79,7 +79,7 @@ class Keybindings {
       ['paragraphHorizontalLine', 'CmdOrCtrl+Alt+-'],
       ['paragraphYAMLFrontMatter', 'CmdOrCtrl+Alt+Y'],
 
-      // format menu
+      // Format menu
       ['formatStrong', 'CmdOrCtrl+B'],
       ['formatEmphasis', 'CmdOrCtrl+I'],
       ['formatUnderline', 'CmdOrCtrl+U'],
@@ -90,10 +90,10 @@ class Keybindings {
       ['formatImage', 'CmdOrCtrl+Shift+I'],
       ['formatClearFormat', 'Shift+CmdOrCtrl+R'],
 
-      // window menu
+      // Window menu
       ['windowMinimize', 'CmdOrCtrl+M'],
 
-      // view menu
+      // View menu
       ['viewToggleFullScreen', isOsx ? 'Ctrl+Command+F' : 'F11'],
       ['viewSourceCodeMode', 'CmdOrCtrl+Alt+S'],
       ['viewTypewriterMode', 'CmdOrCtrl+Alt+T'],
@@ -101,7 +101,12 @@ class Keybindings {
       ['viewToggleSideBar', 'CmdOrCtrl+J'],
       ['viewToggleTabBar', 'CmdOrCtrl+Alt+B'],
       ['viewDevToggleDeveloperTools', 'CmdOrCtrl+Alt+I'],
-      ['viewDevReload', 'CmdOrCtrl+R']
+      ['viewDevReload', 'CmdOrCtrl+R'],
+
+      // Misc
+      ['tabsCycle', 'CmdOrCtrl+Tab'],
+      ['tabsSwitchToLeft', 'CmdOrCtrl+PageUp'],
+      ['tabsSwitchToRight', 'CmdOrCtrl+PageDown']
     ])
 
     // fix non-US keyboards

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -285,9 +285,16 @@ class AppMenu {
 
   _appendMiscShortcuts = shortcutMap => {
     shortcutMap.push({
-      accelerator: this._keybindings.getAccelerator('tabsCycle'),
+      accelerator: this._keybindings.getAccelerator('tabsCycleForward'),
       click: (menuItem, win) => {
         win.webContents.send('mt::tabs-cycle-right')
+      },
+      id: null
+    })
+    shortcutMap.push({
+      accelerator: this._keybindings.getAccelerator('tabsCycleBackward'),
+      click: (menuItem, win) => {
+        win.webContents.send('mt::tabs-cycle-left')
       },
       id: null
     })

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -164,7 +164,7 @@ class AppMenu {
     }
   }
 
-  buildEditorMenu (createShortcutMap, recentUsedDocuments) {
+  buildEditorMenu (createShortcutMap, recentUsedDocuments = null) {
     if (!recentUsedDocuments) {
       recentUsedDocuments = this.getRecentlyUsedDocuments()
     }
@@ -175,6 +175,7 @@ class AppMenu {
     let shortcutMap = null
     if (createShortcutMap) {
       shortcutMap = parseMenu(menuTemplate)
+      this._appendMiscShortcuts(shortcutMap)
     }
 
     return {
@@ -279,6 +280,30 @@ class AppMenu {
         return
       }
       aidouMenu.visible = bool
+    })
+  }
+
+  _appendMiscShortcuts = shortcutMap => {
+    shortcutMap.push({
+      accelerator: this._keybindings.getAccelerator('tabsCycle'),
+      click: (menuItem, win) => {
+        win.webContents.send('mt::tabs-cycle-right')
+      },
+      id: null
+    })
+    shortcutMap.push({
+      accelerator: this._keybindings.getAccelerator('tabsSwitchToLeft'),
+      click: (menuItem, win) => {
+        win.webContents.send('mt::tabs-cycle-left')
+      },
+      id: null
+    })
+    shortcutMap.push({
+      accelerator: this._keybindings.getAccelerator('tabsSwitchToRight'),
+      click: (menuItem, win) => {
+        win.webContents.send('mt::tabs-cycle-right')
+      },
+      id: null
     })
   }
 

--- a/src/renderer/pages/app.vue
+++ b/src/renderer/pages/app.vue
@@ -140,6 +140,7 @@ export default {
     dispatch('LINTEN_FOR_SET_LINE_ENDING')
     dispatch('LISTEN_FOR_NEW_TAB')
     dispatch('LISTEN_FOR_CLOSE_TAB')
+    dispatch('LISTEN_FOR_TAB_CYCLE')
     dispatch('LINTEN_FOR_PRINT_SERVICE_CLEARUP')
     dispatch('LINTEN_FOR_EXPORT_SUCCESS')
     dispatch('LISTEN_FOR_FILE_CHANGE')


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #1124
| License          | MIT

### Description

Added new shortcuts for tab management:

| Id                  | Default                                  | Description             |
| ------------------- | ---------------------------------------- | ----------------------- |
| `tabsCycle`         | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>      | Cycle through tabs      |
| `tabsSwitchToLeft`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>   | Switch tab to the left  |
| `tabsSwitchToRight` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd> | Switch tab to the right |

---

resolves #1124
