### PR TITLE
Ignore dist files in repository, update PRtemplate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Please change the Answers in the table below
+     to reflect the contents of your pull request. -->
+
 | Q                | A
 | ---------------- | ---
 | Bug fix?         | yes/no
@@ -11,7 +14,3 @@
 ### Description
 
 [Description of the bug or feature]
-
---
-
-#### Please don't submit `/dist` files with your PR!

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 .DS_Store
-dist/electron/*
-dist/web/*
+dist/
+*/dist/*
 build/*
 static/themes/*
-src/muya/dist/
 src/muya/node_modules/
 coverage
 .vscode


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | :shrug:
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | none
| License          | MIT

### Description

Fix .gitignore file to never allow dist files to be added and drop warning from PR that is cluttering up ever issue in the tracker.