### PR TITLE
Add TOC generator to document exporter

### DIFF
--- a/src/muya/lib/assets/styles/exportStyle.css
+++ b/src/muya/lib/assets/styles/exportStyle.css
@@ -23,3 +23,43 @@
 .multiple-math.invalid {
   color: rgb(255, 105, 105);
 }
+
+.toc-container {
+  width: 100%;
+}
+
+.toc-container .toc-title {
+  font-weight: 700;
+  font-size: 1.2em;
+  margin-bottom: 0;
+}
+
+.toc-container li,
+.toc-container ul,
+.toc-container ul li {
+  list-style: none !important;
+}
+
+.toc-container > ul {
+  padding-left: 0;
+}
+
+.toc-container ul li span {
+  display : flex;
+}
+
+.toc-container ul li span a {
+  color: inherit;
+  text-decoration: none;
+}
+.toc-container ul li span a:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.toc-container ul li span span.dots {
+  flex: 1;
+  height: 0.65em;
+  margin: 0 10px;
+  border-bottom: 2px dotted black;
+}

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -605,6 +605,12 @@ Lexer.prototype.token = function (src, top) {
     cap = this.rules.paragraph.exec(src)
     if (top && cap) {
       src = src.substring(cap[0].length)
+
+      if (/^\[toc\]\n?$/i.test(cap[1])) {
+        this.tokens.push({ type: 'toc', text: '[TOC]' })
+        continue
+      }
+
       this.tokens.push({
         type: 'paragraph',
         text: cap[1].charAt(cap[1].length - 1) === '\n'

--- a/src/muya/lib/parser/marked/options.js
+++ b/src/muya/lib/parser/marked/options.js
@@ -7,6 +7,7 @@ export default {
   highlight: null,
   mathRenderer: null,
   emojiRenderer: null,
+  tocRenderer: null,
   langPrefix: 'language-',
   mangle: true,
   pedantic: false,

--- a/src/muya/lib/parser/marked/parser.js
+++ b/src/muya/lib/parser/marked/parser.js
@@ -216,6 +216,9 @@ Parser.prototype.tok = function () {
     case 'text': {
       return this.renderer.paragraph(this.parseText())
     }
+    case 'toc': {
+      return this.renderer.toc()
+    }
     default: {
       const errMsg = 'Token with "' + this.token.type + '" type was not found.'
       if (this.options.silent) {

--- a/src/muya/lib/parser/marked/renderer.js
+++ b/src/muya/lib/parser/marked/renderer.js
@@ -223,4 +223,11 @@ Renderer.prototype.text = function (text) {
   return text
 }
 
+Renderer.prototype.toc = function () {
+  if (this.options.tocRenderer) {
+    return this.options.tocRenderer()
+  }
+  return ''
+}
+
 export default Renderer

--- a/src/muya/lib/parser/marked/slugger.js
+++ b/src/muya/lib/parser/marked/slugger.js
@@ -1,9 +1,12 @@
+import { downcode } from './urlify'
+
 /**
  * Slugger generates header id
  */
 
 function Slugger () {
   this.seen = {}
+  this.downcodeUnicode = true
 }
 
 /**
@@ -11,7 +14,8 @@ function Slugger () {
  */
 
 Slugger.prototype.slug = function (value) {
-  let slug = value
+  let slug = this.downcodeUnicode ? downcode(value) : value
+  slug = slug
     .toLowerCase()
     .trim()
     // remove html tags

--- a/src/muya/lib/parser/marked/urlify.js
+++ b/src/muya/lib/parser/marked/urlify.js
@@ -1,0 +1,204 @@
+// License: BSD
+// Source: https://github.com/django/django/blob/master/django/contrib/admin/static/admin/js/urlify.js
+//
+// Copyright (c) Django Software Foundation and individual contributors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//     1. Redistributions of source code must retain the above copyright notice,
+//        this list of conditions and the following disclaimer.
+//
+//     2. Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//
+//     3. Neither the name of Django nor the names of its contributors may be used
+//        to endorse or promote products derived from this software without
+//        specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/* eslint-disable quote-props, object-property-newline */
+
+const LATIN_MAP = {
+  'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'AE', 'Å': 'A', 'Æ': 'AE',
+  'Ç': 'C', 'È': 'E', 'É': 'E', 'Ê': 'E', 'Ë': 'E', 'Ì': 'I', 'Í': 'I',
+  'Î': 'I', 'Ï': 'I', 'Ð': 'D', 'Ñ': 'N', 'Ò': 'O', 'Ó': 'O', 'Ô': 'O',
+  'Õ': 'O', 'Ö': 'O', 'Ő': 'O', 'Ø': 'O', 'Ù': 'U', 'Ú': 'U', 'Û': 'U',
+  'Ü': 'U', 'Ű': 'U', 'Ý': 'Y', 'Þ': 'TH', 'Ÿ': 'Y', 'ß': 'ss', 'à': 'a',
+  'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'ae', 'å': 'a', 'æ': 'ae', 'ç': 'c',
+  'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e', 'ì': 'i', 'í': 'i', 'î': 'i',
+  'ï': 'i', 'ð': 'd', 'ñ': 'n', 'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o',
+  'ö': 'o', 'ő': 'o', 'ø': 'o', 'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u',
+  'ű': 'u', 'ý': 'y', 'þ': 'th', 'ÿ': 'y'
+}
+const LATIN_SYMBOLS_MAP = {
+  '©': '(c)',
+  '$': 'dollar',
+  '¢': 'cent',
+  '£': 'pound',
+  '¤': 'currency',
+  '¥': 'yen',
+  '%': 'percent',
+  '|': 'or',
+
+  // TODO: Not working
+  '&': 'and',
+  '<': 'less',
+  '>': 'greater',
+  '\'': 'single-quote',
+  '"': 'double-quote'
+}
+const GREEK_MAP = {
+  'α': 'a', 'β': 'b', 'γ': 'g', 'δ': 'd', 'ε': 'e', 'ζ': 'z', 'η': 'h',
+  'θ': '8', 'ι': 'i', 'κ': 'k', 'λ': 'l', 'μ': 'm', 'ν': 'n', 'ξ': '3',
+  'ο': 'o', 'π': 'p', 'ρ': 'r', 'σ': 's', 'τ': 't', 'υ': 'y', 'φ': 'f',
+  'χ': 'x', 'ψ': 'ps', 'ω': 'w', 'ά': 'a', 'έ': 'e', 'ί': 'i', 'ό': 'o',
+  'ύ': 'y', 'ή': 'h', 'ώ': 'w', 'ς': 's', 'ϊ': 'i', 'ΰ': 'y', 'ϋ': 'y',
+  'ΐ': 'i', 'Α': 'A', 'Β': 'B', 'Γ': 'G', 'Δ': 'D', 'Ε': 'E', 'Ζ': 'Z',
+  'Η': 'H', 'Θ': '8', 'Ι': 'I', 'Κ': 'K', 'Λ': 'L', 'Μ': 'M', 'Ν': 'N',
+  'Ξ': '3', 'Ο': 'O', 'Π': 'P', 'Ρ': 'R', 'Σ': 'S', 'Τ': 'T', 'Υ': 'Y',
+  'Φ': 'F', 'Χ': 'X', 'Ψ': 'PS', 'Ω': 'W', 'Ά': 'A', 'Έ': 'E', 'Ί': 'I',
+  'Ό': 'O', 'Ύ': 'Y', 'Ή': 'H', 'Ώ': 'W', 'Ϊ': 'I', 'Ϋ': 'Y'
+}
+const TURKISH_MAP = {
+  'ş': 's', 'Ş': 'S', 'ı': 'i', 'İ': 'I', 'ç': 'c', 'Ç': 'C', 'ü': 'u',
+  'Ü': 'U', 'ö': 'o', 'Ö': 'O', 'ğ': 'g', 'Ğ': 'G'
+}
+const ROMANIAN_MAP = {
+  'ă': 'a', 'î': 'i', 'ș': 's', 'ț': 't', 'â': 'a',
+  'Ă': 'A', 'Î': 'I', 'Ș': 'S', 'Ț': 'T', 'Â': 'A'
+}
+const RUSSIAN_MAP = {
+  'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'yo',
+  'ж': 'zh', 'з': 'z', 'и': 'i', 'й': 'j', 'к': 'k', 'л': 'l', 'м': 'm',
+  'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
+  'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sh', 'ъ': '',
+  'ы': 'y', 'ь': '', 'э': 'e', 'ю': 'yu', 'я': 'ya',
+  'А': 'A', 'Б': 'B', 'В': 'V', 'Г': 'G', 'Д': 'D', 'Е': 'E', 'Ё': 'Yo',
+  'Ж': 'Zh', 'З': 'Z', 'И': 'I', 'Й': 'J', 'К': 'K', 'Л': 'L', 'М': 'M',
+  'Н': 'N', 'О': 'O', 'П': 'P', 'Р': 'R', 'С': 'S', 'Т': 'T', 'У': 'U',
+  'Ф': 'F', 'Х': 'H', 'Ц': 'C', 'Ч': 'Ch', 'Ш': 'Sh', 'Щ': 'Sh', 'Ъ': '',
+  'Ы': 'Y', 'Ь': '', 'Э': 'E', 'Ю': 'Yu', 'Я': 'Ya'
+}
+const UKRAINIAN_MAP = {
+  'Є': 'Ye', 'І': 'I', 'Ї': 'Yi', 'Ґ': 'G', 'є': 'ye', 'і': 'i',
+  'ї': 'yi', 'ґ': 'g'
+}
+const CZECH_MAP = {
+  'č': 'c', 'ď': 'd', 'ě': 'e', 'ň': 'n', 'ř': 'r', 'š': 's', 'ť': 't',
+  'ů': 'u', 'ž': 'z', 'Č': 'C', 'Ď': 'D', 'Ě': 'E', 'Ň': 'N', 'Ř': 'R',
+  'Š': 'S', 'Ť': 'T', 'Ů': 'U', 'Ž': 'Z'
+}
+const SLOVAK_MAP = {
+  'á': 'a', 'ä': 'a', 'č': 'c', 'ď': 'd', 'é': 'e', 'í': 'i', 'ľ': 'l',
+  'ĺ': 'l', 'ň': 'n', 'ó': 'o', 'ô': 'o', 'ŕ': 'r', 'š': 's', 'ť': 't',
+  'ú': 'u', 'ý': 'y', 'ž': 'z',
+  'Á': 'a', 'Ä': 'A', 'Č': 'C', 'Ď': 'D', 'É': 'E', 'Í': 'I', 'Ľ': 'L',
+  'Ĺ': 'L', 'Ň': 'N', 'Ó': 'O', 'Ô': 'O', 'Ŕ': 'R', 'Š': 'S', 'Ť': 'T',
+  'Ú': 'U', 'Ý': 'Y', 'Ž': 'Z'
+}
+const POLISH_MAP = {
+  'ą': 'a', 'ć': 'c', 'ę': 'e', 'ł': 'l', 'ń': 'n', 'ó': 'o', 'ś': 's',
+  'ź': 'z', 'ż': 'z',
+  'Ą': 'A', 'Ć': 'C', 'Ę': 'E', 'Ł': 'L', 'Ń': 'N', 'Ó': 'O', 'Ś': 'S',
+  'Ź': 'Z', 'Ż': 'Z'
+}
+const LATVIAN_MAP = {
+  'ā': 'a', 'č': 'c', 'ē': 'e', 'ģ': 'g', 'ī': 'i', 'ķ': 'k', 'ļ': 'l',
+  'ņ': 'n', 'š': 's', 'ū': 'u', 'ž': 'z',
+  'Ā': 'A', 'Č': 'C', 'Ē': 'E', 'Ģ': 'G', 'Ī': 'I', 'Ķ': 'K', 'Ļ': 'L',
+  'Ņ': 'N', 'Š': 'S', 'Ū': 'U', 'Ž': 'Z'
+}
+const ARABIC_MAP = {
+  'أ': 'a', 'ب': 'b', 'ت': 't', 'ث': 'th', 'ج': 'g', 'ح': 'h', 'خ': 'kh', 'د': 'd',
+  'ذ': 'th', 'ر': 'r', 'ز': 'z', 'س': 's', 'ش': 'sh', 'ص': 's', 'ض': 'd', 'ط': 't',
+  'ظ': 'th', 'ع': 'aa', 'غ': 'gh', 'ف': 'f', 'ق': 'k', 'ك': 'k', 'ل': 'l', 'م': 'm',
+  'ن': 'n', 'ه': 'h', 'و': 'o', 'ي': 'y'
+}
+const LITHUANIAN_MAP = {
+  'ą': 'a', 'č': 'c', 'ę': 'e', 'ė': 'e', 'į': 'i', 'š': 's', 'ų': 'u',
+  'ū': 'u', 'ž': 'z',
+  'Ą': 'A', 'Č': 'C', 'Ę': 'E', 'Ė': 'E', 'Į': 'I', 'Š': 'S', 'Ų': 'U',
+  'Ū': 'U', 'Ž': 'Z'
+}
+const SERBIAN_MAP = {
+  'ђ': 'dj', 'ј': 'j', 'љ': 'lj', 'њ': 'nj', 'ћ': 'c', 'џ': 'dz',
+  'đ': 'dj', 'Ђ': 'Dj', 'Ј': 'j', 'Љ': 'Lj', 'Њ': 'Nj', 'Ћ': 'C',
+  'Џ': 'Dz', 'Đ': 'Dj'
+}
+const AZERBAIJANI_MAP = {
+  'ç': 'c', 'ə': 'e', 'ğ': 'g', 'ı': 'i', 'ö': 'o', 'ş': 's', 'ü': 'u',
+  'Ç': 'C', 'Ə': 'E', 'Ğ': 'G', 'İ': 'I', 'Ö': 'O', 'Ş': 'S', 'Ü': 'U'
+}
+const GEORGIAN_MAP = {
+  'ა': 'a', 'ბ': 'b', 'გ': 'g', 'დ': 'd', 'ე': 'e', 'ვ': 'v', 'ზ': 'z',
+  'თ': 't', 'ი': 'i', 'კ': 'k', 'ლ': 'l', 'მ': 'm', 'ნ': 'n', 'ო': 'o',
+  'პ': 'p', 'ჟ': 'j', 'რ': 'r', 'ს': 's', 'ტ': 't', 'უ': 'u', 'ფ': 'f',
+  'ქ': 'q', 'ღ': 'g', 'ყ': 'y', 'შ': 'sh', 'ჩ': 'ch', 'ც': 'c', 'ძ': 'dz',
+  'წ': 'w', 'ჭ': 'ch', 'ხ': 'x', 'ჯ': 'j', 'ჰ': 'h'
+}
+
+const ALL_DOWNCODE_MAPS = [
+  LATIN_MAP,
+  LATIN_SYMBOLS_MAP,
+  GREEK_MAP,
+  TURKISH_MAP,
+  ROMANIAN_MAP,
+  RUSSIAN_MAP,
+  UKRAINIAN_MAP,
+  CZECH_MAP,
+  SLOVAK_MAP,
+  POLISH_MAP,
+  LATVIAN_MAP,
+  ARABIC_MAP,
+  LITHUANIAN_MAP,
+  SERBIAN_MAP,
+  AZERBAIJANI_MAP,
+  GEORGIAN_MAP
+]
+
+let downcoderMap = {}
+let downcoderRegex = null
+
+const initialize = () => {
+  if (downcoderRegex) {
+    return
+  }
+
+  downcoderMap = {}
+  for (const lookup of ALL_DOWNCODE_MAPS) {
+    Object.assign(downcoderMap, lookup)
+  }
+  downcoderRegex = new RegExp(Object.keys(downcoderMap).map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'), 'g')
+}
+
+export const downcode = slug => {
+  initialize()
+  return slug.replace(downcoderRegex, function (m) {
+    return downcoderMap[m]
+  })
+}
+
+export const slugify = s => {
+  let slug = downcode(s)
+    .toLowerCase()
+    .trim()
+    .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
+    .replace(/\s/g, '-')
+
+  // TODO: Use LRU-Cache?
+
+  return slug
+}

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -109,7 +109,7 @@ class ExportHtml {
   }
 
   // render pure html by marked
-  async renderHtml () {
+  async renderHtml (toc) {
     this.mathRendererCalled = false
     let html = marked(this.markdown, {
       superSubScript: this.muya ? this.muya.options.superSubScript : false,
@@ -140,7 +140,13 @@ class ExportHtml {
           return `:${emoji}:`
         }
       },
-      mathRenderer: this.mathRenderer
+      mathRenderer: this.mathRenderer,
+      tocRenderer () {
+        if (!toc) {
+          return ''
+        }
+        return toc
+      }
     })
 
     html = sanitize(html, EXPORT_DOMPURIFY_CONFIG, false)
@@ -181,7 +187,7 @@ class ExportHtml {
 
     // WORKAROUND: Hide Prism.js style when exporting or printing. Otherwise the background color is white in the dark theme.
     const highlightCssStyle = printOptimization ? `@media print { ${highlightCss} }` : highlightCss
-    const html = this._prepareHtml(await this.renderHtml(), options)
+    const html = this._prepareHtml(await this.renderHtml(options.toc), options)
     const katexCssStyle = this.mathRendererCalled ? katexCss : ''
     this.mathRendererCalled = false
 

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -320,6 +320,7 @@ const importRegister = ContentState => {
           break
         }
 
+        case 'toc':
         case 'paragraph': {
           value = token.text
           block = this.createBlock('p')

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -101,7 +101,7 @@ import { isOsSpellcheckerSupported, offsetToWordCursor, validateLineCursor, Spel
 import { delay, isOsx, animatedScrollTo } from '@/util'
 import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
-import { getCssForOptions } from '@/util/pdf'
+import { getCssForOptions, getHtmlToc } from '@/util/pdf'
 import { addCommonStyle, setEditorWidth } from '@/util/theme'
 
 import 'muya/themes/default.css'
@@ -1020,7 +1020,8 @@ export default {
         header,
         footer,
         headerFooterStyled,
-        htmlTitle
+        htmlTitle,
+        tocEnabled
       } = options
 
       if (!/^pdf|print|styledHtml$/.test(type)) {
@@ -1028,13 +1029,16 @@ export default {
       }
 
       const extraCss = getCssForOptions(options)
+      const htmlToc = tocEnabled ? getHtmlToc(this.editor.getTOC(), options) : null
+
       switch (type) {
         case 'styledHtml': {
           try {
             const content = await this.editor.exportStyledHTML({
               title: htmlTitle || '',
               printOptimization: false,
-              extraCss
+              extraCss,
+              toc: htmlToc
             })
             this.$store.dispatch('EXPORT', { type, content })
           } catch (err) {
@@ -1059,6 +1063,7 @@ export default {
               title: '',
               printOptimization: true,
               extraCss,
+              toc: htmlToc,
               header,
               footer,
               headerFooterStyled
@@ -1083,6 +1088,7 @@ export default {
               title: '',
               printOptimization: true,
               extraCss,
+              toc: htmlToc,
               header,
               footer,
               headerFooterStyled

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -1020,8 +1020,7 @@ export default {
         header,
         footer,
         headerFooterStyled,
-        htmlTitle,
-        tocEnabled
+        htmlTitle
       } = options
 
       if (!/^pdf|print|styledHtml$/.test(type)) {
@@ -1029,7 +1028,7 @@ export default {
       }
 
       const extraCss = getCssForOptions(options)
-      const htmlToc = tocEnabled ? getHtmlToc(this.editor.getTOC(), options) : null
+      const htmlToc = getHtmlToc(this.editor.getTOC(), options)
 
       switch (type) {
         case 'styledHtml': {

--- a/src/renderer/components/exportSettings/index.vue
+++ b/src/renderer/components/exportSettings/index.vue
@@ -197,6 +197,7 @@
         <el-tab-pane label="Table of Contents" name="toc">
           <bool
             description="Include top heading:"
+            detailedDescription="Includes the first heading level too."
             :bool="tocIncludeTopHeading"
             :onChange="value => onSelectChange('tocIncludeTopHeading', value)"
           ></bool>
@@ -207,7 +208,6 @@
             :onChange="value => onSelectChange('tocTitle', value)"
           ></text-box>
          </el-tab-pane>
-
       </el-tabs>
       <div class="button-controlls">
         <button class="button-primary" @click="handleClicked">

--- a/src/renderer/components/exportSettings/index.vue
+++ b/src/renderer/components/exportSettings/index.vue
@@ -196,11 +196,6 @@
 
         <el-tab-pane label="Table of Contents" name="toc">
           <bool
-            description="Enable table of contents:"
-            :bool="tocEnabled"
-            :onChange="value => onSelectChange('tocEnabled', value)"
-          ></bool>
-          <bool
             description="Include top heading:"
             :bool="tocIncludeTopHeading"
             :onChange="value => onSelectChange('tocIncludeTopHeading', value)"
@@ -287,7 +282,6 @@ export default {
       headerFooterCustomize: false,
       headerFooterStyled: true,
       headerFooterFontSize: 12,
-      tocEnabled: false,
       tocTitle: '',
       tocIncludeTopHeading: true
     }
@@ -349,7 +343,6 @@ export default {
         headerFooterCustomize,
         headerFooterStyled,
         headerFooterFontSize,
-        tocEnabled,
         tocTitle,
         tocIncludeTopHeading
       } = this
@@ -366,7 +359,6 @@ export default {
         autoNumberingHeadings,
         showFrontMatter,
         theme: theme === 'default' ? null : theme,
-        tocEnabled,
         tocTitle,
         tocIncludeTopHeading
       }

--- a/src/renderer/components/exportSettings/index.vue
+++ b/src/renderer/components/exportSettings/index.vue
@@ -193,6 +193,26 @@
             ></range>
           </div>
         </el-tab-pane>
+
+        <el-tab-pane label="Table of Contents" name="toc">
+          <bool
+            description="Enable table of contents:"
+            :bool="tocEnabled"
+            :onChange="value => onSelectChange('tocEnabled', value)"
+          ></bool>
+          <bool
+            description="Include top heading:"
+            :bool="tocIncludeTopHeading"
+            :onChange="value => onSelectChange('tocIncludeTopHeading', value)"
+          ></bool>
+          <text-box
+            description="Title:"
+            :input="tocTitle"
+            :emitTime="0"
+            :onChange="value => onSelectChange('tocTitle', value)"
+          ></text-box>
+         </el-tab-pane>
+
       </el-tabs>
       <div class="button-controlls">
         <button class="button-primary" @click="handleClicked">
@@ -266,7 +286,10 @@ export default {
       footerTextRight: '',
       headerFooterCustomize: false,
       headerFooterStyled: true,
-      headerFooterFontSize: 12
+      headerFooterFontSize: 12,
+      tocEnabled: false,
+      tocTitle: '',
+      tocIncludeTopHeading: true
     }
   },
   computed: {
@@ -325,7 +348,10 @@ export default {
         footerTextRight,
         headerFooterCustomize,
         headerFooterStyled,
-        headerFooterFontSize
+        headerFooterFontSize,
+        tocEnabled,
+        tocTitle,
+        tocIncludeTopHeading
       } = this
       const options = {
         type: exportType,
@@ -339,7 +365,10 @@ export default {
         pageMarginLeft,
         autoNumberingHeadings,
         showFrontMatter,
-        theme: theme === 'default' ? null : theme
+        theme: theme === 'default' ? null : theme,
+        tocEnabled,
+        tocTitle,
+        tocIncludeTopHeading
       }
 
       if (!isPrintable) {

--- a/src/renderer/prefComponents/common/bool/index.vue
+++ b/src/renderer/prefComponents/common/bool/index.vue
@@ -5,6 +5,15 @@
       <i class="el-icon-info" v-if="more"
         @click="handleMoreClick"
       ></i>
+      <el-tooltip
+        v-else-if="detailedDescription"
+        :content="detailedDescription"
+        class="item"
+        effect="dark"
+        placement="top-start"
+      >
+        <i class="el-icon-info"></i>
+      </el-tooltip>
     </div>
     <el-switch
       v-model="status"
@@ -28,6 +37,7 @@ export default {
     bool: Boolean,
     onChange: Function,
     more: String,
+    detailedDescription: String,
     disable: {
       type: Boolean,
       default: false


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| New feature?      | yes
| Fixed tickets     | #80
| License           | MIT

### Description

Basic TOC generator for the document exporter that I used for quite a time. Maybe we should refactor the code and integrate it into our marked.js fork?

**Example:**

![example-toc](https://user-images.githubusercontent.com/22716132/99085143-233fc200-25c8-11eb-96b2-d42817bd34f9.png)

