### PR TITLE
Fix Desktop File link in curl command.

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -17,7 +17,7 @@ You cannot really install an AppImage. It's a file which can run directly after 
 See [example desktop file](https://github.com/marktext/marktext/blob/develop/resources/linux/marktext.desktop).
 
 ```bash
-$ curl -L https://github.com/marktext/marktext/blob/develop/resources/linux/marktext.desktop -o $HOME/.local/share/applications/marktext.desktop
+$ curl -L https://raw.githubusercontent.com/marktext/marktext/develop/resources/linux/marktext.desktop -o $HOME/.local/share/applications/marktext.desktop
 
 # Update the Exec in desktop file to your real marktext command. Specify Path if necessary.
 $ vim $HOME/.local/share/applications/marktext.desktop


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #ticket number (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Description
The current link after `curl -L` downloads the HTML page for the file link on GitHub. I've updated the link to correctly download the raw file into the correct location(~/.local/share/applications).
