### PR TITLE
Improve conformance with GFM/CM in handling of delimiters

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "^4.0.2",
     "license-checker": "^25.0.1",
-    "marked": "^0.8.2",
+    "marked": "^1.1.1",
     "mini-css-extract-plugin": "^0.9.0",
     "mocha": "^7.2.0",
     "multispinner": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7967,10 +7967,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
-  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+marked@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
+  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
 matcher@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION

Update marked to version 1.1.1, which includes PR 1686:
"Follow GFM spec on EM and STRONG delimiters"

Adds some support for #2086, for nested regular emphasis.

Full support for nested strong emphasis is still outstanding.

