### PR TITLE
Fix double used shortcut

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -132,7 +132,7 @@ Here is an example:
 | `view.command-palette`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Toggle command palette                   |
 | `view.source-code-mode` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode               |
 | `view.typewriter-mode`  | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd>   | Enable typewriter mode                   |
-| `view.focus-mode`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> | Enable focus mode                        |
+| `view.focus-mode`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> | Enable focus mode                        |
 | `view.toggle-sidebar`   | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
 | `view.toggle-tabbar`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
 | `view.toggle-dev-tools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only) |

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -99,7 +99,7 @@ class Keybindings {
       ['view.command-palette', 'CmdOrCtrl+Shift+P'],
       ['view.source-code-mode', 'CmdOrCtrl+Alt+S'],
       ['view.typewriter-mode', 'CmdOrCtrl+Alt+T'],
-      ['view.focus-mode', 'CmdOrCtrl+Shift+F'],
+      ['view.focus-mode', 'CmdOrCtrl+Shift+J'],
       ['view.toggle-sidebar', 'CmdOrCtrl+J'],
       ['view.toggle-tabbar', 'CmdOrCtrl+Alt+B'],
       ['view.toggle-dev-tools', 'CmdOrCtrl+Alt+I'],

--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -43,8 +43,7 @@
       </div>
 
       <div class="search-message-section" v-if="showNoFolderOpenedMessage">
-        <div>You have not opened a folder.</div>
-        <a href="javascript:;" @click="openFolder">Open Folder</a>
+        <span>You have not opened a folder.</span>
       </div>
       <div class="search-message-section" v-if="showNoResultFoundMessage">No results found.</div>
       <div class="search-message-section" v-if="searchErrorString">{{ searchErrorString }}</div>
@@ -74,6 +73,13 @@
           <svg :viewBox="EmptyIcon.viewBox" aria-hidden="true">
             <use :xlink:href="EmptyIcon.url" />
           </svg>
+          <button
+            class="button-primary"
+            v-if="showNoFolderOpenedMessage"
+            @click="openFolder"
+          >
+            Open Folder
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | fixes #2040
| License           | MIT

### Description

Fix double used shortcut for search in folder and focus mode by using `Ctrl+Shift+J` to toggle focus mode. I also changed to "open folder" button when no folder is opened to be consistent to the other UI.
