### PR TITLE
fix: style error in tooltip arrow #1417

### DIFF
--- a/src/renderer/assets/styles/index.css
+++ b/src/renderer/assets/styles/index.css
@@ -150,26 +150,14 @@ body {
 .el-tooltip__popper[x-placement^=left] .popper__arrow {
   border-bottom-color: var(--floatBorderColor);
 }
-.el-tooltip__popper[x-placement^=left] .popper__arrow::after {
-  border-left-color: var(--floatBgColor);
-}
 .el-tooltip__popper[x-placement^=top] .popper__arrow {
   border-bottom-color: var(--floatBorderColor);
-}
-.el-tooltip__popper[x-placement^=top] .popper__arrow::after {
-  border-top-color: var(--floatBgColor);
 }
 .el-tooltip__popper[x-placement^=right] .popper__arrow {
   border-bottom-color: var(--floatBorderColor);
 }
-.el-tooltip__popper[x-placement^=right] .popper__arrow::after {
-  border-right-color: var(--floatBgColor);
-}
 .el-tooltip__popper[x-placement^=bottom] .popper__arrow {
   border-bottom-color: var(--floatBorderColor);
-}
-.el-tooltip__popper[x-placement^=bottom] .popper__arrow::after {
-  border-bottom-color: var(--floatBgColor);
 }
 
 .el-button:hover,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1417 
| License          | MIT

### Description

Fix tooltip arrow styles.

Dear @fxha I've removed part of your code from 72702427f1465579cac2f6cffbe793b09b844cd2, I've found where it can breaks anything.

Tooltip by themes:
**Ulysses Light**
<img width="120" alt="Ulysses Light" src="https://user-images.githubusercontent.com/3466287/66162824-57a82700-e62f-11e9-88b2-e92d01eef422.png">
**One Dark**
<img width="120" alt="One Dark" src="https://user-images.githubusercontent.com/3466287/66162825-57a82700-e62f-11e9-8d35-f9ad76b594b2.png">
**Material Dark**
<img width="117" alt="Material Dark" src="https://user-images.githubusercontent.com/3466287/66162826-5840bd80-e62f-11e9-9371-a66eadb6fc32.png">
**Graphite**
<img width="118" alt="Graphite" src="https://user-images.githubusercontent.com/3466287/66162828-5840bd80-e62f-11e9-8b54-e68b2ddcf4c0.png">
**Dark**
<img width="115" alt="Dark" src="https://user-images.githubusercontent.com/3466287/66162829-5840bd80-e62f-11e9-9e7a-e277c59cd575.png">
**Cadmium**
<img width="117" alt="Cadmium" src="https://user-images.githubusercontent.com/3466287/66162830-58d95400-e62f-11e9-84a7-1dfc94a5df44.png">

It also fixes an issue in Preferences.
Before fix:
<img width="84" alt="Preferences" src="https://user-images.githubusercontent.com/3466287/66162801-495a0b00-e62f-11e9-9d21-84fdebd98cda.png">
