### PR TITLE
Edit README.md to label zh_TW translation with Taiwan flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
     <span>:cn:</span>
   </a>
   <a href="docs/i18n/zh_tw.md#readme">
-    <span>:cn:</span>
+    <span>:taiwan:</span>
   </a>
   <a href="docs/i18n/pl.md#readme">
     <span>:poland:</span>


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

The README translations section currently features two China/PRC flags, one pointing to zh_CN and one to zh_TW. I changed the Taiwanese translation to a Taiwan flag.

However I've heard that it's a bad idea to label the translations with flags in the first place, and that flags represent countries, not languages. One article is here: http://www.flagsarenotlanguages.com/blog/why-flags-do-not-represent-language/