### PR TITLE
fix: settings switch element used 100% of width

### DIFF
--- a/src/renderer/prefComponents/common/bool/index.vue
+++ b/src/renderer/prefComponents/common/bool/index.vue
@@ -7,7 +7,6 @@
       ></i>
     </div>
     <el-switch
-      style="display: block"
       v-model="status"
       @change="handleSwitchChange"
       :active-text="status ? 'On': 'Off'">


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1465 
| License          | MIT

### Description

Checkboxes in settings will use only the needed width.