### PR TITLE
Fix empty shortcuts in shortcut validator

### DIFF
--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -245,7 +245,7 @@ class Keybindings {
     // Check for duplicate user shortcuts
     for (const [keyA, valueA] of userAccelerators) {
       for (const [keyB, valueB] of userAccelerators) {
-        if (keyA !== keyB && this._isEqualAccelerator(valueA, valueB)) {
+        if (valueA !== '' && keyA !== keyB && this._isEqualAccelerator(valueA, valueB)) {
           const err = `Invalid keybindings.json configuration: Duplicate value for "${keyA}" and "${keyB}"!`
           console.log(err)
           log.error(err)


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | fixes #2117
| License           | MIT

### Description

Fixed an issue that multiple empty shortcuts are rejected by the validator.
