### PR TITLE
Fix a typo (Paragraphs instead of Paragraph) in the counter tooltip

### DIFF
--- a/src/renderer/components/titleBar/index.vue
+++ b/src/renderer/components/titleBar/index.vue
@@ -52,7 +52,7 @@
               <span class="front">Characters:</span><span class="text">{{wordCount['character']}}</span>
             </div>
             <div class="title-item">
-              <span class="front">Paragraph:</span><span class="text">{{wordCount['paragraph']}}</span>
+              <span class="front">Paragraphs:</span><span class="text">{{wordCount['paragraph']}}</span>
             </div>
           </div>
           <div


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

Fixes a typo in "Paragraph" for consistency with other elements in the counter toolip (Words, Characters, Paragraphs).
