### PR TITLE
Fix: #1390 prevent XSS attact

### DIFF
--- a/src/muya/lib/parser/render/renderInlines/htmlTag.js
+++ b/src/muya/lib/parser/render/renderInlines/htmlTag.js
@@ -1,5 +1,8 @@
+import createDOMPurify from 'dompurify'
 import { CLASS_OR_ID, BLOCK_TYPE6 } from '../../../config'
 import { snakeToCamel } from '../../../utils'
+
+const { sanitize } = createDOMPurify(window)
 
 export default function htmlTag (h, cursor, block, token, outerClass) {
   const { tag, openTag, closeTag, children, attrs } = token
@@ -35,7 +38,8 @@ export default function htmlTag (h, cursor, block, token, outerClass) {
         // if  tag is a block level element, use a inline element `span` to instead.
         // Because we can not nest a block level element in span element(line is span element)
         // we also recommand user not use block level element in paragraph. use block element in html block.
-        let selector = BLOCK_TYPE6.includes(tag) ? 'span' : tag
+        // Use code !sanitize(`<${tag}>`) to filter some malicious tags. for example: <embed>.
+        let selector = BLOCK_TYPE6.includes(tag) || !sanitize(`<${tag}>`) ? 'span' : tag
         selector += `.${CLASS_OR_ID.AG_INLINE_RULE}`
         const data = {
           attrs: {},

--- a/src/muya/lib/parser/utils.js
+++ b/src/muya/lib/parser/utils.js
@@ -7,7 +7,9 @@ export const PUNCTUATION_REG = new RegExp(/[!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~\x
 export const WHITELIST_ATTRIBUTES = [
   'align', 'alt', 'checked', 'class', 'color', 'dir', 'disabled', 'for', 'height', 'hidden',
   'href', 'id', 'lang', 'lazyload', 'rel', 'spellcheck', 'src', 'srcset', 'start', 'style',
-  'target', 'title', 'type', 'value', 'width', 'data-align'
+  'target', 'title', 'type', 'value', 'width',
+  // Used in img
+  'data-align'
 ]
 
 // export const unicodeZsCategory = [


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1390
| License          | MIT

### Description

Because `dompurify` does not export `safety tags`, so use `sanitize(`<${tag}>`)` to judge whether the tag is safe. if it return empty string, it unsafe tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marktext/marktext/1393)
<!-- Reviewable:end -->
