### PR TITLE
Disable MathML due to DOMPurify security issues

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -226,8 +226,9 @@ export const PREVIEW_DOMPURIFY_CONFIG = Object.freeze({
     html: true,
     svg: true,
     svgFilters: true,
-    mathMl: true
-  }
+    mathMl: false
+  },
+  RETURN_TRUSTED_TYPE: false
 })
 
 export const EXPORT_DOMPURIFY_CONFIG = Object.freeze({
@@ -238,8 +239,9 @@ export const EXPORT_DOMPURIFY_CONFIG = Object.freeze({
     html: true,
     svg: true,
     svgFilters: true,
-    mathMl: true
+    mathMl: false
   },
+  RETURN_TRUSTED_TYPE: false,
   // Allow "file" protocol to export images on Windows (#1997).
   ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i // eslint-disable-line no-useless-escape
 })


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

I disabled MathML in our sanitizer (remove all MathML elements) because DOMPurify had a few MathML exploits in the recent time and we don't use this feature. Also I made explicit that we want a string returned.
