### PR TITLE
Fix typo in `paths.js`

### DIFF
--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -39,7 +39,7 @@ export const hasMarkdownExtension = filename => {
 }
 
 /**
- * Returns ture if the path is an image file.
+ * Returns true if the path is an image file.
  *
  * @param {string} filepath The path
  */


### PR DESCRIPTION
In the jsdoc comment for `isImageFile()`, 'true' is misspelled as 'ture'.  This pr simply fixes that.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

Fixes the aforementioned typo in the documentation comment of one function.
