### PR TITLE
fix: pre tags rendering #1409

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -94,7 +94,7 @@ div.ag-show-quick-insert-hint p.ag-paragraph.ag-active > span.ag-paragraph-conte
   color: transparent;
 }
 
-figure.ag-container-block pre {
+figure.ag-container-block > pre {
   width: 0;
   height: 0;
   opacity: 0;
@@ -120,6 +120,11 @@ figure.ag-active.ag-container-block pre {
 
 figure[data-role="HTML"] .ag-html-preview {
   display: block;
+}
+
+figure[data-role="HTML"] .ag-html-preview > pre{
+  border: 0;
+  background: inherit;
 }
 
 figure[data-role="HTML"].ag-active .ag-html-preview {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1409 
| License          | MIT

### Description

Fix missed visual representation of **pre** tag 