### PR TITLE
Fixed tabs not closing with middle click.

### DIFF
--- a/docs/MARKDOWN_SYNTAX.md
+++ b/docs/MARKDOWN_SYNTAX.md
@@ -465,18 +465,18 @@ Renders to:
 
 **Center text in a column**
 
-To center the text in a column, add a colon to the middle of the dashes in the row beneath the header.
+To center the text in a column, add a colon to the left and right of the dashes in the row beneath the header.
 
 ```markdown
 | Option | Description |
-| -:- | -:- |
+| :-: | :-: |
 | data   | path to data files to supply the data that will be passed into templates. |
 | engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |
 ```
 
 | Option | Description |
-| -:- | -:- |
+| :-: | :-: |
 | data   | path to data files to supply the data that will be passed into templates. |
 | engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |
@@ -484,7 +484,7 @@ To center the text in a column, add a colon to the middle of the dashes in the r
 
 **Right-align the text in a column**
 
-To right-align the text in a column, add a colon to the middle of the dashes in the row beneath the header.
+To right-align the text in a column, add a colon to the right of the dashes in the row beneath the header.
 
 ```markdown
 | Option | Description |

--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -18,7 +18,7 @@
           :key="file.id"
           :data-id="file.id"
           @click.stop="selectFile(file)"
-          @click.middle="closeTab(file)"
+          @click.middle="closeTab(file.id)"
           @contextmenu.prevent="handleContextMenu($event, file)"
         >
           <span>{{ file.filename }}</span>


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? |no
| Deprecations?     | no
| New tests added?  | not needed
| License           | MIT

### Description

The closetab was missing the ".id" for it to work.
