### PR TITLE
Fix unable to open URL

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -409,19 +409,20 @@ ipcMain.on('mt::ask-for-open-project-in-sidebar', async e => {
 })
 
 ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
-  if (!data || !data.href || typeof data.href !== 'string') {
+  if (!data || (!data.href && !data.text)) {
     return
   }
 
-  if (URL_REG.test(data.href)) {
-    return shell.openExternal(data.href)
+  const href = data.href || data.text
+  if (URL_REG.test(href)) {
+    return shell.openExternal(href)
   }
+
   let pathname = null
-  if (path.isAbsolute(data.href) && isMarkdownFile(data.href)) {
-    pathname = data.href
-  }
-  if (!path.isAbsolute(data.href) && isMarkdownFile(path.join(dirname, data.href))) {
-    pathname = path.join(dirname, data.href)
+  if (path.isAbsolute(href) && isMarkdownFile(href)) {
+    pathname = href
+  } else if (!path.isAbsolute(href) && isMarkdownFile(path.join(dirname, href))) {
+    pathname = path.join(dirname, href)
   }
   if (pathname) {
     const win = BrowserWindow.fromWebContents(e.sender)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | #2319
| License           | MIT

### Description

Revert attempt to fix #2355 in #2416 and add a proper fix because `href` is `null`.

Example: `[https://www.google.com]()` -> `href: null` but `text: https://www.google.com` where as `[https://www.google.de](https://www.google.com)` is `href: https://www.google.com` but `text: https://www.google.de`.
