### PR TITLE
Issue 2566: Do not complete markdown syntax if the previous character…

### DIFF
--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -208,6 +208,9 @@ const inputCtrl = ContentState => {
           const isInInlineMath = this.checkCursorInTokenType(block.functionType, text, offset, 'inline_math')
           const isInInlineCode = this.checkCursorInTokenType(block.functionType, text, offset, 'inline_code')
           if (
+            // Issue 2566: Do not complete markdown syntax if the previous character is
+            // alphanumeric.
+            (!/[a-z0-9]{1}/i.test(preInputChar) || !/[*$`~_]{1}/.test(inputChar)) &&
             !/\\/.test(preInputChar) &&
             ((autoPairQuote && /[']{1}/.test(inputChar) && !(/[a-zA-Z\d]{1}/.test(preInputChar))) ||
             (autoPairQuote && /["]{1}/.test(inputChar)) ||


### PR DESCRIPTION
… is alphanumeric.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no (tough one could argue...)
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #2566
| License           | MIT

### Description

Currently markdown characters (*$`~_) are completed unconditionally, which gets in user's way if one needs to use any of these characters in a non-markdown context, like typing "hello_world" or "33$" as it unwantedly doubles the respective characters.

Note that this PR does not affect brackets as users might use them directly after words.

This commit changes the behaviour similar to how Typora handles this:
Markdown syntax characters are not completed if the character before the cursor if alphanumeric.