### PR TITLE
Fix quick open bug and freeze constants to avoid accidental mutation

### DIFF
--- a/src/common/encoding.js
+++ b/src/common/encoding.js
@@ -1,4 +1,4 @@
-export const ENCODING_NAME_MAP = {
+export const ENCODING_NAME_MAP = Object.freeze({
   utf8: 'UTF-8',
   utf16be: 'UTF-16 BE',
   utf16le: 'UTF-16 LE',
@@ -35,7 +35,7 @@ export const ENCODING_NAME_MAP = {
   eucjp: 'Japanese (EUC-JP)',
   euckr: 'Korean (EUC-KR)',
   latin6: 'Nordic (ISO 8859-10)'
-}
+})
 
 /**
  * Try to translate the encoding.

--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { isFile, isSymbolicLink } from './index'
 
-export const MARKDOWN_EXTENSIONS = [
+export const MARKDOWN_EXTENSIONS = Object.freeze([
   'markdown',
   'mdown',
   'mkdn',
@@ -13,18 +13,18 @@ export const MARKDOWN_EXTENSIONS = [
   'mdtext',
   'text',
   'txt'
-]
+])
 
-export const MARKDOWN_INCLUSIONS = MARKDOWN_EXTENSIONS.map(x => '*.' + x)
+export const MARKDOWN_INCLUSIONS = Object.freeze(MARKDOWN_EXTENSIONS.map(x => '*.' + x))
 
-export const IMAGE_EXTENSIONS = [
+export const IMAGE_EXTENSIONS = Object.freeze([
   'jpeg',
   'jpg',
   'png',
   'gif',
   'svg',
   'webp'
-]
+])
 
 /**
  * Returns true if the filename matches one of the markdown extensions.

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -2,7 +2,7 @@ export const isOsx = process.platform === 'darwin'
 export const isWindows = process.platform === 'win32'
 export const isLinux = process.platform === 'linux'
 
-export const editorWinOptions = {
+export const editorWinOptions = Object.freeze({
   minWidth: 550,
   minHeight: 350,
   webPreferences: {
@@ -14,9 +14,9 @@ export const editorWinOptions = {
   frame: false,
   titleBarStyle: 'hiddenInset',
   zoomFactor: 1.0
-}
+})
 
-export const preferencesWinOptions = {
+export const preferencesWinOptions = Object.freeze({
   width: 950,
   height: 650,
   webPreferences: {
@@ -34,9 +34,9 @@ export const preferencesWinOptions = {
   thickFrame: !isOsx,
   titleBarStyle: 'hiddenInset',
   zoomFactor: 1.0
-}
+})
 
-export const PANDOC_EXTENSIONS = [
+export const PANDOC_EXTENSIONS = Object.freeze([
   'html',
   'docx',
   'odt',
@@ -51,16 +51,16 @@ export const PANDOC_EXTENSIONS = [
   'textile',
   'opml',
   'epub'
-]
+])
 
-export const BLACK_LIST = [
+export const BLACK_LIST = Object.freeze([
   '$RECYCLE.BIN'
-]
+])
 
-export const EXTENSION_HASN = {
+export const EXTENSION_HASN = Object.freeze({
   styledHtml: '.html',
   pdf: '.pdf'
-}
+})
 
 export const TITLE_BAR_HEIGHT = isOsx ? 21 : 32
 export const LINE_ENDING_REG = /(?:\r\n|\n)/g

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -7,32 +7,32 @@ import voidHtmlTags from 'html-tags/void'
 export const DEVICE_MEMORY = navigator.deviceMemory || 4 // Get the divice memory number(Chrome >= 63)
 export const UNDO_DEPTH = DEVICE_MEMORY >= 4 ? 100 : 50
 export const HAS_TEXT_BLOCK_REG = /^span$/i
-export const VOID_HTML_TAGS = voidHtmlTags
-export const HTML_TAGS = htmlTags
+export const VOID_HTML_TAGS = Object.freeze(voidHtmlTags)
+export const HTML_TAGS = Object.freeze(htmlTags)
 // TYPE1 ~ TYPE7 according to https://github.github.com/gfm/#html-blocks
-export const BLOCK_TYPE1 = [
+export const BLOCK_TYPE1 = Object.freeze([
   'script', 'pre', 'style'
-]
+])
 
 export const BLOCK_TYPE2_REG = /^<!--(?=\s).*\s+-->$/
 
-export const BLOCK_TYPE6 = [
+export const BLOCK_TYPE6 = Object.freeze([
   'address', 'article', 'aside', 'base', 'basefont', 'blockquote', 'body', 'caption', 'center', 'col', 'colgroup', 'dd',
   'details', 'dialog', 'dir', 'div', 'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'frame', 'frameset',
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hr', 'html', 'iframe', 'legend', 'li', 'link', 'main', 'menu',
   'menuitem', 'meta', 'nav', 'noframes', 'ol', 'optgroup', 'option', 'p', 'param', 'section', 'source', 'summary', 'table',
   'tbody', 'td', 'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul'
-]
+])
 
-export const BLOCK_TYPE7 = htmlTags.filter(tag => {
+export const BLOCK_TYPE7 = Object.freeze(htmlTags.filter(tag => {
   return !BLOCK_TYPE1.find(t => t === tag) && !BLOCK_TYPE6.find(t => t === tag)
-})
+}))
 
 export const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
 
-export const PARAGRAPH_TYPES = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'ul', 'ol', 'li', 'figure']
+export const PARAGRAPH_TYPES = Object.freeze(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'ul', 'ol', 'li', 'figure'])
 
-export const blockContainerElementNames = [
+export const blockContainerElementNames = Object.freeze([
   // elements our editor generates
   ...PARAGRAPH_TYPES,
   // all other known block elements
@@ -40,11 +40,11 @@ export const blockContainerElementNames = [
   'figcaption', 'footer', 'form', 'header', 'hgroup', 'main', 'nav',
   'noscript', 'output', 'section', 'video',
   'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'
-]
+])
 
-export const emptyElementNames = ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr']
+export const emptyElementNames = Object.freeze(['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'])
 
-export const EVENT_KEYS = generateKeyHash([
+export const EVENT_KEYS = Object.freeze(generateKeyHash([
   'Enter',
   'Backspace',
   'Space',
@@ -55,13 +55,13 @@ export const EVENT_KEYS = generateKeyHash([
   'ArrowRight',
   'Tab',
   'Escape'
-])
+]))
 
-export const LOWERCASE_TAGS = generateKeyHash([
+export const LOWERCASE_TAGS = Object.freeze(generateKeyHash([
   ...blockContainerElementNames, ...emptyElementNames, 'div'
-])
+]))
 
-export const CLASS_OR_ID = genUpper2LowerKeyHash([
+export const CLASS_OR_ID = Object.freeze(genUpper2LowerKeyHash([
   'AG_ACTIVE',
   'AG_AUTO_LINK',
   'AG_AUTO_LINK_EXTENSION',
@@ -154,20 +154,20 @@ export const CLASS_OR_ID = genUpper2LowerKeyHash([
   'AG_TOOL_BAR',
   'AG_VEGA_LITE',
   'AG_WARN'
-])
+]))
 
-export const DAED_REMOVE_SELECTOR = new Set([
+export const DAED_REMOVE_SELECTOR = Object.freeze(new Set([
   '.ag-image-marked-text::before',
   '.ag-image-marked-text.ag-image-fail::before',
   '.ag-hide',
   '.ag-gray',
   '.ag-warn'
-])
+]))
 
 export const CURSOR_ANCHOR_DNA = getLongUniqueId()
 export const CURSOR_FOCUS_DNA = getLongUniqueId()
 
-export const DEFAULT_TURNDOWN_CONFIG = {
+export const DEFAULT_TURNDOWN_CONFIG = Object.freeze({
   headingStyle: 'atx', // setext or atx
   hr: '---',
   bulletListMarker: '-', // -, +, or *
@@ -188,9 +188,9 @@ export const DEFAULT_TURNDOWN_CONFIG = {
       return node.isBlock ? '\n\n' : ''
     }
   }
-}
+})
 
-export const FORMAT_MARKER_MAP = {
+export const FORMAT_MARKER_MAP = Object.freeze({
   em: '*',
   inline_code: '`',
   strong: '**',
@@ -212,13 +212,13 @@ export const FORMAT_MARKER_MAP = {
     open: '<mark>',
     close: '</mark>'
   }
-}
+})
 
-export const FORMAT_TYPES = ['strong', 'em', 'del', 'inline_code', 'link', 'image', 'inline_math']
+export const FORMAT_TYPES = Object.freeze(['strong', 'em', 'del', 'inline_code', 'link', 'image', 'inline_math'])
 
 export const LINE_BREAK = '\n'
 
-export const PREVIEW_DOMPURIFY_CONFIG = {
+export const PREVIEW_DOMPURIFY_CONFIG = Object.freeze({
   // do not forbit `class` because `code` element use class to present language
   FORBID_ATTR: ['style', 'contenteditable'],
   ALLOW_DATA_ATTR: false,
@@ -228,9 +228,9 @@ export const PREVIEW_DOMPURIFY_CONFIG = {
     svgFilters: true,
     mathMl: true
   }
-}
+})
 
-export const EXPORT_DOMPURIFY_CONFIG = {
+export const EXPORT_DOMPURIFY_CONFIG = Object.freeze({
   FORBID_ATTR: ['contenteditable'],
   ALLOW_DATA_ATTR: false,
   ADD_ATTR: ['data-align'],
@@ -242,9 +242,9 @@ export const EXPORT_DOMPURIFY_CONFIG = {
   },
   // Allow "file" protocol to export images on Windows (#1997).
   ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i // eslint-disable-line no-useless-escape
-}
+})
 
-export const MUYA_DEFAULT_OPTION = {
+export const MUYA_DEFAULT_OPTION = Object.freeze({
   fontSize: 16,
   lineHeight: 1.6,
   focusMode: false,
@@ -284,11 +284,11 @@ export const MUYA_DEFAULT_OPTION = {
   superSubScript: false,
   footnote: false,
   isGitlabCompatibilityEnabled: false
-}
+})
 
-// export const DIAGRAM_TEMPLATE = {
+// export const DIAGRAM_TEMPLATE = Object.freeze({
 //   'mermaid': `graph LR;\nYou-->|Mark Text|Me;`
-// }
+// })
 
 export const isOsx = window && window.navigator && /Mac/.test(window.navigator.platform)
 export const isWin = window && window.navigator.userAgent && /win32|wow32|win64|wow64/i.test(window.navigator.userAgent)
@@ -299,10 +299,10 @@ export const DATA_URL_REG = /^data:image\/[\w+-]+(;[\w-]+=[\w-]+|;base64)*,[a-zA
 // The smallest transparent gif base64 image.
 // export const SMALLEST_BASE64 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 // export const isIOS = /(?:iPhone|iPad|iPod|iOS)/i.test(window.navigator.userAgent)
-export const defaultSearchOption = {
+export const defaultSearchOption = Object.freeze({
   isCaseSensitive: false,
   isWholeWord: false,
   isRegexp: false,
   selectHighlight: false,
   highlightIndex: -1
-}
+})

--- a/src/muya/lib/contentState/index.js
+++ b/src/muya/lib/contentState/index.js
@@ -83,7 +83,7 @@ class ContentState {
     this.prevCursor = null
     this.historyTimer = null
     this.history = new History(this)
-    this.turndownConfig = Object.assign(DEFAULT_TURNDOWN_CONFIG, { bulletListMarker })
+    this.turndownConfig = Object.assign({}, DEFAULT_TURNDOWN_CONFIG, { bulletListMarker })
     // table drag bar
     this.dragInfo = null
     this.isDragTableBar = false

--- a/src/muya/lib/parser/render/renderBlock/renderToolBar.js
+++ b/src/muya/lib/parser/render/renderBlock/renderToolBar.js
@@ -7,7 +7,7 @@ import AlignRightIcon from '../../../assets/pngicon/algin_right/2.png'
 import AlignCenterIcon from '../../../assets/pngicon/algin_center/2.png'
 import DeleteIcon from '../../../assets/pngicon/table_delete/2.png'
 
-export const TABLE_TOOLS = [{
+export const TABLE_TOOLS = Object.freeze([{
   label: 'table',
   title: 'Resize Table',
   icon: TableIcon
@@ -27,7 +27,7 @@ export const TABLE_TOOLS = [{
   label: 'delete',
   title: 'Delete Table',
   icon: DeleteIcon
-}]
+}])
 
 const renderToolBar = (type, tools, activeBlocks) => {
   const children = tools.map(tool => {

--- a/src/muya/lib/parser/utils.js
+++ b/src/muya/lib/parser/utils.js
@@ -4,38 +4,38 @@
 export const PUNCTUATION_REG = new RegExp(/[!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E42\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDF3C-\uDF3E]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]/)
 /* eslint-enable no-useless-escape */
 // selected from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-export const WHITELIST_ATTRIBUTES = [
+export const WHITELIST_ATTRIBUTES = Object.freeze([
   'align', 'alt', 'checked', 'class', 'color', 'dir', 'disabled', 'for', 'height', 'hidden',
   'href', 'id', 'lang', 'lazyload', 'rel', 'spellcheck', 'src', 'srcset', 'start', 'style',
   'target', 'title', 'type', 'value', 'width',
   // Used in img
   'data-align'
-]
+])
 
-// export const unicodeZsCategory = [
+// export const unicodeZsCategory = Object.freeze([
 //   '\u0020', '\u00A0', '\u1680', '\u2000', '\u2001', '\u2001',
 //   '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007',
 //   '\u2008', '\u2009', '\u200A', '\u202F', '\u205F', '\u3000'
-// ]
+// ])
 
 // export const space = ['\u0020'] // space
 
-// export const whitespaceCharacter = [
+// export const whitespaceCharacter = Object.freeze([
 //   ...space, // space
 //   '\u0009', // tab
 //   '\u000A', // newline
 //   '\u000B', // tabulation
 //   '\u000C', // form feed
 //   '\u000D' // carriage return
-// ]
+// ])
 
-// export const unicodeWhitespaceCharacter = [
+// export const unicodeWhitespaceCharacter = Object.freeze([
 //   ...unicodeZsCategory,
 //   '\u0009', // tab
 //   '\u000D', // carriage return
 //   '\u000A', // newline
 //   '\u000C' // form feed
-// ]
+// ])
 
 const UNICODE_WHITESPACE_REG = /^\s/
 

--- a/src/renderer/commands/quickOpen.js
+++ b/src/renderer/commands/quickOpen.js
@@ -177,9 +177,9 @@ class QuickOpenCommand {
       return [`*${query}`]
     }
 
-    const inclusions = MARKDOWN_INCLUSIONS
-    for (let i = 0; i < inclusions.length; ++i) {
-      inclusions[i] = `*${query}` + inclusions[i]
+    const inclusions = []
+    for (let i = 0; i < MARKDOWN_INCLUSIONS.length; ++i) {
+      inclusions[i] = `*${query}` + MARKDOWN_INCLUSIONS[i]
     }
     return inclusions
   }

--- a/src/renderer/config.js
+++ b/src/renderer/config.js
@@ -6,12 +6,12 @@ export const COMMON_STYLE_ID = 'ag-common-style'
 
 export const DEFAULT_EDITOR_FONT_FAMILY = '"Open Sans", "Clear Sans", "Helvetica Neue", Helvetica, Arial, sans-serif, Segoe UI Emoji, Apple Color Emoji, "Noto Color Emoji"'
 export const DEFAULT_CODE_FONT_FAMILY = '"DejaVu Sans Mono", "Source Code Pro", "Droid Sans Mono", monospace'
-export const DEFAULT_STYLE = {
+export const DEFAULT_STYLE = Object.freeze({
   codeFontFamily: DEFAULT_CODE_FONT_FAMILY,
   codeFontSize: '14px',
   hideScrollbar: false,
   theme: 'light'
-}
+})
 
-export const railscastsThemes = ['dark', 'material-dark']
-export const oneDarkThemes = ['one-dark']
+export const railscastsThemes = Object.freeze(['dark', 'material-dark'])
+export const oneDarkThemes = Object.freeze(['one-dark'])

--- a/src/renderer/contextMenu/editor/menuItems.js
+++ b/src/renderer/contextMenu/editor/menuItems.js
@@ -1,63 +1,63 @@
 import * as contextMenu from './actions'
 
-export const CUT = {
+export const CUT = Object.freeze({
   label: 'Cut',
   id: 'cutMenuItem', // not used yet!
   role: 'cut'
-}
+})
 
-export const COPY = {
+export const COPY = Object.freeze({
   label: 'Copy',
   id: 'copyMenuItem',
   role: 'copy'
-}
+})
 
-export const PASTE = {
+export const PASTE = Object.freeze({
   label: 'Paste',
   id: 'pasteMenuItem',
   role: 'paste'
-}
+})
 
-export const COPY_AS_MARKDOWN = {
+export const COPY_AS_MARKDOWN = Object.freeze({
   label: 'Copy As Markdown',
   id: 'copyAsMarkdownMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.copyAsMarkdown()
   }
-}
+})
 
-export const COPY_AS_HTML = {
+export const COPY_AS_HTML = Object.freeze({
   label: 'Copy As Html',
   id: 'copyAsHtmlMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.copyAsHtml()
   }
-}
+})
 
-export const PASTE_AS_PLAIN_TEXT = {
+export const PASTE_AS_PLAIN_TEXT = Object.freeze({
   label: 'Paste as Plain Text',
   id: 'pasteAsPlainTextMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.pasteAsPlainText()
   }
-}
+})
 
-export const INSERT_BEFORE = {
+export const INSERT_BEFORE = Object.freeze({
   label: 'Insert Paragraph Before',
   id: 'insertParagraphBeforeMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.insertParagraph('before')
   }
-}
+})
 
-export const INSERT_AFTER = {
+export const INSERT_AFTER = Object.freeze({
   label: 'Insert Paragraph After',
   id: 'insertParagraphAfterMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.insertParagraph('after')
   }
-}
+})
 
-export const SEPARATOR = {
+export const SEPARATOR = Object.freeze({
   type: 'separator'
-}
+})

--- a/src/renderer/contextMenu/sideBar/menuItems.js
+++ b/src/renderer/contextMenu/sideBar/menuItems.js
@@ -1,69 +1,69 @@
 import * as contextMenu from './actions'
 
-export const SEPARATOR = {
+export const SEPARATOR = Object.freeze({
   type: 'separator'
-}
+})
 
-export const NEW_FILE = {
+export const NEW_FILE = Object.freeze({
   label: 'New File',
   id: 'newFileMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.newFile()
   }
-}
+})
 
-export const NEW_DIRECTORY = {
+export const NEW_DIRECTORY = Object.freeze({
   label: 'New Directory',
   id: 'newDirectoryMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.newDirectory()
   }
-}
+})
 
-export const COPY = {
+export const COPY = Object.freeze({
   label: 'Copy',
   id: 'copyMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.copy()
   }
-}
+})
 
-export const CUT = {
+export const CUT = Object.freeze({
   label: 'Cut',
   id: 'cutMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.cut()
   }
-}
+})
 
-export const PASTE = {
+export const PASTE = Object.freeze({
   label: 'Paste',
   id: 'pasteMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.paste()
   }
-}
+})
 
-export const RENAME = {
+export const RENAME = Object.freeze({
   label: 'Rename',
   id: 'renameMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.rename()
   }
-}
+})
 
-export const DELETE = {
+export const DELETE = Object.freeze({
   label: 'Move To Trash',
   id: 'deleteMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.remove()
   }
-}
+})
 
-export const SHOW_IN_FOLDER = {
+export const SHOW_IN_FOLDER = Object.freeze({
   label: 'Show In Folder',
   id: 'showInFolderMenuItem',
   click (menuItem, browserWindow) {
     contextMenu.showInFolder()
   }
-}
+})

--- a/src/renderer/contextMenu/tabs/menuItems.js
+++ b/src/renderer/contextMenu/tabs/menuItems.js
@@ -1,61 +1,61 @@
 import * as contextMenu from './actions'
 
-export const SEPARATOR = {
+export const SEPARATOR = Object.freeze({
   type: 'separator'
-}
+})
 
-export const CLOSE_THIS = {
+export const CLOSE_THIS = Object.freeze({
   label: 'Close',
   id: 'closeThisTab',
   click (menuItem, browserWindow) {
     contextMenu.closeThis(menuItem._tabId)
   }
-}
+})
 
-export const CLOSE_OTHERS = {
+export const CLOSE_OTHERS = Object.freeze({
   label: 'Close others',
   id: 'closeOtherTabs',
   click (menuItem, browserWindow) {
     contextMenu.closeOthers(menuItem._tabId)
   }
-}
+})
 
-export const CLOSE_SAVED = {
+export const CLOSE_SAVED = Object.freeze({
   label: 'Close saved tabs',
   id: 'closeSavedTabs',
   click (menuItem, browserWindow) {
     contextMenu.closeSaved()
   }
-}
+})
 
-export const CLOSE_ALL = {
+export const CLOSE_ALL = Object.freeze({
   label: 'Close all tabs',
   id: 'closeAllTabs',
   click (menuItem, browserWindow) {
     contextMenu.closeAll()
   }
-}
+})
 
-export const RENAME = {
+export const RENAME = Object.freeze({
   label: 'Rename',
   id: 'renameFile',
   click (menuItem, browserWindow) {
     contextMenu.rename(menuItem._tabId)
   }
-}
+})
 
-export const COPY_PATH = {
+export const COPY_PATH = Object.freeze({
   label: 'Copy path',
   id: 'copyPath',
   click (menuItem, browserWindow) {
     contextMenu.copyPath(menuItem._tabId)
   }
-}
+})
 
-export const SHOW_IN_FOLDER = {
+export const SHOW_IN_FOLDER = Object.freeze({
   label: 'Show in folder',
   id: 'showInFolder',
   click (menuItem, browserWindow) {
     contextMenu.showInFolder(menuItem._tabId)
   }
-}
+})

--- a/src/renderer/spellchecker/languageMap.js
+++ b/src/renderer/spellchecker/languageMap.js
@@ -43,7 +43,7 @@ export const getHunspellLanguageName = langCode => {
 
 // All available Hunspell dictionary languages.
 // NOTE: Listed as value/label due to settings requirements.
-export const HUNSPELL_DICTIONARY_LANGUAGE_MAP = [{
+export const HUNSPELL_DICTIONARY_LANGUAGE_MAP = Object.freeze([{
   label: 'Afrikaans', // Afrikaans
   value: 'af-ZA'
 }, {
@@ -169,4 +169,4 @@ export const HUNSPELL_DICTIONARY_LANGUAGE_MAP = [{
 }, {
   label: 'Tiếng Việt', // Vietnamese
   value: 'vi-VN'
-}]
+}])

--- a/test/specs/config.js
+++ b/test/specs/config.js
@@ -1,6 +1,6 @@
-export const MT_MARKED_OPTIONS = {
+export const MT_MARKED_OPTIONS = Object.freeze({
   headerIds: false,
   emoji: false,
   math: false,
   frontMatter: false
-}
+})


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #2322
| License           | MIT

### Description

`QuickOpenCommand._getInclusions` was [accidentally mutating](https://github.com/marktext/marktext/pull/2323/files#diff-feaed7ea091ea671155a7b191cce00d9L180) the `MARKDOWN_INCLUSIONS` constant. So all subsequent searches were adding to the last set of inclusion patterns generated instead of making fresh ones. This made it unusable without restarting the application.

Once I fixed this, I wrapped `MARKDOWN_INCLUSIONS` and as many other objects that looked like they should be immutable with `Object.freeze()`.

This showed up a second accidental mutation of `DEFAULT_TURNDOWN_CONFIG`, which I have also fixed.