### PR TITLE
Increase indentation for sidebar treeview

### DIFF
--- a/src/renderer/components/sideBar/treeFile.vue
+++ b/src/renderer/components/sideBar/treeFile.vue
@@ -2,7 +2,7 @@
   <div
     :title="file.pathname"
     class="side-bar-file"
-    :style="{'padding-left': `${depth * 5 + 15}px`, 'opacity': file.isMarkdown ? 1 : 0.75 }"
+    :style="{'padding-left': `${(depth * 20) + 20}px`, 'opacity': file.isMarkdown ? 1 : 0.75 }"
     @click="handleFileClick()"
     :class="[{'current': currentFile.pathname === file.pathname, 'active': file.id === activeItem.id }]"
     ref="file"

--- a/src/renderer/components/sideBar/treeFolder.vue
+++ b/src/renderer/components/sideBar/treeFolder.vue
@@ -4,7 +4,7 @@
   >
     <div
       class="folder-name" @click="folderNameClick"
-      :style="{'padding-left': `${depth * 5 + 15}px`}"
+      :style="{'padding-left': `${(depth * 20) + 20}px`}"
       :class="[{ 'active': folder.id === activeItem.id }]"
       :title="folder.pathname"
       ref="folder"

--- a/src/renderer/components/sideBar/treeOpenedTab.vue
+++ b/src/renderer/components/sideBar/treeOpenedTab.vue
@@ -40,7 +40,7 @@ export default {
     user-select: none;
     height: 28px;
     line-height: 28px;
-    padding-left: 30px;
+    padding-left: 35px;
     position: relative;
     color: var(--sideBarColor);
     & > svg {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

This pull request increases the indentation for each item in the sidebar project treeview. This improves readability and accessibility by making it easier to distinguish which file and folder belongs to which indentation level and consequently, which subfolder

The following image is what the sidepane tree looked like before:

![image](https://user-images.githubusercontent.com/47278150/83245871-f78a6600-a166-11ea-8d12-00f2d90f316c.png)

And this is it now with the changes made

![image](https://user-images.githubusercontent.com/47278150/83245753-c9a52180-a166-11ea-89cc-220e06d6df5c.png)
