### PR TITLE
Better phrasing of the GDPR warning

### DIFF
--- a/src/renderer/prefComponents/imageUploader/legalNoticesCheckbox.vue
+++ b/src/renderer/prefComponents/imageUploader/legalNoticesCheckbox.vue
@@ -6,7 +6,7 @@
       <span class="link" @click="openUrl(uploaderService.privacyUrl)">Privacy Statement</span>
       and
       <span class="link" @click="openUrl(uploaderService.tosUrl)">Terms of Service</span>.
-      <span v-if="!uploaderService.isGdprCompliant">This service is not allowed to use in Europe due GDPR issues.</span>
+      <span v-if="!uploaderService.isGdprCompliant">This service cannot be used in Europe due to GDPR issues.</span>
     </span>
   </div>
 </template>


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description

The wording of this GDPR warning was not proper English, and a word was missing. This just cleans up that text to make it look more professional and polished.
