### PR TITLE
Adjust export theme style

### DIFF
--- a/src/muya/lib/assets/styles/exportStyle.css
+++ b/src/muya/lib/assets/styles/exportStyle.css
@@ -1,3 +1,7 @@
+.markdown-body a.footnote-ref {
+  text-decoration: none;
+}
+
 .footnotes {
   font-size: .85em;
   opacity: .8;
@@ -12,4 +16,5 @@
   font-family: initial;
   top: .2em;
   right: 1em;
+  text-decoration: none;
 }

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -32,6 +32,7 @@ Lexer.prototype.lex = function (src) {
   this.checkFrontmatter = true
   this.footnoteOrder = 0
   this.token(src, true)
+
   // Move footnote token to the end of tokens.
   const { tokens } = this
   const hasNoFootnoteTokens = []

--- a/src/muya/lib/parser/marked/parser.js
+++ b/src/muya/lib/parser/marked/parser.js
@@ -169,7 +169,6 @@ Parser.prototype.tok = function () {
           itemBody += this.tok()
         }
       }
-
       return this.renderer.footnote(body)
     }
     case 'list_start': {

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -283,7 +283,7 @@ class ExportHtml {
     }
 
     if (footer) {
-      output += HF_TABLE_FOOTER()
+      output += HF_TABLE_FOOTER
       output = createRealFooter(options) + output
     }
 

--- a/src/renderer/assets/styles/printService.css
+++ b/src/renderer/assets/styles/printService.css
@@ -1,6 +1,6 @@
 body .ag-render-container,
 body article.print-container {
-  display: none !important;
+  display: none;
 }
 
 @media print {

--- a/src/renderer/assets/themes/export/academic.theme.css
+++ b/src/renderer/assets/themes/export/academic.theme.css
@@ -1,7 +1,6 @@
 /** Academic **/
 
-/* DejaVu Serif --> 11pt */
-/* Don't use "Noto Color Emoji" because it will result in PDF files with multiple MB and weird looking emojis. */
+/* DejaVu Serif should use 11pt */
 .hf-container,
 .markdown-body {
   font-family: Georgia,Palatino,"Palatino Linotype","Times New Roman","DejaVu Serif",serif,"Apple Color Emoji","Segoe UI Emoji";
@@ -23,6 +22,20 @@
 .page-footer:not(.simple) .hf-container {
   padding-top: 2px;
   border-top: 1px solid var(--footerHeaderBorderColor);
+}
+
+.footnotes {
+  font-size: 0.75em;
+  opacity: 0.9;
+}
+.footnotes > hr:first-of-type {
+  width: 250px;
+  height: 1px;
+  background: var(--footerHeaderBorderColor);
+}
+.footnotes > ol > li > p {
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .markdown-body h1,

--- a/src/renderer/assets/themes/export/liber.theme.css
+++ b/src/renderer/assets/themes/export/liber.theme.css
@@ -1,6 +1,5 @@
 /** Liber **/
 
-/* Don't use "Noto Color Emoji" because it will result in PDF files with multiple MB and weird looking emojis. */
 .hf-container,
 .markdown-body {
   font-family: "Source Sans Pro","Segoe UI","Helvetica Neue","Open Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji";
@@ -22,6 +21,26 @@
 .page-footer:not(.simple) .hf-container {
   padding-top: 2px;
   border-top: 1px solid var(--footerHeaderBorderColor);
+}
+
+.footnotes {
+  font-size: 0.75em;
+  opacity: 0.9;
+}
+.footnotes > hr:first-of-type {
+  width: 250px;
+  height: 1px;
+  background: var(--footerHeaderBorderColor);
+}
+.footnotes > ol > li > p {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+.footnotes .footnote-back {
+  color: #212121;
+}
+.markdown-body a.footnote-ref {
+  color: #212121;
 }
 
 .markdown-body h1,

--- a/src/renderer/util/pdf.js
+++ b/src/renderer/util/pdf.js
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import createDOMPurify from 'dompurify'
 import { isFile } from 'common/filesystem'
+import { escapeHtml, unescapeHtml } from 'muya/lib/utils'
 import academicTheme from '@/assets/themes/export/academic.theme.css'
 import liberTheme from '@/assets/themes/export/liber.theme.css'
 
@@ -86,7 +87,7 @@ export const getCssForOptions = options => {
     // Close @page
     output += '}'
   }
-  return sanitize(output, EXPORT_DOMPURIFY_CONFIG)
+  return unescapeHtml(sanitize(escapeHtml(output), EXPORT_DOMPURIFY_CONFIG))
 }
 
 const EXPORT_DOMPURIFY_CONFIG = {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Adjusted export theme style and fixed bug that not content was shown.

Academic and Liber footnotes are almost the same:

![mt_export_style](https://user-images.githubusercontent.com/22716132/68088280-c01c3b00-fe5d-11e9-9908-8e72961e5ed5.png)

@Jocs BTW there is a bug when using the pandoc example and switching between source- and preview editor multiple time, each time 4x spaces are added to the code block.
