### PR TITLE
fix: unable to un-indent a list item

### DIFF
--- a/src/muya/lib/contentState/tabCtrl.js
+++ b/src/muya/lib/contentState/tabCtrl.js
@@ -309,7 +309,7 @@ const tabCtrl = ContentState => {
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)
 
-    if (event.shiftKey && !startBlock.functionType === 'cellContent') {
+    if (event.shiftKey && startBlock.functionType !== 'cellContent') {
       const unindentType = this.isUnindentableListItem(startBlock)
       if (unindentType) {
         this.unindentListItem(startBlock, unindentType)


### PR DESCRIPTION
fixes issue #2466 where shift-tab did not un-indent a list item

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2466 
| License           | MIT

### Description

Fixes issue of not being able to shift-tab to un-indent list item
