### PR TITLE
Allow BCP-47 language codes in spell checker

### DIFF
--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -338,7 +338,7 @@
   },
   "spellcheckerLanguage": {
     "description": "Spelling--The spell checker language",
-    "pattern": "^[a-z]{2}(?:[-][A-Z]{2})?$",
+    "pattern": "^[a-z]{2,3}(?:[-](?:[0-9]|[a-zA-Z]){2,}){0,2}$",
     "default": "en-US"
   },
   "imageInsertAction": {

--- a/src/renderer/spellchecker/index.js
+++ b/src/renderer/spellchecker/index.js
@@ -296,8 +296,9 @@ export class SpellChecker {
     }
 
     if (!this.isHunspell) {
-      // NB: OS X will return lists that are half just a language, half
-      // language + locale, like ['en', 'pt_BR', 'ko']
+      // NOTE: OS X will return lists that are half just a language, half
+      // language + locale, like ['en', 'pt_BR', 'ko'] and Windows also returns
+      // BCP-47 ones.
       return this.provider.currentSpellchecker.getAvailableDictionaries()
         .map(x => {
           if (x.length === 2) return fallbackLocales[x]
@@ -307,6 +308,7 @@ export class SpellChecker {
             return null
           }
         })
+        .filter(x => { return !!x })
     }
 
     // Load hunspell dictionaries from disk.

--- a/src/renderer/spellchecker/languageMap.js
+++ b/src/renderer/spellchecker/languageMap.js
@@ -3,10 +3,10 @@ import langMap from 'iso-639-1'
 /**
  * Return the native language name by language code.
  *
- * @param {string} langCode The ISO two or four-letter language code (e.g. en, en-US).
+ * @param {string} langCode The ISO two or four-letter language code (e.g. en, en-US) or BCP-47 code.
  */
 export const getLanguageName = languageCode => {
-  if (!languageCode || (languageCode.length !== 2 && languageCode.length !== 5)) {
+  if (!languageCode || languageCode.length < 2) {
     return null
   }
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #2280
| License           | MIT

### Description

This PR allow BCP-47 language codes in spell checker to support some odd Windows languages like `en-029`. If you share your settings with another OS, the spell checker will eventually fail to load at start-up with an error message.
