### PR TITLE
Revert #1616 One-Dark color change

### DIFF
--- a/src/renderer/assets/themes/one-dark.theme.css
+++ b/src/renderer/assets/themes/one-dark.theme.css
@@ -60,7 +60,7 @@
   /*marktext*/
   --sideBarColor: #9da5b4;
   --sideBarIconColor: var(--iconColor);
-  --sideBarTitleColor: rgb(255, 255, 255);
+  --sideBarTitleColor: #9da5b4;
   --sideBarTextColor: #9da5b4;
   --sideBarBgColor: #21252b;
   --sideBarItemHoverBgColor: #3a3f4b;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

Revert #1616 One-Dark color change because it's not compatible with One-Dark colors and was too bright.