### PR TITLE
Update BUILD doc: node-gyp supports python 3

### DIFF
--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -11,7 +11,7 @@ git clone https://github.com/marktext/marktext.git
 Before you can get started developing, you need set up your build environment:
 
 - Node.js `>=v12.0.0` and yarn
-- Python `v2.7.x` for node-gyp
+- Python `v2.7` or `>=v3.5` for node-gyp
 - C++ compiler and development tools
 - Build is supported on Linux, macOS and Windows
 


### PR DESCRIPTION
According to official information from https://github.com/nodejs/node-gyp