### PR TITLE
Changing the output format to gfm instead markdown due table missform…

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -189,7 +189,7 @@ const noticePandocNotFound = win => {
 
 const openPandocFile = async (windowId, pathname) => {
   try {
-    const converter = pandoc(pathname, 'markdown')
+    const converter = pandoc(pathname, 'gfm')
     const data = await converter()
     ipcMain.emit('app-open-markdown-by-id', windowId, data)
   } catch (err) {


### PR DESCRIPTION
Changing the output format to gfm instead markdown due table missformating during the import

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | no
| License           | MIT

### Description

Changing the pandoc output format to `gfm` instead `markdown` due table missformating during the import
