### PR TITLE
support custom command as image uploader

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,6 +38,8 @@ files:
 - "!node_modules/@hfelix/spellchecker/vendor"
 extraFiles:
 - "LICENSE"
+- from: "static/logo-small.png"
+  to: "logo.png"
 - from: "resources/THIRD-PARTY-LICENSES.txt"
   to: "THIRD-PARTY-LICENSES.txt"
 extraResources:

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -74,8 +74,8 @@
             :uploaderService="uploadServices.custom"
           ></legal-notices-checkbox>
           <div class="form-group">
-            <el-button size="mini" @click="testCustomCommand()">Test</el-button>
-            <el-button size="mini" @click="setCurrentUploader('custom')"
+            <el-button size="mini" :disabled="customDisable" @click="testCustomCommand()">Test</el-button>
+            <el-button size="mini" :disabled="customDisable" @click="setCurrentUploader('custom')"
               >Set as default</el-button
             >
           </div>
@@ -152,6 +152,9 @@ export default {
     },
     githubDisable () {
       return !this.githubToken || !this.github.owner || !this.github.repo
+    },
+    customDisable () {
+      return !this.command
     }
   },
   watch: {

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -87,7 +87,7 @@
             <span>{{ testResultOutput }}</span>
 
             <span slot="footer" class="dialog-footer">
-              <el-button type="primary" @click="testResultOpen('https://www.baidu.com')">{{ testResultButton }}</el-button>
+              <el-button type="primary" @click="testResultOpen()">{{ testResultButton }}</el-button>
             </span>
           </el-dialog>
         </el-tab-pane>
@@ -232,7 +232,7 @@ export default {
         this.testResultButton = 'OPEN'
       })
     },
-    testResultOpen (url) {
+    testResultOpen () {
       this.testResultDialogVisible = false
       if (this.testResultButton === 'OPEN') {
          this.open(this.testResultOutput)

--- a/src/renderer/prefComponents/imageUploader/index.vue
+++ b/src/renderer/prefComponents/imageUploader/index.vue
@@ -162,7 +162,9 @@ export default {
     }
   },
   created () {
-    this.activeTab = this.currentUploader
+    if (this.currentUploader && this.currentUploader !== 'none') {
+      this.activeTab = this.currentUploader
+    }
     this.$nextTick(() => {
       this.github = this.imageBed.github
       this.githubToken = this.prefGithubToken

--- a/src/renderer/prefComponents/imageUploader/services.js
+++ b/src/renderer/prefComponents/imageUploader/services.js
@@ -35,6 +35,16 @@ const services = {
 
     // Currently a non-persistent value
     agreedToLegalNotices: false
+  },
+
+  custom: {
+    name: 'custom',
+    isGdprCompliant: false,
+    privacyUrl: '',
+    tosUrl: '',
+
+    // Set to true to always allow to change to this dummy service
+    agreedToLegalNotices: false
   }
 }
 

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -87,6 +87,7 @@ const state = {
   webImages: [],
   cloudImages: [],
   currentUploader: 'none',
+  command: '',
   githubToken: '',
   imageBed: {
     github: {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | yes
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

Support custom command as image uploader.
`Command` receives a picture path as a parameter, and the output result is a picture link.
The `Test` button will upload the `logo.png` in the installation root directory to the specified image bed to test whether the command is available.
<img width="715" alt="image" src="https://user-images.githubusercontent.com/51874567/146777911-fbe8b16e-92d1-49e8-8383-ea3d213620ca.png">
