### PR TITLE
Open non-markdown files in default application #2396

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -419,14 +419,19 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
   }
 
   let pathname = null
-  if (path.isAbsolute(href) && isMarkdownFile(href)) {
+  if (path.isAbsolute(href)) {
     pathname = href
-  } else if (!path.isAbsolute(href) && isMarkdownFile(path.join(dirname, href))) {
+  } else if (dirname && !path.isAbsolute(href)) {
     pathname = path.join(dirname, href)
   }
-  if (pathname) {
+
+  if (pathname && isMarkdownFile(pathname)) {
     const win = BrowserWindow.fromWebContents(e.sender)
     return openFileOrFolder(win, pathname)
+  } else if (pathname) {
+    // const win = BrowserWindow.fromWebContents(e.sender)
+    // return openFileOrFolder(win, pathname)
+    return shell.openPath(pathname)
   }
 })
 

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -429,8 +429,6 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     return openFileOrFolder(win, pathname)
   } else if (pathname) {
-    // const win = BrowserWindow.fromWebContents(e.sender)
-    // return openFileOrFolder(win, pathname)
     return shell.openPath(pathname)
   }
 })


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #2396 
| License           | MIT

Local links to non-markdown files will open in the default application. 

Also checks that dirname has a value before joining it in pathname (was suggested in the discussion under this issue). 
