### PR TITLE
Fix image alignment in exported document

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -233,6 +233,7 @@ export const PREVIEW_DOMPURIFY_CONFIG = {
 export const EXPORT_DOMPURIFY_CONFIG = {
   FORBID_ATTR: ['contenteditable'],
   ALLOW_DATA_ATTR: false,
+  ADD_ATTR: ['data-align'],
   USE_PROFILES: {
     html: true,
     svg: true,

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -234,6 +234,14 @@ class ExportHtml {
     .markdown-body table {
       display: table;
     }
+    .markdown-body img[data-align="center"] {
+      display: block;
+      margin: 0 auto;
+    }
+    .markdown-body img[data-align="right"] {
+      display: block;
+      margin: 0 0 0 auto;
+    }
     .markdown-body li.task-list-item {
       list-style-type: none;
     }

--- a/src/renderer/assets/styles/printService.css
+++ b/src/renderer/assets/styles/printService.css
@@ -1,4 +1,5 @@
 body .ag-render-container {
+  position: absolute;
   left: -10000px;
   right: -10000px;
 }
@@ -57,7 +58,7 @@ body article.print-container {
     margin-top: 0;
     display: inline-block;
   }
-  .markdown-body pre code.fenced-code-block {
+  body article.markdown-body pre code.fenced-code-block {
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/src/renderer/assets/styles/printService.css
+++ b/src/renderer/assets/styles/printService.css
@@ -1,5 +1,5 @@
 body .ag-render-container {
-  position: absolute;
+  position: fixed;
   left: -10000px;
   right: -10000px;
 }


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes (?)
| New feature?      | yes
| License           | MIT

### Description

Fixed image alignment in exported document according `data-align` attribute that is used by Mark Text. This is not a CommonMark/GFM compatible change!
