### PR TITLE
Fix middle-click to close tab

### DIFF
--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -18,7 +18,7 @@
           :key="file.id"
           :data-id="file.id"
           @click.stop="selectFile(file)"
-          @click.middle="closeTab(file)"
+          @click.middle="closeTab(file.id)"
           @contextmenu.prevent="handleContextMenu($event, file)"
         >
           <span>{{ file.filename }}</span>


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

Closing tabs on mouse middle-click was added as a feature in #1282, where `click.middle` would pass `file` to `closeTab` as `tab`. In #1434, multiple functions including `closeTab` where changed to received `tabId` instead, but `click.middle`'s behavior was not modified to accommodate this change. 

What this means is that middle-clicking a tab to close it does not work in the current version of the app. This PR changes `click.middle` so it passes `file.id` instead of `file`, making middle-click work again.