### PR TITLE
fix: #2383 Fixed table creation grid highlight issue

### DIFF
--- a/src/muya/lib/ui/tablePicker/index.js
+++ b/src/muya/lib/ui/tablePicker/index.js
@@ -44,9 +44,6 @@ class TablePicker extends BaseFloat {
     let j
     for (i = 0; i < row; i++) {
       let rowSelector = 'div.ag-table-picker-row'
-      if (i === 0) {
-        rowSelector += '.ag-table-picker-header'
-      }
       const cells = []
       for (j = 0; j < column; j++) {
         let cellSelector = 'span.ag-table-picker-cell'


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? |no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2383   
| License           | MIT

### Description

First row of table create grid was always highlighted.

Fixed by deleting code adding '.ag-table-picker-header' class to the first row of the grid. 
This may have been left in as a check during development.
After removal table creation behaves normally.