### PR TITLE
Allow 1x1, 1x2 and 2x1 tables

### DIFF
--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -43,8 +43,8 @@
             size="mini"
             v-model="tableChecker.rows"
             controls-position="right"
-            :min="2"
-            :max="20"
+            :min="1"
+            :max="30"
           ></el-input-number>
         </el-form-item>
         <el-form-item label="Columns">
@@ -52,7 +52,7 @@
             size="mini"
             v-model="tableChecker.columns"
             controls-position="right"
-            :min="2"
+            :min="1"
             :max="20"
           ></el-input-number>
         </el-form-item>

--- a/test/e2e/specs/xss.spec.js
+++ b/test/e2e/specs/xss.spec.js
@@ -12,24 +12,12 @@ describe('Cross-site Scripting Test', function () {
     })
       .then(() => {
         return this.app.client.getRenderProcessLogs()
-        .then(function (logs) {
-          const xssErrorCount = logs.filter(log => {
-            return log.level === 'SEVERE' && /XSS/i.test(log.message) && log.source === 'javascript'
-          }).length
-          expect(xssErrorCount).to.equal(0)
-        })
+          .then(function (logs) {
+            const xssErrorCount = logs.filter(log => {
+              return log.level === 'SEVERE' && /XSS/i.test(log.message) && log.source === 'javascript'
+            }).length
+            expect(xssErrorCount).to.equal(0)
+          })
       })
-    // setTimeout(() => {
-      
-      // If a test fails, an exception is thrown.
-
-      // TODO: The process is not terminated if a test fails because the connection to Electron is lost (spectron bug?).
-      //       I think thats not a problem as long as you kill the process.
-      //   Message:
-      //         chrome not reachable
-      //     Error: Request timed out after the element was still found on the page.
-      //         at execute(<Function>, "require") - api.js:63:26
-
-    // }, 3000)
   })
 })


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #1243
| License          | MIT

### Description

Allow 1x1, 1x2 and 2x1 tables.

---

resolves #1243
