### PR TITLE
fix: dompurify warning when init app

### DIFF
--- a/src/muya/lib/parser/render/renderInlines/htmlTag.js
+++ b/src/muya/lib/parser/render/renderInlines/htmlTag.js
@@ -1,8 +1,6 @@
-import createDOMPurify from 'dompurify'
 import { CLASS_OR_ID, BLOCK_TYPE6 } from '../../../config'
 import { snakeToCamel } from '../../../utils'
-
-const { sanitize } = createDOMPurify(window)
+import sanitize from '../../../utils/dompurify'
 
 export default function htmlTag (h, cursor, block, token, outerClass) {
   const { tag, openTag, closeTag, children, attrs } = token

--- a/src/muya/lib/utils/dompurify.js
+++ b/src/muya/lib/utils/dompurify.js
@@ -1,0 +1,3 @@
+import { sanitize } from 'dompurify'
+
+export default sanitize

--- a/src/muya/lib/utils/index.js
+++ b/src/muya/lib/utils/index.js
@@ -1,7 +1,5 @@
-import createDOMPurify from 'dompurify'
+import runSanitize from './dompurify'
 import { URL_REG, DATA_URL_REG, IMAGE_EXT_REG } from '../config'
-
-const { sanitize: runSanitize } = createDOMPurify(window)
 
 const ID_PREFIX = 'ag-'
 let id = 0

--- a/src/renderer/util/pdf.js
+++ b/src/renderer/util/pdf.js
@@ -1,12 +1,10 @@
 import fs from 'fs-extra'
 import path from 'path'
-import createDOMPurify from 'dompurify'
+import sanitize from 'muya/lib/utils/dompurify'
 import { isFile } from 'common/filesystem'
 import { escapeHtml, unescapeHtml } from 'muya/lib/utils'
 import academicTheme from '@/assets/themes/export/academic.theme.css'
 import liberTheme from '@/assets/themes/export/liber.theme.css'
-
-const { sanitize } = createDOMPurify(window)
 
 export const getCssForOptions = options => {
   const {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no
| License          | MIT

### Description

[Description of the bug or feature]

Fix dompurify warning when init Mark Text.

![屏幕快照 2019-12-02 上午9 50 42](https://user-images.githubusercontent.com/9712830/69925547-bbde4e80-14eb-11ea-9f79-19623d9b09c5.png)


--

#### Please don't submit `/dist` files with your PR!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marktext/marktext/1781)
<!-- Reviewable:end -->
