### PR TITLE
Fix the download section anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
       Features
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Downloads
     </a>
     <span> | </span>

--- a/docs/i18n/french.md
+++ b/docs/i18n/french.md
@@ -59,7 +59,7 @@
       Fonctionnalités
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Téléchargement
     </a>
     <span> | </span>

--- a/docs/i18n/ja.md
+++ b/docs/i18n/ja.md
@@ -59,7 +59,7 @@
       特徴
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       ダウンロード
     </a>
     <span> | </span>

--- a/docs/i18n/ko.md
+++ b/docs/i18n/ko.md
@@ -58,7 +58,7 @@
       Features
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Downloads
     </a>
     <span> | </span>

--- a/docs/i18n/pl.md
+++ b/docs/i18n/pl.md
@@ -59,7 +59,7 @@
       Cechy programu
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Instalacja
     </a>
     <span> | </span>

--- a/docs/i18n/pt.md
+++ b/docs/i18n/pt.md
@@ -59,7 +59,7 @@
       Recursos
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Downloads
     </a>
     <span> | </span>

--- a/docs/i18n/spanish.md
+++ b/docs/i18n/spanish.md
@@ -59,7 +59,7 @@
       Funcionalidades
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       Descargas
     </a>
     <span> | </span>

--- a/docs/i18n/tr.md
+++ b/docs/i18n/tr.md
@@ -63,7 +63,7 @@
       Özellikler
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       İndirmeler
     </a>
     <span> | </span>

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -56,7 +56,7 @@
       特性
     </a>
     <span> | </span>
-    <a href="https://github.com/marktext/marktext#download-and-install">
+    <a href="https://github.com/marktext/marktext#download-and-installation">
       下载
     </a>
     <span> | </span>


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes (typo in README.md)
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | N/A
| License          | MIT

### Description
The anchor to download section isn't linked properly. The link should use `#download-and-installation`, not `#download-and-install`.

--

#### Please, don't submit `/dist` files with your PR!
