### PR TITLE
Update Travi CI distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: node_js
 node_js:
-  - 10
+  - 12
 
 matrix:
   include:
@@ -65,12 +65,10 @@ script:
 
   # Unit and e2e tests
   - yarn run test
-  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" yarn run test ; fi
-  #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run test ; fi
 
   # Build binaries
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn run release:linux ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run release:mac ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn run release:linux --publish always ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run release:mac --publish always ; fi
 
   # Calculate checksums
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x64.tar.gz ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ node_js:
 matrix:
   include:
   - os: osx
-    osx_image: xcode9.2
+    osx_image: xcode9.4
     env: CC=clang CXX=clang++ npm_config_clang=1 MARKTEXT_IS_STABLE=1 MARKTEXT_EXIT_ON_ERROR=1
     compiler: clang
   - os: linux
-    dist: trusty
+    dist: bionic
     env: CC=clang CXX=clang++ npm_config_clang=1 MARKTEXT_IS_STABLE=1 MARKTEXT_EXIT_ON_ERROR=1 DISPLAY=:99.0
     compiler: clang
+    services:
+      - xvfb
 
 cache:
   directories:
@@ -53,7 +55,6 @@ install:
   - yarn --version
 
   # Fix cache between Linux and macOS build workers.
-  # - yarn cache clean vscode-ripgrep
   - rm -rf node_modules/vscode-ripgrep
 
   - yarn install --check-files --frozen-lockfile
@@ -63,8 +64,9 @@ script:
   - yarn run validate-licenses
 
   # Unit and e2e tests
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" yarn run test ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run test ; fi
+  - yarn run test
+  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x24" yarn run test ; fi
+  #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run test ; fi
 
   # Build binaries
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn run release:linux ; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 10 $env:PLATFORM
+  - ps: Install-Product node 12 $env:PLATFORM
 
   - node --version
   - npm --version
@@ -44,12 +44,10 @@ build_script:
   - yarn run validate-licenses
   - yarn run test
 
-  - yarn run release:win
+  - yarn run release:win --publish always
 
-  # calculate checksums
+  # Calculate checksums
   - ps: get-filehash -Algorithm SHA256 "build\marktext-*.exe"
   - ps: get-filehash -Algorithm SHA256 "build\marktext-*-win.zip"
 
 test: off
-# test_script:
-#   - yarn run test

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "main": "./dist/electron/main.js",
   "scripts": {
     "release": "echo 'Please run \"build\" or \"release:{linux,mac,win}\"' && exit 1",
-    "release:linux": "node .electron-vue/build.js && electron-builder build --linux --publish always",
-    "release:mac": "node .electron-vue/build.js && electron-builder build --mac --publish always",
-    "release:win": "node .electron-vue/build.js && electron-builder build --win --publish always",
+    "release:linux": "node .electron-vue/build.js && electron-builder build --linux",
+    "release:mac": "node .electron-vue/build.js && electron-builder build --mac",
+    "release:win": "node .electron-vue/build.js && electron-builder build --win",
     "build": "node .electron-vue/build.js && electron-builder",
     "build:bin": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

- [x] Upgrade distros
- [x] Set minimal node version to 12
- [ ] ~~Publish release only on `/^release-v[0-9.]+(?:-[0-9a-zA-Z\.]+)?$/` branches~~

@Jocs  We should only push releases from the `release-*` branches?!