### PR TITLE
Match keyword not only from the beginning #1607

### DIFF
--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -175,12 +175,12 @@ class QuickOpenCommand {
   _getInclusions = query => {
     // NOTE: This will fail on `foo.m` because we search for `foo.m.md`.
     if (MD_EXTENSION.test(query)) {
-      return [query]
+      return [`*${query}`]
     }
 
     const inclusions = ['*.markdown', '*.mdown', '*.mkdn', '*.md', '*.mkd', '*.mdwn', '*.mdtxt', '*.mdtext', '*.text', '*.txt']
     for (let i = 0; i < inclusions.length; ++i) {
-      inclusions[i] = `${query}` + inclusions[i]
+      inclusions[i] = `*${query}` + inclusions[i]
     }
     return inclusions
   }

--- a/src/renderer/components/commandPalette/index.vue
+++ b/src/renderer/components/commandPalette/index.vue
@@ -153,6 +153,9 @@ export default {
       }
     },
     handleInput (event) {
+      if (event.isComposing) {
+        return
+      }
       // NOTE: We're using keyup to catch "enter" key but `ctrlKey`
       // etc doesn't work here.
       switch (event.key) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| Fixed tickets    | #1607 
| License          | MIT

### Description

- [x] Also fixed no need to search when the keyup event is isComposing(is input by IME).

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marktext/marktext/1612)
<!-- Reviewable:end -->
