### PR TITLE
Add setting for sequence diagram theme (#1628)

### DIFF
--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -52,6 +52,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | frontmatterType     | String  | `-`     | The frontmatter type: `-` (YAML), `+` (TOML), `;` (JSON) or `{` (JSON)                                                               |
 | superSubScript      | Boolean | `false` | Enable pandoc's markdown extension superscript and subscript.                                                                        |
 | footnote            | Boolean | `false` | Enable pandoc's footnote markdown extension                                                                                          |
+| sequenceTheme       | String  | `hand`  | Change the theme of [js-sequence-diagrams]()                                                                                         |
 
 #### Theme
 

--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -52,7 +52,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | frontmatterType     | String  | `-`     | The frontmatter type: `-` (YAML), `+` (TOML), `;` (JSON) or `{` (JSON)                                                               |
 | superSubScript      | Boolean | `false` | Enable pandoc's markdown extension superscript and subscript.                                                                        |
 | footnote            | Boolean | `false` | Enable pandoc's footnote markdown extension                                                                                          |
-| sequenceTheme       | String  | `hand`  | Change the theme of [js-sequence-diagrams]()                                                                                         |
+| sequenceTheme       | String  | `hand`  | Change the theme of [js-sequence-diagrams](https://bramp.github.io/js-sequence-diagrams/)                                                                                         |
 
 #### Theme
 

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -257,6 +257,13 @@
     "type": "boolean",
     "default": false
   },
+  "sequenceTheme": {
+    "description": "Markdown--Sequence diagram theme",
+    "enum": [
+      "hand",
+      "simple"
+    ]
+  },
 
   "theme": {
     "description": "Theme--Select the theme used in Mark Text",

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -71,7 +71,7 @@ class ExportHtml {
       preParent.replaceWith(diagramContainer)
       const options = {}
       if (functionType === 'sequence') {
-        Object.assign(options, { theme: 'hand' })
+        Object.assign(options, { theme: this.muya.options.sequenceTheme })
       } else if (functionType === 'vega-lite') {
         Object.assign(options, {
           actions: false,

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -239,7 +239,7 @@ export default {
     sequenceTheme: function (value, oldValue) {
       const { editor } = this
       if (value !== oldValue && editor) {
-        editor.setOptions({ sequenceTheme: value })
+        editor.setOptions({ sequenceTheme: value }, true)
       }
     },
     listIndentation: function (value, oldValue) {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -151,6 +151,7 @@ export default {
       imageInsertAction: state => state.preferences.imageInsertAction,
       imageFolderPath: state => state.preferences.imageFolderPath,
       theme: state => state.preferences.theme,
+      sequenceTheme: state => state.preferences.sequenceTheme,
       hideScrollbar: state => state.preferences.hideScrollbar,
       spellcheckerEnabled: state => state.preferences.spellcheckerEnabled,
       spellcheckerIsHunspell: state => state.preferences.spellcheckerIsHunspell,
@@ -233,6 +234,12 @@ export default {
             vegaTheme: 'latimes'
           }, true)
         }
+      }
+    },
+    sequenceTheme: function (value, oldValue) {
+      const { editor } = this
+      if (value !== oldValue && editor) {
+        editor.setOptions({ sequenceTheme: value })
       }
     },
     listIndentation: function (value, oldValue) {
@@ -468,6 +475,7 @@ export default {
         hideQuickInsertHint,
         editorLineWidth,
         theme,
+        sequenceTheme,
         spellcheckerEnabled,
         hideLinkPopup
       } = this
@@ -512,6 +520,7 @@ export default {
         footnote,
         hideQuickInsertHint,
         hideLinkPopup,
+        sequenceTheme,
         spellcheckEnabled: spellcheckerEnabled,
         imageAction: this.imageAction.bind(this),
         imagePathPicker: this.imagePathPicker.bind(this),

--- a/src/renderer/prefComponents/markdown/config.js
+++ b/src/renderer/prefComponents/markdown/config.js
@@ -72,3 +72,11 @@ export const frontmatterTypeOptions = [{
   label: 'JSON ({})',
   value: '{'
 }]
+
+export const sequenceThemeOptions = [{
+  label: 'hand',
+  value: 'hand'
+}, {
+  label: 'simple',
+  value: 'simple'
+}]

--- a/src/renderer/prefComponents/markdown/config.js
+++ b/src/renderer/prefComponents/markdown/config.js
@@ -74,9 +74,9 @@ export const frontmatterTypeOptions = [{
 }]
 
 export const sequenceThemeOptions = [{
-  label: 'hand',
+  label: 'Hand drawn',
   value: 'hand'
 }, {
-  label: 'simple',
+  label: 'Simple',
   value: 'simple'
 }]

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -60,6 +60,15 @@
       :onChange="value => onSelectChange('footnote', value)"
       more="https://pandoc.org/MANUAL.html#footnotes"
     ></bool>
+    <separator></separator>
+    <h5>Style</h5>
+    <cus-select
+      description="Sequence diagram theme"
+      :value="sequenceTheme"
+      :options="sequenceThemeOptions"
+      :onChange="value => onSelectChange('sequenceTheme', value)"
+      more="https://bramp.github.io/js-sequence-diagrams/"
+    ></cus-select>
   </div>
 </template>
 
@@ -74,7 +83,8 @@ import {
   preferHeadingStyleOptions,
   tabSizeOptions,
   listIndentationOptions,
-  frontmatterTypeOptions
+  frontmatterTypeOptions,
+  sequenceThemeOptions
 } from './config'
 
 export default {
@@ -90,6 +100,7 @@ export default {
     this.tabSizeOptions = tabSizeOptions
     this.listIndentationOptions = listIndentationOptions
     this.frontmatterTypeOptions = frontmatterTypeOptions
+    this.sequenceThemeOptions = sequenceThemeOptions
     return {}
   },
   computed: {
@@ -102,7 +113,8 @@ export default {
       listIndentation: state => state.preferences.listIndentation,
       frontmatterType: state => state.preferences.frontmatterType,
       superSubScript: state => state.preferences.superSubScript,
-      footnote: state => state.preferences.footnote
+      footnote: state => state.preferences.footnote,
+      sequenceTheme: state => state.preferences.sequenceTheme
     })
   },
   methods: {

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -61,7 +61,7 @@
       more="https://pandoc.org/MANUAL.html#footnotes"
     ></bool>
     <separator></separator>
-    <h5>Style</h5>
+    <h5>Diagram theme</h5>
     <cus-select
       description="Sequence diagram theme"
       :value="sequenceTheme"

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -45,6 +45,7 @@ const state = {
   frontmatterType: '-',
   superSubScript: false,
   footnote: false,
+  sequenceTheme: 'hand',
 
   theme: 'light',
   autoSwitchTheme: 2,

--- a/static/preference.json
+++ b/static/preference.json
@@ -41,6 +41,7 @@
   "frontmatterType": "-",
   "superSubScript": false,
   "footnote": false,
+  "sequenceTheme": "hand",
 
   "theme": "light",
   "autoSwitchTheme": 2,


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1628
| License          | MIT

### Description

Added an option to change the theme of the js-sequence-diagram diagrams. 

I didn't change the default theme to "simple" as suggested in the issue, I'll leave that to a maintainer. However, I do think that would be a good idea as the default "hand drawn" theme is absolutely atrocious.

I did notice some regressions in the diagram rendering that are **unrelated** to this change though. Namely, the diagram text is black even in dark themes, and the diagram gets horribly squished when exporting to both HTML and PDF. These issues did not exist in v0.15.1.

I've also backported this change at the tag v0.15.1-sequence in my fork, where it works great!
https://github.com/sippeangelo/marktext/tree/v0.15.1-sequence