### PR TITLE
Set CodeMirror viewport to infinity

### DIFF
--- a/src/renderer/components/editorWithTabs/sourceCode.vue
+++ b/src/renderer/components/editorWithTabs/sourceCode.vue
@@ -64,6 +64,12 @@ export default {
         lineWrapping: true,
         styleActiveLine: true,
         direction: textDirection,
+        // The amount of updates needed when scrolling. Settings this to >Infinity< or use CSS
+        // >height: auto< result in bad performance because the whole document is always rendered.
+        // Since we are using >height: auto< setting this to >Infinity< to fix #171. The best
+        // solution would be to set a fixed height like in #791 but then the scrollbar is not on
+        // the right side. Please also see CodeMirror#1104.
+        viewportMargin: Infinity,
         lineNumberFormatter (line) {
           if (line % 10 === 0 || line === 1) {
             return line
@@ -254,6 +260,7 @@ export default {
     overflow: auto;
   }
   .source-code .CodeMirror {
+    height: auto;
     margin: 50px auto;
     max-width: var(--editorAreaWidth);
     background: transparent;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #171
| License          | MIT

### Description

Please see code comment to this change. The change don't affect the source-code editor performance because it rendered all lines before too (`height: auto` was/is set on CodeMirror).

fixes #171
closes #791
