### PR TITLE
Add deb/rpm and adjust package file names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons:
     # fontmanager
     - libfontconfig-dev
     # Build RPM on Ubuntu
-    - rpmbuild
+    - rpm
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ addons:
     - libsecret-1-dev
     # fontmanager
     - libfontconfig-dev
+    # Build RPM on Ubuntu
+    - rpmbuild
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update ; fi
@@ -71,10 +73,10 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn run release:mac --publish always ; fi
 
   # Calculate checksums
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x64.tar.gz ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*-x86_64.AppImage ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-*-mac.zip ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-*.dmg ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-x64.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-x86_64.AppImage ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-mac.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext.dmg ; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ script:
   # Calculate checksums
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-x64.tar.gz ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-x86_64.AppImage ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*.deb ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sha256sum build/marktext-*.rpm ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext-mac.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shasum -a 256 build/marktext.dmg ; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ build_script:
   - yarn run release:win --publish always
 
   # Calculate checksums
-  - ps: get-filehash -Algorithm SHA256 "build\marktext-*.exe"
+  - ps: get-filehash -Algorithm SHA256 "build\marktext-setup.exe"
   - ps: get-filehash -Algorithm SHA256 "build\marktext-*-win.zip"
 
 test: off

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -59,7 +59,7 @@ fileAssociations:
   role: "Editor"
   icon: "../resources/icons/md.icns"
 dmg:
-  artifactName: "marktext-${version}.${ext}"
+  artifactName: "marktext.${ext}"
   contents:
   - x: 410
     y: 150
@@ -69,11 +69,11 @@ dmg:
     y: 150
     type: "file"
 mac:
-  artifactName: "marktext-${version}-mac.${ext}"
+  artifactName: "marktext-mac.${ext}"
   icon: "resources/icons/icon.icns"
   darkModeSupport: true
 win:
-  artifactName: "marktext-${version}-${arch}-win.${ext}"
+  artifactName: "marktext-${arch}-win.${ext}"
   icon: "resources/icons/icon.ico"
   target:
   - target: "nsis"
@@ -86,13 +86,16 @@ win:
     - "x64"
   requestedExecutionLevel: "asInvoker"
 nsis:
-  artifactName: "marktext-setup-${version}.${ext}"
+  artifactName: "marktext-setup.${ext}"
   perMachine: false
   oneClick: false
   allowToChangeInstallationDirectory: true
   include: "resources/windows/installer.nsh"
 linux:
-  artifactName: "marktext-${version}-${arch}.${ext}"
+  artifactName: "marktext-${arch}.${ext}"
+  executableName: "marktext"
+  description: "A simple and elegant open-source markdown editor that focused on speed and usability."
+  maintainer: "Mark Text Contributors"
   category: "Office;TextEditor;Utility"
   mimeTypes:
   - "text/markdown"
@@ -102,7 +105,10 @@ linux:
     Keywords: "marktext;"
   target:
   - target: "AppImage"
+  - target: "deb"
+  - target: "rpm"
   - target: "tar.gz"
+  # Workaround because file association array doesn't work.
   fileAssociations:
   - ext: "md"
     name: "Markdown"
@@ -122,3 +128,26 @@ linux:
   - ext: "mdtext"
     name: "Markdown"
     description: "Markdown document"
+deb:
+  # Custom dependencies:
+  depends:
+  # keytar
+  - "libsecret-1-0"
+  # keyboard-layout
+  - "libx11-xcb1"
+  - "libxkbfile1"
+  # fontmanager
+  - "libfontconfig1"
+  fpm:
+  # Expat := MIT like
+  - "--license=Expat"
+rpm:
+  # Custom dependencies:
+  depends:
+  # keytar
+  - "libsecret"
+  # keyboard-layout
+  - "libX11-xcb"
+  - "libxkbfile"
+  # fontmanager
+  - "fontconfig"


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Fixed tickets    | #1687, https://github.com/marktext/website/pull/15
| License          | MIT

### Description

Add deb/rpm packages to Linux and change default package file names.

**Known Issues:**

- License is shown as *proprietary* with both MIT and Expat on Debian packages (`deb`).
- Package name is shown as `marktext` instead `Mark Text`.

---

resolves #1687
