### PR TITLE
Unable to open markdown file by command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marktext",
-  "version": "0.15.0",
+  "version": "0.15.2",
   "homepage": "https://marktext.app/",
   "description": "Next generation markdown editor",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marktext",
-  "version": "0.15.2",
+  "version": "0.15.0",
   "homepage": "https://marktext.app/",
   "description": "Next generation markdown editor",
   "license": "MIT",

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -122,7 +122,7 @@ class App {
     const { _args: args, _openFilesCache } = this
     const { preferences } = this._accessor
 
-    if (!isOsx && args._.length) {
+    if (args._.length) {
       for (const pathname of args._) {
         // Ignore all unknown flags
         if (pathname.startsWith('--')) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1244 
| License          | MIT

### Description

MacOS system also need to read file path from args, `open file` event only listen to `right click` file and select `open with`(open file by menu like bellow).

<img width="998" alt="屏幕快照 2019-10-02 上午10 44 32" src="https://user-images.githubusercontent.com/9712830/66014484-ae174780-e501-11e9-9f5d-06d0b3157179.png">


--

#### Please, don't submit `/dist` files with your PR!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marktext/marktext/1429)
<!-- Reviewable:end -->
