### PR TITLE
Forbid inline math overlay selection

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -35,7 +35,7 @@ mark {
   line-height: 1.2;
 }
 
-mark::before, 
+mark::before,
 mark::after {
   clip-path: inset(100%);
   clip: rect(1px, 1px, 1px, 1px);
@@ -267,6 +267,7 @@ span.ag-math {
   position: absolute;
   top: 100%;
   left: 0;
+  user-select: none;
   z-index: 1;
 }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| License          | MIT

### Description

Forbid inline math overlay selection when selecting multiple lines.
