### PR TITLE
Fix symbolic links and related path issues

### DIFF
--- a/src/common/filesystem/index.js
+++ b/src/common/filesystem/index.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import path from 'path'
 
 /**
  * Test whether or not the given path exists.
@@ -45,6 +46,30 @@ export const isDirectory = dirPath => {
 }
 
 /**
+ * Returns true if the path is a directory or a symbolic link to a directory with read access.
+ *
+ * @param {string} dirPath The directory path.
+ */
+export const isDirectory2 = dirPath => {
+  try {
+    if (!fs.existsSync(dirPath)) {
+      return false
+    }
+
+    const fi = fs.lstatSync(dirPath)
+    if (fi.isDirectory()) {
+      return true
+    } else if (fi.isSymbolicLink()) {
+      const targetPath = path.resolve(path.dirname(dirPath), fs.readlinkSync(dirPath))
+      return isDirectory(targetPath)
+    }
+    return false
+  } catch (_) {
+    return false
+  }
+}
+
+/**
  * Returns true if the path is a file with read access.
  *
  * @param {string} filepath The file path.
@@ -52,6 +77,30 @@ export const isDirectory = dirPath => {
 export const isFile = filepath => {
   try {
     return fs.existsSync(filepath) && fs.lstatSync(filepath).isFile()
+  } catch (_) {
+    return false
+  }
+}
+
+/**
+ * Returns true if the path is a file or a symbolic link to a file with read access.
+ *
+ * @param {string} filepath The file path.
+ */
+export const isFile2 = filepath => {
+  try {
+    if (!fs.existsSync(filepath)) {
+      return false
+    }
+
+    const fi = fs.lstatSync(filepath)
+    if (fi.isFile()) {
+      return true
+    } else if (fi.isSymbolicLink()) {
+      const targetPath = path.resolve(path.dirname(filepath), fs.readlinkSync(filepath))
+      return isFile(targetPath)
+    }
+    return false
   } catch (_) {
     return false
   }

--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -1,6 +1,6 @@
 import fs from 'fs-extra'
 import path from 'path'
-import { isFile, isSymbolicLink } from './index'
+import { isFile, isFile2, isSymbolicLink } from './index'
 
 export const MARKDOWN_EXTENSIONS = Object.freeze([
   'markdown',
@@ -50,31 +50,19 @@ export const isImageFile = filepath => {
 }
 
 /**
- * Returns true if the path is a markdown file.
- *
- * @param {string} filepath The path or link path.
- */
-export const isMarkdownFile = filepath => {
-  return isFile(filepath) && hasMarkdownExtension(filepath)
-}
-
-/**
  * Returns true if the path is a markdown file or symbolic link to a markdown file.
  *
  * @param {string} filepath The path or link path.
  */
-export const isMarkdownFileOrLink = filepath => {
-  if (!isFile(filepath)) return false
-  if (hasMarkdownExtension(filepath)) {
-    return true
-  }
+export const isMarkdownFile = filepath => {
+  if (!isFile2(filepath)) return false
 
-  // Symbolic link to a markdown file
+  // Check symbolic link.
   if (isSymbolicLink(filepath)) {
-    const targetPath = fs.readlinkSync(filepath)
+    const targetPath = path.resolve(path.dirname(filepath), fs.readlinkSync(filepath))
     return isFile(targetPath) && hasMarkdownExtension(targetPath)
   }
-  return false
+  return hasMarkdownExtension(filepath)
 }
 
 /**

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -327,7 +327,7 @@ class App {
         directoriesToOpen[0].fileList.push(...filesToOpen)
         directoriesToOpen.length = 1
       } else {
-        directoriesToOpen.push({ rootDirectory: null, fileList: filesToOpen })
+        directoriesToOpen.push({ rootDirectory: null, fileList: [...filesToOpen] })
       }
       filesToOpen.length = 0
     }
@@ -541,7 +541,7 @@ class App {
         defaultPath: defaultDirectoryToOpen,
         properties: ['openDirectory', 'createDirectory']
       })
-      if (filePaths) {
+      if (filePaths && filePaths[0]) {
         preferences.setItems({ defaultDirectoryToOpen: filePaths[0] })
       }
     })

--- a/src/main/filesystem/markdown.js
+++ b/src/main/filesystem/markdown.js
@@ -3,8 +3,8 @@ import path from 'path'
 import log from 'electron-log'
 import iconv from 'iconv-lite'
 import { LINE_ENDING_REG, LF_LINE_ENDING_REG, CRLF_LINE_ENDING_REG } from '../config'
-import { isDirectory } from 'common/filesystem'
-import { isMarkdownFileOrLink } from 'common/filesystem/paths'
+import { isDirectory2 } from 'common/filesystem'
+import { isMarkdownFile } from 'common/filesystem/paths'
 import { normalizeAndResolvePath, writeFile } from '../filesystem'
 import { guessEncoding } from './encoding'
 
@@ -32,8 +32,8 @@ const convertLineEndings = (text, lineEnding) => {
  * directory hint or null if it's not a directory or markdown file.
  */
 export const normalizeMarkdownPath = pathname => {
-  const isDir = isDirectory(pathname)
-  if (isDir || isMarkdownFileOrLink(pathname)) {
+  const isDir = isDirectory2(pathname)
+  if (isDir || isMarkdownFile(pathname)) {
     // Normalize and resolve the path or link target.
     const resolved = normalizeAndResolvePath(pathname)
     if (resolved) {

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -4,7 +4,7 @@ import path from 'path'
 import log from 'electron-log'
 import isAccelerator from 'electron-is-accelerator'
 import electronLocalshortcut from '@hfelix/electron-localshortcut'
-import { isFile } from 'common/filesystem'
+import { isFile2 } from 'common/filesystem'
 import { isOsx } from '../config'
 import { getKeyboardLanguage, getVirtualLetters } from '../keyboard'
 
@@ -221,7 +221,7 @@ class Keybindings {
   }
 
   _loadLocalKeybindings () {
-    if (global.MARKTEXT_SAFE_MODE || !isFile(this.configPath)) {
+    if (global.MARKTEXT_SAFE_MODE || !isFile2(this.configPath)) {
       return
     }
 

--- a/src/main/menu/actions/edit.js
+++ b/src/main/menu/actions/edit.js
@@ -5,6 +5,11 @@ import { searchFilesAndDir } from '../../utils/imagePathAutoComplement'
 
 ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
   const win = BrowserWindow.fromWebContents(e.sender)
+  if (!src || src !== 'string') {
+    win.webContents.send(`mt::response-of-image-path-${id}`, [])
+    return
+  }
+
   if (src.endsWith('/') || src.endsWith('\\') || src.endsWith('.')) {
     return win.webContents.send(`mt::response-of-image-path-${id}`, [])
   }

--- a/src/main/menu/actions/edit.js
+++ b/src/main/menu/actions/edit.js
@@ -5,7 +5,7 @@ import { searchFilesAndDir } from '../../utils/imagePathAutoComplement'
 
 ipcMain.on('mt::ask-for-image-auto-path', (e, { pathname, src, id }) => {
   const win = BrowserWindow.fromWebContents(e.sender)
-  if (!src || src !== 'string') {
+  if (!src || typeof src !== 'string') {
     win.webContents.send(`mt::response-of-image-path-${id}`, [])
     return
   }

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -2,8 +2,8 @@ import fs from 'fs-extra'
 import path from 'path'
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import log from 'electron-log'
-import { isDirectory, isFile } from 'common/filesystem'
-import { MARKDOWN_EXTENSIONS, isMarkdownFile, isMarkdownFileOrLink } from 'common/filesystem/paths'
+import { isDirectory, isFile, exists } from 'common/filesystem'
+import { MARKDOWN_EXTENSIONS, isMarkdownFile } from 'common/filesystem/paths'
 import { EXTENSION_HASN, PANDOC_EXTENSIONS, URL_REG } from '../../config'
 import { normalizeAndResolvePath, writeFile } from '../../filesystem'
 import { writeMarkdownFile } from '../../filesystem/markdown'
@@ -301,7 +301,7 @@ ipcMain.on('mt::response-print', handleResponseForPrint)
 ipcMain.on('mt::window::drop', async (e, fileList) => {
   const win = BrowserWindow.fromWebContents(e.sender)
   for (const file of fileList) {
-    if (isMarkdownFileOrLink(file)) {
+    if (isMarkdownFile(file)) {
       openFileOrFolder(win, file)
       continue
     }
@@ -339,7 +339,7 @@ ipcMain.on('mt::rename', async (e, { id, pathname, newPathname }) => {
     })
   }
 
-  if (!isFile(newPathname)) {
+  if (!exists(newPathname)) {
     doRename()
   } else {
     const { response } = await dialog.showMessageBox(win, {
@@ -385,11 +385,16 @@ ipcMain.on('mt::ask-for-open-project-in-sidebar', async e => {
   })
 
   if (filePaths && filePaths[0]) {
-    ipcMain.emit('app-open-directory-by-id', win.id, filePaths[0], true)
+    const resolvedPath = normalizeAndResolvePath(filePaths[0])
+    ipcMain.emit('app-open-directory-by-id', win.id, resolvedPath, true)
   }
 })
 
 ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
+  if (!data || !data.href || typeof data.href !== 'string') {
+    return
+  }
+
   if (URL_REG.test(data.href)) {
     return shell.openExternal(data.href)
   }
@@ -475,7 +480,7 @@ export const openFile = async win => {
     }]
   })
 
-  if (filePaths && Array.isArray(filePaths)) {
+  if (Array.isArray(filePaths) && filePaths.length > 0) {
     ipcMain.emit('app-open-files-by-id', win.id, filePaths)
   }
 }

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { app, ipcMain, Menu } from 'electron'
 import log from 'electron-log'
-import { ensureDirSync, isDirectory, isFile } from 'common/filesystem'
+import { ensureDirSync, isDirectory2, isFile2 } from 'common/filesystem'
 import { isLinux, isOsx, isWindows } from '../config'
 import { parseMenu } from '../keyboard/shortcutHandler'
 import { updateSidebarMenu } from '../menu/actions/edit'
@@ -80,13 +80,13 @@ class AppMenu {
    */
   getRecentlyUsedDocuments () {
     const { RECENTS_PATH } = this
-    if (!isFile(RECENTS_PATH)) {
+    if (!isFile2(RECENTS_PATH)) {
       return []
     }
 
     try {
       const recentDocuments = JSON.parse(fs.readFileSync(RECENTS_PATH, 'utf-8'))
-        .filter(f => f && (isFile(f) || isDirectory(f)))
+        .filter(f => f && (isFile2(f) || isDirectory2(f)))
 
       if (recentDocuments.length > MAX_RECENTLY_USED_DOCUMENTS) {
         recentDocuments.splice(MAX_RECENTLY_USED_DOCUMENTS, recentDocuments.length - MAX_RECENTLY_USED_DOCUMENTS)

--- a/src/main/utils/pandoc.js
+++ b/src/main/utils/pandoc.js
@@ -1,7 +1,7 @@
 // Copy from https://github.com/utatti/simple-pandoc/blob/master/index.js
 import { spawn } from 'child_process'
 import commandExists from 'command-exists'
-import { isFile } from 'common/filesystem'
+import { isFile2 } from 'common/filesystem'
 
 const pandocCommand = 'pandoc'
 
@@ -45,7 +45,7 @@ pandoc.exists = () => {
 }
 
 const envPathExists = () => {
-  return !!process.env.MARKTEXT_PANDOC && isFile(process.env.MARKTEXT_PANDOC)
+  return !!process.env.MARKTEXT_PANDOC && isFile2(process.env.MARKTEXT_PANDOC)
 }
 
 export default pandoc

--- a/src/main/windows/editor.js
+++ b/src/main/windows/editor.js
@@ -256,7 +256,7 @@ class EditorWindow extends BaseWindow {
    * @param {string} pathname The directory path.
    */
   openFolder (pathname) {
-    if (this.lifecycle === WindowLifecycle.QUITTED ||
+    if (!pathname || this.lifecycle === WindowLifecycle.QUITTED ||
       isSamePathSync(pathname, this._openedRootDirectory)) {
       return
     }

--- a/src/renderer/components/exportSettings/index.vue
+++ b/src/renderer/components/exportSettings/index.vue
@@ -207,6 +207,7 @@
 import { mapState } from 'vuex'
 import fs from 'fs-extra'
 import path from 'path'
+import { isDirectory, isFile } from 'common/filesystem'
 import bus from '../../bus'
 import Bool from '@/prefComponents/common/bool'
 import CurSelect from '@/prefComponents/common/select'
@@ -393,10 +394,10 @@ export default {
       const themeDir = path.join(userDataPath, 'themes/export')
 
       // Search for dictionaries on filesystem.
-      if (fs.existsSync(themeDir) && fs.lstatSync(themeDir).isDirectory()) {
+      if (isDirectory(themeDir)) {
         fs.readdirSync(themeDir).forEach(async filename => {
           const fullname = path.join(themeDir, filename)
-          if (/.+\.css$/i.test(filename) && fs.lstatSync(fullname).isFile()) {
+          if (/.+\.css$/i.test(filename) && isFile(fullname)) {
             try {
               const content = await fs.readFile(fullname, 'utf8')
 

--- a/src/renderer/spellchecker/index.js
+++ b/src/renderer/spellchecker/index.js
@@ -3,6 +3,7 @@ import path from 'path'
 import os from 'os'
 import { remote } from 'electron'
 import { SpellCheckHandler, fallbackLocales, normalizeLanguageCode } from '@hfelix/electron-spellchecker'
+import { isDirectory, isFile } from 'common/filesystem'
 import { cloneObj, isOsx, isLinux, isWindows } from '@/util'
 
 // NOTE: Hardcoded in "@hfelix/electron-spellchecker/src/spell-check-handler.js"
@@ -74,11 +75,11 @@ export const validateLineCursor = selection => {
 export const getAvailableHunspellDictionaries = () => {
   const dict = []
   // Search for dictionaries on filesystem.
-  if (fs.existsSync(dictionaryPath) && fs.lstatSync(dictionaryPath).isDirectory()) {
+  if (isDirectory(dictionaryPath)) {
     fs.readdirSync(dictionaryPath).forEach(filename => {
       const fullname = path.join(dictionaryPath, filename)
       const match = filename.match(/^([a-z]{2}(?:[-][A-Z]{2})?)\.bdic$/)
-      if (match && match[1] && fs.lstatSync(fullname).isFile()) {
+      if (match && match[1] && isFile(fullname)) {
         dict.push(match[1])
       }
     })


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | fixes #2373, fixes #2325, fixes #2355
| License           | MIT

### Description

1. Fixed file and directory detection on symbolic links.
2. Fixed an issue that the file list disappears when launching Mark Text with `--new-window`.
3. Fixed an issue that an empty editor was opened when you cancel the file selection dialog.
4. The PR should also fix #2355.
