### PR TITLE
fix: 1382 portable application data directory

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **:beetle:Bug fix**
 
+- Fixed portable mode detection if current working directory don't match the application directory (#1382)
+
 ## 0.15.0
 
 **:warning:Breaking Changes:**

--- a/src/main/cli/index.js
+++ b/src/main/cli/index.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import { app } from 'electron'
 import os from 'os'
 import { isDirectory } from 'common/filesystem'
 import parseArgs from './parser'
@@ -51,7 +52,7 @@ const cli = () => {
   // Check for portable mode and ensure the user data path is absolute. We assume
   // that the path is writable if not this lead to an application crash.
   if (!args['--user-data-dir']) {
-    const portablePath = path.resolve('marktext-user-data')
+    const portablePath = path.join(app.getAppPath(), 'marktext-user-data')
     if (isDirectory(portablePath)) {
       args['--user-data-dir'] = portablePath
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New tests added? | yes/not needed
| Fixed tickets    | #1382
| License          | MIT

### Description

Fixed wrong path concatenation.
