### PR TITLE
Conform user-interface text to conventions for trailing punctuation

### DIFF
--- a/src/main/menu/templates/file.js
+++ b/src/main/menu/templates/file.js
@@ -24,13 +24,13 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     }, {
       type: 'separator'
     }, {
-      label: 'Open File',
+      label: 'Open File...',
       accelerator: keybindings.getAccelerator('file.open-file'),
       click (menuItem, browserWindow) {
         actions.openFile(browserWindow)
       }
     }, {
-      label: 'Open Folder',
+      label: 'Open Folder...',
       accelerator: keybindings.getAccelerator('file.open-folder'),
       click (menuItem, browserWindow) {
         actions.openFolder(browserWindow)
@@ -143,7 +143,7 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
     type: 'separator',
     visible: !isOsx
   }, {
-    label: 'Preferences',
+    label: 'Preferences...',
     accelerator: keybindings.getAccelerator('file.preferences'),
     visible: !isOsx,
     click () {

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -32,63 +32,63 @@ export default function () {
     label: '&Help',
     role: 'help',
     submenu: [{
-      label: 'Quick Start',
+      label: 'Quick Start...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/docs/README.md')
       }
     }, {
-      label: 'Markdown Reference',
+      label: 'Markdown Reference...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/docs/MARKDOWN_SYNTAX.md')
       }
     }, {
-      label: 'Changelog',
+      label: 'Changelog...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/.github/CHANGELOG.md')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'Donate via Open Collective',
+      label: 'Donate via Open Collective...',
       click (item, win) {
         shell.openExternal('https://opencollective.com/marktext')
       }
     }, {
-      label: 'Feedback via Twitter',
+      label: 'Feedback via Twitter...',
       click (item, win) {
         actions.showTweetDialog(win, 'twitter')
       }
     }, {
-      label: 'Report Issue or Request Feature',
+      label: 'Report Issue or Request Feature...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/issues')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'Website',
+      label: 'Website...',
       click () {
         shell.openExternal('https://marktext.app')
       }
     }, {
-      label: 'Watch on GitHub',
+      label: 'Watch on GitHub...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext')
       }
     }, {
-      label: 'Follow us on Github',
+      label: 'Follow us on Github...',
       click () {
         shell.openExternal('https://github.com/Jocs')
       }
     }, {
-      label: 'Follow us on Twitter',
+      label: 'Follow us on Twitter...',
       click () {
         shell.openExternal('https://twitter.com/marktextapp')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'License',
+      label: 'License...',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/LICENSE')
       }
@@ -110,7 +110,7 @@ export default function () {
     helpMenu.submenu.push({
       type: 'separator'
     }, {
-      label: 'About Mark Text',
+      label: 'About Mark Text...',
       click (menuItem, browserWindow) {
         actions.showAboutDialog(browserWindow)
       }

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -32,63 +32,63 @@ export default function () {
     label: '&Help',
     role: 'help',
     submenu: [{
-      label: 'Quick Start...',
+      label: 'Quick Start',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/docs/README.md')
       }
     }, {
-      label: 'Markdown Reference...',
+      label: 'Markdown Reference',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/docs/MARKDOWN_SYNTAX.md')
       }
     }, {
-      label: 'Changelog...',
+      label: 'Changelog',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/.github/CHANGELOG.md')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'Donate via Open Collective...',
+      label: 'Donate via Open Collective',
       click (item, win) {
         shell.openExternal('https://opencollective.com/marktext')
       }
     }, {
-      label: 'Feedback via Twitter...',
+      label: 'Feedback via Twitter',
       click (item, win) {
         actions.showTweetDialog(win, 'twitter')
       }
     }, {
-      label: 'Report Issue or Request Feature...',
+      label: 'Report Issue or Request Feature',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/issues')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'Website...',
+      label: 'Website',
       click () {
         shell.openExternal('https://marktext.app')
       }
     }, {
-      label: 'Watch on GitHub...',
+      label: 'Watch on GitHub',
       click () {
         shell.openExternal('https://github.com/marktext/marktext')
       }
     }, {
-      label: 'Follow us on Github...',
+      label: 'Follow us on Github',
       click () {
         shell.openExternal('https://github.com/Jocs')
       }
     }, {
-      label: 'Follow us on Twitter...',
+      label: 'Follow us on Twitter',
       click () {
         shell.openExternal('https://twitter.com/marktextapp')
       }
     }, {
       type: 'separator'
     }, {
-      label: 'License...',
+      label: 'License',
       click () {
         shell.openExternal('https://github.com/marktext/marktext/blob/master/LICENSE')
       }
@@ -110,7 +110,7 @@ export default function () {
     helpMenu.submenu.push({
       type: 'separator'
     }, {
-      label: 'About Mark Text...',
+      label: 'About Mark Text',
       click (menuItem, browserWindow) {
         actions.showAboutDialog(browserWindow)
       }

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -5,7 +5,7 @@ export default function (keybindings) {
   const viewMenu = {
     label: '&View',
     submenu: [{
-      label: 'Command Palette',
+      label: 'Command Palette...',
       accelerator: keybindings.getAccelerator('view.command-palette'),
       click (menuItem, browserWindow) {
         actions.showCommandPalette(browserWindow)

--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -43,7 +43,7 @@
       </div>
 
       <div class="search-message-section" v-if="showNoFolderOpenedMessage">
-        <span>You have not opened a folder.</span>
+        <span>No folder open</span>
       </div>
       <div class="search-message-section" v-if="showNoResultFoundMessage">No results found.</div>
       <div class="search-message-section" v-if="searchErrorString">{{ searchErrorString }}</div>

--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -78,7 +78,7 @@
             v-if="showNoFolderOpenedMessage"
             @click="openFolder"
           >
-            Open Folder
+            Open Folder...
           </button>
         </div>
       </div>

--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -78,7 +78,7 @@
             v-if="showNoFolderOpenedMessage"
             @click="openFolder"
           >
-            Open Folder...
+            Open Folder
           </button>
         </div>
       </div>

--- a/src/renderer/components/sideBar/tree.vue
+++ b/src/renderer/components/sideBar/tree.vue
@@ -73,7 +73,7 @@
           <use :xlink:href="FolderIcon.url"></use>
         </svg>
         <button class="button-primary" @click="openFolder">
-          Open Folder...
+          Open Folder
         </button>
       </div>
     </div>

--- a/src/renderer/components/sideBar/tree.vue
+++ b/src/renderer/components/sideBar/tree.vue
@@ -73,7 +73,7 @@
           <use :xlink:href="FolderIcon.url"></use>
         </svg>
         <button class="button-primary" @click="openFolder">
-          Open Folder
+          Open Folder...
         </button>
       </div>
     </div>

--- a/src/renderer/prefComponents/editor/index.vue
+++ b/src/renderer/prefComponents/editor/index.vue
@@ -2,7 +2,7 @@
   <div class="pref-editor">
     <h4>Editor</h4>
     <range
-      description="Font size in text editor."
+      description="Font size in text editor"
       :value="fontSize"
       :min="12"
       :max="32"
@@ -11,7 +11,7 @@
       :onChange="value => onSelectChange('fontSize', value)"
     ></range>
     <range
-      description="Line height in text editor."
+      description="Line height in text editor"
       :value="lineHeight"
       :min="1.2"
       :max="2.0"
@@ -19,13 +19,13 @@
       :onChange="value => onSelectChange('lineHeight', value)"
     ></range>
     <font-text-box
-      description="Font for text editor."
+      description="Font for text editor"
       :value="editorFontFamily"
       :onChange="value => onSelectChange('editorFontFamily', value)"
     ></font-text-box>
     <separator></separator>
     <range
-      description="Font size in code blocks."
+      description="Font size in code blocks"
       :value="codeFontSize"
       :min="12"
       :max="28"
@@ -34,7 +34,7 @@
       :onChange="value => onSelectChange('codeFontSize', value)"
     ></range>
     <font-text-box
-      description="Font for code blocks."
+      description="Font for code blocks"
       :onlyMonospace="true"
       :value="codeFontFamily"
       :onChange="value => onSelectChange('codeFontFamily', value)"
@@ -42,81 +42,81 @@
     <!-- FIXME: Disabled due to #1648. -->
     <bool
       v-show="false"
-      description="Show line numbers in code blocks."
+      description="Show line numbers in code blocks"
       :bool="codeBlockLineNumbers"
       :onChange="value => onSelectChange('codeBlockLineNumbers', value)"
     ></bool>
     <bool
-      description="Remove leading and trailing empty lines in code blocks."
+      description="Remove leading and trailing empty lines in code blocks"
       :bool="trimUnnecessaryCodeBlockEmptyLines"
       :onChange="value => onSelectChange('trimUnnecessaryCodeBlockEmptyLines', value)"
     ></bool>
     <separator></separator>
     <bool
-      description="Automatically close brackets when writing."
+      description="Automatically close brackets when writing"
       :bool="autoPairBracket"
       :onChange="value => onSelectChange('autoPairBracket', value)"
     ></bool>
     <bool
-      description="Automatically complete markdown syntax."
+      description="Automatically complete markdown syntax"
       :bool="autoPairMarkdownSyntax"
       :onChange="value => onSelectChange('autoPairMarkdownSyntax', value)"
     ></bool>
     <bool
-      description="Automatically close quotation marks."
+      description="Automatically close quotation marks"
       :bool="autoPairQuote"
       :onChange="value => onSelectChange('autoPairQuote', value)"
     ></bool>
     <separator></separator>
     <cur-select
-      description="Line separator type."
+      description="Line separator type"
       :value="endOfLine"
       :options="endOfLineOptions"
       :onChange="value => onSelectChange('endOfLine', value)"
     ></cur-select>
     <separator></separator>
     <cur-select
-      description="Default encoding."
+      description="Default encoding"
       :value="defaultEncoding"
       :options="defaultEncodingOptions"
       :onChange="value => onSelectChange('defaultEncoding', value)"
     ></cur-select>
     <bool
-      description="Automatically detect file encoding."
+      description="Automatically detect file encoding"
       :bool="autoGuessEncoding"
       :onChange="value => onSelectChange('autoGuessEncoding', value)"
     ></bool>
     <cur-select
-      description="What to do with trailing newlines."
+      description="What to do with trailing newlines"
       :value="trimTrailingNewline"
       :options="trimTrailingNewlineOptions"
       :onChange="value => onSelectChange('trimTrailingNewline', value)"
     ></cur-select>
     <separator></separator>
     <cur-select
-      description="Text direction."
+      description="Text direction"
       :value="textDirection"
       :options="textDirectionOptions"
       :onChange="value => onSelectChange('textDirection', value)"
     ></cur-select>
     <bool
-      description="Hide hint for selecting type of new paragraph."
+      description="Hide hint for selecting type of new paragraph"
       :bool="hideQuickInsertHint"
       :onChange="value => onSelectChange('hideQuickInsertHint', value)"
     ></bool>
     <bool
-      description="Hide popup when cursor is over link."
+      description="Hide popup when cursor is over link"
       :bool="hideLinkPopup"
       :onChange="value => onSelectChange('hideLinkPopup', value)"
     ></bool>
     <bool
-      description="Whether to automatically check any related tasks."
+      description="Whether to automatically check any related tasks"
       :bool="autoCheck"
       :onChange="value => onSelectChange('autoCheck', value)"
     ></bool>
     <separator></separator>
     <text-box
-      description="Maximum width of text editor. Empty for theme default, otherwise number with unit suffix (`ch`: characters, `px`: pixels, `%`: percentage)."
+      description="Maximum width of text editor. Empty for theme default, otherwise number with unit suffix (`ch`: characters, `px`: pixels, `%`: percentage)"
       :input="editorLineWidth"
       :regexValidator="/^(?:$|[0-9]+(?:ch|px|%)$)/"
       defaultValue="Default value from current theme"

--- a/src/renderer/prefComponents/editor/index.vue
+++ b/src/renderer/prefComponents/editor/index.vue
@@ -87,7 +87,7 @@
       :onChange="value => onSelectChange('autoGuessEncoding', value)"
     ></bool>
     <cur-select
-      description="What to do with trailing newlines"
+      description="Handling of trailing newline characters"
       :value="trimTrailingNewline"
       :options="trimTrailingNewlineOptions"
       :onChange="value => onSelectChange('trimTrailingNewline', value)"

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -57,7 +57,7 @@
       :disable="true"
     ></cur-select>
     <section class="startup-action-ctrl">
-      <div>What Mark Text should do on startup</div>
+      <div>Action on startup</div>
       <el-radio-group v-model="startUpAction">
         <!--
           Hide "lastState" for now (#2064).

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -2,12 +2,12 @@
   <div class="pref-general">
     <h4>General</h4>
     <bool
-      description="Automatically save document changes."
+      description="Automatically save document changes"
       :bool="autoSave"
       :onChange="value => onSelectChange('autoSave', value)"
     ></bool>
     <range
-      description="Delay following document edit before automatically saving (milliseconds)."
+      description="Delay following document edit before automatically saving (milliseconds)"
       :value="autoSaveDelay"
       :min="1000"
       :max="10000"
@@ -17,40 +17,40 @@
     ></range>
     <cur-select
       v-if="!isOsx"
-      description="Title bar style (requires restart)."
+      description="Title bar style (requires restart)"
       :value="titleBarStyle"
       :options="titleBarStyleOptions"
       :onChange="value => onSelectChange('titleBarStyle', value)"
     ></cur-select>
     <separator></separator>
     <bool
-      description="Open files in new window."
+      description="Open files in new window"
       :bool="openFilesInNewWindow"
       :onChange="value => onSelectChange('openFilesInNewWindow', value)"
     ></bool>
     <bool
-      description="Open folders in new window."
+      description="Open folders in new window"
       :bool="openFolderInNewWindow"
       :onChange="value => onSelectChange('openFolderInNewWindow', value)"
     ></bool>
     <bool
-      description="Hide scrollbars."
+      description="Hide scrollbars"
       :bool="hideScrollbar"
       :onChange="value => onSelectChange('hideScrollbar', value)"
     ></bool>
     <bool
-      description="Wrap text in table of contents."
+      description="Wrap text in table of contents"
       :bool="wordWrapInToc"
       :onChange="value => onSelectChange('wordWrapInToc', value)"
     ></bool>
     <bool
-      description="Use Aidou."
+      description="Use Aidou"
       :bool="aidou"
       :onChange="value => onSelectChange('aidou', value)"
     ></bool>
     <separator></separator>
     <cur-select
-      description="Sort field for files in open folders."
+      description="Sort field for files in open folders"
       :value="fileSortBy"
       :options="fileSortByOptions"
       :onChange="value => onSelectChange('fileSortBy', value)"
@@ -69,7 +69,7 @@
       </el-radio-group>
     </section>
     <cur-select
-      description="Language for user interface."
+      description="Language for user interface"
       :value="language"
       :options="languageOptions"
       :onChange="value => onSelectChange('language', value)"

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -64,7 +64,7 @@
         <el-radio class="ag-underdevelop" label="lastState">Open the last window state</el-radio>
         -->
         <el-radio label="folder">Open the default directory<span>: {{defaultDirectoryToOpen}}</span></el-radio>
-        <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder</el-button>
+        <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder...</el-button>
         <el-radio label="blank">Open a blank page</el-radio>
       </el-radio-group>
     </section>

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -64,7 +64,7 @@
         <el-radio class="ag-underdevelop" label="lastState">Open the last window state</el-radio>
         -->
         <el-radio label="folder">Open the default directory<span>: {{defaultDirectoryToOpen}}</span></el-radio>
-        <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder...</el-button>
+        <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder</el-button>
         <el-radio label="blank">Open a blank page</el-radio>
       </el-radio-group>
     </section>

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -57,7 +57,7 @@
       :disable="true"
     ></cur-select>
     <section class="startup-action-ctrl">
-      <div>What Mark Text should do on startup.</div>
+      <div>What Mark Text should do on startup</div>
       <el-radio-group v-model="startUpAction">
         <!--
           Hide "lastState" for now (#2064).

--- a/src/renderer/prefComponents/image/index.vue
+++ b/src/renderer/prefComponents/image/index.vue
@@ -2,20 +2,20 @@
   <div class="pref-image">
     <h4>Image</h4>
     <section class="image-ctrl">
-      <div>Default action after image is inserted from local folder.
+      <div>Default action after image is inserted from local folder
         <el-tooltip class='item' effect='dark' content='Mark Text can not get image path from paste event on Linux.' placement='top-start'>
           <i class="el-icon-info"></i>
         </el-tooltip>
       </div>
       <el-radio-group v-model="imageInsertAction">
-        <el-radio label="upload">Upload to cloud using selected uploader (must be configured).</el-radio>
-        <el-radio label="folder">Move to designated local folder.</el-radio>
-        <el-radio label="path">Keep original location.</el-radio>
+        <el-radio label="upload">Upload to cloud using selected uploader (must be configured)</el-radio>
+        <el-radio label="folder">Move to designated local folder</el-radio>
+        <el-radio label="path">Keep original location</el-radio>
       </el-radio-group>
     </section>
     <separator></separator>
     <section class="image-folder">
-      <div class="description">Local image folder.</div>
+      <div class="description">Local image folder</div>
       <div class="path">{{imageFolderPath}}</div>
       <div>
         <el-button size="mini" @click="modifyImageFolderPath">Modify</el-button>

--- a/src/renderer/prefComponents/image/index.vue
+++ b/src/renderer/prefComponents/image/index.vue
@@ -18,8 +18,8 @@
       <div class="description">Local image folder.</div>
       <div class="path">{{imageFolderPath}}</div>
       <div>
-        <el-button size="mini" @click="modifyImageFolderPath">Modify</el-button>
-        <el-button size="mini" @click="openImageFolder">Open Folder</el-button>
+        <el-button size="mini" @click="modifyImageFolderPath">Modify...</el-button>
+        <el-button size="mini" @click="openImageFolder">Open Folder...</el-button>
       </div>
     </section>
   </div>

--- a/src/renderer/prefComponents/image/index.vue
+++ b/src/renderer/prefComponents/image/index.vue
@@ -18,8 +18,8 @@
       <div class="description">Local image folder.</div>
       <div class="path">{{imageFolderPath}}</div>
       <div>
-        <el-button size="mini" @click="modifyImageFolderPath">Modify...</el-button>
-        <el-button size="mini" @click="openImageFolder">Open Folder...</el-button>
+        <el-button size="mini" @click="modifyImageFolderPath">Modify</el-button>
+        <el-button size="mini" @click="openImageFolder">Open Folder</el-button>
       </div>
     </section>
   </div>

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -23,7 +23,7 @@
               <el-tooltip
                 class="item"
                 effect="dark"
-                content="The token is saved by Keychain on macOS, Secret Service API/libsecret on Linux and Credential Vault on Windows."
+                content="The token is saved by Keychain on macOS, Secret Service API/libsecret on Linux and Credential Vault on Windows"
                 placement="top-start"
               >
                 <i class="el-icon-info"></i>

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -19,7 +19,7 @@
         <el-tab-pane label="GitHub" name="github">
           <div class="form-group">
             <div class="label">
-              GitHub token:
+              GitHub token
               <el-tooltip
                 class="item"
                 effect="dark"
@@ -32,15 +32,15 @@
             <el-input v-model="githubToken" placeholder="Input token" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Owner name:</div>
+            <div class="label">Owner name</div>
             <el-input v-model="github.owner" placeholder="owner" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Repo name:</div>
+            <div class="label">Repo name</div>
             <el-input v-model="github.repo" placeholder="repo" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Branch name (optional):</div>
+            <div class="label">Branch name (optional)</div>
             <el-input v-model="github.branch" placeholder="branch" size="mini"></el-input>
           </div>
           <legal-notices-checkbox

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -19,7 +19,7 @@
         <el-tab-pane label="GitHub" name="github">
           <div class="form-group">
             <div class="label">
-              GitHub token
+              GitHub token:
               <el-tooltip
                 class="item"
                 effect="dark"
@@ -32,15 +32,15 @@
             <el-input v-model="githubToken" placeholder="Input token" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Owner name</div>
+            <div class="label">Owner name:</div>
             <el-input v-model="github.owner" placeholder="owner" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Repo name</div>
+            <div class="label">Repo name:</div>
             <el-input v-model="github.repo" placeholder="repo" size="mini"></el-input>
           </div>
           <div class="form-group">
-            <div class="label">Branch name (optional)</div>
+            <div class="label">Branch name (optional):</div>
             <el-input v-model="github.branch" placeholder="branch" size="mini"></el-input>
           </div>
           <legal-notices-checkbox

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -2,40 +2,40 @@
   <div class="pref-markdown">
     <h4>markdown</h4>
     <bool
-      description="Prefer loose list items."
+      description="Prefer loose list items"
       :bool="preferLooseListItem"
       :onChange="value => onSelectChange('preferLooseListItem', value)"
       more="https://spec.commonmark.org/0.29/#loose"
     ></bool>
     <cus-select
-      description="Preferred marker for bullet lists."
+      description="Preferred marker for bullet lists"
       :value="bulletListMarker"
       :options="bulletListMarkerOptions"
       :onChange="value => onSelectChange('bulletListMarker', value)"
       more="https://spec.commonmark.org/0.29/#bullet-list-marker"
     ></cus-select>
     <cus-select
-      description="Preferred marker for ordered lists."
+      description="Preferred marker for ordered lists"
       :value="orderListDelimiter"
       :options="orderListDelimiterOptions"
       :onChange="value => onSelectChange('orderListDelimiter', value)"
       more="https://spec.commonmark.org/0.29/#ordered-list"
     ></cus-select>
     <cus-select
-      description="Preferred heading style."
+      description="Preferred heading style"
       :value="preferHeadingStyle"
       :options="preferHeadingStyleOptions"
       :onChange="value => onSelectChange('preferHeadingStyle', value)"
       :disable="true"
     ></cus-select>
     <cus-select
-      description="Preferred tab width."
+      description="Preferred tab width"
       :value="tabSize"
       :options="tabSizeOptions"
       :onChange="value => onSelectChange('tabSize', value)"
     ></cus-select>
     <cus-select
-      description="Preferred list indentation."
+      description="Preferred list indentation"
       :value="listIndentation"
       :options="listIndentationOptions"
       :onChange="value => onSelectChange('listIndentation', value)"
@@ -43,19 +43,19 @@
     <separator></separator>
     <h5>Markdown extension syntax</h5>
     <cus-select
-      description="Format for front matter."
+      description="Format for front matter"
       :value="frontmatterType"
       :options="frontmatterTypeOptions"
       :onChange="value => onSelectChange('frontmatterType', value)"
     ></cus-select>
     <bool
-      description="Enable pandoc's markdown extension superscript and subscript."
+      description="Enable pandoc's markdown extension superscript and subscript"
       :bool="superSubScript"
       :onChange="value => onSelectChange('superSubScript', value)"
       more="https://pandoc.org/MANUAL.html#superscripts-and-subscripts"
     ></bool>
     <bool
-      description="Enable pandoc's markdown extension footnote(need restart Mark Text)."
+      description="Enable pandoc's markdown extension footnote(need restart Mark Text)"
       :bool="footnote"
       :onChange="value => onSelectChange('footnote', value)"
       more="https://pandoc.org/MANUAL.html#footnotes"
@@ -63,7 +63,7 @@
     <separator></separator>
     <h5>Compatibility</h5>
     <bool
-      description="Enable GitLab compatibility mode."
+      description="Enable GitLab compatibility mode"
       :bool="isGitlabCompatibilityEnabled"
       :onChange="value => onSelectChange('isGitlabCompatibilityEnabled', value)"
     ></bool>

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -41,7 +41,7 @@
       :onChange="value => onSelectChange('listIndentation', value)"
     ></cus-select>
     <separator></separator>
-    <h5>Markdown extension syntax</h5>
+    <h5>Markdown extensions</h5>
     <cus-select
       description="Format for front matter"
       :value="frontmatterType"
@@ -49,13 +49,13 @@
       :onChange="value => onSelectChange('frontmatterType', value)"
     ></cus-select>
     <bool
-      description="Enable pandoc's markdown extension superscript and subscript"
+      description="Use Pandoc-style superscript and subscript"
       :bool="superSubScript"
       :onChange="value => onSelectChange('superSubScript', value)"
       more="https://pandoc.org/MANUAL.html#superscripts-and-subscripts"
     ></bool>
     <bool
-      description="Enable pandoc's markdown extension footnote(need restart Mark Text)"
+      description="Use Pandoc-style footnotes (requres restart)"
       :bool="footnote"
       :onChange="value => onSelectChange('footnote', value)"
       more="https://pandoc.org/MANUAL.html#footnotes"

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -55,7 +55,7 @@
       more="https://pandoc.org/MANUAL.html#superscripts-and-subscripts"
     ></bool>
     <bool
-      description="Use Pandoc-style footnotes (requres restart)"
+      description="Use Pandoc-style footnotes (requires restart)"
       :bool="footnote"
       :onChange="value => onSelectChange('footnote', value)"
       more="https://pandoc.org/MANUAL.html#footnotes"

--- a/src/renderer/prefComponents/sideBar/index.vue
+++ b/src/renderer/prefComponents/sideBar/index.vue
@@ -6,7 +6,7 @@
         popper-class="pref-autocomplete"
         v-model="state"
         :fetch-suggestions="querySearch"
-        placeholder="Search preferences..."
+        placeholder="Search preferences"
         :trigger-on-focus="false"
         @select="handleSelect">
         <i

--- a/src/renderer/prefComponents/spellchecker/index.vue
+++ b/src/renderer/prefComponents/spellchecker/index.vue
@@ -47,7 +47,7 @@
       Additional languages may be added through "Language" in your "Time & language" settings.
     </div>
     <div v-if="isHunspellSelected && spellcheckerEnabled">
-      <div class="description">Installed Hunspell dictionaries.</div>
+      <div class="description">Installed Hunspell dictionaries</div>
       <el-table
         :data="availableDictionaries"
         style="width: 100%">
@@ -72,7 +72,7 @@
         </el-table-column>
       </el-table>
 
-      <div class="description">Download additional Hunspell dictionaries.</div>
+      <div class="description">Download additional Hunspell dictionaries</div>
       <div class="dictionary-group">
         <el-select
           v-model="selectedDictionaryToAdd"

--- a/src/renderer/prefComponents/spellchecker/index.vue
+++ b/src/renderer/prefComponents/spellchecker/index.vue
@@ -2,7 +2,7 @@
   <div class="pref-spellchecker">
     <h4>Spelling</h4>
     <bool
-      description="Enable spell checker (experimental)."
+      description="Enable spell checker (experimental)"
       :bool="spellcheckerEnabled"
       :onChange="handleSpellcheckerEnabled"
     ></bool>
@@ -14,7 +14,7 @@
       :onChange="value => onSelectChange('spellcheckerIsHunspell', value)"
     ></bool>
     <bool
-      description="Hide marks for spelling errors."
+      description="Hide marks for spelling errors"
       :bool="spellcheckerNoUnderline"
       :disable="!spellcheckerEnabled"
       :onChange="value => onSelectChange('spellcheckerNoUnderline', value)"
@@ -28,7 +28,7 @@
     ></bool>
     <separator></separator>
     <cur-select
-      description="Default language for spell checker."
+      description="Default language for spell checker"
       :value="spellcheckerLanguage"
       :options="availableDictionaries"
       :disable="!spellcheckerEnabled"

--- a/src/renderer/prefComponents/theme/index.vue
+++ b/src/renderer/prefComponents/theme/index.vue
@@ -20,12 +20,12 @@
     <section class="import-themes ag-underdevelop">
       <div>
         <span>Open the themes folder</span>
-        <el-button size="small">Open Folder</el-button>
+        <el-button size="small">Open Folder...</el-button>
       </div>
 
       <div>
         <span>Import custom themes</span>
-        <el-button size="small">Import theme</el-button>
+        <el-button size="small">Import Theme...</el-button>
       </div>
     </section>
   </div>

--- a/src/renderer/prefComponents/theme/index.vue
+++ b/src/renderer/prefComponents/theme/index.vue
@@ -11,7 +11,7 @@
     </section>
     <separator></separator>
     <cur-select
-      description="Automatically adjust application theme according to system settings."
+      description="Automatically adjust application theme according to system settings"
       :value="autoSwitchTheme"
       :options="autoSwitchThemeOptions"
       :onChange="value => onSelectChange('autoSwitchTheme', value)"

--- a/src/renderer/prefComponents/theme/index.vue
+++ b/src/renderer/prefComponents/theme/index.vue
@@ -25,7 +25,7 @@
 
       <div>
         <span>Import custom themes</span>
-        <el-button size="small">Import theme</el-button>
+        <el-button size="small">Import Theme</el-button>
       </div>
     </section>
   </div>

--- a/src/renderer/prefComponents/theme/index.vue
+++ b/src/renderer/prefComponents/theme/index.vue
@@ -20,12 +20,12 @@
     <section class="import-themes ag-underdevelop">
       <div>
         <span>Open the themes folder</span>
-        <el-button size="small">Open Folder...</el-button>
+        <el-button size="small">Open Folder</el-button>
       </div>
 
       <div>
         <span>Import custom themes</span>
-        <el-button size="small">Import Theme...</el-button>
+        <el-button size="small">Import theme</el-button>
       </div>
     </section>
   </div>


### PR DESCRIPTION
Following #2075, which revised grammar, the current request concerns use of punctuation in user strings, so that they follow conventions familiar for graphic interfaces.


Note that this request does include some further revision to grammar   (d791e529ff9c6e8bfd26ee7fe9a0cf85fe19f5d, d69622d65b7ba85ee16b79cf363171fffa99d775) not included revision to language not included in #2075.


The other changes are the following:
-    Remove full stops (.) trailing widget labels (f22308812a0875554f6f6e2bad557ef8a3a8c509, 4cb011d6fe955e450827127a01f01e7228acbd5d).
-    End with ellipsis ('...') for all menu entries that open windows or other applications (c713a1c424e8365f12457fbc00e153f44f80bcc0, 4cb011d6fe955e450827127a01f01e7228acbd5d).
-    Remove trailing colons (':'), which had appeared in the GitHub section of the image uploader section of the preferences window (c713a1c424e8365f12457fbc00e153f44f80bcc0).


---


- **Bug fix?:** no
- **New feature?:** no
- **Breaking changes?:** no
- **Deprecations?:** no
- **New tests added?:** not needed
- **Fixed tickets:** n/a
- **License:** MIT


