### PR TITLE
build instructions: Correct case for libX11

### DIFF
--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -17,14 +17,14 @@ Before you can get started developing, you need set up your build environment:
 
 **Additional development dependencies on Linux:**
 
-- libx11 (dev)
-- libxkbfile (dev)
-- libsecret (dev)
-- libfontconfig (dev)
+- libX11 (with headers)
+- libxkbfile (with headers)
+- libsecret (with headers)
+- libfontconfig (with headers)
 
 On Debian-based Linux: `sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev libfontconfig-dev`
 
-On Red Hat-based Linux: `sudo dnf install libx11-devel libxkbfile-devel libsecret-devel fontconfig-devel`
+On Red Hat-based Linux: `sudo dnf install libX11-devel libxkbfile-devel libsecret-devel fontconfig-devel`
 
 **Additional development dependencies on Windows:**
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes (in documentation)
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Facts

On Fedora and RHEL/CentOS, the package is spelled `libX11-devel`, with capital X.
Reference: https://pkgs.org/search/?q=libx11
I'm on Fedora 32, attempting `dnf install libx11-devel` didn't work, with capital X did.

### Subjective changes in list of dependencies for humans

On Debian-based distros, the convention for package names is all lowercase, but the installed library file is something like `/usr/lib/x86_64-linux-gnu/libX11.so.6`, and header files have capital X11 e.g. `/usr/include/X11/Xlib.h`, so informally calling it "libX11" is slightly more precise.

(Whereas libxkbfile is lowercase package on all platforms, `libxkbfile.so.1.0.2` library, but `/usr/include/X11/extensions/XKBfile.h` headers. https://pkgs.org/search/?q=libxkbfile)

"(with headers)" is IMHO clearer than "(dev)" but entirely subjective :shrug: 