### PR TITLE
Fix font selection autocomplete

### DIFF
--- a/src/renderer/prefComponents/common/fontTextBox/index.vue
+++ b/src/renderer/prefComponents/common/fontTextBox/index.vue
@@ -48,6 +48,7 @@ import fontManager from 'fontmanager-redux'
 
 export default {
   data () {
+    this.defaultValue = this.value
     return {
       fontFamilies: [],
       selectValue: this.value
@@ -71,6 +72,7 @@ export default {
   watch: {
     value: function (value, oldValue) {
       if (value !== oldValue) {
+        this.defaultValue = value
         this.selectValue = value
       }
     }
@@ -79,7 +81,7 @@ export default {
   methods: {
     querySearch (queryString, callback) {
       const fontFamilies = this.fontFamilies
-      const results = queryString
+      const results = queryString && this.defaultValue !== queryString
         ? fontFamilies.filter(f => f.toLowerCase().indexOf(queryString.toLowerCase()) === 0)
         : fontFamilies
       callback(results)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #1908
| License           | MIT

### Description

Fixed the linked issue that only one font was displayed. The reason was that `queryString` was initial the default font family and the whole list was filtered by that name. Now, we show the whole list for the default font or when an empty text is searched.
