### PR TITLE
Fix: #1267

### DIFF
--- a/src/muya/lib/contentState/enterCtrl.js
+++ b/src/muya/lib/contentState/enterCtrl.js
@@ -423,7 +423,7 @@ const enterCtrl = ContentState => {
         // cursor at end of paragraph or at begin of paragraph
         if (type === 'li') {
           if (block.listItemType === 'task') {
-            const { checked } = block.children[0]
+            const checked = false
             newBlock = this.createTaskItemBlock(null, checked)
           } else {
             newBlock = this.createBlockLi()


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1267 
| License          | MIT

### Description

1. Create the same check type(checked or not) when cursor in in previous task list item content.
2. Create unchecked task list item, when the cursor is at the end of task list item and press enter.

```md
- [x] foo<cursor>bar
```

will create checked task list item.

```md
- [x] foo
- [x] bar
```

if cursor at the end.

```md
- [x] foo bar<cursor>
```

will create unchecked task list item when press enter.

```md
- [x] foo bar
- [ ]<cursor>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marktext/marktext/1372)
<!-- Reviewable:end -->
