### PR TITLE
fix: prism language missing while load dependent language (#1752)

### DIFF
--- a/src/muya/lib/prism/loadLanguage.js
+++ b/src/muya/lib/prism/loadLanguage.js
@@ -1,6 +1,7 @@
 import languages from './languages'
 let peerDependentsMap = null
 export const loadedCache = new Set(['markup', 'css', 'clike', 'javascript'])
+const prismComponentCache = new Map()
 
 function getPeerDependentsMap () {
   const peerDependentsMap = {}
@@ -100,7 +101,12 @@ function initLoadLanguage (Prism) {
       }
 
       delete Prism.languages[language]
-      await import('prismjs/components/prism-' + language)
+      if (!prismComponentCache.has(language)) {
+        await import('prismjs/components/prism-' + language)
+        prismComponentCache.set(language, Prism.languages[language])
+      } else {
+        Prism.languages[language] = prismComponentCache.get(language)
+      }
       loadedCache.add(language)
       promises.push(Promise.resolve({
         status: 'loaded',
@@ -113,6 +119,7 @@ function initLoadLanguage (Prism) {
         // we want to reload it.
         if (Prism.languages[dependent]) {
           delete Prism.languages[dependent]
+          loadedCache.delete(dependent)
           return true
         }
         return false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #1752 
| License           | MIT

### Description

`stylus` is included in `pug`'s peerDependencies.
When we load `stylus`, it try to delete `Prism.languages.pug` reload dependent `pug`.
However, call `dynamic import` twice won't trigger the `IIFE` inside in `prismjs/components/prism-pug` twice.
As a result, the attribute `Prism.language.pug`  is missing after that.