### PR TITLE
fix: #1933 - Cannot copy table cell

### DIFF
--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -816,6 +816,7 @@ const paragraphCtrl = ContentState => {
           column: 1,
           cells: [{
             key: cellBlock.key,
+            text: cellBlock.children[0].text,
             top: true,
             right: true,
             bottom: true,


### PR DESCRIPTION
Hi. I would like to contribute to your project.
This PR fixes #1933. 

cellBlock (sample data):

```json
{
  "key": "ag-460",
  "text": "",
  "type": "td",
  "editable": true,
  "parent": "ag-457",
  "preSibling": "ag-458",
  "nextSibling": null,
  "children": [
    {
      "key": "ag-461",
      "text": "Text goes here",
      "type": "span",
      "editable": true,
      "parent": "ag-460",
      "preSibling": null,
      "nextSibling": null,
      "children": [],
      "functionType": "cellContent"
    }
  ],
  "align": "",
  "column": 1
}
```