### PR TITLE
Fixed: `The file already exists` always pop up even that file doesn't exist.

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -357,7 +357,7 @@ ipcMain.on('mt::rename', async (e, { id, pathname, newPathname }) => {
     })
   }
 
-  if (!exists(newPathname)) {
+  if (!await exists(newPathname)) {
     doRename()
   } else {
     const { response } = await dialog.showMessageBox(win, {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2489
| License           | MIT

### Description
`exists()` is an async function, therefore it returns a `Promise<boolean>` and must `await` / `.then()` it. `!(Promise<boolean>)` will always `false` since `Promise<boolean>` never goes `undefined` or `null`, so the checker will always prompt `The file "${path.basename(newPathname)}" already exists. Do you want to replace it?`, and the `true` branch will be never reached.