### PR TITLE
Add command palette and quick open dialog

### DIFF
--- a/docs/BASICS.md
+++ b/docs/BASICS.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Mark Text is a realtime preview editor for markdown with various markdown extensions. You can simply write and edit text and Mark Text hides all unnecessary syntax elements. When you first start Mark Text an empty editor window is shown. You can see [key bindings](KEYBINDINGS.md) for all available commands or just type `@` to get an overlay with available text elements. Mark Text provides a minimal and simple interface and in the next sections you can learn more about the interface and features.
+Mark Text is a realtime preview editor for markdown with various markdown extensions. You can simply write and edit text and Mark Text hides all unnecessary syntax elements. When you first start Mark Text an empty editor window is shown. You can see [key bindings](KEYBINDINGS.md) or command palette (<kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) for all available commands or just type `@` to get an overlay with available text elements. Mark Text provides a minimal and simple interface and in the next sections you can learn more about the interface and features.
 
 ![](assets/marktext-default.png)
 
@@ -46,7 +46,7 @@ After some modifications you can save your file via <kbd>CmdOrCtrl</kbd>+<kbd>S<
 
 ### Open a directory
 
-Mark Text also have support to open a directory via <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> or the sidebar button *Open Folder*. After opening a directory all files and directories are shown in the sidebar tree view. The tree view allows you to open further files, browse and modify files or directories inside the opened root directory. Above the tree view are all opened files located. To view another sidebar panel like find in files click on the left sidebar icons.
+Mark Text also have support to open a directory via <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> or the sidebar button *Open Folder*. After opening a directory all files and directories are shown in the sidebar tree view. The tree view allows you to open further files, browse and modify files or directories inside the opened root directory. Above the tree view are all opened files located. You can also use quick open (<kbd>CmdOrCtrl</kbd>+<kbd>P</kbd>) to quickly open a file from the opened root directory or editor and navigate via arrow keys or select a file via mouse. To view another sidebar panel like find in files click on the left sidebar icons.
 
 ![](assets/marktext-interface-2.png)
 

--- a/docs/EDITING.md
+++ b/docs/EDITING.md
@@ -100,9 +100,13 @@ The focus mode will help you to focus on the currently line only by fading out o
 
 In typewriter mode, the cursor is always keep in the middle of the editor.
 
+## File encoding
+
+Mark Text try to automatically detect the used file encoding and byte-order mark (BOM) when opening a file. The default encoding is UTF-8 that should support all needed characters but can be changed in settings. You can disable automatically encoding detection but then we assume that all files are UTF-8 encoded. The current used encoding can be shown via command palette and also changed there.
+
 ## Line endings
 
-Mark Text automatically analyzes each file and detect the used line ending.
+Mark Text automatically analyzes each file and detect the used line ending and can be changed via command palette too.
 
 ## Find and replace
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -6,8 +6,8 @@ Here is an example:
 
 ```json
 {
-  "fileSave": "CmdOrCtrl+Shift+S",
-  "fileSaveAs": "CmdOrCtrl+S"
+  "file.save": "CmdOrCtrl+Shift+S",
+  "file.save-as": "CmdOrCtrl+S"
 }
 ```
 
@@ -34,114 +34,116 @@ Here is an example:
 
 | Id                | Default                                        | Description                             |
 | ----------------- | ---------------------------------------------- | --------------------------------------- |
-| `mtHide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide Mark Text                          |
-| `mtHideOthers`    | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
-| `filePreferences` | <kbd>Command</kbd>+<kbd>,</kbd>                | Open settings window                    |
-| `fileQuit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit Mark Text                          |
+| `mt.hide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide Mark Text                          |
+| `mt.hide-others`    | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
+| `file.preferences` | <kbd>Command</kbd>+<kbd>,</kbd>                | Open settings window                    |
+| `file.quit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit Mark Text                          |
 
 **File menu:**
 
-| Id                | Default                                            | Description                               |
-|:----------------- | -------------------------------------------------- | ----------------------------------------- |
-| `fileNewFile`     | <kbd>CmdOrCtrl</kbd>+<kbd>N</kbd>                  | New file                                  |
-| `fileNewTab`      | <kbd>CmdOrCtrl</kbd>+<kbd>T</kbd>                  | New tab                                   |
-| `fileOpenFile`    | <kbd>CmdOrCtrl</kbd>+<kbd>O</kbd>                  | Open markdown file                        |
-| `fileOpenFolder`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                               |
-| `fileSave`        | <kbd>CmdOrCtrl</kbd>+<kbd>S</kbd>                  | Save                                      |
-| `fileSaveAs`      | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                                |
-| `filePrint`       | <kbd>Ctrl</kbd>+<kbd>P</kbd>                       | Print current tab                         |
-| `filePreferences` | <kbd>Ctrl</kbd>+<kbd>,</kbd>                       | Open settings window (Linux/Windows only) |
-| `fileCloseTab`    | <kbd>CmdOrCtrl</kbd>+<kbd>W</kbd>                  | Close tab                                 |
-| `fileCloseWindow` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                              |
-| `fileQuit`        | <kbd>CmdOrCtrl</kbd>+<kbd>Q</kbd>                  | Quit Mark Text (Linux/Windows only)       |
+| Id                  | Default                                            | Description                               |
+|:------------------- | -------------------------------------------------- | ----------------------------------------- |
+| `file.new-file`     | <kbd>CmdOrCtrl</kbd>+<kbd>N</kbd>                  | New file                                  |
+| `file.new-tab`      | <kbd>CmdOrCtrl</kbd>+<kbd>T</kbd>                  | New tab                                   |
+| `file.open-file`    | <kbd>CmdOrCtrl</kbd>+<kbd>O</kbd>                  | Open markdown file                        |
+| `file.open-folder`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                               |
+| `file.save`         | <kbd>CmdOrCtrl</kbd>+<kbd>S</kbd>                  | Save                                      |
+| `file.save-as`      | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                                |
+| `file.print`        | -                                                  | Print current tab                         |
+| `file.preferences`  | <kbd>Ctrl</kbd>+<kbd>,</kbd>                       | Open settings window (Linux/Windows only) |
+| `file.close-tab`    | <kbd>CmdOrCtrl</kbd>+<kbd>W</kbd>                  | Close tab                                 |
+| `file.close-window` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                              |
+| `file.quit`         | <kbd>CmdOrCtrl</kbd>+<kbd>Q</kbd>                  | Quit Mark Text (Linux/Windows only)       |
 
 **Edit menu:**
 
-| Id                    | Default                                            | Description                                     |
-|:--------------------- | -------------------------------------------------- | ----------------------------------------------- |
-| `editUndo`            | <kbd>CmdOrCtrl</kbd>+<kbd>Z</kbd>                  | Undo last operation                             |
-| `editRedo`            | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> | Redo last operation                             |
-| `editCut`             | <kbd>CmdOrCtrl</kbd>+<kbd>X</kbd>                  | Cut selected text                               |
-| `editCopy`            | <kbd>CmdOrCtrl</kbd>+<kbd>C</kbd>                  | Copy selected text                              |
-| `editPaste`           | <kbd>CmdOrCtrl</kbd>+<kbd>V</kbd>                  | Paste text                                      |
-| `editCopyAsMarkdown`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> | Copy selected text as markdown                  |
-| `editCopyAsPlaintext` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> | Copy selected text as plaintext                 |
-| `editSelectAll`       | <kbd>CmdOrCtrl</kbd>+<kbd>A</kbd>                  | Select all text of the document                 |
-| `editDuplicate`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Duplicate the current paragraph                 |
-| `editCreateParagraph` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> | Create a new paragraph after the current one    |
-| `editDeleteParagraph` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> | Delete current paragraph                        |
-| `editFind`            | <kbd>CmdOrCtrl</kbd>+<kbd>F</kbd>                  | Find information in the document                |
-| `editFindNext`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Continue the search and find the next match     |
-| `editFindPrevious`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Continue the search and find the previous match |
-| `editReplace`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>   | Replace the information with a replacement      |
-| `editFindInFolder`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Find files contain the keyword in opend folder  |
-| `editAidou`           | <kbd>CmdOrCtrl</kbd>+<kbd>/</kbd>                  | Show Aidou dialog                               |
-| `editScreenshot`      | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>A</kbd>     | Get the screenshot (macOS only)                 |
+| Id                       | Default                                            | Description                                     |
+|:------------------------ | -------------------------------------------------- | ----------------------------------------------- |
+| `edit.undo`              | <kbd>CmdOrCtrl</kbd>+<kbd>Z</kbd>                  | Undo last operation                             |
+| `edit.redo`              | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> | Redo last operation                             |
+| `edit.cut`               | <kbd>CmdOrCtrl</kbd>+<kbd>X</kbd>                  | Cut selected text                               |
+| `edit.copy`              | <kbd>CmdOrCtrl</kbd>+<kbd>C</kbd>                  | Copy selected text                              |
+| `edit.paste`             | <kbd>CmdOrCtrl</kbd>+<kbd>V</kbd>                  | Paste text                                      |
+| `edit.copy-as-markdown`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> | Copy selected text as markdown                  |
+| `edit.copy-as-plaintext` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> | Copy selected text as plaintext                 |
+| `edit.select-all`        | <kbd>CmdOrCtrl</kbd>+<kbd>A</kbd>                  | Select all text of the document                 |
+| `edit.duplicate`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>   | Duplicate the current paragraph                 |
+| `edit.create-paragraph`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> | Create a new paragraph after the current one    |
+| `edit.delete-paragraph`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> | Delete current paragraph                        |
+| `edit.find`              | <kbd>CmdOrCtrl</kbd>+<kbd>F</kbd>                  | Find information in the document                |
+| `edit.find-next`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Continue the search and find the next match     |
+| `edit.find-previous`     | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Continue the search and find the previous match |
+| `edit.replace`           | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>   | Replace the information with a replacement      |
+| `edit.find-in-folder`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Find files contain the keyword in opend folder  |
+| `edit.aidou`             | <kbd>CmdOrCtrl</kbd>+<kbd>/</kbd>                  | Show Aidou dialog                               |
+| `edit.screenshot`        | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>A</kbd>     | Get the screenshot (macOS only)                 |
 
 **Paragraph menu:**
 
 | Id                         | Default                                            | Description                                       |
 | -------------------------- | -------------------------------------------------- | ------------------------------------------------- |
-| `paragraphHeading1`        | <kbd>CmdOrCtrl</kbd>+<kbd>1</kbd>                  | Set line as heading 1                             |
-| `paragraphHeading2`        | <kbd>CmdOrCtrl</kbd>+<kbd>2</kbd>                  | Set line as heading 2                             |
-| `paragraphHeading3`        | <kbd>CmdOrCtrl</kbd>+<kbd>3</kbd>                  | Set line as heading 3                             |
-| `paragraphHeading4`        | <kbd>CmdOrCtrl</kbd>+<kbd>4</kbd>                  | Set line as heading 4                             |
-| `paragraphHeading5`        | <kbd>CmdOrCtrl</kbd>+<kbd>5</kbd>                  | Set line as heading 5                             |
-| `paragraphHeading6`        | <kbd>CmdOrCtrl</kbd>+<kbd>6</kbd>                  | Set line as heading 6                             |
-| `paragraphUpgradeHeading`  | <kbd>CmdOrCtrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                                 |
-| `paragraphDegradeHeading`  | <kbd>CmdOrCtrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                                 |
-| `paragraphTable`           | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> | Insert a table                                    |
-| `paragraphCodeFence`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>   | Insert a code block                               |
-| `paragraphQuoteBlock`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd>   | Insert a quote block                              |
-| `paragraphMathBlock`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>   | Insert a math block                               |
-| `paragraphHtmlBlock`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>J/H</kbd> | Insert a HTML block (`J` on macOS, `H` otherwise) |
-| `paragraphOrderList`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>   | Insert a ordered list                             |
-| `paragraphBulletList`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Insert a unordered list                           |
-| `paragraphTaskList`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>   | Insert a task list                                |
-| `paragraphLooseListItem`   | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>   | Convert a list item to a loose list item          |
-| `paragraphParagraph`       | <kbd>CmdOrCtrl</kbd>+<kbd>0</kbd>                  | Convert a heading to a paragraph                  |
-| `paragraphHorizontalLine`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>-</kbd>   | Add a horizontal line                             |
-| `paragraphYAMLFrontMatter` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd>   | Insert a YAML frontmatter block                   |
+| `paragraph.heading-1`        | <kbd>CmdOrCtrl</kbd>+<kbd>1</kbd>                  | Set line as heading 1                             |
+| `paragraph.heading-2`        | <kbd>CmdOrCtrl</kbd>+<kbd>2</kbd>                  | Set line as heading 2                             |
+| `paragraph.heading-3`        | <kbd>CmdOrCtrl</kbd>+<kbd>3</kbd>                  | Set line as heading 3                             |
+| `paragraph.heading-4`        | <kbd>CmdOrCtrl</kbd>+<kbd>4</kbd>                  | Set line as heading 4                             |
+| `paragraph.heading-5`        | <kbd>CmdOrCtrl</kbd>+<kbd>5</kbd>                  | Set line as heading 5                             |
+| `paragraph.heading-6`        | <kbd>CmdOrCtrl</kbd>+<kbd>6</kbd>                  | Set line as heading 6                             |
+| `paragraph.upgrade-heading`  | <kbd>CmdOrCtrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                                 |
+| `paragraph.degrade-heading`  | <kbd>CmdOrCtrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                                 |
+| `paragraph.table`           | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> | Insert a table                                    |
+| `paragraph.code-fence`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>   | Insert a code block                               |
+| `paragraph.quote-block`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd>   | Insert a quote block                              |
+| `paragraph.math-formula`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>   | Insert a math block                               |
+| `paragraph.html-block`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>J/H</kbd> | Insert a HTML block (`J` on macOS, `H` otherwise) |
+| `paragraph.order-list`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>   | Insert a ordered list                             |
+| `paragraph.bullet-list`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Insert a unordered list                           |
+| `paragraph.task-list`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>   | Insert a task list                                |
+| `paragraph.loose-list-item`   | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>   | Convert a list item to a loose list item          |
+| `paragraph.paragraph`       | <kbd>CmdOrCtrl</kbd>+<kbd>0</kbd>                  | Convert a heading to a paragraph                  |
+| `paragraph.horizontal-line`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>-</kbd>   | Add a horizontal line                             |
+| `paragraph.front-matter` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd>   | Insert a YAML frontmatter block                   |
 
 **Format menu:**
 
-| Id                  | Default                                            | Description                                 |
-| ------------------- | -------------------------------------------------- | ------------------------------------------- |
-| `formatStrong`      | <kbd>CmdOrCtrl</kbd>+<kbd>B</kbd>                  | Set the font of the selected text to bold   |
-| `formatEmphasis`    | <kbd>CmdOrCtrl</kbd>+<kbd>I</kbd>                  | Set the font of the selected text to italic |
-| `formatUnderline`   | <kbd>CmdOrCtrl</kbd>+<kbd>U</kbd>                  | Change the selected text to underline       |
-| `highlight`         | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd> | Highlight the selected text by <mark> tag   |
-| `formatInlineCode`  | <kbd>CmdOrCtrl</kbd>+<kbd>`</kbd>                  | Change the selected text to inline code     |
-| `formatInlineMath`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> | Change the selected text to inline math     |
-| `formatStrike`      | <kbd>CmdOrCtrl</kbd>+<kbd>D</kbd>                  | Strike through the selected text            |
-| `formatHyperlink`   | <kbd>CmdOrCtrl</kbd>+<kbd>L</kbd>                  | Insert a hyperlink                          |
-| `formatImage`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> | Insert a image                              |
-| `formatClearFormat` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> | Clear the formatting of the selected text   |
+| Id                    | Default                                            | Description                                 |
+| --------------------- | -------------------------------------------------- | ------------------------------------------- |
+| `format.strong`       | <kbd>CmdOrCtrl</kbd>+<kbd>B</kbd>                  | Set the font of the selected text to bold   |
+| `format.emphasis`     | <kbd>CmdOrCtrl</kbd>+<kbd>I</kbd>                  | Set the font of the selected text to italic |
+| `format.underline`    | <kbd>CmdOrCtrl</kbd>+<kbd>U</kbd>                  | Change the selected text to underline       |
+| `format.highlight`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd> | Highlight the selected text by <mark> tag   |
+| `format.inline-code`  | <kbd>CmdOrCtrl</kbd>+<kbd>`</kbd>                  | Change the selected text to inline code     |
+| `format.inline-math`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> | Change the selected text to inline math     |
+| `format.strike`       | <kbd>CmdOrCtrl</kbd>+<kbd>D</kbd>                  | Strike through the selected text            |
+| `format.hyperlink`    | <kbd>CmdOrCtrl</kbd>+<kbd>L</kbd>                  | Insert a hyperlink                          |
+| `format.image`        | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> | Insert a image                              |
+| `format.clear-format` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> | Clear the formatting of the selected text   |
 
 **Window menu:**
 
-| Id               | Default                           | Description         |
-| ---------------- | --------------------------------- | ------------------- |
-| `windowMinimize` | <kbd>CmdOrCtrl</kbd>+<kbd>M</kbd> | Minimize the window |
+| Id                       | Default                           | Description                                                                          |
+| ------------------------ | --------------------------------- | ------------------------------------------------------------------------------------ |
+| `window.minimize`         | <kbd>CmdOrCtrl</kbd>+<kbd>M</kbd> | Minimize the window                                                                  |
+| `window.toggle-full-screen` | <kbd>F11</kbd>                    | Toggle fullscreen mode (or <kbd>Ctrl</kbd>+<kbd>Command</kbd>+<kbd>F</kbd> on macOS) |
 
 **View menu:**
 
-| Id                            | Default                                            | Description                                                                          |
-| ----------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `viewToggleFullScreen`        | <kbd>F11</kbd>                                     | Toggle fullscreen mode (or <kbd>Ctrl</kbd>+<kbd>Command</kbd>+<kbd>F</kbd> on macOS) |
-| `viewSourceCodeMode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode                                                           |
-| `viewTypewriterMode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                                                               |
-| `viewFocusMode`               | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                                                                    |
-| `viewToggleSideBar`           | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                                                                       |
-| `viewToggleTabBar`            | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                                                                        |
-| `viewDevToggleDeveloperTools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only)                                             |
-| `viewDevReload`               | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)                                                      |
+| Id                            | Default                                            | Description                              |
+| ----------------------------- | -------------------------------------------------- | ---------------------------------------- |
+| `view.command-palette`          | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Toggle command palette                   |
+| `view.source-code-mode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode               |
+| `view.typewriter-mode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                   |
+| `view.focus-mode`               | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                        |
+| `view.toggle-sidebar`           | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
+| `view.toggle-tabbar`            | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
+| `view.toggle-dev-tools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only) |
+| `view.dev-reload`               | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)          |
 
 **Misc**
 
-| Id                  | Default                                              | Description                  |
-| ------------------- | ---------------------------------------------------- | ---------------------------- |
-| `tabsCycleForward`  | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>                  | Cycle through tabs           |
-| `tabsCycleBackward` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> | Cycle backwards through tabs |
-| `tabsSwitchToLeft`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>               | Switch tab to the left       |
-| `tabsSwitchToRight` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd>             | Switch tab to the right      |
+| Id                     | Default                                              | Description                  |
+| ---------------------- | ---------------------------------------------------- | ---------------------------- |
+| `tabs.cycle-forward`   | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>                  | Cycle through tabs           |
+| `tabs.cycle-backward`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> | Cycle backwards through tabs |
+| `tabs.switch-to-left`  | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>               | Switch tab to the left       |
+| `tabs.switch-to-right` | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd>             | Switch tab to the right      |
+| `file.quick-open`      | <kbd>CmdOrCtrl</kbd>+<kbd>P</kbd>                    | Open quick open dialog       |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -32,10 +32,10 @@ Here is an example:
 
 **Mark Text menu (macOS only):**
 
-| Id                | Default                                        | Description                             |
-| ----------------- | ---------------------------------------------- | --------------------------------------- |
+| Id                 | Default                                        | Description                             |
+| ------------------ | ---------------------------------------------- | --------------------------------------- |
 | `mt.hide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide Mark Text                          |
-| `mt.hide-others`    | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
+| `mt.hide-others`   | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
 | `file.preferences` | <kbd>Command</kbd>+<kbd>,</kbd>                | Open settings window                    |
 | `file.quit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit Mark Text                          |
 
@@ -74,34 +74,34 @@ Here is an example:
 | `edit.find-next`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Continue the search and find the next match     |
 | `edit.find-previous`     | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> | Continue the search and find the previous match |
 | `edit.replace`           | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>   | Replace the information with a replacement      |
-| `edit.find-in-folder`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Find files contain the keyword in opend folder  |
+| `edit.find-in-folder`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Find files contain the keyword in opend folder  |
 | `edit.aidou`             | <kbd>CmdOrCtrl</kbd>+<kbd>/</kbd>                  | Show Aidou dialog                               |
 | `edit.screenshot`        | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>A</kbd>     | Get the screenshot (macOS only)                 |
 
 **Paragraph menu:**
 
-| Id                         | Default                                            | Description                                       |
-| -------------------------- | -------------------------------------------------- | ------------------------------------------------- |
-| `paragraph.heading-1`        | <kbd>CmdOrCtrl</kbd>+<kbd>1</kbd>                  | Set line as heading 1                             |
-| `paragraph.heading-2`        | <kbd>CmdOrCtrl</kbd>+<kbd>2</kbd>                  | Set line as heading 2                             |
-| `paragraph.heading-3`        | <kbd>CmdOrCtrl</kbd>+<kbd>3</kbd>                  | Set line as heading 3                             |
-| `paragraph.heading-4`        | <kbd>CmdOrCtrl</kbd>+<kbd>4</kbd>                  | Set line as heading 4                             |
-| `paragraph.heading-5`        | <kbd>CmdOrCtrl</kbd>+<kbd>5</kbd>                  | Set line as heading 5                             |
-| `paragraph.heading-6`        | <kbd>CmdOrCtrl</kbd>+<kbd>6</kbd>                  | Set line as heading 6                             |
-| `paragraph.upgrade-heading`  | <kbd>CmdOrCtrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                                 |
-| `paragraph.degrade-heading`  | <kbd>CmdOrCtrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                                 |
+| Id                          | Default                                            | Description                                       |
+| --------------------------- | -------------------------------------------------- | ------------------------------------------------- |
+| `paragraph.heading-1`       | <kbd>CmdOrCtrl</kbd>+<kbd>1</kbd>                  | Set line as heading 1                             |
+| `paragraph.heading-2`       | <kbd>CmdOrCtrl</kbd>+<kbd>2</kbd>                  | Set line as heading 2                             |
+| `paragraph.heading-3`       | <kbd>CmdOrCtrl</kbd>+<kbd>3</kbd>                  | Set line as heading 3                             |
+| `paragraph.heading-4`       | <kbd>CmdOrCtrl</kbd>+<kbd>4</kbd>                  | Set line as heading 4                             |
+| `paragraph.heading-5`       | <kbd>CmdOrCtrl</kbd>+<kbd>5</kbd>                  | Set line as heading 5                             |
+| `paragraph.heading-6`       | <kbd>CmdOrCtrl</kbd>+<kbd>6</kbd>                  | Set line as heading 6                             |
+| `paragraph.upgrade-heading` | <kbd>CmdOrCtrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                                 |
+| `paragraph.degrade-heading` | <kbd>CmdOrCtrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                                 |
 | `paragraph.table`           | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> | Insert a table                                    |
-| `paragraph.code-fence`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>   | Insert a code block                               |
-| `paragraph.quote-block`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd>   | Insert a quote block                              |
-| `paragraph.math-formula`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>   | Insert a math block                               |
-| `paragraph.html-block`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>J/H</kbd> | Insert a HTML block (`J` on macOS, `H` otherwise) |
-| `paragraph.order-list`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>   | Insert a ordered list                             |
-| `paragraph.bullet-list`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Insert a unordered list                           |
-| `paragraph.task-list`        | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>   | Insert a task list                                |
-| `paragraph.loose-list-item`   | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>   | Convert a list item to a loose list item          |
+| `paragraph.code-fence`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>   | Insert a code block                               |
+| `paragraph.quote-block`     | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Q</kbd>   | Insert a quote block                              |
+| `paragraph.math-formula`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd>   | Insert a math block                               |
+| `paragraph.html-block`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>J/H</kbd> | Insert a HTML block (`J` on macOS, `H` otherwise) |
+| `paragraph.order-list`      | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd>   | Insert a ordered list                             |
+| `paragraph.bullet-list`     | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>U</kbd>   | Insert a unordered list                           |
+| `paragraph.task-list`       | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd>   | Insert a task list                                |
+| `paragraph.loose-list-item` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>   | Convert a list item to a loose list item          |
 | `paragraph.paragraph`       | <kbd>CmdOrCtrl</kbd>+<kbd>0</kbd>                  | Convert a heading to a paragraph                  |
-| `paragraph.horizontal-line`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>-</kbd>   | Add a horizontal line                             |
-| `paragraph.front-matter` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd>   | Insert a YAML frontmatter block                   |
+| `paragraph.horizontal-line` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>-</kbd>   | Add a horizontal line                             |
+| `paragraph.front-matter`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>Y</kbd>   | Insert a YAML frontmatter block                   |
 
 **Format menu:**
 
@@ -120,23 +120,23 @@ Here is an example:
 
 **Window menu:**
 
-| Id                       | Default                           | Description                                                                          |
-| ------------------------ | --------------------------------- | ------------------------------------------------------------------------------------ |
-| `window.minimize`         | <kbd>CmdOrCtrl</kbd>+<kbd>M</kbd> | Minimize the window                                                                  |
+| Id                          | Default                           | Description                                                                          |
+| --------------------------- | --------------------------------- | ------------------------------------------------------------------------------------ |
+| `window.minimize`           | <kbd>CmdOrCtrl</kbd>+<kbd>M</kbd> | Minimize the window                                                                  |
 | `window.toggle-full-screen` | <kbd>F11</kbd>                    | Toggle fullscreen mode (or <kbd>Ctrl</kbd>+<kbd>Command</kbd>+<kbd>F</kbd> on macOS) |
 
 **View menu:**
 
 | Id                            | Default                                            | Description                              |
-| ----------------------------- | -------------------------------------------------- | ---------------------------------------- |
-| `view.command-palette`          | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Toggle command palette                   |
-| `view.source-code-mode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode               |
-| `view.typewriter-mode`          | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                   |
-| `view.focus-mode`               | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                        |
-| `view.toggle-sidebar`           | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
-| `view.toggle-tabbar`            | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
+| ----------------------- | -------------------------------------------------- | ---------------------------------------- |
+| `view.command-palette`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Toggle command palette                   |
+| `view.source-code-mode` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode               |
+| `view.typewriter-mode`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                   |
+| `view.focus-mode`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                        |
+| `view.toggle-sidebar`   | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
+| `view.toggle-tabbar`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
 | `view.toggle-dev-tools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only) |
-| `view.dev-reload`               | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)          |
+| `view.dev-reload`       | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)          |
 
 **Misc**
 

--- a/docs/dev/code/COMMANDS.md
+++ b/docs/dev/code/COMMANDS.md
@@ -1,0 +1,95 @@
+# Commands
+
+A command can execute a procedure and is shown in the command palette or can be run from bus. We distinguish between static commands that are defined at compile time (maybe completed at runtime) and dynamtic commands that are created at runtime. Static commands are pure objects that are listed as array and most dynamic commands are classes that need access to the editor or other components. Each command can have nestled subcommands that have the same properties like a command. A root command is the command from which all subcommands are loaded that are displayed on screen. You can change the root command by calling `bus.$emit('show-command-palette', <command-reference>)`. Please note: a root command has special requirements such as a `run` method.
+
+**Static command:**
+
+```js
+{
+  id: 'file.new-tab', // Unique id
+  description: 'File: New Tab',
+  execute: async () => {
+    // Set `null` as first parameter to fake the sender event.
+    ipcRenderer.emit('mt::new-untitled-tab', null)
+  }
+}
+```
+
+**Dynamic command:**
+
+You can use either a class or object at runtime to register a command via bus event `CMD::register-command`. A simple class example can be found below or a more complex [here](https://github.com/marktext/marktext/blob/develop/src/renderer/commands/quickOpen.js).
+
+```js
+export class ExampleCommand {
+  constructor () {
+    this.id = 'example-id'
+    this.description = 'Example'
+  }
+
+  // Execute the command.
+  async execute () {
+    // No-op
+  }
+}
+
+export class Example2Command {
+  constructor () {
+    this.id = 'example-2-id'
+    this.description = 'Example 2'
+    this.title = '' // Tooltip (optional)
+    this.subcommands = [] // (optional)
+    this.subcommandSelectedIndex = -1 // Required if `subcommands` defined (optional)
+  }
+
+  // Prepare subcommands and run the command when the entry is set as root.
+  // `run` must prepare the `subcommands`.
+  // `run` is only required if the command can be loaded as root command. If
+  // `execute` and `run` are not defined but `subcommands` is defined the
+  // subcommands are automatically loaded when the command is selected. Please
+  // note that `subcommands` must be available and the command cannot be loaded
+  // as root command when no `run` method is available (optional).
+  run = async () => {
+    this.subcommands = [{
+      id: 'example-2-sub-1',
+      description: 'Subcommand 1',
+      execute: async () => {
+        // No-op
+      }
+    },
+    {
+      id: 'example-2-sub-2',
+      description: 'Subcommand 2',
+      execute: async () => {
+        // No-op
+      }
+    }]
+  }
+
+  // Run when the command palette is unloaded and the command is root.
+  unload = () => {
+    this.subcommands = []
+  }
+
+  // Handle search queries when the entry is root. Must return available
+  // entries that should be shown in UI. If not defined the default searcher
+  // is used (optional).
+  search = async query => {
+    return []
+  }
+
+  // Execute the command. Required but ignore if the parent has a
+  // `executeSubcommand` method.
+  execute = async () => {
+    // The timeout is required to hide the command palette and then show again
+    // to prevent issues.
+    await delay(100)
+    bus.$emit('show-command-palette', this)
+  }
+
+  // When defined this method is called when a subcommand is executed
+  // instead `execute` on subcommand (optional).
+  executeSubcommand = async id => {
+    // No-op
+  }
+}
+```

--- a/docs/dev/code/COMMANDS.md
+++ b/docs/dev/code/COMMANDS.md
@@ -1,6 +1,6 @@
 # Commands
 
-A command can execute a procedure and is shown in the command palette or can be run from bus. We distinguish between static commands that are defined at compile time (maybe completed at runtime) and dynamtic commands that are created at runtime. Static commands are pure objects that are listed as array and most dynamic commands are classes that need access to the editor or other components. Each command can have nestled subcommands that have the same properties like a command. A root command is the command from which all subcommands are loaded that are displayed on screen. You can change the root command by calling `bus.$emit('show-command-palette', <command-reference>)`. Please note: a root command has special requirements such as a `run` method.
+A command can execute a procedure and is shown in the command palette or can be run from event bus. We distinguish between static commands that are defined at compile time (maybe completed at runtime) and dynamtic commands that are created at runtime. Static commands are pure objects that are listed as array and most dynamic commands are classes that need access to the editor or other components. Each command can have nestled subcommands that have the same properties like a command. A root command is the command from which all subcommands are loaded that are displayed on screen. You can change the root command by calling `bus.$emit('show-command-palette', <command-reference>)`. Please note: a root command has special requirements such as a `run` method.
 
 **Static command:**
 
@@ -17,7 +17,7 @@ A command can execute a procedure and is shown in the command palette or can be 
 
 **Dynamic command:**
 
-You can use either a class or object at runtime to register a command via bus event `CMD::register-command`. A simple class example can be found below or a more complex [here](https://github.com/marktext/marktext/blob/develop/src/renderer/commands/quickOpen.js).
+You can use either a class or object at runtime to register a command via the bus event `CMD::register-command`. A simple class example can be found below or a more complex [here](https://github.com/marktext/marktext/blob/develop/src/renderer/commands/quickOpen.js).
 
 ```js
 export class ExampleCommand {

--- a/docs/dev/code/COMMANDS.md
+++ b/docs/dev/code/COMMANDS.md
@@ -36,6 +36,7 @@ export class Example2Command {
   constructor () {
     this.id = 'example-2-id'
     this.description = 'Example 2'
+    this.placeholder = '' // Textbox placeholder (optional)
     this.title = '' // Tooltip (optional)
     this.subcommands = [] // (optional)
     this.subcommandSelectedIndex = -1 // Required if `subcommands` defined (optional)

--- a/docs/dev/code/README.md
+++ b/docs/dev/code/README.md
@@ -3,4 +3,5 @@
 WIP documentation of Mark Text internals.
 
 - [Block addition properties and its value](BLOCK_ADDITION_PROPERTY.md)
+- [Commands](COMMANDS.md)
 - [Inter-Process Communication (IPC)](IPC.md)

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -7,6 +7,7 @@ import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme } from 'ele
 import { isChildOfDirectory } from 'common/filesystem/paths'
 import { isLinux, isOsx, isWindows } from '../config'
 import parseArgs from '../cli/parser'
+import { normalizeAndResolvePath } from '../filesystem'
 import { normalizeMarkdownPath } from '../filesystem/markdown'
 import { selectTheme } from '../menu/actions/theme'
 import { dockMenu } from '../menu/templates'
@@ -410,6 +411,21 @@ class App {
     pathsToOpen.length = 0
   }
 
+  _openSettingsWindow () {
+    const settingWins = this._windowManager.getWindowsByType(WindowType.SETTING)
+    if (settingWins.length >= 1) {
+      // A setting window is already created
+      const browserSettingWindow = settingWins[0].win.browserWindow
+      if (isLinux) {
+        browserSettingWindow.focus()
+      } else {
+        browserSettingWindow.moveTop()
+      }
+      return
+    }
+    this._createSettingWindow()
+  }
+
   _listenForIpcMain () {
     ipcMain.on('app-create-editor-window', () => {
       this._createEditorWindow()
@@ -444,18 +460,7 @@ class App {
     })
 
     ipcMain.on('app-create-settings-window', () => {
-      const settingWins = this._windowManager.getWindowsByType(WindowType.SETTING)
-      if (settingWins.length >= 1) {
-        // A setting window is already created
-        const browserSettingWindow = settingWins[0].win.browserWindow
-        if (isLinux) {
-          browserSettingWindow.focus()
-        } else {
-          browserSettingWindow.moveTop()
-        }
-        return
-      }
-      this._createSettingWindow()
+      this._openSettingsWindow()
     })
 
     ipcMain.on('app-open-file-by-id', (windowId, filePath) => {
@@ -510,6 +515,23 @@ class App {
 
     // --- renderer -------------------
 
+    ipcMain.on('mt::app-try-quit', () => {
+      app.quit()
+    })
+
+    ipcMain.on('mt::open-file-by-window-id', (e, windowId, filePath) => {
+      const resolvedPath = normalizeAndResolvePath(filePath)
+      const openFilesInNewWindow = this._accessor.preferences.getItem('openFilesInNewWindow')
+      if (openFilesInNewWindow) {
+        this._createEditorWindow(null, [resolvedPath])
+      } else {
+        const editor = this._windowManager.get(windowId)
+        if (editor) {
+          editor.openTab(resolvedPath, {}, true)
+        }
+      }
+    })
+
     ipcMain.on('mt::select-default-directory-to-open', async e => {
       const { preferences } = this._accessor
       const { defaultDirectoryToOpen } = preferences.getAll()
@@ -525,7 +547,19 @@ class App {
     })
 
     ipcMain.on('mt::open-setting-window', () => {
-      ipcMain.emit('app-create-settings-window')
+      this._openSettingsWindow()
+    })
+
+    ipcMain.on('mt::make-screenshot', e => {
+      const win = BrowserWindow.fromWebContents(e.sender)
+      ipcMain.emit('screen-capture', win)
+    })
+
+    ipcMain.on('mt::request-keybindings', e => {
+      const win = BrowserWindow.fromWebContents(e.sender)
+      const { keybindings } = this._accessor
+      // Convert map to object
+      win.webContents.send('mt::keybindings-response', Object.fromEntries(keybindings.keys))
     })
   }
 }

--- a/src/main/app/windowManager.js
+++ b/src/main/app/windowManager.js
@@ -376,6 +376,13 @@ class WindowManager extends EventEmitter {
       }
     })
 
+    ipcMain.on('mt::window-toggle-always-on-top', e => {
+      const win = BrowserWindow.fromWebContents(e.sender)
+      const flag = !win.isAlwaysOnTop()
+      win.setAlwaysOnTop(flag)
+      this._appMenu.updateAlwaysOnTopMenu(win.id, flag)
+    })
+
     // --- local events ---------------
 
     ipcMain.on('watcher-unwatch-all-by-id', windowId => {

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -3,8 +3,8 @@ export const isWindows = process.platform === 'win32'
 export const isLinux = process.platform === 'linux'
 
 export const editorWinOptions = {
-  minWidth: 450,
-  minHeight: 220,
+  minWidth: 550,
+  minHeight: 350,
   webPreferences: {
     nodeIntegration: true,
     webSecurity: false

--- a/src/main/filesystem/watcher.js
+++ b/src/main/filesystem/watcher.js
@@ -143,10 +143,10 @@ class Watcher {
         // This function is called twice, once with a single argument (the path),
         // second time with two arguments (the path and the "fs.Stats" object of that path).
         if (!fileInfo) {
-          return /(^|[/\\])(\..|node_modules)/.test(pathname)
+          return /(?:^|[/\\])(?:\..|node_modules|(?:.+\.asar))/.test(pathname)
         }
 
-        if (/(^|[/\\])(\..|node_modules)/.test(pathname)) {
+        if (/(?:^|[/\\])(?:\..|node_modules|(?:.+\.asar))/.test(pathname)) {
           return true
         }
         if (fileInfo.isDirectory()) {

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -22,94 +22,95 @@ class Keybindings {
 
     this.keys = new Map([
       // Mark Text - macOS only
-      ['mtHide', 'Command+H'],
-      ['mtHideOthers', 'Command+Alt+H'],
+      ['mt.hide', 'Command+H'],
+      ['mt.hide-others', 'Command+Alt+H'],
 
       // File menu
-      ['fileNewFile', 'CmdOrCtrl+N'],
-      ['fileNewTab', 'CmdOrCtrl+T'],
-      ['fileOpenFile', 'CmdOrCtrl+O'],
-      ['fileOpenFolder', 'CmdOrCtrl+Shift+O'],
-      ['fileSave', 'CmdOrCtrl+S'],
-      ['fileSaveAs', 'CmdOrCtrl+Shift+S'],
-      ['filePrint', 'CmdOrCtrl+P'],
-      ['filePreferences', 'CmdOrCtrl+,'], // marktext menu in macOS
-      ['fileCloseTab', 'CmdOrCtrl+W'],
-      ['fileCloseWindow', 'CmdOrCtrl+Shift+W'],
-      ['fileQuit', 'CmdOrCtrl+Q'],
+      ['file.new-file', 'CmdOrCtrl+N'],
+      ['file.new-tab', 'CmdOrCtrl+T'],
+      ['file.open-file', 'CmdOrCtrl+O'],
+      ['file.open-folder', 'CmdOrCtrl+Shift+O'],
+      ['file.save', 'CmdOrCtrl+S'],
+      ['file.save-as', 'CmdOrCtrl+Shift+S'],
+      ['file.preferences', 'CmdOrCtrl+,'], // marktext menu in macOS
+      ['file.close-tab', 'CmdOrCtrl+W'],
+      ['file.close-window', 'CmdOrCtrl+Shift+W'],
+      ['file.quit', 'CmdOrCtrl+Q'],
 
       // Edit menu
-      ['editUndo', 'CmdOrCtrl+Z'],
-      ['editRedo', 'CmdOrCtrl+Shift+Z'],
-      ['editCut', 'CmdOrCtrl+X'],
-      ['editCopy', 'CmdOrCtrl+C'],
-      ['editPaste', 'CmdOrCtrl+V'],
-      ['editCopyAsMarkdown', 'CmdOrCtrl+Shift+C'],
-      ['editCopyAsPlaintext', 'CmdOrCtrl+Shift+V'],
-      ['editSelectAll', 'CmdOrCtrl+A'],
-      ['editDuplicate', 'Shift+CmdOrCtrl+P'],
-      ['editCreateParagraph', 'Shift+CmdOrCtrl+N'],
-      ['editDeleteParagraph', 'Shift+CmdOrCtrl+D'],
-      ['editFind', 'CmdOrCtrl+F'],
-      ['editFindNext', 'CmdOrCtrl+Alt+U'],
-      ['editFindPrevious', 'CmdOrCtrl+Shift+U'],
-      ['editReplace', 'CmdOrCtrl+Alt+F'],
-      ['editFindInFolder', 'Shift+CmdOrCtrl+F'],
-      ['editAidou', 'CmdOrCtrl+/'],
-      ['editScreenshot', 'CmdOrCtrl+Alt+A'],
+      ['edit.undo', 'CmdOrCtrl+Z'],
+      ['edit.redo', 'CmdOrCtrl+Shift+Z'],
+      ['edit.cut', 'CmdOrCtrl+X'],
+      ['edit.copy', 'CmdOrCtrl+C'],
+      ['edit.paste', 'CmdOrCtrl+V'],
+      ['edit.copy-as-markdown', 'CmdOrCtrl+Shift+C'],
+      ['edit.copy-as-plaintext', 'CmdOrCtrl+Shift+V'],
+      ['edit.select-all', 'CmdOrCtrl+A'],
+      ['edit.duplicate', 'CmdOrCtrl+Alt+D'],
+      ['edit.create-paragraph', 'Shift+CmdOrCtrl+N'],
+      ['edit.delete-paragraph', 'Shift+CmdOrCtrl+D'],
+      ['edit.find', 'CmdOrCtrl+F'],
+      ['edit.find-next', 'CmdOrCtrl+Alt+U'],
+      ['edit.find-previous', 'CmdOrCtrl+Shift+U'],
+      ['edit.replace', 'CmdOrCtrl+Alt+F'],
+      ['edit.find-in-folder', 'Shift+CmdOrCtrl+F'],
+      ['edit.aidou', 'CmdOrCtrl+/'],
+      ['edit.screenshot', 'CmdOrCtrl+Alt+A'], // macOS only
 
       // Paragraph menu
-      ['paragraphHeading1', 'CmdOrCtrl+1'],
-      ['paragraphHeading2', 'CmdOrCtrl+2'],
-      ['paragraphHeading3', 'CmdOrCtrl+3'],
-      ['paragraphHeading4', 'CmdOrCtrl+4'],
-      ['paragraphHeading5', 'CmdOrCtrl+5'],
-      ['paragraphHeading6', 'CmdOrCtrl+6'],
-      ['paragraphUpgradeHeading', 'CmdOrCtrl+='],
-      ['paragraphDegradeHeading', 'CmdOrCtrl+-'],
-      ['paragraphTable', 'CmdOrCtrl+Shift+T'],
-      ['paragraphCodeFence', 'CmdOrCtrl+Alt+C'],
-      ['paragraphQuoteBlock', 'CmdOrCtrl+Alt+Q'],
-      ['paragraphMathBlock', 'CmdOrCtrl+Alt+M'],
-      ['paragraphHtmlBlock', isOsx ? 'CmdOrCtrl+Alt+J' : 'CmdOrCtrl+Alt+H'],
-      ['paragraphOrderList', 'CmdOrCtrl+Alt+O'],
-      ['paragraphBulletList', 'CmdOrCtrl+Alt+U'],
-      ['paragraphTaskList', 'CmdOrCtrl+Alt+X'],
-      ['paragraphLooseListItem', 'CmdOrCtrl+Alt+L'],
-      ['paragraphParagraph', 'CmdOrCtrl+0'],
-      ['paragraphHorizontalLine', 'CmdOrCtrl+Alt+-'],
-      ['paragraphYAMLFrontMatter', 'CmdOrCtrl+Alt+Y'],
+      ['paragraph.heading-1', 'CmdOrCtrl+1'],
+      ['paragraph.heading-2', 'CmdOrCtrl+2'],
+      ['paragraph.heading-3', 'CmdOrCtrl+3'],
+      ['paragraph.heading-4', 'CmdOrCtrl+4'],
+      ['paragraph.heading-5', 'CmdOrCtrl+5'],
+      ['paragraph.heading-6', 'CmdOrCtrl+6'],
+      ['paragraph.upgrade-heading', 'CmdOrCtrl+='],
+      ['paragraph.degrade-heading', 'CmdOrCtrl+-'],
+      ['paragraph.table', 'CmdOrCtrl+Shift+T'],
+      ['paragraph.code-fence', 'CmdOrCtrl+Alt+C'],
+      ['paragraph.quote-block', 'CmdOrCtrl+Alt+Q'],
+      ['paragraph.math-formula', 'CmdOrCtrl+Alt+M'],
+      ['paragraph.html-block', isOsx ? 'CmdOrCtrl+Alt+J' : 'CmdOrCtrl+Alt+H'],
+      ['paragraph.order-list', 'CmdOrCtrl+Alt+O'],
+      ['paragraph.bullet-list', 'CmdOrCtrl+Alt+U'],
+      ['paragraph.task-list', 'CmdOrCtrl+Alt+X'],
+      ['paragraph.loose-list-item', 'CmdOrCtrl+Alt+L'],
+      ['paragraph.paragraph', 'CmdOrCtrl+0'],
+      ['paragraph.horizontal-line', 'CmdOrCtrl+Alt+-'],
+      ['paragraph.front-matter', 'CmdOrCtrl+Alt+Y'],
 
       // Format menu
-      ['formatStrong', 'CmdOrCtrl+B'],
-      ['formatEmphasis', 'CmdOrCtrl+I'],
-      ['formatUnderline', 'CmdOrCtrl+U'],
-      ['highlight', 'Shift+CmdOrCtrl+H'],
-      ['formatInlineCode', 'CmdOrCtrl+`'],
-      ['formatInlineMath', 'Shift+CmdOrCtrl+M'],
-      ['formatStrike', 'CmdOrCtrl+D'],
-      ['formatHyperlink', 'CmdOrCtrl+L'],
-      ['formatImage', 'CmdOrCtrl+Shift+I'],
-      ['formatClearFormat', 'Shift+CmdOrCtrl+R'],
+      ['format.strong', 'CmdOrCtrl+B'],
+      ['format.emphasis', 'CmdOrCtrl+I'],
+      ['format.underline', 'CmdOrCtrl+U'],
+      ['format.highlight', 'Shift+CmdOrCtrl+H'],
+      ['format.inline-code', 'CmdOrCtrl+`'],
+      ['format.inline-math', 'Shift+CmdOrCtrl+M'],
+      ['format.strike', 'CmdOrCtrl+D'],
+      ['format.hyperlink', 'CmdOrCtrl+L'],
+      ['format.image', 'CmdOrCtrl+Shift+I'],
+      ['format.clear-format', 'Shift+CmdOrCtrl+R'],
 
       // Window menu
-      ['windowMinimize', 'CmdOrCtrl+M'],
+      ['window.minimize', 'CmdOrCtrl+M'],
+      ['window.toggle-full-screen', isOsx ? 'Ctrl+Command+F' : 'F11'],
 
       // View menu
-      ['viewToggleFullScreen', isOsx ? 'Ctrl+Command+F' : 'F11'],
-      ['viewSourceCodeMode', 'CmdOrCtrl+Alt+S'],
-      ['viewTypewriterMode', 'CmdOrCtrl+Alt+T'],
-      ['viewFocusMode', 'CmdOrCtrl+Shift+F'],
-      ['viewToggleSideBar', 'CmdOrCtrl+J'],
-      ['viewToggleTabBar', 'CmdOrCtrl+Alt+B'],
-      ['viewDevToggleDeveloperTools', 'CmdOrCtrl+Alt+I'],
-      ['viewDevReload', 'CmdOrCtrl+R'],
+      ['view.command-palette', 'CmdOrCtrl+Shift+P'],
+      ['view.source-code-mode', 'CmdOrCtrl+Alt+S'],
+      ['view.typewriter-mode', 'CmdOrCtrl+Alt+T'],
+      ['view.focus-mode', 'CmdOrCtrl+Shift+F'],
+      ['view.toggle-sidebar', 'CmdOrCtrl+J'],
+      ['view.toggle-tabbar', 'CmdOrCtrl+Alt+B'],
+      ['view.toggle-dev-tools', 'CmdOrCtrl+Alt+I'],
+      ['view.dev-reload', 'CmdOrCtrl+R'],
 
       // Misc
-      ['tabsCycleForward', 'CmdOrCtrl+Tab'],
-      ['tabsCycleBackward', 'CmdOrCtrl+Shift+Tab'],
-      ['tabsSwitchToLeft', 'CmdOrCtrl+PageUp'],
-      ['tabsSwitchToRight', 'CmdOrCtrl+PageDown']
+      ['tabs.cycle-forward', 'CmdOrCtrl+Tab'],
+      ['tabs.cycle-backward', 'CmdOrCtrl+Shift+Tab'],
+      ['tabs.switch-to-left', 'CmdOrCtrl+PageUp'],
+      ['tabs.switch-to-right', 'CmdOrCtrl+PageDown'],
+      ['file.quick-open', 'CmdOrCtrl+P']
     ])
 
     // Fix non-US keyboards
@@ -206,7 +207,7 @@ class Keybindings {
 
   // Fix dead backquote key on layouts like German
   _fixInlineCode () {
-    this.keys.set('formatInlineCode', 'CmdOrCtrl+Shift+B')
+    this.keys.set('format.inline-code', 'CmdOrCtrl+Shift+B')
   }
 
   _loadLocalKeybindings () {
@@ -222,8 +223,8 @@ class Keybindings {
 
     // keybindings.json example:
     // {
-    //   "fileSave": "CmdOrCtrl+S",
-    //   "fileSaveAs": "CmdOrCtrl+Shift+S"
+    //   "file.save": "CmdOrCtrl+S",
+    //   "file.save-as": "CmdOrCtrl+Shift+S"
     // }
 
     const userAccelerators = new Map()

--- a/src/main/menu/actions/edit.js
+++ b/src/main/menu/actions/edit.js
@@ -1,7 +1,6 @@
 import path from 'path'
 import { ipcMain, BrowserWindow } from 'electron'
 import log from 'electron-log'
-import { getMenuItemById } from '../index'
 import { searchFilesAndDir } from '../../utils/imagePathAutoComplement'
 
 ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
@@ -24,11 +23,7 @@ ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
 
 export const edit = (win, type) => {
   if (win && win.webContents) {
-    if (type === 'findInFolder') {
-      const sideBarMenuItem = getMenuItemById('sideBarMenuItem')
-      sideBarMenuItem.checked = true
-    }
-    win.webContents.send('mt::editor-edit-action', { type })
+    win.webContents.send('mt::editor-edit-action', type)
   }
 }
 
@@ -40,4 +35,14 @@ export const lineEnding = (win, lineEnding) => {
   if (win && win.webContents) {
     win.webContents.send('mt::set-line-ending', lineEnding)
   }
+}
+
+// --- IPC events -------------------------------------------------------------
+
+// NOTE: Don't use static `getMenuItemById` here, instead request the menu by
+//       window id from `AppMenu` manager.
+
+export const updateSidebarMenu = (applicationMenu, value) => {
+  const sideBarMenuItem = applicationMenu.getMenuItemById('sideBarMenuItem')
+  sideBarMenuItem.checked = !!value
 }

--- a/src/main/menu/actions/edit.js
+++ b/src/main/menu/actions/edit.js
@@ -23,22 +23,21 @@ ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
 })
 
 export const edit = (win, type) => {
-  if (type === 'findInFolder') {
-    const sideBarMenuItem = getMenuItemById('sideBarMenuItem')
-    sideBarMenuItem.checked = true
-  }
-
   if (win && win.webContents) {
-    win.webContents.send('AGANI::edit', { type })
+    if (type === 'findInFolder') {
+      const sideBarMenuItem = getMenuItemById('sideBarMenuItem')
+      sideBarMenuItem.checked = true
+    }
+    win.webContents.send('mt::editor-edit-action', { type })
   }
 }
 
-export const screenshot = (win, type) => {
+export const screenshot = win => {
   ipcMain.emit('screen-capture', win)
 }
 
 export const lineEnding = (win, lineEnding) => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::set-line-ending', { lineEnding, ignoreSaveStatus: false })
+    win.webContents.send('mt::set-line-ending', lineEnding)
   }
 }

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -406,6 +406,32 @@ ipcMain.on('AGANI::format-link-click', (e, { data, dirname }) => {
   }
 })
 
+// --- commands -------------------------------------
+
+ipcMain.on('mt::cmd-open-file', e => {
+  const win = BrowserWindow.fromWebContents(e.sender)
+  openFile(win)
+})
+
+ipcMain.on('mt::cmd-new-editor-window', () => {
+  newEditorWindow()
+})
+
+ipcMain.on('mt::cmd-open-folder', e => {
+  const win = BrowserWindow.fromWebContents(e.sender)
+  openFolder(win)
+})
+
+ipcMain.on('mt::cmd-close-window', e => {
+  const win = BrowserWindow.fromWebContents(e.sender)
+  win.close()
+})
+
+ipcMain.on('mt::cmd-import-file', e => {
+  const win = BrowserWindow.fromWebContents(e.sender)
+  importFile(win)
+})
+
 // --- menu -------------------------------------
 
 export const exportFile = (win, type) => {
@@ -487,19 +513,19 @@ export const newEditorWindow = () => {
 
 export const closeTab = win => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::close-tab')
+    win.webContents.send('mt::editor-close-tab')
   }
 }
 
 export const save = win => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::ask-file-save')
+    win.webContents.send('mt::editor-ask-file-save')
   }
 }
 
 export const saveAs = win => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::ask-file-save-as')
+    win.webContents.send('mt::editor-ask-file-save-as')
   }
 }
 
@@ -510,13 +536,13 @@ export const autoSave = (menuItem, browserWindow) => {
 
 export const moveTo = win => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::ask-file-move-to')
+    win.webContents.send('mt::editor-move-file')
   }
 }
 
 export const rename = win => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::ask-file-rename')
+    win.webContents.send('mt::editor-rename-file')
   }
 }
 

--- a/src/main/menu/actions/format.js
+++ b/src/main/menu/actions/format.js
@@ -10,7 +10,7 @@ const MENU_ID_FORMAT_MAP = {
 
 export const format = (win, type) => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::format', { type })
+    win.webContents.send('mt::editor-format-action', { type })
   }
 }
 

--- a/src/main/menu/actions/paragraph.js
+++ b/src/main/menu/actions/paragraph.js
@@ -28,7 +28,7 @@ const MENU_ID_MAP = {
 
 export const paragraph = (win, type) => {
   if (win && win.webContents) {
-    win.webContents.send('AGANI::paragraph', { type })
+    win.webContents.send('mt::editor-paragraph-action', { type })
   }
 }
 

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -5,6 +5,7 @@ import log from 'electron-log'
 import { ensureDirSync, isDirectory, isFile } from 'common/filesystem'
 import { isLinux, isOsx, isWindows } from '../config'
 import { parseMenu } from '../keyboard/shortcutHandler'
+import { updateSidebarMenu } from '../menu/actions/edit'
 import { updateFormatMenu } from '../menu/actions/format'
 import { updateSelectionMenus } from '../menu/actions/paragraph'
 import { viewLayoutChanged } from '../menu/actions/view'
@@ -434,6 +435,9 @@ class AppMenu {
     })
     ipcMain.on('mt::update-format-menu', (e, windowId, formats) => {
       updateFormatMenu(this.getWindowMenuById(windowId), formats)
+    })
+    ipcMain.on('mt::update-sidebar-menu', (e, windowId, value) => {
+      updateSidebarMenu(this.getWindowMenuById(windowId), value)
     })
     ipcMain.on('mt::view-layout-changed', (e, windowId, viewSettings) => {
       viewLayoutChanged(this.getWindowMenuById(windowId), viewSettings)

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -349,30 +349,37 @@ class AppMenu {
    */
   _appendMiscShortcuts = shortcutMap => {
     shortcutMap.push({
-      accelerator: this._keybindings.getAccelerator('tabsCycleForward'),
+      accelerator: this._keybindings.getAccelerator('tabs.cycle-forward'),
       click: (menuItem, win) => {
         win.webContents.send('mt::tabs-cycle-right')
       },
       id: null
     })
     shortcutMap.push({
-      accelerator: this._keybindings.getAccelerator('tabsCycleBackward'),
+      accelerator: this._keybindings.getAccelerator('tabs.cycle-backward'),
       click: (menuItem, win) => {
         win.webContents.send('mt::tabs-cycle-left')
       },
       id: null
     })
     shortcutMap.push({
-      accelerator: this._keybindings.getAccelerator('tabsSwitchToLeft'),
+      accelerator: this._keybindings.getAccelerator('tabs.switch-to-left'),
       click: (menuItem, win) => {
         win.webContents.send('mt::tabs-cycle-left')
       },
       id: null
     })
     shortcutMap.push({
-      accelerator: this._keybindings.getAccelerator('tabsSwitchToRight'),
+      accelerator: this._keybindings.getAccelerator('tabs.switch-to-right'),
       click: (menuItem, win) => {
         win.webContents.send('mt::tabs-cycle-right')
+      },
+      id: null
+    })
+    shortcutMap.push({
+      accelerator: this._keybindings.getAccelerator('file.quick-open'),
+      click: (menuItem, win) => {
+        win.webContents.send('mt::execute-command-by-id', 'file.quick-open')
       },
       id: null
     })

--- a/src/main/menu/templates/edit.js
+++ b/src/main/menu/templates/edit.js
@@ -7,13 +7,13 @@ export default function (keybindings, userPreference) {
     label: '&Edit',
     submenu: [{
       label: 'Undo',
-      accelerator: keybindings.getAccelerator('editUndo'),
+      accelerator: keybindings.getAccelerator('edit.undo'),
       click: (menuItem, browserWindow) => {
         actions.edit(browserWindow, 'undo')
       }
     }, {
       label: 'Redo',
-      accelerator: keybindings.getAccelerator('editRedo'),
+      accelerator: keybindings.getAccelerator('edit.redo'),
       click: (menuItem, browserWindow) => {
         actions.edit(browserWindow, 'redo')
       }
@@ -21,32 +21,32 @@ export default function (keybindings, userPreference) {
       type: 'separator'
     }, {
       label: 'Cut',
-      accelerator: keybindings.getAccelerator('editCut'),
+      accelerator: keybindings.getAccelerator('edit.cut'),
       role: 'cut'
     }, {
       label: 'Copy',
-      accelerator: keybindings.getAccelerator('editCopy'),
+      accelerator: keybindings.getAccelerator('edit.copy'),
       role: 'copy'
     }, {
       label: 'Paste',
-      accelerator: keybindings.getAccelerator('editPaste'),
+      accelerator: keybindings.getAccelerator('edit.paste'),
       role: 'paste'
     }, {
       type: 'separator'
     }, {
-      label: 'Copy As Markdown',
-      accelerator: keybindings.getAccelerator('editCopyAsMarkdown'),
+      label: 'Copy as Markdown',
+      accelerator: keybindings.getAccelerator('edit.copy-as-markdown'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'copyAsMarkdown')
       }
     }, {
-      label: 'Copy As HTML',
+      label: 'Copy as HTML',
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'copyAsHtml')
       }
     }, {
-      label: 'Paste As Plain Text',
-      accelerator: keybindings.getAccelerator('editCopyAsPlaintext'),
+      label: 'Paste as Plain Text',
+      accelerator: keybindings.getAccelerator('edit.copy-as-plaintext'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'pasteAsPlainText')
       }
@@ -54,7 +54,7 @@ export default function (keybindings, userPreference) {
       type: 'separator'
     }, {
       label: 'Select All',
-      accelerator: keybindings.getAccelerator('editSelectAll'),
+      accelerator: keybindings.getAccelerator('edit.select-all'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'selectAll')
       }
@@ -62,19 +62,19 @@ export default function (keybindings, userPreference) {
       type: 'separator'
     }, {
       label: 'Duplicate',
-      accelerator: keybindings.getAccelerator('editDuplicate'),
+      accelerator: keybindings.getAccelerator('edit.duplicate'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'duplicate')
       }
     }, {
       label: 'Create Paragraph',
-      accelerator: keybindings.getAccelerator('editCreateParagraph'),
+      accelerator: keybindings.getAccelerator('edit.create-paragraph'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'createParagraph')
       }
     }, {
       label: 'Delete Paragraph',
-      accelerator: keybindings.getAccelerator('editDeleteParagraph'),
+      accelerator: keybindings.getAccelerator('edit.delete-paragraph'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'deleteParagraph')
       }
@@ -82,25 +82,25 @@ export default function (keybindings, userPreference) {
       type: 'separator'
     }, {
       label: 'Find',
-      accelerator: keybindings.getAccelerator('editFind'),
+      accelerator: keybindings.getAccelerator('edit.find'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'find')
       }
     }, {
       label: 'Find Next',
-      accelerator: keybindings.getAccelerator('editFindNext'),
+      accelerator: keybindings.getAccelerator('edit.find-next'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'fineNext')
       }
     }, {
       label: 'Find Previous',
-      accelerator: keybindings.getAccelerator('editFindPrevious'),
+      accelerator: keybindings.getAccelerator('edit.find-previous'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'findPrev')
       }
     }, {
       label: 'Replace',
-      accelerator: keybindings.getAccelerator('editReplace'),
+      accelerator: keybindings.getAccelerator('edit.replace'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'replace')
       }
@@ -108,7 +108,7 @@ export default function (keybindings, userPreference) {
       type: 'separator'
     }, {
       label: 'Find in Folder',
-      accelerator: keybindings.getAccelerator('editFindInFolder'),
+      accelerator: keybindings.getAccelerator('edit.find-in-folder'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'findInFolder')
       }
@@ -118,7 +118,7 @@ export default function (keybindings, userPreference) {
       label: 'Aidou',
       visible: aidou,
       id: 'aidou',
-      accelerator: keybindings.getAccelerator('editAidou'),
+      accelerator: keybindings.getAccelerator('edit.aidou'),
       click (menuItem, browserWindow) {
         actions.edit(browserWindow, 'aidou')
       }
@@ -126,9 +126,9 @@ export default function (keybindings, userPreference) {
       label: 'Screenshot',
       id: 'screenshot',
       visible: isOsx,
-      accelerator: keybindings.getAccelerator('editScreenshot'),
+      accelerator: keybindings.getAccelerator('edit.screenshot'),
       click (menuItem, browserWindow) {
-        actions.screenshot(browserWindow, 'screenshot')
+        actions.screenshot(browserWindow)
       }
     }, {
       type: 'separator'

--- a/src/main/menu/templates/file.js
+++ b/src/main/menu/templates/file.js
@@ -10,14 +10,14 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     label: '&File',
     submenu: [{
       label: 'New Tab',
-      accelerator: keybindings.getAccelerator('fileNewTab'),
+      accelerator: keybindings.getAccelerator('file.new-tab'),
       click (menuItem, browserWindow) {
         actions.newBlankTab(browserWindow)
         showTabBar(browserWindow)
       }
     }, {
       label: 'New Window',
-      accelerator: keybindings.getAccelerator('fileNewFile'),
+      accelerator: keybindings.getAccelerator('file.new-file'),
       click (menuItem, browserWindow) {
         actions.newEditorWindow()
       }
@@ -25,13 +25,13 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
       type: 'separator'
     }, {
       label: 'Open File',
-      accelerator: keybindings.getAccelerator('fileOpenFile'),
+      accelerator: keybindings.getAccelerator('file.open-file'),
       click (menuItem, browserWindow) {
         actions.openFile(browserWindow)
       }
     }, {
       label: 'Open Folder',
-      accelerator: keybindings.getAccelerator('fileOpenFolder'),
+      accelerator: keybindings.getAccelerator('file.open-folder'),
       click (menuItem, browserWindow) {
         actions.openFolder(browserWindow)
       }
@@ -81,13 +81,13 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     type: 'separator'
   }, {
     label: 'Save',
-    accelerator: keybindings.getAccelerator('fileSave'),
+    accelerator: keybindings.getAccelerator('file.save'),
     click (menuItem, browserWindow) {
       actions.save(browserWindow)
     }
   }, {
     label: 'Save As...',
-    accelerator: keybindings.getAccelerator('fileSaveAs'),
+    accelerator: keybindings.getAccelerator('file.save-as'),
     click (menuItem, browserWindow) {
       actions.saveAs(browserWindow)
     }
@@ -135,7 +135,7 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     ]
   }, {
     label: 'Print',
-    accelerator: keybindings.getAccelerator('filePrint'),
+    accelerator: keybindings.getAccelerator('file.print'),
     click (menuItem, browserWindow) {
       actions.print(browserWindow)
     }
@@ -144,29 +144,29 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     visible: !isOsx
   }, {
     label: 'Preferences',
-    accelerator: keybindings.getAccelerator('filePreferences'),
+    accelerator: keybindings.getAccelerator('file.preferences'),
     visible: !isOsx,
-    click (menuItem, browserWindow) {
-      userSetting(menuItem, browserWindow)
+    click () {
+      userSetting()
     }
   }, {
     type: 'separator'
   }, {
     label: 'Close Tab',
-    accelerator: keybindings.getAccelerator('fileCloseTab'),
+    accelerator: keybindings.getAccelerator('file.close-tab'),
     click (menuItem, browserWindow) {
       actions.closeTab(browserWindow)
     }
   }, {
     label: 'Close Window',
-    accelerator: keybindings.getAccelerator('fileCloseWindow'),
+    accelerator: keybindings.getAccelerator('file.close-window'),
     role: 'close'
   }, {
     type: 'separator',
     visible: !isOsx
   }, {
     label: 'Quit',
-    accelerator: keybindings.getAccelerator('fileQuit'),
+    accelerator: keybindings.getAccelerator('file.quit'),
     visible: !isOsx,
     click: app.quit
   })

--- a/src/main/menu/templates/format.js
+++ b/src/main/menu/templates/format.js
@@ -8,7 +8,7 @@ export default function (keybindings) {
       id: 'strongMenuItem',
       label: 'Strong',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatStrong'),
+      accelerator: keybindings.getAccelerator('format.strong'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'strong')
       }
@@ -16,7 +16,7 @@ export default function (keybindings) {
       id: 'emphasisMenuItem',
       label: 'Emphasis',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatEmphasis'),
+      accelerator: keybindings.getAccelerator('format.emphasis'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'em')
       }
@@ -24,7 +24,7 @@ export default function (keybindings) {
       id: 'underlineMenuItem',
       label: 'Underline',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatUnderline'),
+      accelerator: keybindings.getAccelerator('format.underline'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'u')
       }
@@ -48,7 +48,7 @@ export default function (keybindings) {
       id: 'highlightMenuItem',
       label: 'Highlight',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('highlight'),
+      accelerator: keybindings.getAccelerator('format.highlight'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'mark')
       }
@@ -58,7 +58,7 @@ export default function (keybindings) {
       id: 'inlineCodeMenuItem',
       label: 'Inline Code',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatInlineCode'),
+      accelerator: keybindings.getAccelerator('format.inline-code'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'inline_code')
       }
@@ -66,7 +66,7 @@ export default function (keybindings) {
       id: 'inlineMathMenuItem',
       label: 'Inline Math',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatInlineMath'),
+      accelerator: keybindings.getAccelerator('format.inline-math'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'inline_math')
       }
@@ -76,7 +76,7 @@ export default function (keybindings) {
       id: 'strikeMenuItem',
       label: 'Strike',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatStrike'),
+      accelerator: keybindings.getAccelerator('format.strike'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'del')
       }
@@ -84,7 +84,7 @@ export default function (keybindings) {
       id: 'hyperlinkMenuItem',
       label: 'Hyperlink',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatHyperlink'),
+      accelerator: keybindings.getAccelerator('format.hyperlink'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'link')
       }
@@ -92,7 +92,7 @@ export default function (keybindings) {
       id: 'imageMenuItem',
       label: 'Image',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('formatImage'),
+      accelerator: keybindings.getAccelerator('format.image'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'image')
       }
@@ -100,7 +100,7 @@ export default function (keybindings) {
       type: 'separator'
     }, {
       label: 'Clear Format',
-      accelerator: keybindings.getAccelerator('formatClearFormat'),
+      accelerator: keybindings.getAccelerator('format.clear-format'),
       click (menuItem, browserWindow) {
         actions.format(browserWindow, 'clear')
       }

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -84,7 +84,7 @@ export default function () {
     }, {
       label: 'Check for updates...',
       click (menuItem, browserWindow) {
-        checkUpdates(menuItem, browserWindow)
+        checkUpdates(browserWindow)
       }
     })
   }

--- a/src/main/menu/templates/marktext.js
+++ b/src/main/menu/templates/marktext.js
@@ -13,13 +13,13 @@ export default function (keybindings) {
     }, {
       label: 'Check for updates...',
       click (menuItem, browserWindow) {
-        actions.checkUpdates(menuItem, browserWindow)
+        actions.checkUpdates(browserWindow)
       }
     }, {
       label: 'Preferences',
-      accelerator: keybindings.getAccelerator('filePreferences'),
-      click (menuItem, browserWindow) {
-        actions.userSetting(menuItem, browserWindow)
+      accelerator: keybindings.getAccelerator('file.preferences'),
+      click () {
+        actions.userSetting()
       }
     }, {
       type: 'separator'
@@ -31,11 +31,11 @@ export default function (keybindings) {
       type: 'separator'
     }, {
       label: 'Hide Mark Text',
-      accelerator: keybindings.getAccelerator('mtHide'),
+      accelerator: keybindings.getAccelerator('mt.hide'),
       role: 'hide'
     }, {
       label: 'Hide Others',
-      accelerator: keybindings.getAccelerator('mtHideOthers'),
+      accelerator: keybindings.getAccelerator('mt.hide-others'),
       role: 'hideothers'
     }, {
       label: 'Show All',
@@ -44,7 +44,7 @@ export default function (keybindings) {
       type: 'separator'
     }, {
       label: 'Quit Mark Text',
-      accelerator: keybindings.getAccelerator('fileQuit'),
+      accelerator: keybindings.getAccelerator('file.quit'),
       click: app.quit
     }]
   }

--- a/src/main/menu/templates/paragraph.js
+++ b/src/main/menu/templates/paragraph.js
@@ -8,7 +8,7 @@ export default function (keybindings) {
       id: 'heading1MenuItem',
       label: 'Heading 1',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading1'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-1'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 1')
       }
@@ -16,7 +16,7 @@ export default function (keybindings) {
       id: 'heading2MenuItem',
       label: 'Heading 2',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading2'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-2'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 2')
       }
@@ -24,7 +24,7 @@ export default function (keybindings) {
       id: 'heading3MenuItem',
       label: 'Heading 3',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading3'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-3'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 3')
       }
@@ -32,7 +32,7 @@ export default function (keybindings) {
       id: 'heading4MenuItem',
       label: 'Heading 4',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading4'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-4'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 4')
       }
@@ -40,7 +40,7 @@ export default function (keybindings) {
       id: 'heading5MenuItem',
       label: 'Heading 5',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading5'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-5'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 5')
       }
@@ -48,7 +48,7 @@ export default function (keybindings) {
       id: 'heading6MenuItem',
       label: 'Heading 6',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHeading6'),
+      accelerator: keybindings.getAccelerator('paragraph.heading-6'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'heading 6')
       }
@@ -57,14 +57,14 @@ export default function (keybindings) {
     }, {
       id: 'upgradeHeadingMenuItem',
       label: 'Upgrade Heading',
-      accelerator: keybindings.getAccelerator('paragraphUpgradeHeading'),
+      accelerator: keybindings.getAccelerator('paragraph.upgrade-heading'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'upgrade heading')
       }
     }, {
       id: 'degradeHeadingMenuItem',
       label: 'Degrade Heading',
-      accelerator: keybindings.getAccelerator('paragraphDegradeHeading'),
+      accelerator: keybindings.getAccelerator('paragraph.degrade-heading'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'degrade heading')
       }
@@ -74,7 +74,7 @@ export default function (keybindings) {
       id: 'tableMenuItem',
       label: 'Table',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphTable'),
+      accelerator: keybindings.getAccelerator('paragraph.table'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'table')
       }
@@ -82,7 +82,7 @@ export default function (keybindings) {
       id: 'codeFencesMenuItem',
       label: 'Code Fences',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphCodeFence'),
+      accelerator: keybindings.getAccelerator('paragraph.code-fence'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'pre')
       }
@@ -90,7 +90,7 @@ export default function (keybindings) {
       id: 'quoteBlockMenuItem',
       label: 'Quote Block',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphQuoteBlock'),
+      accelerator: keybindings.getAccelerator('paragraph.quote-block'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'blockquote')
       }
@@ -98,7 +98,7 @@ export default function (keybindings) {
       id: 'mathBlockMenuItem',
       label: 'Math Block',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphMathBlock'),
+      accelerator: keybindings.getAccelerator('paragraph.math-formula'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'mathblock')
       }
@@ -106,7 +106,7 @@ export default function (keybindings) {
       id: 'htmlBlockMenuItem',
       label: 'Html Block',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHtmlBlock'),
+      accelerator: keybindings.getAccelerator('paragraph.html-block'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'html')
       }
@@ -116,7 +116,7 @@ export default function (keybindings) {
       id: 'orderListMenuItem',
       label: 'Order List',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphOrderList'),
+      accelerator: keybindings.getAccelerator('paragraph.order-list'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'ol-order')
       }
@@ -124,7 +124,7 @@ export default function (keybindings) {
       id: 'bulletListMenuItem',
       label: 'Bullet List',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphBulletList'),
+      accelerator: keybindings.getAccelerator('paragraph.bullet-list'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'ul-bullet')
       }
@@ -132,7 +132,7 @@ export default function (keybindings) {
       id: 'taskListMenuItem',
       label: 'Task List',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphTaskList'),
+      accelerator: keybindings.getAccelerator('paragraph.task-list'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'ul-task')
       }
@@ -142,7 +142,7 @@ export default function (keybindings) {
       id: 'looseListItemMenuItem',
       label: 'Loose List Item',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphLooseListItem'),
+      accelerator: keybindings.getAccelerator('paragraph.loose-list-item'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'loose-list-item')
       }
@@ -152,7 +152,7 @@ export default function (keybindings) {
       id: 'paragraphMenuItem',
       label: 'Paragraph',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphParagraph'),
+      accelerator: keybindings.getAccelerator('paragraph.paragraph'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'paragraph')
       }
@@ -160,7 +160,7 @@ export default function (keybindings) {
       id: 'horizontalLineMenuItem',
       label: 'Horizontal Line',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphHorizontalLine'),
+      accelerator: keybindings.getAccelerator('paragraph.horizontal-line'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'hr')
       }
@@ -168,7 +168,7 @@ export default function (keybindings) {
       id: 'frontMatterMenuItem',
       label: 'Front Matter',
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('paragraphYAMLFrontMatter'),
+      accelerator: keybindings.getAccelerator('paragraph.front-matter'),
       click (menuItem, browserWindow) {
         actions.paragraph(browserWindow, 'front-matter')
       }

--- a/src/main/menu/templates/prefEdit.js
+++ b/src/main/menu/templates/prefEdit.js
@@ -3,21 +3,21 @@ export default function (keybindings) {
     label: 'Edit',
     submenu: [{
       label: 'Cut',
-      accelerator: keybindings.getAccelerator('editCut'),
+      accelerator: keybindings.getAccelerator('edit.cut'),
       role: 'cut'
     }, {
       label: 'Copy',
-      accelerator: keybindings.getAccelerator('editCopy'),
+      accelerator: keybindings.getAccelerator('edit.copy'),
       role: 'copy'
     }, {
       label: 'Paste',
-      accelerator: keybindings.getAccelerator('editPaste'),
+      accelerator: keybindings.getAccelerator('edit.paste'),
       role: 'paste'
     }, {
       type: 'separator'
     }, {
       label: 'Select All',
-      accelerator: keybindings.getAccelerator('editSelectAll'),
+      accelerator: keybindings.getAccelerator('edit.select-all'),
       role: 'selectAll'
     }]
   }

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -5,9 +5,17 @@ export default function (keybindings) {
   const viewMenu = {
     label: '&View',
     submenu: [{
+      label: 'Command Palette',
+      accelerator: keybindings.getAccelerator('view.command-palette'),
+      click (menuItem, browserWindow) {
+        actions.showCommandPalette(browserWindow)
+      }
+    }, {
+      type: 'separator'
+    }, {
       id: 'sourceCodeModeMenuItem',
       label: 'Source Code Mode',
-      accelerator: keybindings.getAccelerator('viewSourceCodeMode'),
+      accelerator: keybindings.getAccelerator('view.source-code-mode'),
       type: 'checkbox',
       checked: false,
       click (item, browserWindow, event) {
@@ -20,7 +28,7 @@ export default function (keybindings) {
     }, {
       id: 'typewriterModeMenuItem',
       label: 'Typewriter Mode',
-      accelerator: keybindings.getAccelerator('viewTypewriterMode'),
+      accelerator: keybindings.getAccelerator('view.typewriter-mode'),
       type: 'checkbox',
       checked: false,
       click (item, browserWindow, event) {
@@ -33,7 +41,7 @@ export default function (keybindings) {
     }, {
       id: 'focusModeMenuItem',
       label: 'Focus Mode',
-      accelerator: keybindings.getAccelerator('viewFocusMode'),
+      accelerator: keybindings.getAccelerator('view.focus-mode'),
       type: 'checkbox',
       checked: false,
       click (item, browserWindow, event) {
@@ -46,9 +54,9 @@ export default function (keybindings) {
     }, {
       type: 'separator'
     }, {
-      label: 'Toggle Side Bar',
+      label: 'Toggle Sidebar',
       id: 'sideBarMenuItem',
-      accelerator: keybindings.getAccelerator('viewToggleSideBar'),
+      accelerator: keybindings.getAccelerator('view.toggle-sidebar'),
       type: 'checkbox',
       checked: false,
       click (item, browserWindow, event) {
@@ -60,9 +68,9 @@ export default function (keybindings) {
         actions.layout(item, browserWindow, 'showSideBar')
       }
     }, {
-      label: 'Toggle Tab Bar',
+      label: 'Toggle Tabbar',
       id: 'tabBarMenuItem',
-      accelerator: keybindings.getAccelerator('viewToggleTabBar'),
+      accelerator: keybindings.getAccelerator('view.toggle-tabbar'),
       type: 'checkbox',
       checked: false,
       click (item, browserWindow, event) {
@@ -81,7 +89,7 @@ export default function (keybindings) {
   if (global.MARKTEXT_DEBUG) {
     viewMenu.submenu.push({
       label: 'Toggle Developer Tools',
-      accelerator: keybindings.getAccelerator('viewDevToggleDeveloperTools'),
+      accelerator: keybindings.getAccelerator('view.toggle-dev-tools'),
       click (item, focusedWindow) {
         if (focusedWindow) {
           focusedWindow.webContents.toggleDevTools()
@@ -90,7 +98,7 @@ export default function (keybindings) {
     })
     viewMenu.submenu.push({
       label: 'Reload',
-      accelerator: keybindings.getAccelerator('viewDevReload'),
+      accelerator: keybindings.getAccelerator('view.dev-reload'),
       click (item, focusedWindow) {
         if (focusedWindow) {
           ipcMain.emit('window-reload-by-id', focusedWindow.id)

--- a/src/main/menu/templates/window.js
+++ b/src/main/menu/templates/window.js
@@ -7,7 +7,7 @@ export default function (keybindings) {
     role: 'window',
     submenu: [{
       label: 'Minimize',
-      accelerator: keybindings.getAccelerator('windowMinimize'),
+      accelerator: keybindings.getAccelerator('window.minimize'),
       role: 'minimize'
     }, {
       id: 'alwaysOnTopMenuItem',
@@ -32,7 +32,7 @@ export default function (keybindings) {
       type: 'separator'
     }, {
       label: 'Toggle Full Screen',
-      accelerator: keybindings.getAccelerator('viewToggleFullScreen'),
+      accelerator: keybindings.getAccelerator('window.toggle-full-screen'),
       click (item, focusedWindow) {
         if (focusedWindow) {
           focusedWindow.setFullScreen(!focusedWindow.isFullScreen())

--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -133,9 +133,11 @@ class Preference extends EventEmitter {
       const win = BrowserWindow.fromWebContents(e.sender)
       win.webContents.send('AGANI::user-preference', this.getAll())
     })
-
     ipcMain.on('mt::set-user-preference', (e, settings) => {
       this.setItems(settings)
+    })
+    ipcMain.on('mt::cmd-toggle-autosave', e => {
+      this.setItem('autoSave', !!this.getItem('autoSave'))
     })
 
     ipcMain.on('set-user-preference', settings => {

--- a/src/main/windows/setting.js
+++ b/src/main/windows/setting.js
@@ -87,7 +87,7 @@ class SettingWindow extends BaseWindow {
 
     electronLocalshortcut.register(
       win,
-      keybindings.getAccelerator('viewDevToggleDeveloperTools'),
+      keybindings.getAccelerator('view.toggle-dev-tools'),
       () => {
         win.webContents.toggleDevTools()
       }

--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -446,8 +446,30 @@ const paragraphCtrl = ContentState => {
   ContentState.prototype.updateParagraph = function (paraType, insertMode = false) {
     const { start, end } = this.cursor
     const block = this.getBlock(start.key)
-    const { text } = block
+    const { text, type } = block
     let needDispatchChange = true
+
+    // Only allow valid transformations.
+    if (!this.isAllowedTransformation(block, paraType, start.key !== end.key)) {
+      return
+    }
+
+    // Convert back to paragraph.
+    if (paraType === 'reset-to-paragraph') {
+      const blockType = this.getTypeFromBlock(block)
+      if (!blockType) {
+        return
+      }
+
+      // FIXME: This will fail on blockquotes and list items because we cannot distinguish from a paragraph.
+      if (blockType === 'table') {
+        return
+      } else if (/heading|hr/.test(blockType)) {
+        paraType = 'paragraph'
+      } else {
+        paraType = blockType
+      }
+    }
 
     switch (paraType) {
       case 'front-matter': {
@@ -499,7 +521,10 @@ const paragraphCtrl = ContentState => {
       case 'upgrade heading':
       case 'degrade heading':
       case 'paragraph': {
-        if (start.key !== end.key) return
+        if (start.key !== end.key) {
+          return
+        }
+
         const headingStyle = DEFAULT_TURNDOWN_CONFIG.headingStyle
         const parent = this.getParent(block)
         // \u00A0 is &nbsp;
@@ -530,9 +555,14 @@ const paragraphCtrl = ContentState => {
         const endOffset = newLevel > 0
           ? end.offset + newLevel - hash.length + 1
           : end.offset - hash.length
-        const newText = newLevel > 0
-          ? '#'.repeat(newLevel) + `${String.fromCharCode(160)}${partText}` // &nbsp; code: 160
-          : partText
+
+        // Remove <hr> content when converting to paragraph.
+        let newText = ''
+        if (type !== 'span' && block.functionType !== 'thematicBreakLine') {
+          newText = newLevel > 0
+            ? '#'.repeat(newLevel) + `${String.fromCharCode(160)}${partText}` // &nbsp; code: 160
+            : partText
+        }
 
         // No change
         if (newType === 'p' && parent.type === newType) {
@@ -833,6 +863,131 @@ const paragraphCtrl = ContentState => {
     }
 
     return this.selectAllContent()
+  }
+
+  // Test whether the paragraph transformation is valid.
+  ContentState.prototype.isAllowedTransformation = function (block, toType, isMultilineSelection) {
+    const fromType = this.getTypeFromBlock(block)
+    if (toType === 'front-matter') {
+      // Front matter block is added at the beginning.
+      return true
+    } else if (!fromType) {
+      return false
+    } else if (isMultilineSelection && /heading|table/.test(toType)) {
+      return false
+    } else if (fromType === toType || toType === 'reset-to-paragraph') {
+      // Convert back to paragraph.
+      return true
+    }
+
+    switch (fromType) {
+      case 'paragraph':
+        return !/hr|table/.test(toType)
+      case 'heading 1':
+      case 'heading 2':
+      case 'heading 3':
+      case 'heading 4':
+      case 'heading 5':
+      case 'heading 6':
+        return /paragraph|heading/.test(toType)
+      case 'ul-bulle':
+      case 'ul-task':
+      case 'ol-order':
+        return /ul|ol|loose-list-item/.test(toType)
+      default:
+        // Tables and all code blocks are not allowed.
+        return false
+    }
+  }
+
+  // Translate block type into internal name.
+  ContentState.prototype.getTypeFromBlock = function (block) {
+    const { type } = block
+
+    let internalType = ''
+    const headingMatch = type.match(/^h([1-6]{1})$/)
+    if (headingMatch && headingMatch[1]) {
+      internalType = `heading ${headingMatch[1]}`
+    }
+
+    switch (type) {
+      case 'span': {
+        if (block.functionType === 'atxLine') {
+          internalType = 'heading 1' // loose match
+        } else if (block.functionType === 'languageInput') {
+          internalType = 'pre'
+        } else if (block.functionType === 'codeContent') {
+          if (block.lang === 'markup') {
+            internalType = 'html'
+          } else if (block.lang === 'latex') {
+            internalType = 'mathblock'
+          }
+
+          // FIXME: We cannot distinguish between diagram and code blocks.
+          internalType = 'pre'
+        } else if (block.functionType === 'cellContent') {
+          internalType = 'table'
+        } else if (block.functionType === 'paragraphContent') {
+          internalType = 'paragraph'
+        } else if (block.functionType === 'thematicBreakLine') {
+          internalType = 'hr'
+        }
+        break
+      }
+      case 'div': {
+        // Preview for math formulas or diagramms.
+        return ''
+      }
+      case 'figure': {
+        if (block.functionType === 'multiplemath') {
+          internalType = 'mathblock'
+        } else {
+          internalType = block.functionType
+        }
+        break
+      }
+      case 'pre': {
+        if (block.functionType === 'multiplemath') {
+          internalType = 'mathblock'
+        } else if (block.functionType === 'fencecode' || block.functionType === 'indentcode') {
+          internalType = 'pre'
+        } else if (block.functionType === 'frontmatter') {
+          internalType = 'front-matter'
+        } else {
+          internalType = block.functionType
+        }
+        break
+      }
+      case 'ul': {
+        if (block.listType === 'task') {
+          internalType = 'ul-task'
+        } else {
+          internalType = 'ul-bullet'
+        }
+        break
+      }
+      case 'ol': {
+        internalType = 'ol-order'
+        break
+      }
+      case 'li': {
+        if (block.listItemType === 'order') {
+          internalType = 'ol-order'
+        } else if (block.listItemType === 'bullet') {
+          internalType = 'ul-bullet'
+        } else if (block.listItemType === 'task') {
+          internalType = 'ul-task'
+        }
+        break
+      }
+      case 'table':
+      case 'th':
+      case 'td': {
+        internalType = 'table'
+        break
+      }
+    }
+    return internalType
   }
 }
 

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -267,10 +267,11 @@ class Muya {
   }
 
   blur (isRemoveAllRange = false) {
-    const selection = document.getSelection()
     if (isRemoveAllRange) {
+      const selection = document.getSelection()
       selection.removeAllRanges()
     }
+    this.hideAllFloatTools()
     this.container.blur()
   }
 

--- a/src/muya/lib/ui/frontMenu/config.js
+++ b/src/muya/lib/ui/frontMenu/config.js
@@ -3,10 +3,10 @@ import newIcon from '../../assets/pngicon/paragraph/2.png'
 import deleteIcon from '../../assets/pngicon/delete/2.png'
 import turnIcon from '../../assets/pngicon/turninto/2.png'
 import { isOsx } from '../../config'
-import { quicInsertObj } from '../quickInsert/config'
+import { quickInsertObj } from '../quickInsert/config'
 
-const wholeSubMenu = Object.keys(quicInsertObj).reduce((acc, key) => {
-  const items = quicInsertObj[key]
+const wholeSubMenu = Object.keys(quickInsertObj).reduce((acc, key) => {
+  const items = quickInsertObj[key]
   return [...acc, ...items]
 }, [])
 

--- a/src/muya/lib/ui/quickInsert/config.js
+++ b/src/muya/lib/ui/quickInsert/config.js
@@ -30,7 +30,7 @@ const COMMAND_KEY = isOsx ? '⌘' : '⌃'
 // Caps Lock ⇪
 // Fn
 
-export const quicInsertObj = {
+export const quickInsertObj = {
   'basic block': [{
     title: 'Paragraph',
     subTitle: 'Lorem Ipsum is simply dummy text',

--- a/src/muya/lib/ui/quickInsert/index.js
+++ b/src/muya/lib/ui/quickInsert/index.js
@@ -2,7 +2,7 @@ import { filter } from 'fuzzaldrin'
 import { patch, h } from '../../parser/render/snabbdom'
 import { deepCopy } from '../../utils'
 import BaseScrollFloat from '../baseScrollFloat'
-import { quicInsertObj } from './config'
+import { quickInsertObj } from './config'
 import './index.css'
 
 class QuickInsert extends BaseScrollFloat {
@@ -17,7 +17,7 @@ class QuickInsert extends BaseScrollFloat {
     this.renderArray = null
     this.activeItem = null
     this.block = null
-    this.renderObj = quicInsertObj
+    this.renderObj = quickInsertObj
     this.render()
     this.listen()
   }
@@ -104,7 +104,7 @@ class QuickInsert extends BaseScrollFloat {
   search (text) {
     const { contentState } = this.muya
     const canInserFrontMatter = contentState.canInserFrontMatter(this.block)
-    const obj = deepCopy(quicInsertObj)
+    const obj = deepCopy(quickInsertObj)
     if (!canInserFrontMatter) {
       obj['basic block'].splice(2, 1)
     }

--- a/src/muya/lib/utils/exportMarkdown.js
+++ b/src/muya/lib/utils/exportMarkdown.js
@@ -158,7 +158,7 @@ class ExportMarkdown {
           break
         }
         default: {
-          console.log(block.type)
+          console.warn('translateBlocks2Markdown: Unknown block type:', block.type)
           break
         }
       }

--- a/src/renderer/commands/fileEncoding.js
+++ b/src/renderer/commands/fileEncoding.js
@@ -1,0 +1,80 @@
+import { ipcRenderer } from 'electron'
+import { ENCODING_NAME_MAP, getEncodingName } from 'common/encoding'
+import { delay } from '@/util'
+import bus from '../bus'
+
+class FileEncodingCommand {
+  constructor (editorState) {
+    this.id = 'file.change-encoding'
+    this.description = 'File: Change Encoding'
+
+    this.subcommands = []
+    this.subcommandSelectedIndex = -1
+
+    // Reference to editor state.
+    this._editorState = editorState
+  }
+
+  run = async () => {
+    this.subcommands = []
+    this.subcommandSelectedIndex = -1
+
+    // Load encoding from current tab to highlight it.
+    const encodingObj = this._getCurrentEncoding()
+    const { encoding, isBom } = encodingObj
+
+    // NOTE: We support UTF-BOM encodings but don't allow to set them.
+    if (isBom) {
+      this.subcommandSelectedIndex = 0
+      this.subcommands.push({
+        id: `${encoding}-bom`,
+        description: `${getEncodingName(encodingObj)} (current)`
+      })
+    }
+
+    let i = 0
+    for (const [key, value] of Object.entries(ENCODING_NAME_MAP)) {
+      const isTabEncoding = !isBom && key === encoding
+      const item = {
+        id: key,
+        description: isTabEncoding ? `${value} (current)` : value
+      }
+      if (isTabEncoding) {
+        // Highlight current encoding and set it as first entry.
+        this.subcommandSelectedIndex = i
+        this.subcommands.unshift(item)
+      } else {
+        this.subcommands.push(item)
+      }
+      ++i
+    }
+  }
+
+  execute = async () => {
+    // Timeout to hide the command palette and then show again to prevent issues.
+    await delay(100)
+    bus.$emit('show-command-palette', this)
+  }
+
+  executeSubcommand = async id => {
+    // NOTE: We support UTF-BOM encodings but don't allow to set them.
+    if (!id.endsWith('-bom')) {
+      ipcRenderer.emit('mt::set-file-encoding', null, id)
+    }
+  }
+
+  unload = () => {
+    this.subcommands = []
+  }
+
+  _getCurrentEncoding = () => {
+    const { _editorState } = this
+    const { currentFile } = _editorState
+    if (currentFile) {
+      return currentFile.encoding
+    }
+    return {}
+  }
+}
+
+export default FileEncodingCommand

--- a/src/renderer/commands/fileEncoding.js
+++ b/src/renderer/commands/fileEncoding.js
@@ -28,7 +28,7 @@ class FileEncodingCommand {
       this.subcommandSelectedIndex = 0
       this.subcommands.push({
         id: `${encoding}-bom`,
-        description: `${getEncodingName(encodingObj)} (current)`
+        description: `${getEncodingName(encodingObj)} - current`
       })
     }
 
@@ -37,7 +37,7 @@ class FileEncodingCommand {
       const isTabEncoding = !isBom && key === encoding
       const item = {
         id: key,
-        description: isTabEncoding ? `${value} (current)` : value
+        description: isTabEncoding ? `${value} - current` : value
       }
       if (isTabEncoding) {
         // Highlight current encoding and set it as first entry.

--- a/src/renderer/commands/index.js
+++ b/src/renderer/commands/index.js
@@ -1,19 +1,12 @@
 // List of all static commands that are loaded into command center.
 import { ipcRenderer, remote, shell } from 'electron'
 import bus from '../bus'
-import { isOsx } from '@/util'
+import { delay, isOsx } from '@/util'
 import { isUpdatable } from './utils'
 
 export { default as FileEncodingCommand } from './fileEncoding'
 export { default as LineEndingCommand } from './lineEnding'
 export { default as QuickOpenCommand } from './quickOpen'
-
-// ----------------------------------------------------------------------------
-
-// TODO: Load shortcuts from main process.
-// TODO: Only execute command if it not "disabled"/ not allowed by Editor/Muya
-
-// ----------------------------------------------------------------------------
 
 export class RootCommand {
   constructor (subcommands = []) {
@@ -30,6 +23,11 @@ export class RootCommand {
   async execute () {
     throw new Error('Root command.')
   }
+}
+
+const focusEditorAndExecute = fn => {
+  setTimeout(() => bus.$emit('editor-focus'), 10)
+  setTimeout(() => fn(), 150)
 }
 
 const commands = [
@@ -68,7 +66,7 @@ const commands = [
     }
   }, {
     id: 'file.save-as',
-    description: 'File: Save As',
+    description: 'File: Save As...',
     execute: async () => {
       ipcRenderer.emit('mt::editor-ask-file-save-as', null)
     }
@@ -76,6 +74,7 @@ const commands = [
     id: 'file.print',
     description: 'File: Print current Tab',
     execute: async () => {
+      await delay(50)
       ipcRenderer.emit('mt::show-export-dialog', null, 'print')
     }
   }, {
@@ -108,6 +107,7 @@ const commands = [
     id: 'file.rename-file',
     description: 'File: Rename...',
     execute: async () => {
+      await delay(50)
       ipcRenderer.emit('mt::editor-rename-file', null)
     }
   }, {
@@ -123,12 +123,14 @@ const commands = [
       id: 'file.export-file-html',
       description: 'HTML',
       execute: async () => {
+        await delay(50)
         bus.$emit('export', 'styledHtml')
       }
     }, {
       id: 'file.export-file-pdf',
       description: 'PDF',
       execute: async () => {
+        await delay(50)
         bus.$emit('export', 'pdf')
       }
     }]
@@ -153,49 +155,63 @@ const commands = [
     id: 'edit.duplicate',
     description: 'Edit: Duplicate',
     execute: async () => {
-      bus.$emit('duplicate', 'duplicate')
+      focusEditorAndExecute(
+        () => bus.$emit('duplicate', 'duplicate')
+      )
     }
   }, {
     id: 'edit.create-paragraph',
     description: 'Edit: Create Paragraph',
     execute: async () => {
-      bus.$emit('createParagraph', 'createParagraph')
+      focusEditorAndExecute(
+        () => bus.$emit('createParagraph', 'createParagraph')
+      )
     }
   }, {
     id: 'edit.delete-paragraph',
     description: 'Edit: Delete Paragraph',
     execute: async () => {
-      bus.$emit('deleteParagraph', 'deleteParagraph')
+      focusEditorAndExecute(
+        () => bus.$emit('deleteParagraph', 'deleteParagraph')
+      )
     }
   }, {
     id: 'edit.find',
     description: 'Edit: Find',
     execute: async () => {
-      setTimeout(() => bus.$emit('find', 'find'), 150)
+      await delay(150)
+      bus.$emit('find', 'find')
     }
-  }, {
-    id: 'edit.find-next',
-    description: 'Edit: Find Next',
-    execute: async () => {
-      setTimeout(() => bus.$emit('fineNext', 'fineNext'), 150)
-    }
-  }, {
-    id: 'edit.find-previous',
-    description: 'Edit: Find Previous',
-    execute: async () => {
-      setTimeout(() => bus.$emit('findPrev', 'findPrev'), 150)
-    }
-  }, {
+  },
+  // TODO: Find next/previous doesn't work.
+  // {
+  //   id: 'edit.find-next',
+  //   description: 'Edit: Find Next',
+  //   execute: async () => {
+  //     await delay(150)
+  //     bus.$emit('fineNext', 'fineNext')
+  //   }
+  // }, {
+  //   id: 'edit.find-previous',
+  //   description: 'Edit: Find Previous',
+  //   execute: async () => {
+  //     await delay(150)
+  //     bus.$emit('findPrev', 'findPrev')
+  //   }
+  // },
+  {
     id: 'edit.replace',
     description: 'Edit: Replace',
     execute: async () => {
-      setTimeout(() => bus.$emit('replace', 'replace'), 150)
+      await delay(150)
+      bus.$emit('replace', 'replace')
     }
   }, {
     id: 'edit.find-in-folder',
     description: 'Edit: Find in Folder',
     execute: async () => {
-      setTimeout(() => bus.$emit('findInFolder', 'findInFolder'), 150)
+      await delay(150)
+      ipcRenderer.emit('mt::editor-edit-action', null, 'findInFolder')
     }
   }, {
     id: 'edit.aidou',
@@ -210,200 +226,274 @@ const commands = [
 
   {
     id: 'paragraph.heading-1',
-    description: 'Paragraph: Heading 1',
+    description: 'Paragraph: Transform into Heading 1',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 1')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 1')
+      )
     }
   }, {
     id: 'paragraph.heading-2',
-    description: 'Paragraph: Heading 2',
+    description: 'Paragraph: Transform into Heading 2',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 2')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 2')
+      )
     }
   }, {
     id: 'paragraph.heading-3',
-    description: 'Paragraph: Heading 3',
+    description: 'Paragraph: Transform into Heading 3',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 3')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 3')
+      )
     }
   }, {
     id: 'paragraph.heading-4',
-    description: 'Paragraph: Heading 4',
+    description: 'Paragraph: Transform into Heading 4',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 4')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 4')
+      )
     }
   }, {
     id: 'paragraph.heading-5',
-    description: 'Paragraph: Heading 5',
+    description: 'Paragraph: Transform into Heading 5',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 5')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 5')
+      )
     }
   }, {
     id: 'paragraph.heading-6',
-    description: 'Paragraph: Heading 6',
+    description: 'Paragraph: Transform into Heading 6',
     execute: async () => {
-      bus.$emit('paragraph', 'heading 6')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'heading 6')
+      )
     }
   }, {
     id: 'paragraph.upgrade-heading',
     description: 'Paragraph: Upgrade Heading',
     execute: async () => {
-      bus.$emit('paragraph', 'upgrade heading')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'upgrade heading')
+      )
     }
   }, {
     id: 'paragraph.degrade-heading',
     description: 'Paragraph: Degrade Heading',
     execute: async () => {
-      bus.$emit('paragraph', 'degrade heading')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'degrade heading')
+      )
     }
   }, {
     id: 'paragraph.table',
-    description: 'Paragraph: Create table',
+    description: 'Paragraph: Create Table',
     execute: async () => {
-      bus.$emit('paragraph', 'table')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'table')
+      )
     }
   }, {
     id: 'paragraph.code-fence',
-    description: 'Paragraph: Create Code Fence',
+    description: 'Paragraph: Transform into Code Fence',
     execute: async () => {
-      bus.$emit('paragraph', 'pre')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'pre')
+      )
     }
   }, {
     id: 'paragraph.quote-block',
-    description: 'Paragraph: Quote Block',
+    description: 'Paragraph: Transform into Quote Block',
     execute: async () => {
-      bus.$emit('paragraph', 'blockquote')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'blockquote')
+      )
     }
   }, {
     id: 'paragraph.math-formula',
-    description: 'Paragraph: Math Formula',
+    description: 'Paragraph: Transform into Math Formula',
     execute: async () => {
-      bus.$emit('paragraph', 'mathblock')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'mathblock')
+      )
     }
   }, {
     id: 'paragraph.html-block',
-    description: 'Paragraph: HTML Block',
+    description: 'Paragraph: Transform into HTML Block',
     execute: async () => {
-      bus.$emit('paragraph', 'html')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'html')
+      )
     }
   }, {
     id: 'paragraph.order-list',
-    description: 'Paragraph: Create Order List',
+    description: 'Paragraph: Transform into Order List',
     execute: async () => {
-      bus.$emit('paragraph', 'ol-bullet')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'ol-bullet')
+      )
     }
   }, {
     id: 'paragraph.bullet-list',
-    description: 'Paragraph: Create Bullet List',
+    description: 'Paragraph: Transform into Bullet List',
     execute: async () => {
-      bus.$emit('paragraph', 'ul-bullet')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'ul-bullet')
+      )
     }
   }, {
     id: 'paragraph.task-list',
-    description: 'Paragraph: Create Task List',
+    description: 'Paragraph: Transform into Task List',
     execute: async () => {
-      bus.$emit('paragraph', 'ul-task')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'ul-task')
+      )
     }
   }, {
     id: 'paragraph.loose-list-item',
     description: 'Paragraph: Convert to Loose List Item',
     execute: async () => {
-      bus.$emit('paragraph', 'loose-list-item')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'loose-list-item')
+      )
     }
   }, {
     id: 'paragraph.paragraph',
-    description: 'Paragraph: Paragraph',
+    description: 'Paragraph: Create new Paragraph',
     execute: async () => {
-      bus.$emit('paragraph', 'paragraph')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'paragraph')
+      )
+    }
+  }, {
+    id: 'paragraph.reset-paragraph',
+    description: 'Paragraph: Transform into Paragraph',
+    execute: async () => {
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'reset-to-paragraph')
+      )
     }
   }, {
     id: 'paragraph.horizontal-line',
     description: 'Paragraph: Insert Horizontal Line',
     execute: async () => {
-      bus.$emit('paragraph', 'hr')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'hr')
+      )
     }
   }, {
     id: 'paragraph.front-matter',
     description: 'Paragraph: Insert Front Matter',
     execute: async () => {
-      bus.$emit('paragraph', 'front-matter')
+      focusEditorAndExecute(
+        () => bus.$emit('paragraph', 'front-matter')
+      )
     }
   },
 
   // --------------------------------------------------------------------------
   // Format
 
+  // NOTE: Focus editor to restore selection and try to apply the commmand.
+
   {
     id: 'format.strong',
     description: 'Format: Strong',
     execute: async () => {
-      bus.$emit('format', 'strong')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'strong')
+      )
     }
   }, {
     id: 'format.emphasis',
     description: 'Format: Emphasis',
     execute: async () => {
-      bus.$emit('format', 'em')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'em')
+      )
     }
   }, {
     id: 'format.underline',
     description: 'Format: Underline',
     execute: async () => {
-      bus.$emit('format', 'u')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'u')
+      )
     }
   }, {
     id: 'format.highlight',
     description: 'Format: Highlight',
     execute: async () => {
-      bus.$emit('format', 'mark')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'mark')
+      )
     }
   }, {
     id: 'format.superscript',
     description: 'Format: Superscript',
     execute: async () => {
-      bus.$emit('format', 'sup')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'sup')
+      )
     }
   }, {
     id: 'format.subscript',
     description: 'Format: Subscript',
     execute: async () => {
-      bus.$emit('format', 'sub')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'sub')
+      )
     }
   }, {
     id: 'format.inline-code',
     description: 'Format: Inline Code',
     execute: async () => {
-      bus.$emit('format', 'inline_code')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'inline_code')
+      )
     }
   }, {
     id: 'format.inline-math',
     description: 'Format: Inline Math',
     execute: async () => {
-      bus.$emit('format', 'inline_math')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'inline_math')
+      )
     }
   }, {
     id: 'format.strike',
     description: 'Format: Strike',
     execute: async () => {
-      bus.$emit('format', 'del')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'del')
+      )
     }
   }, {
     id: 'format.hyperlink',
     description: 'Format: Hyperlink',
     execute: async () => {
-      bus.$emit('format', 'link')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'link')
+      )
     }
   }, {
     id: 'format.image',
     description: 'Format: Insert Image',
     execute: async () => {
-      bus.$emit('format', 'image')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'image')
+      )
     }
   }, {
     id: 'format.clear-format',
     description: 'Format: Clear Format',
     execute: async () => {
-      bus.$emit('format', 'clear')
+      focusEditorAndExecute(
+        () => bus.$emit('format', 'clear')
+      )
     }
   },
 

--- a/src/renderer/commands/index.js
+++ b/src/renderer/commands/index.js
@@ -1,0 +1,617 @@
+// List of all static commands that are loaded into command center.
+import { ipcRenderer, remote, shell } from 'electron'
+import bus from '../bus'
+import { isOsx } from '@/util'
+import { isUpdatable } from './utils'
+
+export { default as FileEncodingCommand } from './fileEncoding'
+export { default as LineEndingCommand } from './lineEnding'
+export { default as QuickOpenCommand } from './quickOpen'
+
+// ----------------------------------------------------------------------------
+
+// TODO: Load shortcuts from main process.
+// TODO: Only execute command if it not "disabled"/ not allowed by Editor/Muya
+
+// ----------------------------------------------------------------------------
+
+export class RootCommand {
+  constructor (subcommands = []) {
+    this.id = '#'
+    this.description = '#'
+    this.subcommands = subcommands
+    this.subcommandSelectedIndex = -1
+  }
+
+  async run () {}
+  async unload () {}
+
+  // Execute the command.
+  async execute () {
+    throw new Error('Root command.')
+  }
+}
+
+const commands = [
+  // --------------------------------------------------------------------------
+  // File
+
+  {
+    id: 'file.new-tab',
+    description: 'File: New Tab',
+    execute: async () => {
+      ipcRenderer.emit('mt::new-untitled-tab', null)
+    }
+  }, {
+    id: 'file.new-file',
+    description: 'File: New Window',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-new-editor-window')
+    }
+  }, {
+    id: 'file.open-file',
+    description: 'File: Open file',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-open-file')
+    }
+  }, {
+    id: 'file.open-folder',
+    description: 'File: Open Folder',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-open-folder')
+    }
+  }, {
+    id: 'file.save',
+    description: 'File: Save',
+    execute: async () => {
+      ipcRenderer.emit('mt::editor-ask-file-save', null)
+    }
+  }, {
+    id: 'file.save-as',
+    description: 'File: Save As',
+    execute: async () => {
+      ipcRenderer.emit('mt::editor-ask-file-save-as', null)
+    }
+  }, {
+    id: 'file.print',
+    description: 'File: Print current Tab',
+    execute: async () => {
+      ipcRenderer.emit('mt::show-export-dialog', null, 'print')
+    }
+  }, {
+    id: 'file.close-tab',
+    description: 'File: Close current Tab',
+    execute: async () => {
+      ipcRenderer.emit('mt::editor-close-tab', null)
+    }
+  }, {
+    id: 'file.close-window',
+    description: 'File: Close Window',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-close-window')
+    }
+  },
+
+  {
+    id: 'file.toggle-auto-save',
+    description: 'File: Toggle Auto Save',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-toggle-autosave')
+    }
+  }, {
+    id: 'file.move-file',
+    description: 'File: Move...',
+    execute: async () => {
+      ipcRenderer.emit('mt::editor-move-file', null)
+    }
+  }, {
+    id: 'file.rename-file',
+    description: 'File: Rename...',
+    execute: async () => {
+      ipcRenderer.emit('mt::editor-rename-file', null)
+    }
+  }, {
+    id: 'file.import-file',
+    description: 'File: Import...',
+    execute: async () => {
+      ipcRenderer.send('mt::cmd-import-file')
+    }
+  }, {
+    id: 'file.export-file',
+    description: 'File: Export...',
+    subcommands: [{
+      id: 'file.export-file-html',
+      description: 'HTML',
+      execute: async () => {
+        bus.$emit('export', 'styledHtml')
+      }
+    }, {
+      id: 'file.export-file-pdf',
+      description: 'PDF',
+      execute: async () => {
+        bus.$emit('export', 'pdf')
+      }
+    }]
+  },
+
+  // --------------------------------------------------------------------------
+  // Edit
+
+  {
+    id: 'edit.undo',
+    description: 'Edit: Undo',
+    execute: async () => {
+      bus.$emit('undo', 'undo')
+    }
+  }, {
+    id: 'edit.redo',
+    description: 'Edit: Redo',
+    execute: async () => {
+      bus.$emit('redo', 'redo')
+    }
+  }, {
+    id: 'edit.duplicate',
+    description: 'Edit: Duplicate',
+    execute: async () => {
+      bus.$emit('duplicate', 'duplicate')
+    }
+  }, {
+    id: 'edit.create-paragraph',
+    description: 'Edit: Create Paragraph',
+    execute: async () => {
+      bus.$emit('createParagraph', 'createParagraph')
+    }
+  }, {
+    id: 'edit.delete-paragraph',
+    description: 'Edit: Delete Paragraph',
+    execute: async () => {
+      bus.$emit('deleteParagraph', 'deleteParagraph')
+    }
+  }, {
+    id: 'edit.find',
+    description: 'Edit: Find',
+    execute: async () => {
+      setTimeout(() => bus.$emit('find', 'find'), 150)
+    }
+  }, {
+    id: 'edit.find-next',
+    description: 'Edit: Find Next',
+    execute: async () => {
+      setTimeout(() => bus.$emit('fineNext', 'fineNext'), 150)
+    }
+  }, {
+    id: 'edit.find-previous',
+    description: 'Edit: Find Previous',
+    execute: async () => {
+      setTimeout(() => bus.$emit('findPrev', 'findPrev'), 150)
+    }
+  }, {
+    id: 'edit.replace',
+    description: 'Edit: Replace',
+    execute: async () => {
+      setTimeout(() => bus.$emit('replace', 'replace'), 150)
+    }
+  }, {
+    id: 'edit.find-in-folder',
+    description: 'Edit: Find in Folder',
+    execute: async () => {
+      setTimeout(() => bus.$emit('findInFolder', 'findInFolder'), 150)
+    }
+  }, {
+    id: 'edit.aidou',
+    description: 'Edit: Aidou',
+    execute: async () => {
+      bus.$emit('aidou', 'aidou')
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Paragraph
+
+  {
+    id: 'paragraph.heading-1',
+    description: 'Paragraph: Heading 1',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 1')
+    }
+  }, {
+    id: 'paragraph.heading-2',
+    description: 'Paragraph: Heading 2',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 2')
+    }
+  }, {
+    id: 'paragraph.heading-3',
+    description: 'Paragraph: Heading 3',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 3')
+    }
+  }, {
+    id: 'paragraph.heading-4',
+    description: 'Paragraph: Heading 4',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 4')
+    }
+  }, {
+    id: 'paragraph.heading-5',
+    description: 'Paragraph: Heading 5',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 5')
+    }
+  }, {
+    id: 'paragraph.heading-6',
+    description: 'Paragraph: Heading 6',
+    execute: async () => {
+      bus.$emit('paragraph', 'heading 6')
+    }
+  }, {
+    id: 'paragraph.upgrade-heading',
+    description: 'Paragraph: Upgrade Heading',
+    execute: async () => {
+      bus.$emit('paragraph', 'upgrade heading')
+    }
+  }, {
+    id: 'paragraph.degrade-heading',
+    description: 'Paragraph: Degrade Heading',
+    execute: async () => {
+      bus.$emit('paragraph', 'degrade heading')
+    }
+  }, {
+    id: 'paragraph.table',
+    description: 'Paragraph: Create table',
+    execute: async () => {
+      bus.$emit('paragraph', 'table')
+    }
+  }, {
+    id: 'paragraph.code-fence',
+    description: 'Paragraph: Create Code Fence',
+    execute: async () => {
+      bus.$emit('paragraph', 'pre')
+    }
+  }, {
+    id: 'paragraph.quote-block',
+    description: 'Paragraph: Quote Block',
+    execute: async () => {
+      bus.$emit('paragraph', 'blockquote')
+    }
+  }, {
+    id: 'paragraph.math-formula',
+    description: 'Paragraph: Math Formula',
+    execute: async () => {
+      bus.$emit('paragraph', 'mathblock')
+    }
+  }, {
+    id: 'paragraph.html-block',
+    description: 'Paragraph: HTML Block',
+    execute: async () => {
+      bus.$emit('paragraph', 'html')
+    }
+  }, {
+    id: 'paragraph.order-list',
+    description: 'Paragraph: Create Order List',
+    execute: async () => {
+      bus.$emit('paragraph', 'ol-bullet')
+    }
+  }, {
+    id: 'paragraph.bullet-list',
+    description: 'Paragraph: Create Bullet List',
+    execute: async () => {
+      bus.$emit('paragraph', 'ul-bullet')
+    }
+  }, {
+    id: 'paragraph.task-list',
+    description: 'Paragraph: Create Task List',
+    execute: async () => {
+      bus.$emit('paragraph', 'ul-task')
+    }
+  }, {
+    id: 'paragraph.loose-list-item',
+    description: 'Paragraph: Convert to Loose List Item',
+    execute: async () => {
+      bus.$emit('paragraph', 'loose-list-item')
+    }
+  }, {
+    id: 'paragraph.paragraph',
+    description: 'Paragraph: Paragraph',
+    execute: async () => {
+      bus.$emit('paragraph', 'paragraph')
+    }
+  }, {
+    id: 'paragraph.horizontal-line',
+    description: 'Paragraph: Insert Horizontal Line',
+    execute: async () => {
+      bus.$emit('paragraph', 'hr')
+    }
+  }, {
+    id: 'paragraph.front-matter',
+    description: 'Paragraph: Insert Front Matter',
+    execute: async () => {
+      bus.$emit('paragraph', 'front-matter')
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Format
+
+  {
+    id: 'format.strong',
+    description: 'Format: Strong',
+    execute: async () => {
+      bus.$emit('format', 'strong')
+    }
+  }, {
+    id: 'format.emphasis',
+    description: 'Format: Emphasis',
+    execute: async () => {
+      bus.$emit('format', 'em')
+    }
+  }, {
+    id: 'format.underline',
+    description: 'Format: Underline',
+    execute: async () => {
+      bus.$emit('format', 'u')
+    }
+  }, {
+    id: 'format.highlight',
+    description: 'Format: Highlight',
+    execute: async () => {
+      bus.$emit('format', 'mark')
+    }
+  }, {
+    id: 'format.superscript',
+    description: 'Format: Superscript',
+    execute: async () => {
+      bus.$emit('format', 'sup')
+    }
+  }, {
+    id: 'format.subscript',
+    description: 'Format: Subscript',
+    execute: async () => {
+      bus.$emit('format', 'sub')
+    }
+  }, {
+    id: 'format.inline-code',
+    description: 'Format: Inline Code',
+    execute: async () => {
+      bus.$emit('format', 'inline_code')
+    }
+  }, {
+    id: 'format.inline-math',
+    description: 'Format: Inline Math',
+    execute: async () => {
+      bus.$emit('format', 'inline_math')
+    }
+  }, {
+    id: 'format.strike',
+    description: 'Format: Strike',
+    execute: async () => {
+      bus.$emit('format', 'del')
+    }
+  }, {
+    id: 'format.hyperlink',
+    description: 'Format: Hyperlink',
+    execute: async () => {
+      bus.$emit('format', 'link')
+    }
+  }, {
+    id: 'format.image',
+    description: 'Format: Insert Image',
+    execute: async () => {
+      bus.$emit('format', 'image')
+    }
+  }, {
+    id: 'format.clear-format',
+    description: 'Format: Clear Format',
+    execute: async () => {
+      bus.$emit('format', 'clear')
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Window
+
+  {
+    id: 'window.minimize',
+    description: 'Window: Minimize',
+    execute: async () => {
+      remote.getCurrentWindow().minimize()
+    }
+  }, {
+    id: 'window.always-on-top',
+    description: 'Window: Always on Top',
+    execute: async () => {
+      ipcRenderer.send('mt::window-toggle-always-on-top')
+    }
+  }, {
+    id: 'window.toggle-full-screen',
+    description: 'Window: Toggle Full Screen',
+    execute: async () => {
+      const win = remote.getCurrentWindow()
+      win.setFullScreen(!win.isFullScreen())
+    }
+  },
+
+  {
+    id: 'file.zoom',
+    description: 'Window: Zoom...',
+    subcommands: [{
+      id: 'file.zoom-0',
+      description: '1.0',
+      value: 1.0
+    }, {
+      id: 'file.zoom-1',
+      description: '1.125',
+      value: 1.125
+    }, {
+      id: 'file.zoom-2',
+      description: '1.25',
+      value: 1.25
+    }, {
+      id: 'file.zoom-3',
+      description: '1.375',
+      value: 1.375
+    }, {
+      id: 'file.zoom-4',
+      description: '1.5',
+      value: 1.5
+    }, {
+      id: 'file.zoom-5',
+      description: '1.625',
+      value: 1.625
+    }, {
+      id: 'file.zoom-6',
+      description: '1.75',
+      value: 1.75
+    }, {
+      id: 'file.zoom-7',
+      description: '1.875',
+      value: 1.875
+    }, {
+      id: 'file.zoom-8',
+      description: '2.0',
+      value: 2.0
+    }],
+    executeSubcommand: async (_, value) => {
+      ipcRenderer.emit('mt::window-zoom', null, value)
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Window
+
+  {
+    id: 'window.change-theme',
+    description: 'Theme: Change Theme',
+    subcommands: [{
+      id: 'window.change-theme-light',
+      description: 'Cadmium Light',
+      value: 'light'
+    }, {
+      id: 'window.change-theme-dark',
+      description: 'Dark',
+      value: 'dark'
+    }, {
+      id: 'window.change-theme-graphite',
+      description: 'Graphite',
+      value: 'graphite'
+    }, {
+      id: 'window.change-theme-material-dark',
+      description: 'Material Dark',
+      value: 'material-dark'
+    }, {
+      id: 'window.change-theme-one-dark',
+      description: 'One Dark',
+      value: 'one-dark'
+    }, {
+      id: 'window.change-theme-ulysses',
+      description: 'Ulysses',
+      value: 'ulysses'
+    }],
+    executeSubcommand: async (_, theme) => {
+      ipcRenderer.send('mt::set-user-preference', { theme })
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // View
+
+  {
+    id: 'view.source-code-mode',
+    description: 'View: Toggle Source Code Mode',
+    execute: async () => {
+      bus.$emit('view:toggle-view-entry', 'sourceCode')
+    }
+  }, {
+    id: 'view.typewriter-mode',
+    description: 'View: Toggle Typewriter Mode',
+    execute: async () => {
+      bus.$emit('view:toggle-view-entry', 'typewriter')
+    }
+  }, {
+    id: 'view.focus-mode',
+    description: 'View: Focus Mode',
+    execute: async () => {
+      bus.$emit('view:toggle-view-entry', 'focus')
+    }
+  }, {
+    id: 'view.toggle-sidebar',
+    description: 'View: Toggle Sidebar',
+    execute: async () => {
+      bus.$emit('view:toggle-view-layout-entry', 'showSideBar')
+    }
+  }, {
+    id: 'view.toggle-tabbar',
+    description: 'View: Toggle Tabs',
+    execute: async () => {
+      bus.$emit('view:toggle-view-layout-entry', 'showTabBar')
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Mark Text
+
+  {
+    id: 'file.preferences',
+    description: 'Mark Text: Preferences',
+    execute: async () => {
+      ipcRenderer.send('mt::open-setting-window')
+    }
+  }, {
+    id: 'file.quit',
+    description: 'Mark Text: Quit',
+    execute: async () => {
+      ipcRenderer.send('mt::app-try-quit')
+    }
+  }, {
+    id: 'docs.user-guide',
+    description: 'Mark Text: End User Guide',
+    execute: async () => {
+      shell.openExternal('https://github.com/marktext/marktext/blob/develop/docs/README.md')
+    }
+  }, {
+    id: 'docs.markdown-syntax',
+    description: 'Mark Text: Markdown Syntax Guide',
+    execute: async () => {
+      shell.openExternal('https://github.com/marktext/marktext/blob/develop/docs/MARKDOWN_SYNTAX.md')
+    }
+  },
+
+  // --------------------------------------------------------------------------
+  // Misc
+
+  {
+    id: 'tabs.cycle-forward',
+    description: 'Misc: Cycle Tabs Forward',
+    execute: async () => {
+      ipcRenderer.emit('mt::tabs-cycle-right', null)
+    }
+  }, {
+    id: 'tabs.cycle-backward',
+    description: 'Misc: Cycle Tabs Backward',
+    execute: async () => {
+      ipcRenderer.emit('mt::tabs-cycle-left', null)
+    }
+  }
+]
+
+if (isUpdatable()) {
+  commands.push({
+    id: 'file.check-update',
+    description: 'Mark Text: Check for Updates',
+    execute: async () => {
+      ipcRenderer.send('mt::check-for-update')
+    }
+  })
+}
+
+if (isOsx) {
+  commands.push({
+    id: 'edit.screenshot',
+    description: 'Edit: Make Screenshot',
+    execute: async () => {
+      ipcRenderer.send('mt::make-screenshot')
+    }
+  })
+}
+
+export default commands

--- a/src/renderer/commands/lineEnding.js
+++ b/src/renderer/commands/lineEnding.js
@@ -1,0 +1,44 @@
+import { ipcRenderer } from 'electron'
+import { delay } from '@/util'
+import bus from '../bus'
+
+class LineEndingCommand {
+  constructor (editorState) {
+    this.id = 'file.line-ending'
+    this.description = 'File: Change Line Ending'
+
+    this.subcommands = [{
+      id: 'file.line-ending-crlf',
+      description: 'Carriage return and line feed (CRLF)',
+      value: 'crlf'
+    },
+    {
+      id: 'file.line-ending-lf',
+      description: 'Line feed (LF)',
+      value: 'lf'
+    }]
+    this.subcommandSelectedIndex = -1
+
+    // Reference to editor state.
+    this._editorState = editorState
+  }
+
+  run = async () => {
+    const { lineEnding } = this._editorState.currentFile
+    this.subcommandSelectedIndex = lineEnding === 'crlf' ? 0 : 1
+  }
+
+  execute = async () => {
+    // Timeout to hide the command palette and then show again to prevent issues.
+    await delay(100)
+    bus.$emit('show-command-palette', this)
+  }
+
+  executeSubcommand = async (_, value) => {
+    ipcRenderer.emit('mt::set-line-ending', null, value)
+  }
+
+  unload = () => {}
+}
+
+export default LineEndingCommand

--- a/src/renderer/commands/lineEnding.js
+++ b/src/renderer/commands/lineEnding.js
@@ -2,6 +2,9 @@ import { ipcRenderer } from 'electron'
 import { delay } from '@/util'
 import bus from '../bus'
 
+const crlfDescription = 'Carriage return and line feed (CRLF)'
+const lfDescription = 'Line feed (LF)'
+
 class LineEndingCommand {
   constructor (editorState) {
     this.id = 'file.line-ending'
@@ -9,12 +12,11 @@ class LineEndingCommand {
 
     this.subcommands = [{
       id: 'file.line-ending-crlf',
-      description: 'Carriage return and line feed (CRLF)',
+      description: crlfDescription,
       value: 'crlf'
-    },
-    {
+    }, {
       id: 'file.line-ending-lf',
-      description: 'Line feed (LF)',
+      description: lfDescription,
       value: 'lf'
     }]
     this.subcommandSelectedIndex = -1
@@ -25,7 +27,15 @@ class LineEndingCommand {
 
   run = async () => {
     const { lineEnding } = this._editorState.currentFile
-    this.subcommandSelectedIndex = lineEnding === 'crlf' ? 0 : 1
+    if (lineEnding === 'crlf') {
+      this.subcommandSelectedIndex = 0
+      this.subcommands[0].description = `${crlfDescription} - current`
+      this.subcommands[1].description = lfDescription
+    } else {
+      this.subcommandSelectedIndex = 1
+      this.subcommands[0].description = crlfDescription
+      this.subcommands[1].description = `${lfDescription} - current`
+    }
   }
 
   execute = async () => {

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -13,6 +13,7 @@ class QuickOpenCommand {
   constructor (rootState) {
     this.id = 'file.quick-open'
     this.description = 'File: Quick Open'
+    this.placeholder = 'Search file to open'
     this.shortcut = null
 
     this.subcommands = []

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -5,7 +5,7 @@ import bus from '../bus'
 import { delay } from '@/util'
 import FileSearcher from '@/node/fileSearcher'
 
-const MD_EXTENSION = /\.markdown|\.mdown|\.mkdn|\.md|\.mkd|\.mdwn|\.mdtxt|\.mdtext|\.text|\.txt$/i
+const MD_EXTENSION = /\.(?:markdown|mdown|mkdn|md|mkd|mdwn|mdtxt|mdtext|text|txt)$/i
 const SPECIAL_CHARS = /[\[\]\\^$.\|\?\*\+\(\)\/]{1}/g // eslint-disable-line no-useless-escape
 
 // The quick open command
@@ -82,7 +82,7 @@ class QuickOpenCommand {
 
   // --- private ------------------------------------------
 
-  _doSearch = async query => {
+  _doSearch = query => {
     this._cancelFn = null
     const { _editorState, _folderState } = this
     const isRootDirOpened = !!_folderState.projectTree

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -172,6 +172,7 @@ class QuickOpenCommand {
   }
 
   _getInclusions = query => {
+    // NOTE: This will fail on `foo.m` because we search for `foo.m.md`.
     if (MD_EXTENSION.test(query)) {
       return [query]
     }

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -189,7 +189,13 @@ class QuickOpenCommand {
     if (!isChildOfDirectory(rootPath, pathname)) {
       return { title: pathname, description: pathname }
     }
-    return { description: path.relative(rootPath, pathname) }
+
+    const p = path.relative(rootPath, pathname)
+    const item = { description: p }
+    if (p.length > 50) {
+      item.title = p
+    }
+    return item
   }
 }
 

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -1,0 +1,195 @@
+import path from 'path'
+import { ipcRenderer } from 'electron'
+import { isChildOfDirectory } from 'common/filesystem/paths'
+import bus from '../bus'
+import { delay } from '@/util'
+import FileSearcher from '@/node/fileSearcher'
+
+const MD_EXTENSION = /\.markdown|\.mdown|\.mkdn|\.md|\.mkd|\.mdwn|\.mdtxt|\.mdtext|\.text|\.txt$/i
+const SPECIAL_CHARS = /[\[\]\\^$.\|\?\*\+\(\)\/]{1}/g // eslint-disable-line no-useless-escape
+
+// The quick open command
+class QuickOpenCommand {
+  constructor (rootState) {
+    this.id = 'file.quick-open'
+    this.description = 'File: Quick Open'
+    this.shortcut = null
+
+    this.subcommands = []
+    this.subcommandSelectedIndex = -1
+
+    // Reference to folder and editor and project state.
+    this._editorState = rootState.editor
+    this._folderState = rootState.project
+
+    this._directorySearcher = new FileSearcher()
+    this._cancelFn = null
+  }
+
+  search = async query => {
+    // Show opened files when no query given.
+    if (!query) {
+      return this.subcommands
+    }
+
+    const { _cancelFn } = this
+    if (_cancelFn) {
+      _cancelFn()
+      this._cancelFn = null
+    }
+
+    const timeout = delay(300)
+    this._cancelFn = () => {
+      timeout.cancel()
+      this._cancelFn = null
+    }
+
+    await timeout
+    return await this._doSearch(query)
+  }
+
+  run = async () => {
+    const { _editorState, _folderState } = this
+    if (!_folderState.projectTree && _editorState.tabs.length === 0) {
+      throw new Error(null)
+    }
+
+    this.subcommands = _editorState.tabs
+      .map(t => t.pathname)
+      // Filter untitled tabs
+      .filter(t => !!t)
+      .map(pathname => {
+        const item = { id: pathname }
+        Object.assign(item, this._getPath(pathname))
+        return item
+      })
+  }
+
+  execute = async () => {
+    // Timeout to hide the command palette and then show again to prevent issues.
+    await delay(100)
+    bus.$emit('show-command-palette', this)
+  }
+
+  executeSubcommand = async id => {
+    const { windowId } = global.marktext.env
+    ipcRenderer.send('mt::open-file-by-window-id', windowId, id)
+  }
+
+  unload = () => {
+    this.subcommands = []
+  }
+
+  // --- private ------------------------------------------
+
+  _doSearch = async query => {
+    this._cancelFn = null
+    const { _editorState, _folderState } = this
+    const isRootDirOpened = !!_folderState.projectTree
+    const tabsAvailable = _editorState.tabs.length > 0
+
+    // Only show opened files if no directory is opened.
+    if (!isRootDirOpened && !tabsAvailable) {
+      return []
+    }
+
+    const searchResult = []
+    const rootPath = isRootDirOpened ? _folderState.projectTree.pathname : null
+
+    // Add files that are not in the current root directory but opened.
+    if (tabsAvailable) {
+      const re = new RegExp(query.replace(SPECIAL_CHARS, p => {
+        if (p === '*') return '.*'
+        return p === '\\' ? '\\\\' : `\\${p}`
+      }), 'i')
+
+      for (const tab of _editorState.tabs) {
+        const { pathname } = tab
+        if (pathname && re.test(pathname) &&
+          (!rootPath || !isChildOfDirectory(rootPath, pathname))
+        ) {
+          searchResult.push(pathname)
+        }
+      }
+    }
+
+    if (!isRootDirOpened) {
+      return searchResult
+        .map(pathname => {
+          return {
+            id: pathname,
+            description: pathname,
+            title: pathname
+          }
+        })
+    }
+
+    // Search root directory on disk.
+    return new Promise((resolve, reject) => {
+      let canceled = false
+      const promises = this._directorySearcher.search([rootPath], '', {
+        didMatch: result => {
+          if (canceled) return
+          searchResult.push(result)
+        },
+        didSearchPaths: numPathsFound => {
+          // Cancel when more than 30 files were found. User should specify the search query.
+          if (!canceled && numPathsFound > 30) {
+            canceled = true
+            if (promises.cancel) {
+              promises.cancel()
+            }
+          }
+        },
+
+        // Only search markdown files that contain the query string.
+        inclusions: this._getInclusions(query)
+      })
+        .then(() => {
+          this._cancelFn = null
+          resolve(
+            searchResult
+              .map(pathname => {
+                const item = { id: pathname }
+                Object.assign(item, this._getPath(pathname))
+                return item
+              })
+          )
+        })
+        .catch(error => {
+          this._cancelFn = null
+          reject(error)
+        })
+
+      this._cancelFn = () => {
+        this._cancelFn = null
+        canceled = true
+        if (promises.cancel) {
+          promises.cancel()
+        }
+      }
+    })
+  }
+
+  _getInclusions = query => {
+    if (MD_EXTENSION.test(query)) {
+      return [query]
+    }
+
+    const inclusions = ['*.markdown', '*.mdown', '*.mkdn', '*.md', '*.mkd', '*.mdwn', '*.mdtxt', '*.mdtext', '*.text', '*.txt']
+    for (let i = 0; i < inclusions.length; ++i) {
+      inclusions[i] = `${query}` + inclusions[i]
+    }
+    return inclusions
+  }
+
+  _getPath = pathname => {
+    const rootPath = this._folderState.projectTree.pathname
+    if (!isChildOfDirectory(rootPath, pathname)) {
+      return { title: pathname, description: pathname }
+    }
+    return { description: path.relative(rootPath, pathname) }
+  }
+}
+
+export default QuickOpenCommand

--- a/src/renderer/commands/utils.js
+++ b/src/renderer/commands/utils.js
@@ -1,0 +1,25 @@
+import path from 'path'
+import { isFile } from 'common/filesystem'
+
+/// Check whether the package is updatable at runtime.
+export const isUpdatable = () => {
+  // TODO: If not updatable, allow to check whether there is a new version available.
+
+  const resFile = isFile(path.join(process.resourcesPath, 'app-update.yml'))
+  if (!resFile) {
+    // No update resource file available.
+    return false
+  } else if (process.env.APPIMAGE) {
+    // We are running as AppImage.
+    return true
+  } else if (process.platform === 'win32' && isFile(path.join(process.resourcesPath, 'md.ico'))) {
+    // Windows is a little but tricky. The update resource file is always available and
+    // there is no way to check the target type at runtime (electron-builder#4119).
+    // As workaround we check whether "md.ico" exists that is only included in the setup.
+    return true
+  }
+
+  // Otherwise assume that we cannot perform an auto update (standalone binary, archives,
+  // packed for package manager).
+  return false
+}

--- a/src/renderer/components/aidou/aidou.vue
+++ b/src/renderer/components/aidou/aidou.vue
@@ -95,6 +95,7 @@ export default {
     })
   },
   beforeDestroy () {
+    bus.$off('aidou', this.handleShowAiDou)
     const container = this.$refs.emojis
     if (container) {
       container.removeEventListener('scroll', this.handlerScroll)

--- a/src/renderer/components/commandPalette/index.vue
+++ b/src/renderer/components/commandPalette/index.vue
@@ -17,7 +17,7 @@
             class="search"
             @keydown="handleBeforeInput"
             @keyup="handleInput"
-            placeholder="Type a command to execute"
+            :placeholder="placeholderText"
           >
         </div>
         <loading v-if="searcherBusy"></loading>
@@ -65,8 +65,10 @@ export default {
   },
   data () {
     this.currentCommand = null
+    this.defaultPlaceholderText = 'Type a command to execute'
     return {
       showCommandPalette: false,
+      placeholderText: this.defaultPlaceholderText,
       query: '',
       selectedCommandIndex: -1,
       availableCommands: [],
@@ -88,6 +90,7 @@ export default {
         .then(() => {
           this.availableCommands = this.currentCommand.subcommands
           this.selectedCommandIndex = this.currentCommand.subcommandSelectedIndex
+          this.placeholderText = this.currentCommand.placeholder || this.defaultPlaceholderText
           this.query = ''
           this.showCommandPalette = true
           bus.$emit('editor-blur')
@@ -347,7 +350,6 @@ export default {
     background: var(--floatHoverColor);
   }
   ul.commands li span {
-    height: 35px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/src/renderer/components/commandPalette/index.vue
+++ b/src/renderer/components/commandPalette/index.vue
@@ -100,7 +100,7 @@ export default {
         .catch(error => {
           // Allow to throw new Error(null) to indicate an invalid state.
           if (error && error.message) {
-            log.error(error)
+            log.error('Unable to initialize command:', error)
           }
         })
     },
@@ -331,6 +331,7 @@ export default {
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    max-width: 100%;
     height: 35px;
     padding: 0 8px;
     font-size: 14px;
@@ -346,8 +347,10 @@ export default {
     background: var(--floatHoverColor);
   }
   ul.commands li span {
+    height: 35px;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
   }
   ul.commands li span.shortcut {
     font-size: 12px;

--- a/src/renderer/components/commandPalette/index.vue
+++ b/src/renderer/components/commandPalette/index.vue
@@ -1,0 +1,383 @@
+<template>
+  <div class="command-palette">
+    <el-dialog
+      :visible.sync="showCommandPalette"
+      :show-close="false"
+      :modal="true"
+      @close="handleDialogClose"
+      custom-class="ag-dialog-table"
+      width="500px"
+    >
+      <div slot="title" class="search-wrapper">
+        <div class="input-wrapper">
+          <input
+            ref="search"
+            type="text"
+            v-model="query"
+            class="search"
+            @keydown="handleBeforeInput"
+            @keyup="handleInput"
+            placeholder="Type a command to execute"
+          >
+        </div>
+        <loading v-if="searcherBusy"></loading>
+        <transition name="fade" v-else-if="availableCommands.length">
+          <ul class="commands">
+            <li
+              v-for="(item, index) of availableCommands"
+              :key="index"
+              ref="command-items"
+              @click="search(item.id)"
+              :class="{'active': index === selectedCommandIndex}"
+            >
+              <span class="title" :title="item.title">{{item.description}}</span>
+              <span class="shortcut">
+                <span
+                  class="shortcut"
+                  v-for="(accelerator, index) of item.shortcut"
+                  :key="index"
+                >
+                    <kbd>{{accelerator}}</kbd>
+                </span>
+              </span>
+            </li>
+          </ul>
+        </transition>
+      </div>
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import log from 'electron-log'
+import bus from '../../bus'
+import loading from '../aidou/loading'
+
+export default {
+  components: {
+    loading
+  },
+  computed: {
+    ...mapState({
+      rootCommand: state => state.commandCenter.rootCommand
+    })
+  },
+  data () {
+    this.currentCommand = null
+    return {
+      showCommandPalette: false,
+      query: '',
+      selectedCommandIndex: -1,
+      availableCommands: [],
+      searcherBusy: false
+    }
+  },
+  created () {
+    this.$nextTick(() => {
+      bus.$on('show-command-palette', this.handleShow)
+    })
+  },
+  beforeDestroy () {
+    bus.$off('show-command-palette', this.handleShow)
+  },
+  methods: {
+    handleShow (command) {
+      this.currentCommand = command || this.rootCommand
+      this.currentCommand.run()
+        .then(() => {
+          this.availableCommands = this.currentCommand.subcommands
+          this.selectedCommandIndex = this.currentCommand.subcommandSelectedIndex
+          this.query = ''
+          this.showCommandPalette = true
+          bus.$emit('editor-blur')
+          this.$nextTick(() => {
+            if (this.$refs.search) {
+              this.$refs.search.focus()
+            }
+          })
+        })
+        .catch(error => {
+          // Allow to throw new Error(null) to indicate an invalid state.
+          if (error && error.message) {
+            log.error(error)
+          }
+        })
+    },
+    handleDialogClose () {
+      // Reset all settings
+      this.selectedCommandIndex = -1
+      this.query = ''
+      this.availableCommands = []
+      if (this.currentCommand.unload) {
+        this.currentCommand.unload()
+      }
+      this.currentCommand = null
+    },
+    handleBeforeInput (event) {
+      const { availableCommands, selectedCommandIndex } = this
+      switch (event.key) {
+        case 'ArrowUp': {
+          event.preventDefault()
+          event.stopPropagation()
+          if (selectedCommandIndex <= 0) {
+            this.selectedCommandIndex = availableCommands.length - 1
+          } else {
+            this.selectedCommandIndex--
+          }
+
+          const items = this.$refs['command-items']
+          if (items && items.length > 0) {
+            this.$refs['command-items'][this.selectedCommandIndex].scrollIntoView({ block: 'end' })
+          }
+          break
+        }
+        case 'ArrowDown': {
+          event.preventDefault()
+          event.stopPropagation()
+          if (selectedCommandIndex + 1 >= availableCommands.length) {
+            this.selectedCommandIndex = 0
+          } else {
+            this.selectedCommandIndex++
+          }
+
+          const items = this.$refs['command-items']
+          if (items && items.length > 0) {
+            this.$refs['command-items'][this.selectedCommandIndex].scrollIntoView({ block: 'end' })
+          }
+          break
+        }
+      }
+    },
+    handleInput (event) {
+      // NOTE: We're using keyup to catch "enter" key but `ctrlKey`
+      // etc doesn't work here.
+      switch (event.key) {
+        case 'Control':
+        case 'Alt':
+        case 'Meta':
+        case 'Shift':
+        case 'Escape':
+        case 'PageDown':
+        case 'PageUp':
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight': {
+          // No-op
+          break
+        }
+        case 'Enter': {
+          this.search()
+          break
+        }
+        default: {
+          this.updateCommands()
+          break
+        }
+      }
+    },
+    search (commandId = null) {
+      const { availableCommands, selectedCommandIndex } = this
+      if (commandId) {
+        // Command selected from dropdown.
+        this.executeCommand(commandId)
+        return
+      } else if (selectedCommandIndex >= 0 && selectedCommandIndex < availableCommands.length) {
+        // Pressed enter on selected command.
+        this.executeCommand(availableCommands[selectedCommandIndex].id)
+        return
+      }
+
+      // Otherwise update list
+      this.updateCommands()
+    },
+    updateCommands () {
+      const { currentCommand, query } = this
+      const queryString = query.trim()
+
+      // Allow to handle search result by command (e.g. quick search).
+      if (currentCommand.search) {
+        this.searcherBusy = true
+        currentCommand.search(queryString)
+          .then(result => {
+            this.searcherBusy = false
+            this.availableCommands = result || []
+            this.selectedCommandIndex = this.availableCommands.length ? 0 : -1
+          })
+          .catch(error => {
+            // The query was cancel or restarted if `message` is null.
+            if (error && error.message) {
+              this.searcherBusy = false
+              this.availableCommands = []
+              this.selectedCommandIndex = -1
+              log.error(error)
+            }
+          })
+        return
+      }
+
+      // Default handler
+      if (!queryString) {
+        this.availableCommands = currentCommand.subcommands
+      } else {
+        this.availableCommands = currentCommand.subcommands
+          .filter(c => c.description.toLowerCase().indexOf(queryString.toLowerCase()) !== -1)
+      }
+      this.selectedCommandIndex = this.availableCommands.length ? 0 : -1
+    },
+    executeCommand (commandId) {
+      const { availableCommands, currentCommand } = this
+      const command = availableCommands.find(c => c.id === commandId)
+      if (!command) {
+        log.error(`Cannot find command "${commandId}".`)
+        return
+      }
+
+      const { executeSubcommand } = currentCommand
+      if (executeSubcommand) {
+        this.showCommandPalette = false
+        executeSubcommand(commandId, command.value)
+      } else {
+        const { execute, subcommands, run } = command
+
+        // Allow to load static commands without reloading command palette.
+        if (execute === undefined && run === undefined && subcommands) {
+          // Load subcommands
+          this.currentCommand = command
+          // NOTE: selected index is always -1 by static state loaded this way.
+          this.selectedCommandIndex = -1
+          this.query = ''
+          this.updateCommands()
+        } else {
+          this.showCommandPalette = false
+          execute()
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+  /* Hide scrollbar for this dialog */
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  .search-wrapper {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 500px;
+    height: auto;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 8px;
+    margin: 0 auto;
+    margin-top: 8px;
+    box-sizing: border-box;
+    color: var(--editorColor);
+    background: var(--floatBgColor);
+    border: 1px solid var(--floatBorderColor);
+    border-radius: 4px;
+    box-shadow: 0 3px 8px 3px var(--floatShadow);
+    z-index: 10000;
+  }
+  .input-wrapper {
+    display: block;
+    width: 100%;
+    border: 1px solid var(--sideBarTextColor);
+  }
+  input.search {
+    width: 100%;
+    height: 30px;
+    margin: 0 10px;
+    font-size: 14px;
+    color: var(--editorColor);
+    background: transparent;
+    outline: none;
+    border: none;
+  }
+  .cpt-loading {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 50px;
+    padding: 0;
+    margin: 8px 0 0 0;
+    box-sizing: border-box;
+  }
+  ul.commands {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-height: 300px;
+    padding: 0;
+    margin: 8px 0 0 0;
+    box-sizing: border-box;
+    list-style: none;
+    overflow: hidden;
+    overflow-y: scroll;
+  }
+  ul.commands li {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    height: 35px;
+    padding: 0 8px;
+    font-size: 14px;
+    line-height: 35px;
+    text-overflow: ellipsis;
+    cursor: pointer;
+  }
+  ul.commands li:hover {
+    background: var(--floatHoverColor);
+    opacity: 0.9;
+  }
+  ul.commands li.active {
+    background: var(--floatHoverColor);
+  }
+  ul.commands li span {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+  ul.commands li span.shortcut {
+    font-size: 12px;
+    line-height: 20px;
+    & > kbd {
+      margin-left: 2px;
+    }
+  }
+
+  .fade-enter-active, .fade-leave-active {
+    transition: opacity .2s;
+  }
+  .fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
+    opacity: 0;
+  }
+</style>
+<style>
+  .command-palette .cpt-loading .loader {
+    margin-top: 20px;
+  }
+
+  .command-palette .el-dialog,
+  .command-palette .el-dialog.ag-dialog-table {
+    box-shadow: none !important;
+    border: none !important;
+    background: none !important;
+  }
+  .command-palette .el-dialog__header {
+    margin-bottom: 20px;
+    padding: 0 !important;
+  }
+  .command-palette .el-dialog__body {
+    display: none !important;
+  }
+</style>

--- a/src/renderer/components/commandPalette/index.vue
+++ b/src/renderer/components/commandPalette/index.vue
@@ -289,7 +289,9 @@ export default {
   .input-wrapper {
     display: block;
     width: 100%;
-    border: 1px solid var(--sideBarTextColor);
+    border: 1px solid var(--inputBgColor);
+    background: var(--inputBgColor);
+    border-radius: 3px;
   }
   input.search {
     width: 100%;

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -548,6 +548,7 @@ export default {
       bus.$on('image-uploaded', this.handleUploadedImage)
       bus.$on('file-changed', this.handleFileChange)
       bus.$on('editor-blur', this.blurEditor)
+      bus.$on('editor-focus', this.focusEditor)
       bus.$on('copyAsMarkdown', this.handleCopyPaste)
       bus.$on('copyAsHtml', this.handleCopyPaste)
       bus.$on('pasteAsPlainText', this.handleCopyPaste)
@@ -975,8 +976,8 @@ export default {
         this.$nextTick(() => {
           this.$refs.rowInput.focus()
         })
-      } else {
-        this.editor && this.editor.updateParagraph(type)
+      } else if (this.editor) {
+        this.editor.updateParagraph(type)
       }
     },
 
@@ -1051,6 +1052,10 @@ export default {
       this.editor.blur()
     },
 
+    focusEditor () {
+      this.editor.focus()
+    },
+
     handleScreenShot () {
       if (this.editor) {
         document.execCommand('paste')
@@ -1073,6 +1078,7 @@ export default {
     bus.$off('image-uploaded', this.handleUploadedImage)
     bus.$off('file-changed', this.handleFileChange)
     bus.$off('editor-blur', this.blurEditor)
+    bus.$off('editor-focus', this.focusEditor)
     bus.$off('copyAsMarkdown', this.handleCopyPaste)
     bus.$off('copyAsHtml', this.handleCopyPaste)
     bus.$off('pasteAsPlainText', this.handleCopyPaste)

--- a/src/renderer/node/fileSearcher.js
+++ b/src/renderer/node/fileSearcher.js
@@ -1,0 +1,83 @@
+import { spawn } from 'child_process'
+import RipgrepDirectorySearcher from './ripgrepSearcher'
+
+// Use ripgrep searcher to search for files on disk only.
+class FileSearcher extends RipgrepDirectorySearcher {
+  searchInDirectory (directoryPath, pattern, options, numPathsFound) {
+    const args = ['--files']
+
+    if (options.followSymlinks) {
+      args.push('--follow')
+    }
+    if (!options.includeHidden) {
+      args.push('--hidden')
+    }
+    if (options.noIgnore) {
+      args.push('--no-ignore')
+    }
+
+    for (const inclusion of this.prepareGlobs(options.inclusions, directoryPath)) {
+      args.push('--iglob', inclusion)
+    }
+
+    args.push('--')
+    args.push(directoryPath)
+
+    let child = null
+    try {
+      child = spawn(this.rgPath, args, {
+        cwd: directoryPath,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+    } catch (err) {
+      return Promise.reject(err)
+    }
+
+    const didMatch = options.didMatch || (() => {})
+    let cancelled = false
+
+    const returnedPromise = new Promise((resolve, reject) => {
+      let buffer = ''
+      let bufferError = ''
+
+      child.on('close', (code, signal) => {
+        // code 1 is used when no results are found.
+        if (code !== null && code > 1) {
+          reject(new Error(bufferError))
+        } else {
+          resolve()
+        }
+      })
+      child.on('error', err => {
+        reject(err)
+      })
+
+      child.stderr.on('data', chunk => {
+        bufferError += chunk
+      })
+
+      child.stdout.on('data', chunk => {
+        if (cancelled) {
+          return
+        }
+
+        buffer += chunk
+        const lines = buffer.split('\n')
+        buffer = lines.pop()
+        for (const line of lines) {
+          options.didSearchPaths(++numPathsFound.num)
+          didMatch(line)
+        }
+      })
+    })
+
+    returnedPromise.cancel = () => {
+      child.kill()
+      cancelled = true
+    }
+
+    return returnedPromise
+  }
+}
+
+export default FileSearcher

--- a/src/renderer/node/ripgrepSearcher.js
+++ b/src/renderer/node/ripgrepSearcher.js
@@ -210,10 +210,10 @@ class RipgrepDirectorySearcher {
       args.push('--after-context', options.trailingContextLineCount)
     }
     for (const inclusion of this.prepareGlobs(options.inclusions, directoryPath)) {
-      args.push('--glob', inclusion)
+      args.push('--iglob', inclusion)
     }
     for (const exclusion of this.prepareGlobs(options.exclusions, directoryPath)) {
-      args.push('--glob', '!' + exclusion)
+      args.push('--iglob', '!' + exclusion)
     }
 
     args.push('--')

--- a/src/renderer/pages/app.vue
+++ b/src/renderer/pages/app.vue
@@ -27,6 +27,7 @@
         :platform="platform"
       ></editor-with-tabs>
       <aidou></aidou>
+      <command-palette></command-palette>
       <about-dialog></about-dialog>
       <export-setting-dialog></export-setting-dialog>
       <rename></rename>
@@ -44,6 +45,7 @@ import TitleBar from '@/components/titleBar'
 import SideBar from '@/components/sideBar'
 import Aidou from '@/components/aidou/aidou'
 import AboutDialog from '@/components/about'
+import CommandPalette from '@/components/commandPalette'
 import ExportSettingDialog from '@/components/exportSettings'
 import Rename from '@/components/rename'
 import Tweet from '@/components/tweet'
@@ -65,7 +67,8 @@ export default {
     ExportSettingDialog,
     Rename,
     Tweet,
-    ImportModal
+    ImportModal,
+    CommandPalette
   },
   mixins: [loadingPageMixins],
   data () {
@@ -112,6 +115,8 @@ export default {
 
     // store/index.js
     dispatch('LINTEN_WIN_STATUS')
+    // module: command center
+    dispatch('LISTEN_COMMAND_CENTER_BUS')
     // module: tweet
     dispatch('LISTEN_FOR_TWEET')
     // module: layout
@@ -131,6 +136,7 @@ export default {
     // module: editor
     dispatch('LISTEN_SCREEN_SHOT')
     dispatch('ASK_FOR_USER_PREFERENCE')
+    dispatch('LISTEN_TOGGLE_VIEW')
     dispatch('LISTEN_FOR_CLOSE')
     dispatch('LISTEN_FOR_SAVE_AS')
     dispatch('LISTEN_FOR_MOVE_TO')
@@ -140,6 +146,7 @@ export default {
     dispatch('LISTEN_FOR_SAVE_CLOSE')
     dispatch('LISTEN_FOR_RENAME')
     dispatch('LINTEN_FOR_SET_LINE_ENDING')
+    dispatch('LINTEN_FOR_SET_ENCODING')
     dispatch('LISTEN_FOR_NEW_TAB')
     dispatch('LISTEN_FOR_CLOSE_TAB')
     dispatch('LISTEN_FOR_TAB_CYCLE')

--- a/src/renderer/store/commandCenter.js
+++ b/src/renderer/store/commandCenter.js
@@ -1,0 +1,75 @@
+import { ipcRenderer } from 'electron'
+import log from 'electron-log'
+import bus from '../bus'
+import staticCommands, { RootCommand } from '../commands'
+import { isOsx } from '@/util'
+
+const state = {
+  rootCommand: new RootCommand(staticCommands)
+}
+
+const getters = {}
+
+const mutations = {
+  REGISTER_COMMAND (state, command) {
+    state.rootCommand.subcommands.push(command)
+  },
+  SORT_COMMANDS (state) {
+    state.rootCommand.subcommands.sort((a, b) => a.description.localeCompare(b.description))
+  }
+}
+
+const actions = {
+  LISTEN_COMMAND_CENTER_BUS ({ commit, state }) {
+    // Init stuff
+    bus.$on('cmd::sort-commands', () => {
+      commit('SORT_COMMANDS')
+    })
+    ipcRenderer.on('mt::keybindings-response', (e, keybindingMap) => {
+      const { subcommands } = state.rootCommand
+      for (const entry of subcommands) {
+        const value = keybindingMap[entry.id]
+        if (value) {
+          entry.shortcut = normalizeAccelerator(value)
+        }
+      }
+    })
+
+    // Register commands that are created at runtime.
+    bus.$on('cmd::register-command', command => {
+      commit('REGISTER_COMMAND', command)
+    })
+
+    // Allow other compontents to execute commands with predefined values.
+    bus.$on('cmd::execute', commandId => {
+      executeCommand(state, commandId)
+    })
+    ipcRenderer.on('mt::execute-command-by-id', (e, commandId) => {
+      executeCommand(state, commandId)
+    })
+  }
+}
+
+const executeCommand = (state, commandId) => {
+  const { subcommands } = state.rootCommand
+  const command = subcommands.find(c => c.id === commandId)
+  if (!command) {
+    const errorMsg = `Cannot execute command "${commandId}" because it's missing.`
+    log.error(errorMsg)
+    throw new Error(errorMsg)
+  }
+  command.execute()
+}
+
+const defaultCtrlKey = isOsx ? 'Cmd' : 'Ctrl'
+const normalizeAccelerator = acc => {
+  try {
+    return acc
+      .replace(/cmdorctrl|cmd|ctrl/i, defaultCtrlKey)
+      .split('+')
+  } catch (_) {
+    return [acc]
+  }
+}
+
+export default { state, getters, mutations, actions }

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -11,6 +11,7 @@ import preferences from './preferences'
 import autoUpdates from './autoUpdates'
 import notification from './notification'
 import tweet from './tweet'
+import commandCenter from './commandCenter'
 
 Vue.use(Vuex)
 
@@ -61,7 +62,8 @@ const store = new Vuex.Store({
     aidou,
     preferences,
     editor,
-    layout
+    layout,
+    commandCenter
   }
 })
 

--- a/src/renderer/store/layout.js
+++ b/src/renderer/store/layout.js
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import bus from '../bus'
 
 const width = localStorage.getItem('side-bar-width')
 const sideBarWidth = typeof +width === 'number' ? Math.max(+width, 220) : 280
@@ -17,6 +18,9 @@ const mutations = {
   SET_LAYOUT (state, layout) {
     Object.assign(state, layout)
   },
+  TOGGLE_LAYOUT_ENTRY (state, entryName) {
+    state[entryName] = !state[entryName]
+  },
   SET_SIDE_BAR_WIDTH (state, width) {
     // TODO: Add side bar to session (GH#732).
     localStorage.setItem('side-bar-width', Math.max(+width, 220))
@@ -26,8 +30,16 @@ const mutations = {
 
 const actions = {
   LISTEN_FOR_LAYOUT ({ commit }) {
-    ipcRenderer.on('AGANI::listen-for-view-layout', (e, layout) => {
+    ipcRenderer.on('mt::set-view-layout', (e, layout) => {
       commit('SET_LAYOUT', layout)
+    })
+
+    bus.$on('view:toggle-view-layout-entry', entryName => {
+      commit('TOGGLE_LAYOUT_ENTRY', entryName)
+      const item = {}
+      item[entryName] = state[entryName]
+      const { windowId } = global.marktext.env
+      ipcRenderer.send('mt::view-layout-changed', windowId, item)
     })
   },
   LISTEN_FOR_REQUEST_LAYOUT ({ dispatch }) {

--- a/src/renderer/store/layout.js
+++ b/src/renderer/store/layout.js
@@ -16,6 +16,10 @@ const getters = {}
 
 const mutations = {
   SET_LAYOUT (state, layout) {
+    if (layout.showSideBar !== undefined) {
+      const { windowId } = global.marktext.env
+      ipcRenderer.send('mt::update-sidebar-menu', windowId, !!layout.showSideBar)
+    }
     Object.assign(state, layout)
   },
   TOGGLE_LAYOUT_ENTRY (state, entryName) {

--- a/src/renderer/store/listenForMain.js
+++ b/src/renderer/store/listenForMain.js
@@ -10,7 +10,7 @@ const mutations = {}
 
 const actions = {
   LISTEN_FOR_EDIT ({ commit }) {
-    ipcRenderer.on('mt::editor-edit-action', (e, { type }) => {
+    ipcRenderer.on('mt::editor-edit-action', (e, type) => {
       if (type === 'findInFolder') {
         commit('SET_LAYOUT', {
           rightColumn: 'search',

--- a/src/renderer/store/listenForMain.js
+++ b/src/renderer/store/listenForMain.js
@@ -10,7 +10,7 @@ const mutations = {}
 
 const actions = {
   LISTEN_FOR_EDIT ({ commit }) {
-    ipcRenderer.on('AGANI::edit', (e, { type }) => {
+    ipcRenderer.on('mt::editor-edit-action', (e, { type }) => {
       if (type === 'findInFolder') {
         commit('SET_LAYOUT', {
           rightColumn: 'search',
@@ -22,8 +22,11 @@ const actions = {
   },
 
   LISTEN_FOR_VIEW ({ commit }) {
-    ipcRenderer.on('AGANI::view', (e, data) => {
+    ipcRenderer.on('mt::editor-change-view', (e, data) => {
       commit('SET_MODE', data)
+    })
+    ipcRenderer.on('mt::show-command-palette', () => {
+      bus.$emit('show-command-palette')
     })
   },
 
@@ -36,11 +39,11 @@ const actions = {
     })
   },
 
-  LISTEN_FOR_PARAGRAPH_INLINE_STYLE ({ commit }) {
-    ipcRenderer.on('AGANI::paragraph', (e, { type }) => {
+  LISTEN_FOR_PARAGRAPH_INLINE_STYLE () {
+    ipcRenderer.on('mt::editor-paragraph-action', (e, { type }) => {
       bus.$emit('paragraph', type)
     })
-    ipcRenderer.on('AGANI::format', (e, { type }) => {
+    ipcRenderer.on('mt::editor-format-action', (e, { type }) => {
       bus.$emit('format', type)
     })
   }

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import bus from '../bus'
 
 // user preference
 const state = {
@@ -99,6 +100,9 @@ const mutations = {
   },
   SET_MODE (state, { type, checked }) {
     state[type] = checked
+  },
+  TOGGLE_VIEW_MODE (state, entryName) {
+    state[entryName] = !state[entryName]
   }
 }
 
@@ -127,6 +131,17 @@ const actions = {
 
   SELECT_DEFAULT_DIRECTORY_TO_OPEN ({ commit }) {
     ipcRenderer.send('mt::select-default-directory-to-open')
+  },
+
+  // Toggle a view option and notify main process to toggle menu item.
+  LISTEN_TOGGLE_VIEW ({ commit, state }) {
+    bus.$on('view:toggle-view-entry', entryName => {
+      commit('TOGGLE_VIEW_MODE', entryName)
+      const item = {}
+      item[entryName] = state[entryName]
+      const { windowId } = global.marktext.env
+      ipcRenderer.send('mt::view-layout-changed', windowId, item)
+    })
   }
 }
 

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -1,5 +1,22 @@
 import crypto from 'crypto'
 
+export const delay = time => {
+  let timerId
+  let rejectFn
+  const p = new Promise((resolve, reject) => {
+    rejectFn = reject
+    timerId = setTimeout(resolve, time)
+  })
+
+  p.cancel = () => {
+    clearTimeout(timerId)
+    timerId = null
+    rejectFn()
+    rejectFn = null
+  }
+  return p
+}
+
 // help functions
 const easeInOutQuad = function (t, b, c, d) {
   t /= d / 2


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| New feature?     | yes
| Fixed tickets    | #581. #1408, #1225
| License          | MIT

### Description

This PR should add both command palette and quick open dialog to Mark Text and also add window zoom feature. Please see [here](https://github.com/marktext/marktext/blob/1f87ba6215f75d7e1909c684782544858da499e5/docs/dev/code/COMMANDS.md) for command details.

**Todo's:**

- [x] Pressing `Ctrl+A` on a dialog will enter the editor and you can edit content (#1489).
- [x] We can execute paragraph commands that are not allowed by Muya in current state. Muya should handle this, otherwise exceptions are thrown when using paragraph commants in invalid states (blocked by #1491).
- [x] All format entries don't work because the selection is removed before/after the dialog is closed and the cursor is invalid (blocked by #1491).

---

fixes #581
fixes #1408
fixes #1225