### PR TITLE
fix: ag front submenu is not corresponded to other menus

### DIFF
--- a/src/muya/lib/ui/frontMenu/index.css
+++ b/src/muya/lib/ui/frontMenu/index.css
@@ -78,9 +78,8 @@
   position: absolute;
   left: calc(100% + 5px);
   top: -46px;
-  border-radius: 8px;
+  border-radius: 2px;
   box-shadow: var(--floatShadow);
-  border: 1px solid var(--floatBorderColor);
   background-color: var(--floatBgColor);
   transition: all .25s ease-in-out;
   transform-origin: left;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no ticket
| License          | MIT

### Description

Front sub-menu has extra border and border-radius which is not fit to other menus.

Before:
<img width="521" alt="Screenshot 2019-10-03 at 23 54 21" src="https://user-images.githubusercontent.com/3466287/66167222-d1dda900-e639-11e9-8313-bd5c4a733961.png">

After:
<img width="481" alt="Screenshot 2019-10-04 at 00 00 36" src="https://user-images.githubusercontent.com/3466287/66167302-0baeaf80-e63a-11e9-9e40-44f9fa8694ae.png">
