### PR TITLE
Fix footnote renderer exception in markedjs

### DIFF
--- a/src/muya/lib/parser/marked/inlineLexer.js
+++ b/src/muya/lib/parser/marked/inlineLexer.js
@@ -81,8 +81,12 @@ InlineLexer.prototype.output = function (src) {
         src = src.substring(cap[0].length)
         lastChar = cap[0].charAt(cap[0].length - 1)
         const identifier = cap[1]
+
         const footnoteInfo = this.footnotes[identifier] || {}
-        footnoteInfo.footnoteIdentifierId = getUniqueId()
+        if (footnoteInfo.footnoteIdentifierId === undefined) {
+          footnoteInfo.footnoteIdentifierId = getUniqueId()
+        }
+
         out += this.renderer.footnoteIdentifier(identifier, footnoteInfo)
       }
     }

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -155,6 +155,7 @@ Lexer.prototype.token = function (src, top) {
       }
     }
 
+    // footnote
     if (footnote) {
       cap = this.rules.footnote.exec(src)
       if (top && cap) {
@@ -164,11 +165,14 @@ Lexer.prototype.token = function (src, top) {
           type: 'footnote_start',
           identifier
         })
+
+        // NOTE: Order is wrong if footnote identifier 1 is behind footnote identifier 2 in text.
         this.tokens.footnotes[identifier] = {
           order: ++this.footnoteOrder,
           identifier,
           footnoteId: getUniqueId()
         }
+
         /* eslint-disable no-useless-escape */
         // Remove the footnote identifer prefix. eg: `[^identifier]: `.
         cap = cap[0].replace(/^\[\^[^\^\[\]\s]+?(?<!\\)\]:\s+/gm, '')

--- a/src/muya/lib/parser/marked/textRenderer.js
+++ b/src/muya/lib/parser/marked/textRenderer.js
@@ -19,6 +19,10 @@ TextRenderer.prototype.inlineMath = function (math, displayMode) {
   return math
 }
 
+TextRenderer.prototype.footnoteIdentifier = function (identifier, { footnoteId, footnoteIdentifierId, order }) {
+  return `<a href="#${footnoteId ? `fn${footnoteId}` : ''}" class="footnote-ref" id="fnref${footnoteIdentifierId}" role="doc-noteref"><sup>${order || identifier}</sup></a>`
+}
+
 TextRenderer.prototype.emoji = function (text, emoji) {
   return emoji
 }


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| License           | MIT

### Description

This PR fixes two issue when exporting documents:

- Fixed a crash in markedjs because `footnoteIdentifier` function was not implemented for inline renderer.
- Fixed issue that the footnote link reference was wrong.