### PR TITLE
Fix markdown syntax document mistake for table content align (#2282)

### DIFF
--- a/docs/MARKDOWN_SYNTAX.md
+++ b/docs/MARKDOWN_SYNTAX.md
@@ -465,18 +465,18 @@ Renders to:
 
 **Center text in a column**
 
-To center the text in a column, add a colon to the middle of the dashes in the row beneath the header.
+To center the text in a column, add a colon to the left and right of the dashes in the row beneath the header.
 
 ```markdown
 | Option | Description |
-| -:- | -:- |
+| :-: | :-: |
 | data   | path to data files to supply the data that will be passed into templates. |
 | engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |
 ```
 
 | Option | Description |
-| -:- | -:- |
+| :-: | :-: |
 | data   | path to data files to supply the data that will be passed into templates. |
 | engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |
@@ -484,7 +484,7 @@ To center the text in a column, add a colon to the middle of the dashes in the r
 
 **Right-align the text in a column**
 
-To right-align the text in a column, add a colon to the middle of the dashes in the row beneath the header.
+To right-align the text in a column, add a colon to the right of the dashes in the row beneath the header.
 
 ```markdown
 | Option | Description |


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | #2282
| License           | MIT

### Description

See #2282
