### PR TITLE
Add option to disable HTML rendering

### DIFF
--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -289,6 +289,11 @@
     "type": "boolean",
     "default": false
   },
+  "isHtmlEnabled": {
+    "description": "Markdown-Enable HTML rendering",
+    "type": "boolean",
+    "default": true
+  },
   "isGitlabCompatibilityEnabled": {
     "description": "Markdown-Enable GitLab compatibility mode.",
     "type": "boolean",

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -283,7 +283,10 @@ export const MUYA_DEFAULT_OPTION = Object.freeze({
   // Markdown extensions
   superSubScript: false,
   footnote: false,
-  isGitlabCompatibilityEnabled: false
+  isGitlabCompatibilityEnabled: false,
+
+  // Whether HTML rendering is disabled or not.
+  disableHtml: true
 })
 
 // export const DIAGRAM_TEMPLATE = Object.freeze({

--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -74,7 +74,8 @@ const pasteCtrl = ContentState => {
     }
 
     // Prevent XSS and sanitize HTML.
-    const sanitizedHtml = sanitize(html, PREVIEW_DOMPURIFY_CONFIG)
+    const { disableHtml } = this.muya.options
+    const sanitizedHtml = sanitize(html, PREVIEW_DOMPURIFY_CONFIG, disableHtml)
     const tempWrapper = document.createElement('div')
     tempWrapper.innerHTML = sanitizedHtml
 

--- a/src/muya/lib/parser/marked/options.js
+++ b/src/muya/lib/parser/marked/options.js
@@ -30,5 +30,7 @@ export default {
   frontMatter: true,
   superSubScript: false,
   footnote: false,
-  isGitlabCompatibilityEnabled: false
+  isGitlabCompatibilityEnabled: false,
+
+  isHtmlEnabled: true
 }

--- a/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
+++ b/src/muya/lib/parser/render/renderBlock/renderLeafBlock.js
@@ -132,7 +132,8 @@ export default function renderLeafBlock (parent, block, activeBlocks, matches, u
         selector += `.${CLASS_OR_ID.AG_HTML_PREVIEW}`
         Object.assign(data.attrs, { spellcheck: 'false' })
 
-        const htmlContent = sanitize(code, PREVIEW_DOMPURIFY_CONFIG)
+        const { disableHtml } = this.muya.options
+        const htmlContent = sanitize(code, PREVIEW_DOMPURIFY_CONFIG, disableHtml)
 
         // handle empty html bock
         if (/^<([a-z][a-z\d]*)[^>]*?>(\s*)<\/\1>$/.test(htmlContent.trim())) {

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -13,7 +13,7 @@ import { validEmoji } from '../ui/emojis'
 
 export const getSanitizeHtml = (markdown, options) => {
   const html = marked(markdown, options)
-  return sanitize(html, EXPORT_DOMPURIFY_CONFIG)
+  return sanitize(html, EXPORT_DOMPURIFY_CONFIG, false)
 }
 
 const DIAGRAM_TYPE = [
@@ -143,7 +143,7 @@ class ExportHtml {
       mathRenderer: this.mathRenderer
     })
 
-    html = sanitize(html, EXPORT_DOMPURIFY_CONFIG)
+    html = sanitize(html, EXPORT_DOMPURIFY_CONFIG, false)
 
     const exportContainer = this.exportContainer = document.createElement('div')
     exportContainer.classList.add('ag-render-container')
@@ -192,7 +192,7 @@ class ExportHtml {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${sanitize(title, EXPORT_DOMPURIFY_CONFIG)}</title>
+  <title>${sanitize(title, EXPORT_DOMPURIFY_CONFIG, true)}</title>
   <style>
   ${githubMarkdownCss}
   </style>
@@ -304,7 +304,7 @@ class ExportHtml {
     }
 
     output = output + createTableBody(html) + HF_TABLE_END
-    return sanitize(output, EXPORT_DOMPURIFY_CONFIG)
+    return sanitize(output, EXPORT_DOMPURIFY_CONFIG, false)
   }
 }
 

--- a/src/muya/lib/utils/index.js
+++ b/src/muya/lib/utils/index.js
@@ -6,6 +6,14 @@ let id = 0
 
 const TIMEOUT = 1500
 
+const HTML_TAG_REPLACEMENTS = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+}
+
 export const getUniqueId = () => `${ID_PREFIX}${id++}`
 
 export const getLongUniqueId = () => `${getUniqueId()}-${(+new Date()).toString(32)}`
@@ -322,6 +330,10 @@ export const escapeInBlockHtml = html => {
     })
 }
 
+export const escapeHtmlTags = html => {
+  return html.replace(/[&<>"']/g, x => { return HTML_TAG_REPLACEMENTS[x] })
+}
+
 export const wordCount = markdown => {
   const paragraph = markdown.split(/\n{2,}/).filter(line => line).length
   let word = 0
@@ -363,8 +375,12 @@ export const mixins = (constructor, ...object) => {
   return Object.assign(constructor.prototype, ...object)
 }
 
-export const sanitize = (html, options) => {
-  return runSanitize(escapeInBlockHtml(html), options)
+export const sanitize = (html, purifyOptions, disableHtml) => {
+  if (disableHtml) {
+    return runSanitize(escapeHtmlTags(html), purifyOptions)
+  } else {
+    return runSanitize(escapeInBlockHtml(html), purifyOptions)
+  }
 }
 
 export const getParagraphReference = (ele, id) => {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -140,6 +140,7 @@ export default {
       frontmatterType: state => state.preferences.frontmatterType,
       superSubScript: state => state.preferences.superSubScript,
       footnote: state => state.preferences.footnote,
+      isHtmlEnabled: state => state.preferences.isHtmlEnabled,
       isGitlabCompatibilityEnabled: state => state.preferences.isGitlabCompatibilityEnabled,
       lineHeight: state => state.preferences.lineHeight,
       fontSize: state => state.preferences.fontSize,
@@ -282,6 +283,13 @@ export default {
       const { editor } = this
       if (value !== oldValue && editor) {
         editor.setOptions({ footnote: value }, true)
+      }
+    },
+
+    isHtmlEnabled: function (value, oldValue) {
+      const { editor } = this
+      if (value !== oldValue && editor) {
+        editor.setOptions({ disableHtml: !value }, true)
       }
     },
 
@@ -525,6 +533,7 @@ export default {
         frontmatterType,
         superSubScript,
         footnote,
+        isHtmlEnabled,
         isGitlabCompatibilityEnabled,
         hideQuickInsertHint,
         editorLineWidth,
@@ -573,6 +582,7 @@ export default {
         frontmatterType,
         superSubScript,
         footnote,
+        disableHtml: !isHtmlEnabled,
         isGitlabCompatibilityEnabled,
         hideQuickInsertHint,
         hideLinkPopup,

--- a/src/renderer/prefComponents/markdown/index.vue
+++ b/src/renderer/prefComponents/markdown/index.vue
@@ -63,6 +63,11 @@
     <separator></separator>
     <h5>Compatibility</h5>
     <bool
+      description="Enable HTML rendering"
+      :bool="isHtmlEnabled"
+      :onChange="value => onSelectChange('isHtmlEnabled', value)"
+    ></bool>
+    <bool
       description="Enable GitLab compatibility mode"
       :bool="isGitlabCompatibilityEnabled"
       :onChange="value => onSelectChange('isGitlabCompatibilityEnabled', value)"
@@ -121,6 +126,7 @@ export default {
       frontmatterType: state => state.preferences.frontmatterType,
       superSubScript: state => state.preferences.superSubScript,
       footnote: state => state.preferences.footnote,
+      isHtmlEnabled: state => state.preferences.isHtmlEnabled,
       isGitlabCompatibilityEnabled: state => state.preferences.isGitlabCompatibilityEnabled,
       sequenceTheme: state => state.preferences.sequenceTheme
     })

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -47,6 +47,7 @@ const state = {
   frontmatterType: '-',
   superSubScript: false,
   footnote: false,
+  isHtmlEnabled: true,
   isGitlabCompatibilityEnabled: false,
   sequenceTheme: 'hand',
 

--- a/static/preference.json
+++ b/static/preference.json
@@ -43,6 +43,7 @@
   "frontmatterType": "-",
   "superSubScript": false,
   "footnote": false,
+  "isHtmlEnabled": true,
   "isGitlabCompatibilityEnabled": false,
   "sequenceTheme": "hand",
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| License           | MIT

### Description

Follow-up PR for #2360. This PR add the ability to disable HTML rendering in settings. For security reasons this settings option should be disabled by default and we should notify the user to enable this if we detect HTML. Currently this feature is enable by default!

For more security we should:

1. Disable HTML rendering by default and notify the user how to enable it, if needed.
2. Export the markdown document only in a separate and isolated window. If you bypass dompurify, you can still inject code via exporting - a quick and dirty workaround would be 3.
3. Fast verify the sanitized HTML and escape all HTML if the sanitized HTML looks suspicious.
