### PR TITLE
fix: #1299 add system emoji fallback fonts

### DIFF
--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -1,11 +1,10 @@
 import path from 'path'
-import { isLinux } from './util'
 export const PATH_SEPARATOR = path.sep
 
 export const THEME_STYLE_ID = 'ag-theme'
 export const COMMON_STYLE_ID = 'ag-common-style'
 
-export const DEFAULT_EDITOR_FONT_FAMILY = `"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif ${isLinux ? ', "Noto Color Emoji"' : ''}`
+export const DEFAULT_EDITOR_FONT_FAMILY = '"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif, Segoe UI Emoji, Apple Color Emoji, "Noto Color Emoji"'
 export const DEFAULT_CODE_FONT_FAMILY = '"DejaVu Sans Mono", "Source Code Pro", "Droid Sans Mono", monospace'
 export const DEFAULT_STYLE = {
   codeFontFamily: DEFAULT_CODE_FONT_FAMILY,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1299
| License          | MIT

### Description

This PR fixes #1299.

@Jocs Should we add `Noto Color Emoji` TTF font to Mark Text resource files? The only problem is that the font is 7,4MB large but we also ship ~60MB diagram libraries. I think we should outsource diagram libraries in extensions if available.
