### PR TITLE
Search when invoked should get prefilled from the currently selected text #1729

### DIFF
--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -133,6 +133,7 @@ export default {
   created () {
     this.keyword = this.searchMatches.value
     bus.$on('findInFolder', this.handleFindInFolder)
+    this.search()
   },
   computed: {
     ...mapState({


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #1729
| License           | MIT

### Description

When performing a global search after highlighting a word or phrase, it will now automatically perform the search through all files without the user having to press "enter" on the search bar
