### PR TITLE
Fix footnote inline code font size

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -246,6 +246,12 @@ figure[data-role="FOOTNOTE"] .ag-footnote-input::after {
   content: ']:';
 }
 
+figure[data-role="FOOTNOTE"] span code,
+figure[data-role="FOOTNOTE"] td code,
+figure[data-role="FOOTNOTE"] th code {
+  font-size: .8em;
+}
+
 .ag-highlight {
   animation-name: highlight;
   animation-duration: .25s;


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| License           | MIT

### Description

Changed footnote inline code font size from `14px` to default footnote font size.
