### PR TITLE
Variables shouldn't use same color as strings

### DIFF
--- a/src/renderer/assets/themes/prismjs/dark.theme.css
+++ b/src/renderer/assets/themes/prismjs/dark.theme.css
@@ -93,7 +93,7 @@ pre.ag-paragraph {
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #f8f8f2;
+  color: #e67e65;
 }
 
 .token.atrule,

--- a/src/renderer/assets/themes/prismjs/dark.theme.css
+++ b/src/renderer/assets/themes/prismjs/dark.theme.css
@@ -92,8 +92,7 @@ pre.ag-paragraph {
 .token.entity,
 .token.url,
 .language-css .token.string,
-.style .token.string,
-.token.variable {
+.style .token.string {
   color: #f8f8f2;
 }
 
@@ -109,7 +108,8 @@ pre.ag-paragraph {
 }
  
 .token.regex,
-.token.important {
+.token.important,
+.token.variable {
   color: #fd971f;
 }
  


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description

In dark theme, variables become unrecognizable since they are white and same as plain text. For example in SQL language, the `AND` and `LIKE` look same as default text.
