### PR TITLE
Add mhchem support to math blocks

### DIFF
--- a/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
+++ b/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
@@ -1,4 +1,5 @@
 import katex from 'katex'
+import 'katex/dist/contrib/mhchem.min.js'
 import prism, { loadedCache, transfromAliasToOrigin } from '../../../prism/'
 import { CLASS_OR_ID, DEVICE_MEMORY, PREVIEW_DOMPURIFY_CONFIG, HAS_TEXT_BLOCK_REG } from '../../../config'
 import { tokenizer } from '../../'

--- a/src/muya/lib/parser/render/renderInlines/inlineMath.js
+++ b/src/muya/lib/parser/render/renderInlines/inlineMath.js
@@ -1,4 +1,5 @@
 import katex from 'katex'
+import 'katex/dist/contrib/mhchem.min.js'
 import { CLASS_OR_ID } from '../../../config'
 import { htmlToVNode } from '../snabbdom'
 

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -1,6 +1,7 @@
 import marked from '../parser/marked'
 import Prism from 'prismjs'
 import katex from 'katex'
+import 'katex/dist/contrib/mhchem.min.js'
 import loadRenderer from '../renderers'
 import githubMarkdownCss from 'github-markdown-css/github-markdown.css'
 import exportStyle from '../assets/styles/exportStyle.css'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2301 
| License           | MIT

### Description

Adds support for mhchem in math blocks. Works by importing KaTeX mhchem extension after KaTeX.
