### PR TITLE
do not strike through completed tasks (#1680)

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -496,11 +496,6 @@ li.ag-task-list-item > input.ag-checkbox-checked ~ * {
   color: var(--editorColor50);
 }
 
-li.ag-task-list-item > input.ag-checkbox-checked ~ p {
-  text-decoration: line-through;
-  color: var(--editorColor50);
-}
-
 li.ag-task-list-item > input[type=checkbox]::before {
   content: '';
   width: 18px;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | (what is this?)
| Deprecations?    | no
| New tests added? | no
| Fixed tickets    | #1680
| License          | MIT

### Description

Stop rendering completed tasks as struck through; it was obscuring struck-through text entered by the user.