### PR TITLE
Fix application menu exceptions

### DIFF
--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -8,7 +8,6 @@ import { isChildOfDirectory } from 'common/filesystem/paths'
 import { isLinux, isOsx } from '../config'
 import parseArgs from '../cli/parser'
 import { normalizeMarkdownPath } from '../filesystem/markdown'
-import { getMenuItemById } from '../menu'
 import { selectTheme } from '../menu/actions/theme'
 import { dockMenu } from '../menu/templates'
 import { watchers } from '../utils/imagePathAutoComplement'
@@ -155,21 +154,15 @@ class App {
         () => {
           const preferences = this._accessor.preferences
           const { theme } = preferences.getAll()
-          let setedTheme = null
-          if (systemPreferences.isDarkMode() && theme !== 'dark') {
+
+          // Application menu is automatically updated via preference manager.
+          if (systemPreferences.isDarkMode() && theme !== 'dark' &&
+            theme !== 'material-dark' && theme !== 'one-dark') {
             selectTheme('dark')
-            setedTheme = 'dark'
           }
-          if (!systemPreferences.isDarkMode() && theme === 'dark') {
+          if (!systemPreferences.isDarkMode() && theme !== 'light' &&
+            theme !== 'ulysses' && theme !== 'graphite') {
             selectTheme('light')
-            setedTheme = 'light'
-          }
-          if (setedTheme) {
-            const themeMenu = getMenuItemById('themeMenu')
-            const menuItem = themeMenu.submenu.items.filter(item => (item.id === setedTheme))[0]
-            if (menuItem) {
-              menuItem.checked = true
-            }
           }
         }
       )

--- a/src/main/app/windowManager.js
+++ b/src/main/app/windowManager.js
@@ -429,7 +429,7 @@ class WindowManager extends EventEmitter {
     ipcMain.on('window-toggle-always-on-top', win => {
       const flag = !win.isAlwaysOnTop()
       win.setAlwaysOnTop(flag)
-      this._appMenu.updateAlwaysOnTopMenu(flag)
+      this._appMenu.updateAlwaysOnTopMenu(win.id, flag)
     })
 
     ipcMain.on('broadcast-preferences-changed', prefs => {

--- a/src/main/menu/actions/edit.js
+++ b/src/main/menu/actions/edit.js
@@ -1,7 +1,6 @@
 import path from 'path'
 import { ipcMain, BrowserWindow } from 'electron'
 import log from 'electron-log'
-import { updateLineEndingMenu } from '../../menu'
 import { searchFilesAndDir } from '../../utils/imagePathAutoComplement'
 
 ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
@@ -20,10 +19,6 @@ ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
       log.error(err)
       return win.webContents.send(`mt::response-of-image-path-${id}`, [])
     })
-})
-
-ipcMain.on('AGANI::update-line-ending-menu', (e, lineEnding) => {
-  updateLineEndingMenu(lineEnding)
 })
 
 export const edit = (win, type) => {

--- a/src/main/menu/actions/format.js
+++ b/src/main/menu/actions/format.js
@@ -1,6 +1,3 @@
-import { ipcMain } from 'electron'
-import { getMenuItemById } from '../../menu'
-
 const MENU_ID_FORMAT_MAP = {
   strongMenuItem: 'strong',
   emphasisMenuItem: 'em',
@@ -9,17 +6,6 @@ const MENU_ID_FORMAT_MAP = {
   hyperlinkMenuItem: 'link',
   imageMenuItem: 'image',
   mathMenuItem: 'inline_math'
-}
-
-const selectFormat = formats => {
-  const formatMenuItem = getMenuItemById('formatMenuItem')
-  formatMenuItem.submenu.items.forEach(item => (item.checked = false))
-  formatMenuItem.submenu.items
-    .forEach(item => {
-      if (item.id && formats.some(format => format.type === MENU_ID_FORMAT_MAP[item.id])) {
-        item.checked = true
-      }
-    })
 }
 
 export const format = (win, type) => {
@@ -31,6 +17,18 @@ export const format = (win, type) => {
   win.webContents.send('AGANI::format', { type })
 }
 
-ipcMain.on('AGANI::selection-formats', (e, formats) => {
-  selectFormat(formats)
-})
+// --- IPC events -------------------------------------------------------------
+
+// NOTE: Don't use static `getMenuItemById` here, instead request the menu by
+//       window id from `AppMenu` manager.
+
+export const updateFormatMenu = (applicationMenu, formats) => {
+  const formatMenuItem = applicationMenu.getMenuItemById('formatMenuItem')
+  formatMenuItem.submenu.items.forEach(item => (item.checked = false))
+  formatMenuItem.submenu.items
+    .forEach(item => {
+      if (item.id && formats.some(format => format.type === MENU_ID_FORMAT_MAP[item.id])) {
+        item.checked = true
+      }
+    })
+}

--- a/src/main/menu/actions/view.js
+++ b/src/main/menu/actions/view.js
@@ -1,7 +1,5 @@
-import { ipcMain, BrowserWindow } from 'electron'
 import { getMenuItemById } from '../../menu'
 
-const sourceCodeModeMenuItemId = 'sourceCodeModeMenuItem'
 const typewriterModeMenuItemId = 'typewriterModeMenuItem'
 const focusModeMenuItemId = 'focusModeMenuItem'
 
@@ -28,23 +26,14 @@ export const showTabBar = win => {
   }
 }
 
-ipcMain.on('AGANI::ask-for-mode', e => {
-  const sourceCodeModeMenuItem = getMenuItemById(sourceCodeModeMenuItemId)
-  const typewriterModeMenuItem = getMenuItemById(typewriterModeMenuItemId)
-  const focusModeMenuItem = getMenuItemById(focusModeMenuItemId)
-  const modes = {
-    sourceCode: sourceCodeModeMenuItem.checked,
-    typewriter: typewriterModeMenuItem.checked,
-    focus: focusModeMenuItem.checked
-  }
-  const win = BrowserWindow.fromWebContents(e.sender)
-  win.webContents.send('AGANI::res-for-mode', modes)
-})
+// --- IPC events -------------------------------------------------------------
 
-ipcMain.on('AGANI::set-view-layout', (e, { showSideBar, showTabBar }) => {
-  const sideBarMenuItem = getMenuItemById('sideBarMenuItem')
-  const tabBarMenuItem = getMenuItemById('tabBarMenuItem')
+// NOTE: Don't use static `getMenuItemById` here, instead request the menu by
+//       window id from `AppMenu` manager.
 
+export const viewLayoutChanged = (applicationMenu, { showSideBar, showTabBar }) => {
+  const sideBarMenuItem = applicationMenu.getMenuItemById('sideBarMenuItem')
+  const tabBarMenuItem = applicationMenu.getMenuItemById('tabBarMenuItem')
   sideBarMenuItem.checked = showSideBar
   tabBarMenuItem.checked = showTabBar
-})
+}

--- a/src/main/menu/templates/edit.js
+++ b/src/main/menu/templates/edit.js
@@ -125,6 +125,7 @@ export default function (keybindings, userPreference) {
     }, {
       type: 'separator'
     }, {
+      // TODO: Remove this menu entry and add it to the command palette (#1408).
       label: 'Line Ending',
       submenu: [{
         id: 'crlfLineEndingMenuEntry',
@@ -141,8 +142,6 @@ export default function (keybindings, userPreference) {
           actions.lineEnding(browserWindow, 'lf')
         }
       }]
-    }, {
-      type: 'separator'
     }]
   }
 }

--- a/src/main/windows/editor.js
+++ b/src/main/windows/editor.js
@@ -81,7 +81,7 @@ class EditorWindow extends BaseWindow {
       this.bringToFront()
 
       const lineEnding = preferences.getPreferedEOL()
-      appMenu.updateLineEndingMenu(lineEnding)
+      appMenu.updateLineEndingMenu(this.id, lineEnding)
 
       win.webContents.send('mt::bootstrap-editor', {
         addBlankTab,

--- a/src/renderer/bootstrap.js
+++ b/src/renderer/bootstrap.js
@@ -25,8 +25,13 @@ const parseUrlArgs = () => {
   const theme = params.get('theme')
   const titleBarStyle = params.get('tbs')
   const userDataPath = params.get('udp')
-  const windowId = params.get('wid')
+  const windowId = Number(params.get('wid'))
   const type = params.get('type')
+
+  if (Number.isNaN(windowId)) {
+    throw new Error('Error while parsing URL arguments: windowId!')
+  }
+
   return {
     type,
     debug,

--- a/src/renderer/pages/app.vue
+++ b/src/renderer/pages/app.vue
@@ -129,7 +129,6 @@ export default {
     // module: editor
     dispatch('LISTEN_SCREEN_SHOT')
     dispatch('ASK_FOR_USER_PREFERENCE')
-    dispatch('ASK_FOR_MODE')
     dispatch('LISTEN_FOR_CLOSE')
     dispatch('LISTEN_FOR_SAVE_AS')
     dispatch('LISTEN_FOR_MOVE_TO')

--- a/src/renderer/store/layout.js
+++ b/src/renderer/store/layout.js
@@ -25,19 +25,20 @@ const mutations = {
 }
 
 const actions = {
-  LISTEN_FOR_LAYOUT ({ commit }, layout) {
+  LISTEN_FOR_LAYOUT ({ commit }) {
     ipcRenderer.on('AGANI::listen-for-view-layout', (e, layout) => {
       commit('SET_LAYOUT', layout)
     })
   },
-  LISTEN_FOR_REQUEST_LAYOUT ({ commit, dispatch }) {
+  LISTEN_FOR_REQUEST_LAYOUT ({ dispatch }) {
     ipcRenderer.on('AGANI::request-for-view-layout', () => {
       dispatch('SET_LAYOUT_MENU_ITEM')
     })
   },
-  SET_LAYOUT_MENU_ITEM ({ commit, state }) {
+  SET_LAYOUT_MENU_ITEM ({ state }) {
+    const { windowId } = global.marktext.env
     const { showTabBar, showSideBar } = state
-    ipcRenderer.send('AGANI::set-view-layout', { showTabBar, showSideBar })
+    ipcRenderer.send('mt::view-layout-changed', windowId, { showTabBar, showSideBar })
   },
   CHANGE_SIDE_BAR_WIDTH ({ commit }, width) {
     commit('SET_SIDE_BAR_WIDTH', width)

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -99,18 +99,6 @@ const actions = {
     })
   },
 
-  ASK_FOR_MODE ({ commit }) {
-    ipcRenderer.send('AGANI::ask-for-mode')
-    ipcRenderer.on('AGANI::res-for-mode', (e, modes) => {
-      Object.keys(modes).forEach(type => {
-        commit('SET_MODE', {
-          type,
-          checked: modes[type]
-        })
-      })
-    })
-  },
-
   SET_SINGLE_PREFERENCE ({ commit }, { type, value }) {
     // save to electron-store
     ipcRenderer.send('mt::set-user-preference', { [type]: value })


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| BC breaks?       | yes
| License          | MIT

### Description

- Fixed multiple potential main process exceptions because the application menu may be `null`. E.g. when creating a new editor window and focusing the settings window.
- Fixed `windowId` type in renderer process
- Fixed line ending menu item state when switching tabs
- Breaking change: After creating a window the editor is either preview or source-code according settings but don't respect the last active editor window settings any more.
