### PR TITLE
fix: wrap long lines and a little bit of padding for pre element

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -126,6 +126,9 @@ figure[data-role="HTML"] .ag-html-preview {
 figure[data-role="HTML"] .ag-html-preview > pre{
   border: 0;
   background: inherit;
+  padding: 0 .5rem;
+  border-radius: 0.3em;
+  white-space: pre-wrap;
 }
 
 figure[data-role="HTML"].ag-active .ag-html-preview {

--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -126,7 +126,7 @@ figure[data-role="HTML"] .ag-html-preview {
 figure[data-role="HTML"] .ag-html-preview > pre{
   border: 0;
   background: inherit;
-  padding: 0 .5rem;
+  padding: 0 1rem;
   border-radius: 0.3em;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1452 
| License          | MIT

### Description

Wrap long lines and adds padding for pre element

<img width="694" alt="Screenshot 2019-10-10 at 21 40 49" src="https://user-images.githubusercontent.com/3466287/66600951-048e2100-eba7-11e9-861a-318d5916aa65.png">