### PR TITLE
add link to FAQ in Aidou preference

### DIFF
--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -47,6 +47,7 @@
       description="Use Aidou"
       :bool="aidou"
       :onChange="value => onSelectChange('aidou', value)"
+      more="https://github.com/marktext/marktext/blob/develop/docs/FAQ.md#what-is-a-aidou-"
     ></bool>
     <separator></separator>
     <cur-select


### PR DESCRIPTION
There are a lot of questions regarding [what is Aidou](https://github.com/marktext/marktext/issues/1286). There is a [little explanation in the FAQ](https://github.com/marktext/marktext/blob/develop/docs/FAQ.md#what-is-a-aidou-), so I added a 'more' link to that article on the preference.

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #[1286](https://github.com/marktext/marktext/issues/1286)
| License           | MIT

---

See also [here](https://github.com/marktext/marktext/pull/2693) for clarification of docs.