### PR TITLE
fix new tab filepath err

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -133,6 +133,8 @@ const handleResponseForSave = async (e, { id, filename, markdown, pathname, opti
   }
 
   filePath = path.resolve(filePath)
+  const extension = path.extname(filePath) || '.md'
+  filePath = !filePath.endsWith(extension) ? filePath += extension : filePath
   return writeMarkdownFile(filePath, markdown, options, win)
     .then(() => {
       if (!alreadyExistOnDisk) {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      |no
| Breaking changes? |/no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

Description
Make sure that the filepath written to tab is the filepath that has processed the suffix name

[Description of the bug or feature]
When saving a new tag, the saved real filepath is inconsistent with the filepath written to the tab, resulting in two different tags of the same file