### PR TITLE
feat: add shortcut for toggle-toc (#1863)

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -135,7 +135,7 @@ Here is an example:
 | `view.focus-mode`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> | Enable focus mode                        |
 | `view.toggle-sidebar`   | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
 | `view.toggle-tabbar`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
-| `view.toggle-toc` .     | <kbd>CmdOrCtrl</kbd>+<kbd>K</kbd>                  | Toggle TOC                               |
+| `view.toggle-toc` .     | <kbd>CmdOrCtrl</kbd>+<kbd>K</kbd>                  | Toggle table of contents                 |
 | `view.toggle-dev-tools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only) |
 | `view.dev-reload`       | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)          |
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -135,6 +135,7 @@ Here is an example:
 | `view.focus-mode`       | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> | Enable focus mode                        |
 | `view.toggle-sidebar`   | <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>                  | Toggle sidebar                           |
 | `view.toggle-tabbar`    | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd>   | Toggle tabbar                            |
+| `view.toggle-toc` .     | <kbd>CmdOrCtrl</kbd>+<kbd>K</kbd>                  | Toggle TOC                               |
 | `view.toggle-dev-tools` | <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd>   | Toggle developer tools (debug mode only) |
 | `view.dev-reload`       | <kbd>CmdOrCtrl</kbd>+<kbd>R</kbd>                  | Reload window (debug mode only)          |
 

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -101,6 +101,7 @@ class Keybindings {
       ['view.typewriter-mode', 'CmdOrCtrl+Alt+T'],
       ['view.focus-mode', 'CmdOrCtrl+Shift+J'],
       ['view.toggle-sidebar', 'CmdOrCtrl+J'],
+      ['view.toggle-toc', 'CmdOrCtrl+K'],
       ['view.toggle-tabbar', 'CmdOrCtrl+Alt+B'],
       ['view.toggle-dev-tools', 'CmdOrCtrl+Alt+I'],
       ['view.dev-reload', 'CmdOrCtrl+R'],

--- a/src/main/menu/actions/view.js
+++ b/src/main/menu/actions/view.js
@@ -22,9 +22,9 @@ export const typeMode = (win, type, item) => {
   }
 }
 
-export const layout = (item, win, type) => {
+export const layout = (item, win, type, value) => {
   if (win && win.webContents) {
-    win.webContents.send('mt::set-view-layout', { [type]: item.checked })
+    win.webContents.send('mt::set-view-layout', { [type]: value || item.checked })
   }
 }
 

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -82,7 +82,7 @@ export default function (keybindings) {
         actions.layout(item, browserWindow, 'showTabBar')
       }
     }, {
-      label: 'Toggle TOC',
+      label: 'Toggle Table of Contents',
       id: 'tocMenuItem',
       accelerator: keybindings.getAccelerator('view.toggle-toc'),
       click (_, browserWindow) {

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -82,6 +82,13 @@ export default function (keybindings) {
         actions.layout(item, browserWindow, 'showTabBar')
       }
     }, {
+      label: 'Toggle TOC',
+      id: 'tocMenuItem',
+      accelerator: keybindings.getAccelerator('view.toggle-toc'),
+      click (_, browserWindow) {
+        actions.layout(null, browserWindow, 'rightColumn', 'toc')
+      }
+    }, {
       type: 'separator'
     }]
   }

--- a/src/renderer/store/layout.js
+++ b/src/renderer/store/layout.js
@@ -33,9 +33,17 @@ const mutations = {
 }
 
 const actions = {
-  LISTEN_FOR_LAYOUT ({ commit }) {
+  LISTEN_FOR_LAYOUT ({ state, commit }) {
     ipcRenderer.on('mt::set-view-layout', (e, layout) => {
-      commit('SET_LAYOUT', layout)
+      if (layout.rightColumn) {
+        commit('SET_LAYOUT', {
+          ...layout,
+          rightColumn: layout.rightColumn === state.rightColumn ? '' : layout.rightColumn,
+          showSideBar: true
+        })
+      } else {
+        commit('SET_LAYOUT', layout)
+      }
     })
 
     bus.$on('view:toggle-view-layout-entry', entryName => {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #1863 
| License           | MIT

### Description

Add shortcut `CmdOrCtrl + k` for 'toggle Toc'.
- If sidebar is hidden, will open sidebar and show the Toc
- If both sidebar and Toc are visible, Toc will be closed
- If sidebar is open but not Toc, will switch to Toc
![Sep-02-2020 16-51-15](https://user-images.githubusercontent.com/11732386/91960864-fefc7500-ed3c-11ea-937c-52cfc80953b4.gif)
