### PR TITLE
Add paste as markdown option, set paste as plaintext is default

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -65,7 +65,7 @@ Here is an example:
 | `edit.copy`              | <kbd>CmdOrCtrl</kbd>+<kbd>C</kbd>                  | Copy selected text                                                                                         |
 | `edit.paste`             | <kbd>CmdOrCtrl</kbd>+<kbd>V</kbd>                  | Paste text                                                                                                 |
 | `edit.copy-as-markdown`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> | Copy selected text as markdown                                                                             |
-| `edit.copy-as-plaintext` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> | Copy selected text as plaintext                                                                            |
+| `edit.paste-as-markdown` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd> | Paste text as markdown                                                                                     |
 | `edit.select-all`        | <kbd>CmdOrCtrl</kbd>+<kbd>A</kbd>                  | Select all text of the document                                                                            |
 | `edit.duplicate`         | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>   | Duplicate the current paragraph                                                                            |
 | `edit.create-paragraph`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd> | Create a new paragraph after the current one                                                               |
@@ -127,7 +127,7 @@ Here is an example:
 
 **View menu:**
 
-| Id                            | Default                                            | Description                              |
+| Id                      | Default                                            | Description                              |
 | ----------------------- | -------------------------------------------------- | ---------------------------------------- |
 | `view.command-palette`  | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> | Toggle command palette                   |
 | `view.source-code-mode` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>   | Switch to source code mode               |

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -44,7 +44,7 @@ class Keybindings {
       ['edit.copy', 'CmdOrCtrl+C'],
       ['edit.paste', 'CmdOrCtrl+V'],
       ['edit.copy-as-markdown', 'CmdOrCtrl+Shift+C'],
-      ['edit.copy-as-plaintext', 'CmdOrCtrl+Shift+V'],
+      ['edit.paste-as-markdown', 'CmdOrCtrl+Shift+V'],
       ['edit.select-all', 'CmdOrCtrl+A'],
       ['edit.duplicate', 'CmdOrCtrl+Alt+D'],
       ['edit.create-paragraph', 'Shift+CmdOrCtrl+N'],

--- a/src/main/menu/templates/edit.js
+++ b/src/main/menu/templates/edit.js
@@ -45,10 +45,10 @@ export default function (keybindings, userPreference) {
         actions.edit(browserWindow, 'copyAsHtml')
       }
     }, {
-      label: 'Paste as Plain Text',
-      accelerator: keybindings.getAccelerator('edit.copy-as-plaintext'),
+      label: 'Paste as Markdown',
+      accelerator: keybindings.getAccelerator('edit.paste-as-markdown'),
       click (menuItem, browserWindow) {
-        actions.edit(browserWindow, 'pasteAsPlainText')
+        actions.edit(browserWindow, 'pasteAsMarkdown')
       }
     }, {
       type: 'separator'

--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -230,7 +230,7 @@ const pasteCtrl = ContentState => {
     }
   }
 
-  // Handle `normal` and `pasteAsPlainText` paste for preview mode.
+  // Handle `normal` and `pasteAsMarkdown` paste for preview mode.
   ContentState.prototype.pasteHandler = async function (event, type = 'normal', rawText, rawHtml) {
     event.preventDefault()
     event.stopPropagation()
@@ -345,14 +345,6 @@ const pasteCtrl = ContentState => {
     if (copyType === 'copyAsHtml') {
       switch (type) {
         case 'normal': {
-          const htmlBlock = this.createBlockP(text.trim())
-          this.insertAfter(htmlBlock, parent)
-          this.removeBlock(parent)
-          // handler heading
-          this.insertHtmlBlock(htmlBlock)
-          break
-        }
-        case 'pasteAsPlainText': {
           const lines = text.trim().split(LINE_BREAKS_REG)
           let htmlBlock = null
 
@@ -370,11 +362,19 @@ const pasteCtrl = ContentState => {
           }
           break
         }
+        case 'pasteAsMarkdown': {
+          const htmlBlock = this.createBlockP(text.trim())
+          this.insertAfter(htmlBlock, parent)
+          this.removeBlock(parent)
+          // handler heading
+          this.insertHtmlBlock(htmlBlock)
+          break
+        }
       }
       return this.partialRender()
     }
 
-    const stateFragments = type === 'pasteAsPlainText' || copyType === 'copyAsMarkdown'
+    const stateFragments = type === 'normal' || copyType === 'copyAsMarkdown'
       ? this.markdownToState(text)
       : this.html2State(html)
 

--- a/src/muya/lib/eventHandler/clipboard.js
+++ b/src/muya/lib/eventHandler/clipboard.js
@@ -2,7 +2,7 @@ class Clipboard {
   constructor (muya) {
     this.muya = muya
     this._copyType = 'normal' // `normal` or `copyAsMarkdown` or `copyAsHtml`
-    this._pasteType = 'normal' // `normal` or `pasteAsPlainText`
+    this._pasteType = 'normal' // `normal` or `pasteAsMarkdown`
     this._copyInfo = null
     this.listen()
   }
@@ -53,8 +53,8 @@ class Clipboard {
     document.execCommand('copy')
   }
 
-  pasteAsPlainText () {
-    this._pasteType = 'pasteAsPlainText'
+  pasteAsMarkdown () {
+    this._pasteType = 'pasteAsMarkdown'
     document.execCommand('paste')
   }
 

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -361,8 +361,8 @@ class Muya {
     this.clipboard.copyAsHtml()
   }
 
-  pasteAsPlainText () {
-    this.clipboard.pasteAsPlainText()
+  pasteAsMarkdown () {
+    this.clipboard.pasteAsMarkdown()
   }
 
   /**

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -628,7 +628,7 @@ export default {
       bus.$on('editor-focus', this.focusEditor)
       bus.$on('copyAsMarkdown', this.handleCopyPaste)
       bus.$on('copyAsHtml', this.handleCopyPaste)
-      bus.$on('pasteAsPlainText', this.handleCopyPaste)
+      bus.$on('pasteAsMarkdown', this.handleCopyPaste)
       bus.$on('duplicate', this.handleParagraph)
       bus.$on('createParagraph', this.handleParagraph)
       bus.$on('deleteParagraph', this.handleParagraph)
@@ -942,7 +942,7 @@ export default {
       }
     },
 
-    // Custom copyAsMarkdown copyAsHtml pasteAsPlainText
+    // Custom copyAsMarkdown copyAsHtml pasteAsMarkdown
     handleCopyPaste (type) {
       if (this.editor) {
         this.editor[type]()
@@ -1209,7 +1209,7 @@ export default {
     bus.$off('editor-focus', this.focusEditor)
     bus.$off('copyAsMarkdown', this.handleCopyPaste)
     bus.$off('copyAsHtml', this.handleCopyPaste)
-    bus.$off('pasteAsPlainText', this.handleCopyPaste)
+    bus.$off('pasteAsMarkdown', this.handleCopyPaste)
     bus.$off('duplicate', this.handleParagraph)
     bus.$off('createParagraph', this.handleParagraph)
     bus.$off('deleteParagraph', this.handleParagraph)

--- a/src/renderer/contextMenu/editor/actions.js
+++ b/src/renderer/contextMenu/editor/actions.js
@@ -8,8 +8,8 @@ export const copyAsHtml = (menuItem, browserWindow) => {
   bus.$emit('copyAsHtml', 'copyAsHtml')
 }
 
-export const pasteAsPlainText = (menuItem, browserWindow) => {
-  bus.$emit('pasteAsPlainText', 'pasteAsPlainText')
+export const pasteAsMarkdown = (menuItem, browserWindow) => {
+  bus.$emit('pasteAsMarkdown', 'pasteAsMarkdown')
 }
 
 export const insertParagraph = location => {

--- a/src/renderer/contextMenu/editor/index.js
+++ b/src/renderer/contextMenu/editor/index.js
@@ -5,7 +5,7 @@ import {
   PASTE,
   COPY_AS_MARKDOWN,
   COPY_AS_HTML,
-  PASTE_AS_PLAIN_TEXT,
+  PASTE_AS_MARKDOWN,
   SEPARATOR,
   INSERT_BEFORE,
   INSERT_AFTER
@@ -29,7 +29,7 @@ export const showContextMenu = (event, selection, spellchecker, selectedWord, wo
   const menu = new Menu()
   const win = remote.getCurrentWindow()
   const disableCutAndCopy = start.key === end.key && start.offset === end.offset
-  const CONTEXT_ITEMS = [INSERT_BEFORE, INSERT_AFTER, SEPARATOR, CUT, COPY, PASTE, SEPARATOR, COPY_AS_MARKDOWN, COPY_AS_HTML, PASTE_AS_PLAIN_TEXT]
+  const CONTEXT_ITEMS = [INSERT_BEFORE, INSERT_AFTER, SEPARATOR, CUT, COPY, PASTE, SEPARATOR, COPY_AS_MARKDOWN, COPY_AS_HTML, PASTE_AS_MARKDOWN]
 
   const spellingSubmenu = spellcheckMenuBuilder(spellchecker, selectedWord, wordSuggestions, replaceCallback)
   if (spellingSubmenu) {

--- a/src/renderer/contextMenu/editor/menuItems.js
+++ b/src/renderer/contextMenu/editor/menuItems.js
@@ -34,11 +34,11 @@ export const COPY_AS_HTML = {
   }
 }
 
-export const PASTE_AS_PLAIN_TEXT = {
-  label: 'Paste as Plain Text',
-  id: 'pasteAsPlainTextMenuItem',
+export const PASTE_AS_MARKDOWN = {
+  label: 'Paste As Markdown',
+  id: 'pasteAsMarkdownTextMenuItem',
   click (menuItem, browserWindow) {
-    contextMenu.pasteAsPlainText()
+    contextMenu.pasteAsMarkdown()
   }
 }
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2259 
| License           | MIT

### Description

Following discussion in #2259 , this adds option of "Paste as Markdown" instead of "Paste as Plaintext", in line with "Copy as Markdown". 

Changes behavior since "Paste" (`Ctrl+V`) action no longer formats to Markdown. `Ctrl+Shift+V` shortcut is to be used for Markdown formatting.
