### PR TITLE
Docs: Add link pointing 'download the AppImage' to the latest release

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -2,7 +2,7 @@
 
 ## AppImage
 
-Download the AppImage and type the following:
+[Download the AppImage](https://github.com/marktext/marktext/releases/latest) and type the following:
 
 1. `chmod +x marktext-%version%-x86_64.AppImage`
 2. `./marktext-%version%-x86_64.AppImage`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

Just a small suggestion to link "download the AppImage" in the first line of the Linux documentation to the place where you can actually download that file.
