### PR TITLE
Fix bad font when exporting document on macOS

### DIFF
--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -204,6 +204,7 @@ class ExportHtml {
   </style>
   <style>
     .markdown-body {
+      font-family: -apple-system,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
       box-sizing: border-box;
       min-width: 200px;
       max-width: 980px;


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes/no
| Breaking changes? | yes/no
| Deprecations?     | yes/no
| New tests added?  | yes/not needed
| Fixed tickets     | fixes #1142
| License           | MIT

### Description

Workaround for strange character encoding when exporting a document to PDF on macOS.
