### PR TITLE
Graphite light wordcount fix

### DIFF
--- a/src/renderer/assets/themes/graphite.theme.css
+++ b/src/renderer/assets/themes/graphite.theme.css
@@ -17,7 +17,7 @@
   --editorColor60: rgba(43, 48, 50, .6);
   --editorColor50: rgba(43, 48, 50, .5);
   --editorColor40: rgba(43, 48, 50, .4);
-  --editorColor30: rgba(43, 48, 50, .3);
+  --editorColor30: rgba(150, 150, 150, .8);
   --editorColor10: rgba(43, 48, 50, .1);
   --editorColor04: rgba(43, 48, 50, .04);
   --editorBgColor: #f7f7f7;

--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -18,7 +18,7 @@
           :key="file.id"
           :data-id="file.id"
           @click.stop="selectFile(file)"
-          @click.middle="closeTab(file)"
+          @click.middle="closeTab(file.id)"
           @contextmenu.prevent="handleContextMenu($event, file)"
         >
           <span>{{ file.filename }}</span>


### PR DESCRIPTION
Changed the color value of the word count color to be viewed against the sidebar in the graphite-light theme.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2363
| License           | MIT

### Description
Fixed the color of the word counter in the graphite light theme so that it is viewable on the side bar.
![image](https://user-images.githubusercontent.com/49735648/99142536-1eecc680-2613-11eb-99e0-fda86fec9957.png)
