### PR TITLE
Add codeblock highlight and coloration for the SPARQL and Turtle languages

### DIFF
--- a/src/muya/lib/prism/languages.json
+++ b/src/muya/lib/prism/languages.json
@@ -998,6 +998,11 @@
       "tpl"
     ]
   },
+  "sparql": {
+    "title": "SPARQL",
+    "require": "turtle",
+    "ext": []
+  },
   "sql": {
     "title": "SQL",
     "ext": [
@@ -1053,6 +1058,10 @@
       "clike",
       "markup-templating"
     ],
+    "ext": []
+  },
+  "turtle": {
+    "title": "Turtle",
     "ext": []
   },
   "twig": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | 
| License           | MIT

### Description

Add codeblock highlight and coloration for the [SPARQL](https://www.w3.org/TR/sparql11-query/) and [Turtle](https://www.w3.org/TR/turtle/) languages (standard data format and query language for RDF knowledge graph). 

Those languages were already included in Prism languages, they have been added to the list in `src/muya/lib/prism/languages.json`