### PR TITLE
Open other files with associated application

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -418,15 +418,12 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
     return shell.openExternal(href)
   }
 
-  let pathname = null
-  if (path.isAbsolute(href) && isMarkdownFile(href)) {
-    pathname = href
-  } else if (!path.isAbsolute(href) && isMarkdownFile(path.join(dirname, href))) {
-    pathname = path.join(dirname, href)
-  }
-  if (pathname) {
+  let pathname = path.isAbsolute(href) ? href : path.join(dirname, href)
+  if (isMarkdownFile(pathname)) {
     const win = BrowserWindow.fromWebContents(e.sender)
     return openFileOrFolder(win, pathname)
+  } else {
+    return shell.openPath(pathname)
   }
 })
 


### PR DESCRIPTION
Open other files (not markdown) with associated application

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #2540
| License           | MIT

### Description

It should be possible to give links to files in local directory. These links should be opened with associated application (libreoffice etc.). This behaviour exists in typora.
