### PR TITLE
Removed the space in 'Mark Text' (#2763)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -188,7 +188,7 @@ v0.15.1 is an unplanned release to fix a XSS security vulnerability.
 - Added portable zip archive for both x86 and x64 Windows.
 - Changed `viewToggleFullScreen` and `windowCloseWindow` key bindings to `windowToggleFullScreen` and `fileCloseWindow`.
 - Removed `viewChangeFont` key binding.
-- Mark Text is now single-instance application on Linux and Windows too.
+- MarkText is now single-instance application on Linux and Windows too.
 
 **:cactus:Feature**
 
@@ -199,7 +199,7 @@ v0.15.1 is an unplanned release to fix a XSS security vulnerability.
 - add tab scrolling and drag&drop (#953)
 - Support to replace the root folder in a window
 - Second-instance files and directories via command-line are opened in the best window
-- Mark Text can use a default directory that is automatically opened during startup (#711)
+- MarkText can use a default directory that is automatically opened during startup (#711)
 - New CLI flags: `--disable-gpu`, `-n,--new-window` and `--user-data-dir`
 - Find in files use ripgrep as searcher.
 - You can know automatically save your document after a predefined intervall.
@@ -294,7 +294,7 @@ foo<section>bar</section>zar
 - Making images display smaller (#659)
 - Open local markdown file when you click on it in another tab (#359)
 - Clicking a link should open it in the browser (#425)
-- Support maxOS `dark mode`, when you change `mode dark or light` in system, Mark Text will change its theme.
+- Support maxOS `dark mode`, when you change `mode dark or light` in system, MarkText will change its theme.
 - Add new themes: Ulysses Light, Graphite Light, Material Dark and One Dark.
 - Watch file changed in tabs and show a notice(autoSave is `false`) or update the file(autoSave is `true`)
 - Support input inline Ruby charactors as raw html (#257)
@@ -327,7 +327,7 @@ foo<section>bar</section>zar
 - Fix dark preview box background color (#587)
 - Use white PDF background color (#583)
 - Fix document printing
-- Restore default Mark Text style after exporting/printing
+- Restore default MarkText style after exporting/printing
 - Prevent enter key as language identifier (#569)
 - Allow pasting text into the code block language text-box (#553)
 - Fixed a crash when opening a directory with an unknown file extension
@@ -373,7 +373,7 @@ foo<section>bar</section>zar
 - Fixed list parse error [more info](https://github.com/marktext/marktext/issues/831#issuecomment-477719256)
 - Fixed source code mode tab switching
 - Fixed source code mode to preview switching
-- Mark Text didn't remove highlight when I delete the markdown symbol like * or `. (#893)
+- MarkText didn't remove highlight when I delete the markdown symbol like * or `. (#893)
 - After delete ``` at the beginning to paragraph by backspace, then type other text foo, the color will be strange, if you type 1. bar. error happened. (#892)
 - Fix highlight error in code block (#545 #890)
 - Fix files sorting in folder (#438)
@@ -565,7 +565,7 @@ foo<section>bar</section>zar
 
 **:notebook_with_decorative_cover:​Note**
 
-You need uninstall the old version of Mark Text before install version 0.10.21, because we changed the AppId when build.
+You need uninstall the old version of MarkText before install version 0.10.21, because we changed the AppId when build.
 
 **:cactus:Feature**
 
@@ -638,9 +638,9 @@ You need uninstall the old version of Mark Text before install version 0.10.21, 
 
 **:cactus:Feature**
 
-- Add user preferences in `Mark Text menu`, the shoutcut is `CmdorCtrl + ,`, you can set the default `theme` and `autoSave`.
-- Add `autoSave` to `file menu`, the default value is in `preferences.md` which you can open in `Mark Text menu`. #45
-- Add drag and drop to open Markdown file with Mark Text @fxha
+- Add user preferences in `MarkText menu`, the shoutcut is `CmdorCtrl + ,`, you can set the default `theme` and `autoSave`.
+- Add `autoSave` to `file menu`, the default value is in `preferences.md` which you can open in `MarkText menu`. #45
+- Add drag and drop to open Markdown file with MarkText @fxha
 - User setting: fontSize, lineHeight, color in realtime mode.
 - Move your file to other folder @DXXL
 - Rename filename
@@ -652,7 +652,7 @@ You need uninstall the old version of Mark Text before install version 0.10.21, 
 
 **:beetle:Bug fix**
 
-- fix: prevent open image or file directly when drag and drop over Mark Text #42
+- fix: prevent open image or file directly when drag and drop over MarkText #42
 - fix: set theme to all the open window not just the active one.
 - fix: set correct application menu offset on windows #44
 - fix: Missing preferences menu in Linux and Windows. @fxha

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -188,7 +188,7 @@ v0.15.1 is an unplanned release to fix a XSS security vulnerability.
 - Added portable zip archive for both x86 and x64 Windows.
 - Changed `viewToggleFullScreen` and `windowCloseWindow` key bindings to `windowToggleFullScreen` and `fileCloseWindow`.
 - Removed `viewChangeFont` key binding.
-- MarkText is now single-instance application on Linux and Windows too.
+- Mark Text is now single-instance application on Linux and Windows too.
 
 **:cactus:Feature**
 
@@ -199,7 +199,7 @@ v0.15.1 is an unplanned release to fix a XSS security vulnerability.
 - add tab scrolling and drag&drop (#953)
 - Support to replace the root folder in a window
 - Second-instance files and directories via command-line are opened in the best window
-- MarkText can use a default directory that is automatically opened during startup (#711)
+- Mark Text can use a default directory that is automatically opened during startup (#711)
 - New CLI flags: `--disable-gpu`, `-n,--new-window` and `--user-data-dir`
 - Find in files use ripgrep as searcher.
 - You can know automatically save your document after a predefined intervall.
@@ -294,7 +294,7 @@ foo<section>bar</section>zar
 - Making images display smaller (#659)
 - Open local markdown file when you click on it in another tab (#359)
 - Clicking a link should open it in the browser (#425)
-- Support maxOS `dark mode`, when you change `mode dark or light` in system, MarkText will change its theme.
+- Support maxOS `dark mode`, when you change `mode dark or light` in system, Mark Text will change its theme.
 - Add new themes: Ulysses Light, Graphite Light, Material Dark and One Dark.
 - Watch file changed in tabs and show a notice(autoSave is `false`) or update the file(autoSave is `true`)
 - Support input inline Ruby charactors as raw html (#257)
@@ -327,7 +327,7 @@ foo<section>bar</section>zar
 - Fix dark preview box background color (#587)
 - Use white PDF background color (#583)
 - Fix document printing
-- Restore default MarkText style after exporting/printing
+- Restore default Mark Text style after exporting/printing
 - Prevent enter key as language identifier (#569)
 - Allow pasting text into the code block language text-box (#553)
 - Fixed a crash when opening a directory with an unknown file extension
@@ -373,7 +373,7 @@ foo<section>bar</section>zar
 - Fixed list parse error [more info](https://github.com/marktext/marktext/issues/831#issuecomment-477719256)
 - Fixed source code mode tab switching
 - Fixed source code mode to preview switching
-- MarkText didn't remove highlight when I delete the markdown symbol like * or `. (#893)
+- Mark Text didn't remove highlight when I delete the markdown symbol like * or `. (#893)
 - After delete ``` at the beginning to paragraph by backspace, then type other text foo, the color will be strange, if you type 1. bar. error happened. (#892)
 - Fix highlight error in code block (#545 #890)
 - Fix files sorting in folder (#438)
@@ -565,7 +565,7 @@ foo<section>bar</section>zar
 
 **:notebook_with_decorative_cover:​Note**
 
-You need uninstall the old version of MarkText before install version 0.10.21, because we changed the AppId when build.
+You need uninstall the old version of Mark Text before install version 0.10.21, because we changed the AppId when build.
 
 **:cactus:Feature**
 
@@ -638,9 +638,9 @@ You need uninstall the old version of MarkText before install version 0.10.21, b
 
 **:cactus:Feature**
 
-- Add user preferences in `MarkText menu`, the shoutcut is `CmdorCtrl + ,`, you can set the default `theme` and `autoSave`.
-- Add `autoSave` to `file menu`, the default value is in `preferences.md` which you can open in `MarkText menu`. #45
-- Add drag and drop to open Markdown file with MarkText @fxha
+- Add user preferences in `Mark Text menu`, the shoutcut is `CmdorCtrl + ,`, you can set the default `theme` and `autoSave`.
+- Add `autoSave` to `file menu`, the default value is in `preferences.md` which you can open in `Mark Text menu`. #45
+- Add drag and drop to open Markdown file with Mark Text @fxha
 - User setting: fontSize, lineHeight, color in realtime mode.
 - Move your file to other folder @DXXL
 - Rename filename
@@ -652,7 +652,7 @@ You need uninstall the old version of MarkText before install version 0.10.21, b
 
 **:beetle:Bug fix**
 
-- fix: prevent open image or file directly when drag and drop over MarkText #42
+- fix: prevent open image or file directly when drag and drop over Mark Text #42
 - fix: set theme to all the open window not just the active one.
 - fix: set correct application menu offset on windows #44
 - fix: Missing preferences menu in Linux and Windows. @fxha

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-<!-- Attention: please fill in the issue in the template format, including but not limited to: detailed description, reproduction steps, expected results, actual results, error screenshots (not required), Mark Text and operation system version. If an issue is marked as `more detail`, stating that the issue is opened and no content has been added after one week and will be closed, thanks for your cooperation. -->
+<!-- Attention: please fill in the issue in the template format, including but not limited to: detailed description, reproduction steps, expected results, actual results, error screenshots (not required), MarkText and operation system version. If an issue is marked as `more detail`, stating that the issue is opened and no content has been added after one week and will be closed, thanks for your cooperation. -->
 
-<!-- 注意：请按照 template 格式填写 issue，包括但不仅限于：详尽的描述、重现步骤、期望结果、实际结果、错误截图（非必须）、Mark Text 和 操作系统版本型号或版本号，如果一个 issue 被标记为 `more detail`，说明 issue 填写不完整，一周后仍未补充任何内容，将被关闭,谢谢合作 -->
+<!-- 注意：请按照 template 格式填写 issue，包括但不仅限于：详尽的描述、重现步骤、期望结果、实际结果、错误截图（非必须）、MarkText 和 操作系统版本型号或版本号，如果一个 issue 被标记为 `more detail`，说明 issue 填写不完整，一周后仍未补充任何内容，将被关闭,谢谢合作 -->
 
 <!-- Please make sure your application version is up to date -->
 
@@ -28,5 +28,5 @@
 
 ### Versions
 
-- Mark Text:
+- MarkText:
 - Operating system:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-<!-- Attention: please fill in the issue in the template format, including but not limited to: detailed description, reproduction steps, expected results, actual results, error screenshots (not required), MarkText and operation system version. If an issue is marked as `more detail`, stating that the issue is opened and no content has been added after one week and will be closed, thanks for your cooperation. -->
+<!-- Attention: please fill in the issue in the template format, including but not limited to: detailed description, reproduction steps, expected results, actual results, error screenshots (not required), Mark Text and operation system version. If an issue is marked as `more detail`, stating that the issue is opened and no content has been added after one week and will be closed, thanks for your cooperation. -->
 
-<!-- 注意：请按照 template 格式填写 issue，包括但不仅限于：详尽的描述、重现步骤、期望结果、实际结果、错误截图（非必须）、MarkText 和 操作系统版本型号或版本号，如果一个 issue 被标记为 `more detail`，说明 issue 填写不完整，一周后仍未补充任何内容，将被关闭,谢谢合作 -->
+<!-- 注意：请按照 template 格式填写 issue，包括但不仅限于：详尽的描述、重现步骤、期望结果、实际结果、错误截图（非必须）、Mark Text 和 操作系统版本型号或版本号，如果一个 issue 被标记为 `more detail`，说明 issue 填写不完整，一周后仍未补充任何内容，将被关闭,谢谢合作 -->
 
 <!-- Please make sure your application version is up to date -->
 
@@ -28,5 +28,5 @@
 
 ### Versions
 
-- MarkText:
+- Mark Text:
 - Operating system:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,5 @@ about: Create a bug report to help us improve
 
 ### Versions
 
-- Mark Text version:
+- MarkText version:
 - Operating system:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,5 @@ about: Create a bug report to help us improve
 
 ### Versions
 
-- MarkText version:
+- Mark Text version:
 - Operating system:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for Mark Text
+about: Suggest an idea for MarkText
 ---
 
 ### Describe your feature request

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for MarkText
+about: Suggest an idea for Mark Text
 ---
 
 ### Describe your feature request

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about Mark Text
+about: Ask a question about MarkText
 ---
 
 ### Question description

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about MarkText
+about: Ask a question about Mark Text
 ---
 
 ### Question description

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Mark Text",
+      "name": "Launch MarkText",
       "program": "${workspaceFolder}/.electron-vue/dev-runner.js",
       "env": {
         "NODE_ENV": "development",
@@ -38,9 +38,9 @@
   ],
   "compounds": [
     {
-      "name": "Debug Mark Text",
+      "name": "Debug MarkText",
       "configurations": [
-        "Launch Mark Text",
+        "Launch MarkText",
         "Attach to Main Process",
         "Attach to Renderer Process"
       ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Mark Text Contributing Guide
+# MarkText Contributing Guide
 
-We are really excited that you are interested in contributing to Mark Text :tada:. Before submitting your contribution though, please make sure to take a moment and read through the following guidelines.
+We are really excited that you are interested in contributing to MarkText :tada:. Before submitting your contribution though, please make sure to take a moment and read through the following guidelines.
 
 - [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 - [Philosophy](#philosophy)
@@ -14,7 +14,7 @@ We are really excited that you are interested in contributing to Mark Text :tada
 
 ## Philosophy
 
-Mark Text is still in development, many things will change and feature will be added but our philosophy is to keep things clean, simple and minimal. For example our side bar and tabs: these two panels provide a lot of functionality but don't disturb the user if it's need it. We'll add more and more feature, maybe extended by plugins, that can be activated via settings to improve Mark Text. So we allow everyone to customize Mark Text for it needs and provide a minimal default interface.
+MarkText is still in development, many things will change and feature will be added but our philosophy is to keep things clean, simple and minimal. For example our side bar and tabs: these two panels provide a lot of functionality but don't disturb the user if it's need it. We'll add more and more feature, maybe extended by plugins, that can be activated via settings to improve MarkText. So we allow everyone to customize MarkText for it needs and provide a minimal default interface.
 
 ## Issue reporting guidelines
 
@@ -44,16 +44,16 @@ If fix a bug:
 
 ### Where should I start?
 
-A good way to start to find an issue flagged as a `bug`, `help wanted` or `feature request`. The `good first issue` issues are good for newcomers. Please discuss the solution for larger issues first and after the final solution is approved by the Mark Text members, you can submit/work on the PR. For small changes you can directly open a PR.
+A good way to start to find an issue flagged as a `bug`, `help wanted` or `feature request`. The `good first issue` issues are good for newcomers. Please discuss the solution for larger issues first and after the final solution is approved by the MarkText members, you can submit/work on the PR. For small changes you can directly open a PR.
 
 Other ways to help:
 
 - Documentation
 - Translation (currently unavailable)
 - Design icons and logos and improve the UI
-- Help to test Mark Text
+- Help to test MarkText
 - Help to answer issues or discuss changes and features.
-- Let us know you opinion about Mark Text, missing features and report bugs and problems. :+1: features you like and discuss with us about upcoming changes and features.
+- Let us know you opinion about MarkText, missing features and report bugs and problems. :+1: features you like and discuss with us about upcoming changes and features.
 
 ## Quick start
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2017-present Luo Ran
-Copyright (c) 2018-present Mark Text Contributors
+Copyright (c) 2018-present MarkText Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<p align="center"><img src="static/logo-small.png" alt="Mark Text" width="100" height="100"></p>
+<p align="center"><img src="static/logo-small.png" alt="MarkText" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
@@ -111,18 +111,18 @@
 
 <br />
 
-<h2 align="center">Supporting Mark Text</h2>
+<h2 align="center">Supporting MarkText</h2>
 
-Mark Text is an MIT licensed open source project, and the latest version will always be downloadable for free from the GitHub release page. Mark Text is still in development, and its development is inseparable from all sponsors. I hope you join them:
+MarkText is an MIT licensed open source project, and the latest version will always be downloadable for free from the GitHub release page. MarkText is still in development, and its development is inseparable from all sponsors. I hope you join them:
 
 - [Become a backer or sponsor on Patreon](https://www.patreon.com/ranluo) or [One time donation](https://github.com/Jocs/sponsor.me)
 - [Become a backer or sponsor on Open Collective](https://opencollective.com/marktext)
 
 ##### What's the difference between Patreon and Open Collective?
 
-Patreon: Funds will be directly sponsored to Luo Ran (@jocs) who created Mark Text and continues to maintain it.
-Open Collective: All expenses are transparent. The funds will be used for the development and maintenance of Mark Text, funding online and offline activities, and acquiring other necessary resources.
-Names and company logos of all sponsors (from both Patreon and Open Collective) will appear on the official website for Mark Text and in its README.md file.
+Patreon: Funds will be directly sponsored to Luo Ran (@jocs) who created MarkText and continues to maintain it.
+Open Collective: All expenses are transparent. The funds will be used for the development and maintenance of MarkText, funding online and offline activities, and acquiring other necessary resources.
+Names and company logos of all sponsors (from both Patreon and Open Collective) will appear on the official website for MarkText and in its README.md file.
 
 **Special Sponsors**
 
@@ -193,9 +193,9 @@ Names and company logos of all sponsors (from both Patreon and Open Collective) 
 
 ## Why write another editor?
 
-1. I love writing. I have used a lot of markdown editors, yet there is still not an editor that can fully meet my needs. I don't like to be disturbed when I write by some unbearable bug. **Mark Text** uses virtual DOM to render pages which has the added benefits of being highly efficient and being open source. That way anyone who loves markdown and writing can use Mark Text.
-2. As mentioned above, **Mark Text** is completely free and open source and will be open source forever. We hope that all markdown lovers will contribute their own code and help develop **Mark Text** into a popular markdown editor.
-3. There are many markdown editors and all have their own merits, some have features which others don't. It's difficult to satisfy each markdown users' needs but we hope **Mark Text** will be able to satisfy each markdown user as much as possible. Although the latest **Mark Text** is still not perfect, we will try to make it as best as we possibly can.
+1. I love writing. I have used a lot of markdown editors, yet there is still not an editor that can fully meet my needs. I don't like to be disturbed when I write by some unbearable bug. **MarkText** uses virtual DOM to render pages which has the added benefits of being highly efficient and being open source. That way anyone who loves markdown and writing can use MarkText.
+2. As mentioned above, **MarkText** is completely free and open source and will be open source forever. We hope that all markdown lovers will contribute their own code and help develop **MarkText** into a popular markdown editor.
+3. There are many markdown editors and all have their own merits, some have features which others don't. It's difficult to satisfy each markdown users' needs but we hope **MarkText** will be able to satisfy each markdown user as much as possible. Although the latest **MarkText** is still not perfect, we will try to make it as best as we possibly can.
 
 ## Download and Installation
 
@@ -209,7 +209,7 @@ Want to see new features of the latest version? Please refer to [CHANGELOG](.git
 
 #### macOS
 
-You can either download the latest `marktext-%version%.dmg` from the [release page](https://github.com/marktext/marktext/releases/latest) or install Mark Text using [**homebrew cask**](https://github.com/caskroom/homebrew-cask). To use Homebrew-Cask you just need to have [Homebrew](https://brew.sh/) installed.
+You can either download the latest `marktext-%version%.dmg` from the [release page](https://github.com/marktext/marktext/releases/latest) or install MarkText using [**homebrew cask**](https://github.com/caskroom/homebrew-cask). To use Homebrew-Cask you just need to have [Homebrew](https://brew.sh/) installed.
 
 ```bash
 brew install --cask mark-text
@@ -217,9 +217,9 @@ brew install --cask mark-text
 
 #### Windows
 
-Simply download and install Mark Text via setup wizard (`marktext-setup-%version%.exe`) and choose whether to install per-user or machine wide.
+Simply download and install MarkText via setup wizard (`marktext-setup-%version%.exe`) and choose whether to install per-user or machine wide.
 
-Alternatively, install Mark Text using a package manager such as [Chocolatey](https://chocolatey.org/) or [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/). 
+Alternatively, install MarkText using a package manager such as [Chocolatey](https://chocolatey.org/) or [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/). 
 
   - To use Chocolatey you need to have [Chocolatey](https://chocolatey.org/install) installed.
 
@@ -243,26 +243,26 @@ All binaries for Linux, macOS and Windows can be downloaded from the [release pa
 
 ## Development
 
-If you wish to build **Mark Text** yourself, please check out our [build instructions](docs/dev/BUILD.md).
+If you wish to build **MarkText** yourself, please check out our [build instructions](docs/dev/BUILD.md).
 
 - [User documentation](docs/README.md)
 - [Developer documentation](docs/dev/README.md)
 
-If you have any questions regarding **Mark Text**, you are welcome to write an issue. When doing so please use the default format found when opening an issue. Of course, if you submit a PR directly, it will be greatly appreciated.
+If you have any questions regarding **MarkText**, you are welcome to write an issue. When doing so please use the default format found when opening an issue. Of course, if you submit a PR directly, it will be greatly appreciated.
 
 ## Integrations
 
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text): A Workflow for the macOS app Alfred: Use "mt" to open files/folder with Mark Text.
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text): A Workflow for the macOS app Alfred: Use "mt" to open files/folder with MarkText.
 
 ## Contribution
 
-Mark Text is in full development, please make sure to read the [Contributing Guide](CONTRIBUTING.md) before making a pull request. Want to add some features to Mark Text? Refer to our [roadmap](https://github.com/marktext/marktext/projects) and open issues.
+MarkText is in full development, please make sure to read the [Contributing Guide](CONTRIBUTING.md) before making a pull request. Want to add some features to MarkText? Refer to our [roadmap](https://github.com/marktext/marktext/projects) and open issues.
 
 ## Contributors
 
-Thank you to all the people who have already contributed to Mark Text[[contributors](https://github.com/marktext/marktext/graphs/contributors)]
+Thank you to all the people who have already contributed to MarkText[[contributors](https://github.com/marktext/marktext/graphs/contributors)]
 
-Special thanks to @[Yasujizr](https://github.com/Yasujizr) who designed the Mark Text logo.
+Special thanks to @[Yasujizr](https://github.com/Yasujizr) who designed the MarkText logo.
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/BASICS.md
+++ b/docs/BASICS.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Mark Text is a realtime preview editor for markdown with various markdown extensions. You can simply write and edit text and Mark Text hides all unnecessary syntax elements. When you first start Mark Text an empty editor window is shown. You can see [key bindings](KEYBINDINGS.md) or command palette (<kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) for all available commands or just type `@` to get an overlay with available text elements. Mark Text provides a minimal and simple interface and in the next sections you can learn more about the interface and features.
+MarkText is a realtime preview editor for markdown with various markdown extensions. You can simply write and edit text and MarkText hides all unnecessary syntax elements. When you first start MarkText an empty editor window is shown. You can see [key bindings](KEYBINDINGS.md) or command palette (<kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) for all available commands or just type `@` to get an overlay with available text elements. MarkText provides a minimal and simple interface and in the next sections you can learn more about the interface and features.
 
 ![](assets/marktext-default.png)
 
@@ -18,7 +18,7 @@ The sidebar consists of three panels and you can toggle the sidebar by pressing 
 
 #### Toggle tabs
 
-Mark Text can be used as a single editor but opens all files in a separate tab. Tabs can be toggled via <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd> and reordered by drag and drop.
+MarkText can be used as a single editor but opens all files in a separate tab. Tabs can be toggled via <kbd>CmdOrCtrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd> and reordered by drag and drop.
 
 **Want to use tabs without showing them?**
 
@@ -38,7 +38,7 @@ Use <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> to enter distraction free
 
 ### Open your first file
 
-You can use the menu `File -> Open File` or press <kbd>CmdOrCtrl</kbd>+<kbd>O</kbd> to open a file dialog to choose a markdown file. Another way to is to launch Mark Text with directories or files via command line.
+You can use the menu `File -> Open File` or press <kbd>CmdOrCtrl</kbd>+<kbd>O</kbd> to open a file dialog to choose a markdown file. Another way to is to launch MarkText with directories or files via command line.
 
 ### Save your edited file
 
@@ -46,7 +46,7 @@ After some modifications you can save your file via <kbd>CmdOrCtrl</kbd>+<kbd>S<
 
 ### Open a directory
 
-Mark Text also has support to open a directory via <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> or the sidebar button *Open Folder*. After opening a directory all files and directories are shown in the sidebar tree view. The tree view allows you to open further files, browse and modify files or directories inside the opened root directory. Above the tree view are all opened files located. You can also use quick open (<kbd>CmdOrCtrl</kbd>+<kbd>P</kbd>) to quickly open a file from the opened root directory or editor and navigate via arrow keys or select a file via mouse. To view another sidebar panel like find in files click on the left sidebar icons.
+MarkText also has support to open a directory via <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> or the sidebar button *Open Folder*. After opening a directory all files and directories are shown in the sidebar tree view. The tree view allows you to open further files, browse and modify files or directories inside the opened root directory. Above the tree view are all opened files located. You can also use quick open (<kbd>CmdOrCtrl</kbd>+<kbd>P</kbd>) to quickly open a file from the opened root directory or editor and navigate via arrow keys or select a file via mouse. To view another sidebar panel like find in files click on the left sidebar icons.
 
 ![](assets/marktext-interface-2.png)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,7 +16,7 @@ Usage: marktext [commands] [path ...]
     -h, --help                    Print this help message
 ```
 
-`marktext` should point to your installation of Mark Text. The exact location will vary from platform to platform. On macOS, you can create a convenient alias like:
+`marktext` should point to your installation of MarkText. The exact location will vary from platform to platform. On macOS, you can create a convenient alias like:
 
 ```sh
 alias marktext="/Applications/Mark\ Text.app/Contents/MacOS/Mark\ Text"

--- a/docs/EDITING.md
+++ b/docs/EDITING.md
@@ -4,7 +4,7 @@ Let us take a look at the realtime editor and editing features.
 
 ## Text manipulation
 
-Mark Text shows you formatted text in realtime while you can simply write and edit text but also use markdown syntax. To improve your writing efficiency there are a lot of key bindings for better text manipulation. In the preferences you can control the editor settings such as font settings, autocompletion and line width.
+MarkText shows you formatted text in realtime while you can simply write and edit text but also use markdown syntax. To improve your writing efficiency there are a lot of key bindings for better text manipulation. In the preferences you can control the editor settings such as font settings, autocompletion and line width.
 
 ## Selections
 
@@ -34,7 +34,7 @@ Do you want to delete headings, lists or tables? Just select the area and press 
 
 ## Brackets and quotes autocompletion
 
-You can configure Mark Text to autocomplete markdown syntax, brackets and quotes. By default `()`, `[]`, `{}`, `**`, `__`, `$$`, `""` and `''` are completed when the first character is typed.
+You can configure MarkText to autocomplete markdown syntax, brackets and quotes. By default `()`, `[]`, `{}`, `**`, `__`, `$$`, `""` and `''` are completed when the first character is typed.
 
 ## Links
 
@@ -44,7 +44,7 @@ Links are shown by default as normal text but if you click on a link the link is
 
 ## Formatting
 
-Mark Text will automatically format your markdown document according CommonMark and GitHub Flavored Markdown specification. You can control few settings via preferences such as list indentation.
+MarkText will automatically format your markdown document according CommonMark and GitHub Flavored Markdown specification. You can control few settings via preferences such as list indentation.
 
 ## Editing features
 
@@ -62,7 +62,7 @@ You can transform a line into another type by clicking on the highlighted icon i
 
 #### Table tools
 
-It's sometimes hard to write and manage tables in markdown. In Mark Text you can press <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> to get a table dialog and create a table with variable row and column count. Both row and column count can be changed via the table tools (first icon above the table) later if necessary. You can use all inline styles in a table cell and align the text via table tools at the top of the table.
+It's sometimes hard to write and manage tables in markdown. In MarkText you can press <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> to get a table dialog and create a table with variable row and column count. Both row and column count can be changed via the table tools (first icon above the table) later if necessary. You can use all inline styles in a table cell and align the text via table tools at the top of the table.
 
 **Insert and delete rows and columns:**
 
@@ -80,7 +80,7 @@ You can simply move a row or column by clicking on the cell menu (like above) an
 
 ![](assets/marktext-image-viewer.png)
 
-Mark Text provides an image viewer and a pop up to select and label images. You can resize any image by your mouse cursor and changes are applied in realtime. By clicking on an image or writing `![]()` a pop up is automatically shown that allows you to select an image from disk or paste a path or URL. Images can be automatically uploaded to cloud, moved to a relative or absolute path on disk. Even pasting images that are not located on disk is supported and these images are stored in the background. In addition, you can control the image alignment whether inline, left, centered or right.
+MarkText provides an image viewer and a pop up to select and label images. You can resize any image by your mouse cursor and changes are applied in realtime. By clicking on an image or writing `![]()` a pop up is automatically shown that allows you to select an image from disk or paste a path or URL. Images can be automatically uploaded to cloud, moved to a relative or absolute path on disk. Even pasting images that are not located on disk is supported and these images are stored in the background. In addition, you can control the image alignment whether inline, left, centered or right.
 
 ![](assets/marktext-image-popup.png)
 
@@ -102,11 +102,11 @@ In typewriter mode, the cursor is always keep in the middle of the editor.
 
 ## File encoding
 
-Mark Text tries to automatically detect the used file encoding and byte-order mark (BOM) when opening a file. The default encoding is UTF-8 that should support all needed characters but can be changed in settings. You can disable automatically encoding detection but then we assume that all files are UTF-8 encoded. The current used encoding can be shown via command palette and also changed there.
+MarkText tries to automatically detect the used file encoding and byte-order mark (BOM) when opening a file. The default encoding is UTF-8 that should support all needed characters but can be changed in settings. You can disable automatically encoding detection but then we assume that all files are UTF-8 encoded. The current used encoding can be shown via command palette and also changed there.
 
 ## Line endings
 
-Mark Text automatically analyzes each file and detects the used line ending and can be changed via command palette too.
+MarkText automatically analyzes each file and detects the used line ending and can be changed via command palette too.
 
 ## Find and replace
 
@@ -116,4 +116,4 @@ To quickly find a keyword in your document press <kbd>CmdOrCtrl</kbd>+<kbd>F</kb
 
 **Search in opened folder:**
 
-Mark Text provides a build-in filesystem explorer (tree view) with a fast file searcher. Type a keyword in the search bar and select the needed options like regex or case-insensitive search. That's all, now Mark Text will search all markdown files in the opened root directory.
+MarkText provides a build-in filesystem explorer (tree view) with a fast file searcher. Type a keyword in the search bar and select the needed options like regex or case-insensitive search. That's all, now MarkText will search all markdown files in the opened root directory.

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -1,6 +1,6 @@
 # Export a Document
 
-Mark Text allows you to export a markdown document as PDF and HTML file or to print the document.
+MarkText allows you to export a markdown document as PDF and HTML file or to print the document.
 
 ## Options
 
@@ -18,7 +18,7 @@ Adjust the page style without modify the page theme:
 
 ### Theme
 
-Mark Text allows you to select a page theme before exporting. You can learn more about page themes [here](EXPORT_THEMES.md).
+MarkText allows you to select a page theme before exporting. You can learn more about page themes [here](EXPORT_THEMES.md).
 
 ### Header and footer
 

--- a/docs/EXPORT_THEMES.md
+++ b/docs/EXPORT_THEMES.md
@@ -1,14 +1,14 @@
 # Themes (Export)
 
-Mark Text allows you to modify the appearance of the document that you want to export. By default we provide three themes: Academic, GitHub and Liber (writing theme).
+MarkText allows you to modify the appearance of the document that you want to export. By default we provide three themes: Academic, GitHub and Liber (writing theme).
 
 ## Install a theme
 
-You can install a theme by copying the `.css` file to `themes/export/` directory inside the [application data directory](APPLICATION_DATA_DIRECTORY.md) location but you may need to restart Mark Text to detect the theme.
+You can install a theme by copying the `.css` file to `themes/export/` directory inside the [application data directory](APPLICATION_DATA_DIRECTORY.md) location but you may need to restart MarkText to detect the theme.
 
 ## Create a theme
 
-Mark Text use the GitHub theme as basic style that is always available. A custom theme can add additional styles but have to overwrite the GitHub style to make changes such as font family or the underling for heading. You can see all predefined styles [here](https://github.com/sindresorhus/github-markdown-css/blob/gh-pages/github-markdown.css). An example for custom themes can be found [here](https://github.com/marktext/marktext/blob/develop/src/renderer/assets/themes/export/academic.theme.css) and [here](https://github.com/marktext/marktext/blob/develop/src/renderer/assets/themes/export/liber.theme.css).
+MarkText use the GitHub theme as basic style that is always available. A custom theme can add additional styles but have to overwrite the GitHub style to make changes such as font family or the underling for heading. You can see all predefined styles [here](https://github.com/sindresorhus/github-markdown-css/blob/gh-pages/github-markdown.css). An example for custom themes can be found [here](https://github.com/marktext/marktext/blob/develop/src/renderer/assets/themes/export/academic.theme.css) and [here](https://github.com/marktext/marktext/blob/develop/src/renderer/assets/themes/export/liber.theme.css).
 
 ### Theme settings
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,19 +2,19 @@
 
 ### What are the supported platforms?
 
-Mark Text is a desktop application and available for:
+MarkText is a desktop application and available for:
 
 - Linux x64 (tested on Debian and Red Hat based distros)
 - macOS 10.10 x64 or later
 - Windows 7-10 x86 and x64
 
-### Is Mark Text open-source and free?
+### Is MarkText open-source and free?
 
-Yes, Mark Text is licensed under the [MIT](https://github.com/marktext/marktext/blob/develop/LICENSE) license and completely free for everyone. The source-code is available on [GitHub](https://github.com/marktext/marktext).
+Yes, MarkText is licensed under the [MIT](https://github.com/marktext/marktext/blob/develop/LICENSE) license and completely free for everyone. The source-code is available on [GitHub](https://github.com/marktext/marktext).
 
-### Can I use Mark Text as note management/taking app?
+### Can I use MarkText as note management/taking app?
 
-Mark Text is a pure markdown editor without feature such as knowledge management and tags but yes, you can do this via the integrated filesystem explorer and task lists.
+MarkText is a pure markdown editor without feature such as knowledge management and tags but yes, you can do this via the integrated filesystem explorer and task lists.
 
 ### Where can I find documentation?
 
@@ -24,7 +24,7 @@ Documentation is currently under development.
 
 - [Developer documentation](https://github.com/marktext/marktext/blob/develop/docs/dev/README.md)
 
-### Can I run a portable version of Mark Text?
+### Can I run a portable version of MarkText?
 
 Yes, please see [here](PORTABLE.md) for further information.
 
@@ -32,15 +32,15 @@ Yes, please see [here](PORTABLE.md) for further information.
 
 You can report bugs and problems via our [GitHub issue tracker](https://github.com/marktext/marktext/issues). Please provide a detailed description of the problem to better solve the issue.
 
-### I cannot launch Mark Text on Linux (SUID sandbox)
+### I cannot launch MarkText on Linux (SUID sandbox)
 
 > *The SUID sandbox helper binary was found, but is not configured correctly.*
 
-Normally, you should never get this error but if you disabled user namespaces, this error message may appears in the command output when launching Mark Text. To solve the issue, that Chromium cannot start the sandbox (process), you can choose one of the following steps:
+Normally, you should never get this error but if you disabled user namespaces, this error message may appears in the command output when launching MarkText. To solve the issue, that Chromium cannot start the sandbox (process), you can choose one of the following steps:
 
 - Enable Linux kernel user namespaces to use the preferred sandbox: `sudo sysctl kernel.unprivileged_userns_clone=1`.
 - Set correct SUID sandbox helper binary permissions: `sudo chown root <path_to_marktext_dir>/chrome-sandbox && sudo chmod 4755 <path_to_marktext_dir>/chrome-sandbox`. This is prefered if you don't want to enable user namespaces.
-- Launch Mark Text with `--no-sandbox` argument.
+- Launch MarkText with `--no-sandbox` argument.
 
 ### What is a "Aidou" ?
 

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -1,6 +1,6 @@
 # Image support
 
-Mark Text can automatically copy your images into a specified directory or handle images from clipboard.
+MarkText can automatically copy your images into a specified directory or handle images from clipboard.
 
 ### Upload to cloud using selected uploader
 
@@ -14,7 +14,7 @@ All images are automatically copied into the specified local directory that may 
 
 When this option is enabled, all images are copied relative to the opened file or the root directory when a project is opened. You can specify the path via the *relative image folder name* text box. The local resource directory is used if the file is not saved.
 
-NB: The assets directory name must be a valid path name and Mark Text need write access to the directory.
+NB: The assets directory name must be a valid path name and MarkText need write access to the directory.
 
 Examples for relative paths:
 
@@ -25,4 +25,4 @@ Examples for relative paths:
 
 ### Keep original location
 
-Mark Text only saves images from clipboard into the specified local directory.
+MarkText only saves images from clipboard into the specified local directory.

--- a/docs/IMAGE_UPLOADER_CONFIGRATION.md
+++ b/docs/IMAGE_UPLOADER_CONFIGRATION.md
@@ -14,10 +14,10 @@ No need to config, it's a free uploading service up-to 5MB, thanks!
 
 ![5ce17bd849d5589341](https://i.loli.net/2019/05/19/5ce17bd849d5589341.png)
 
-3. Config in Mark Text Preferences window. click `CmdOrCtrl + ,` to open Mark Text Preferences window.
+3. Config in MarkText Preferences window. click `CmdOrCtrl + ,` to open MarkText Preferences window.
 
 ![5ce17cb97b0f111638](https://i.loli.net/2019/05/19/5ce17cb97b0f111638.png)
 
 4. Input you `token`, `owner name` and `repo name` whick you just created. Click `Save` and `Set As default Uploader`.
 
-5. Paste an image into Mark Text and open you created repo to see the uploaded image.
+5. Paste an image into MarkText and open you created repo to see the uploaded image.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -30,14 +30,14 @@ Here is an example:
 
 ## Available id's
 
-**Mark Text menu (macOS only):**
+**MarkText menu (macOS only):**
 
 | Id                 | Default                                        | Description                             |
 | ------------------ | ---------------------------------------------- | --------------------------------------- |
-| `mt.hide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide Mark Text                          |
-| `mt.hide-others`   | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except Mark Text |
+| `mt.hide`          | <kbd>Command</kbd>+<kbd>H</kbd>                | Hide MarkText                          |
+| `mt.hide-others`   | <kbd>Command</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> | Hide all other windows except MarkText |
 | `file.preferences` | <kbd>Command</kbd>+<kbd>,</kbd>                | Open settings window                    |
-| `file.quit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit Mark Text                          |
+| `file.quit`        | <kbd>Command</kbd>+<kbd>Q</kbd>                | Quit MarkText                          |
 
 **File menu:**
 
@@ -53,7 +53,7 @@ Here is an example:
 | `file.preferences`  | <kbd>Ctrl</kbd>+<kbd>,</kbd>                       | Open settings window (Linux/Windows only) |
 | `file.close-tab`    | <kbd>CmdOrCtrl</kbd>+<kbd>W</kbd>                  | Close tab                                 |
 | `file.close-window` | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                              |
-| `file.quit`         | <kbd>CmdOrCtrl</kbd>+<kbd>Q</kbd>                  | Quit Mark Text (Linux/Windows only)       |
+| `file.quit`         | <kbd>CmdOrCtrl</kbd>+<kbd>Q</kbd>                  | Quit MarkText (Linux/Windows only)       |
 
 **Edit menu:**
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -6,7 +6,7 @@
 
 1. `chmod +x marktext-%version%-x86_64.AppImage`
 2. `./marktext-%version%-x86_64.AppImage`
-3. Now you can execute Mark Text.
+3. Now you can execute MarkText.
 
 ### Installation
 
@@ -48,7 +48,7 @@ You can integrate the AppImage into the system via [AppImageLauncher](https://gi
 
 ### Known issues
 
-- Mark Text is always integrated into desktop environment after updating
+- MarkText is always integrated into desktop environment after updating
 
 ## Binary
 
@@ -64,7 +64,7 @@ You need to install the `flatpak` package for your distribution. Please see the 
 
 **Install from Flathub:**
 
-After you install flatpak and flathub repository, you can install [Mark Text](https://flathub.org/apps/details/com.github.marktext.marktext) with just one command (note that you may be asked to enter your password):
+After you install flatpak and flathub repository, you can install [MarkText](https://flathub.org/apps/details/com.github.marktext.marktext) with just one command (note that you may be asked to enter your password):
 
 ```
 flatpak install flathub com.github.marktext.marktext
@@ -72,11 +72,11 @@ flatpak install flathub com.github.marktext.marktext
 
 or `flatpak install --user flathub com.github.marktext.marktext` to install for the current user only.
 
-To run Mark Text just execute `flatpak run com.github.marktext.marktext` or click on the Mark Text icon in your application launcher.
+To run MarkText just execute `flatpak run com.github.marktext.marktext` or click on the MarkText icon in your application launcher.
 
 ### Update
 
-To update Mark Text run the following command:
+To update MarkText run the following command:
 
 ```
 flatpak update com.github.marktext.marktext

--- a/docs/MARKDOWN_SYNTAX.md
+++ b/docs/MARKDOWN_SYNTAX.md
@@ -235,18 +235,18 @@ Note that placement of achors is arbitrary, you can put them anywhere you want, 
 Images have a similar syntax to links but include a preceding exclamation point.
 
 ```markdown
-![Mark Text](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png)
+![MarkText](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png)
 ```
 
-![Mark Text](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png)
+![MarkText](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png)
 
 or
 
 ```markdown
-![Alt text](hhttps://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png "Mark Text logo")
+![Alt text](hhttps://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png "MarkText logo")
 ```
 
-![Alt text](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png "Mark Text logo")
+![Alt text](https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png "MarkText logo")
 
 Like links, Images also have a footnote style syntax
 
@@ -258,10 +258,10 @@ Like links, Images also have a footnote style syntax
 
 With a reference later in the document defining the URL location:
 
-[id]: https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png  "Mark Text logo"
+[id]: https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png  "MarkText logo"
 
 ```markdown
-[id]: https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png  "Mark Text logo"
+[id]: https://raw.githubusercontent.com/marktext/marktext/develop/resources/icons/256x256/marktext.png  "MarkText logo"
 ```
 
 <br>
@@ -639,7 +639,7 @@ Which renders to:
 
 :heart: :zap: :cow: :dollar: :star: :tada:
 
-**NOTE:** Mark Text provides an emoji picker with search functionality.
+**NOTE:** MarkText provides an emoji picker with search functionality.
 
 <br>
 
@@ -728,7 +728,7 @@ $$
 
 ## Diagrams
 
-Mark Text support class, flow chart, gantt and sequence diagrams powered by flowchart.js, mermaid and Vega-Lite. [Code](#code) blocks with special language identifiers are used for diagrams.
+MarkText support class, flow chart, gantt and sequence diagrams powered by flowchart.js, mermaid and Vega-Lite. [Code](#code) blocks with special language identifiers are used for diagrams.
 
 For example, this:
 

--- a/docs/PORTABLE.md
+++ b/docs/PORTABLE.md
@@ -1,6 +1,6 @@
 # Portable Mode
 
-Mark Text stores all user configuration inside the [application data directory](APPLICATION_DATA_DIRECTORY.md) that can be changed with `--user-data-dir` command-line flag.
+MarkText stores all user configuration inside the [application data directory](APPLICATION_DATA_DIRECTORY.md) that can be changed with `--user-data-dir` command-line flag.
 
 ## Linux and Windows
 
@@ -8,7 +8,7 @@ On Linux and Windows you can also create a directory called `marktext-user-data`
 
 ```
 marktext-portable/
- ├── marktext (Linux) or Mark Text.exe (Windows)
+ ├── marktext (Linux) or MarkText.exe (Windows)
  ├── marktext-user-data/
  ├── resources/
  ├── THIRD-PARTY-LICENSES.txt

--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -1,4 +1,4 @@
-## Mark Text Preferences
+## MarkText Preferences
 
 Preferences can be controlled and modified in the settings window or via the `preferences.json` file in the [application data directory](APPLICATION_DATA_DIRECTORY.md).
 
@@ -15,9 +15,9 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | wordWrapInToc          | Boolean | false         | Whether to enable word wrap in TOC. Optional value: true, false                                                                                            |
 | aidou                  | Boolean | true          | Enable aidou. Optional value: true, false                                                                                                                  |
 | fileSortBy             | String  | created       | Sort files in opened folder by `created` time, modified time and title.                                                                                    |
-| startUpAction          | String  | lastState     | The action after Mark Text startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank` |
+| startUpAction          | String  | lastState     | The action after MarkText startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank` |
 | defaultDirectoryToOpen | String  | `""`          | The path that should be opened if `startUpAction=folder`.                                                                                                  |
-| language               | String  | en            | The language Mark Text use.                                                                                                                                |
+| language               | String  | en            | The language MarkText use.                                                                                                                                |
 
 #### Editor
 
@@ -35,7 +35,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | codeFontFamily                     | String  | `DejaVu Sans Mono` | Code font family                                                                                                                                                               |
 | trimUnnecessaryCodeBlockEmptyLines | Boolean | true               | Whether to trim the beginning and end empty line in Code block                                                                                                                 |
 | hideQuickInsertHint                | Boolean | false              | Hide hint for quickly creating paragraphs                                                                                                                                      |
-| imageDropAction                    | String  | folder             | The default behavior after paste or drag the image to Mark Text, upload it to the image cloud (if configured), move to the specified folder, insert the path          |
+| imageDropAction                    | String  | folder             | The default behavior after paste or drag the image to MarkText, upload it to the image cloud (if configured), move to the specified folder, insert the path          |
 | defaultEncoding                    | String  | `utf8`             | The default file encoding                                                                                                                                                      |
 | autoGuessEncoding                  | Boolean | true               | Try to automatically guess the file encoding when opening files                                                                                                                |
 | trimTrailingNewline                | Enum    | `2`                | Ensure a single trailing newline or whether trailing newlines should be removed: `0`: trim all trailing newlines, `1`: ensure single newline, `2`: auto detect, `3`: disabled. |
@@ -49,7 +49,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | preferLooseListItem | Boolean | true    | The preferred list type.                                                                                                             |
 | bulletListMarker    | String  | `-`     | The preferred marker used in bullet list, optional value: `-`, `*` `+`                                                               |
 | orderListDelimiter  | String  | `.`     | The preferred delimiter used in order list, optional value: `.` `)`                                                                  |
-| preferHeadingStyle  | String  | `atx`   | The preferred heading style in Mark Text, optional value `atx` `setext`, [more info](https://spec.commonmark.org/0.29/#atx-headings) |
+| preferHeadingStyle  | String  | `atx`   | The preferred heading style in MarkText, optional value `atx` `setext`, [more info](https://spec.commonmark.org/0.29/#atx-headings) |
 | tabSize             | Number  | 4       | The number of spaces a tab is equal to                                                                                               |
 | listIndentation     | String  | 1       | The list indentation of sub list items or paragraphs, optional value `dfm`, `tab` or number 1~4                                      |
 | frontmatterType     | String  | `-`     | The frontmatter type: `-` (YAML), `+` (TOML), `;` (JSON) or `{` (JSON)                                                               |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # User Documentation
 
-Welcome to the end-user documentation of Mark Text.
+Welcome to the end-user documentation of MarkText.
 
 ![](assets/marktext-interface-2.png)
 

--- a/docs/SPELLING.md
+++ b/docs/SPELLING.md
@@ -1,6 +1,6 @@
 #  Spelling
 
-Mark Text can automatically check your text for misspelled words as you type and suggest corrections. You just need to enable spell checking in settings under *spelling* to never miss a misspelled word. We're using Hunspell for Linux and older Windows versions and on macOS and Window 10 you can choose between Hunspell or the system spell checker (default). You can control the default proofing language via settings but can change the language at runtime via right-click menu `Change Language` entry under `Spelling` without changing the default language. By default Mark Text only support American English for Hunspell and the local available languages for the system spell checker. You can download 42 languages for Hunspell and many more for macOS and Windows 10 via system settings.
+MarkText can automatically check your text for misspelled words as you type and suggest corrections. You just need to enable spell checking in settings under *spelling* to never miss a misspelled word. We're using Hunspell for Linux and older Windows versions and on macOS and Window 10 you can choose between Hunspell or the system spell checker (default). You can control the default proofing language via settings but can change the language at runtime via right-click menu `Change Language` entry under `Spelling` without changing the default language. By default MarkText only support American English for Hunspell and the local available languages for the system spell checker. You can download 42 languages for Hunspell and many more for macOS and Windows 10 via system settings.
 
 ![](assets/marktext-spellchecker-menu.png)
 
@@ -8,7 +8,7 @@ Mark Text can automatically check your text for misspelled words as you type and
 
 **Automatic language detection:**
 
-Mark Text can try to automatically detect the language while typing and we're currently support over 160 languages by Compact Language Detector.
+MarkText can try to automatically detect the language while typing and we're currently support over 160 languages by Compact Language Detector.
 
 **Don't underline misspelled words:**
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,3 +1,3 @@
 # Themes
 
-Mark Text currently doesn't support user-defined application themes. This feature is planned for v0.17.0.
+MarkText currently doesn't support user-defined application themes. This feature is planned for v0.17.0.

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -9,21 +9,21 @@
 - `docs/`: Documentation and assets
 - `resources/`: Application assets using at build time
 - `node_modules/`: Dependencies
-- `src`: Mark Text source code
+- `src`: MarkText source code
   - `common/`: Common source files that only require Node.js APIs. Code from this folder can be used in all other folders except `muya`.
   - `main/`: Main process source files that require Electron main-process APIs. `main` files can use `common` source code.
-  - `muya/`: Mark Texts backend that only allow pure JavaScript, BOM and DOM APIs. Don't use Electron or Node.js APIs!
+  - `muya/`: MarkTexts backend that only allow pure JavaScript, BOM and DOM APIs. Don't use Electron or Node.js APIs!
   - `renderer`: Frontend that require Electron renderer-process APIs and may use `common` or `muya` source code.
 - `static/`: Application assets (images, themes, etc)
 - `test/`: Contains (unit) tests
 
-## Introduction to Mark Text
+## Introduction to MarkText
 
-Mark Text is a realtime preview (WYSIWYG) editor for markdown with various markdown extensions and our philosophy is to keep things clean, simple and minimal. The application is build with HTML, JS and CSS on top of Electron. Currently we're using a few native node libraries and our UI is build with Vue/Vuex. Mark Text can be split in three parts: the core called Muya, the main- and renderer process.
+MarkText is a realtime preview (WYSIWYG) editor for markdown with various markdown extensions and our philosophy is to keep things clean, simple and minimal. The application is build with HTML, JS and CSS on top of Electron. Currently we're using a few native node libraries and our UI is build with Vue/Vuex. MarkText can be split in three parts: the core called Muya, the main- and renderer process.
 
-Muya provides realtime preview and markdown editing via multiple modules based on a block structure. You can imagine it as the editor backend with modules for markdown parsing, data store as block structure, markdown document transformations according CommonMark and GitHub Flavored Markdown specification with some extra specifications, event listeners and an exporter to generate standalone HTML and markdown files but also to generate the WYSIWYG editor. Muya is single threaded as well as Mark Text but use asynchronous functions to boost performance.
+Muya provides realtime preview and markdown editing via multiple modules based on a block structure. You can imagine it as the editor backend with modules for markdown parsing, data store as block structure, markdown document transformations according CommonMark and GitHub Flavored Markdown specification with some extra specifications, event listeners and an exporter to generate standalone HTML and markdown files but also to generate the WYSIWYG editor. Muya is single threaded as well as MarkText but use asynchronous functions to boost performance.
 
-> NOTE: Mark Text's source-code editor is provided by CodeMirror and not well optimized nor feature rich. It's not part of Muya and an editor (renderer process) feature that load the markdown text from Muya (export), operate on it and re-import the text into Muya when switching to preview mode.
+> NOTE: MarkText's source-code editor is provided by CodeMirror and not well optimized nor feature rich. It's not part of Muya and an editor (renderer process) feature that load the markdown text from Muya (export), operate on it and re-import the text into Muya when switching to preview mode.
 
 > NOTE: Muya requires a core refactoring to provide better modularization, APIs and plugins. Furthermore, the data structure need improvements for better performance and stability.
 

--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -35,8 +35,8 @@ On Red Hat-based Linux: `sudo dnf install libX11-devel libxkbfile-devel libsecre
 
 1. Go to `marktext` folder
 2. Install dependencies: `yarn install` or `yarn install --frozen-lockfile`
-3. Build Mark Text binaries and packages: `yarn run build`
-4. Mark Text binary is located under `build` folder
+3. Build MarkText binaries and packages: `yarn run build`
+4. MarkText binary is located under `build` folder
 
 Copy the build app to applications folder, or if on Windows run the executable installer.
 
@@ -48,9 +48,9 @@ $ yarn run <script> # or npm run <script>
 
 | Script          | Description                                       |
 | --------------- | ------------------------------------------------- |
-| `build`         | Build Mark Text binaries and packages for your OS |
-| `build:bin`     | Build Mark Text binary for your OS                |
-| `dev`           | Build and run Mark Text in developer mode         |
+| `build`         | Build MarkText binaries and packages for your OS |
+| `build:bin`     | Build MarkText binary for your OS                |
+| `dev`           | Build and run MarkText in developer mode         |
 | `lint`          | Lint code style                                   |
 | `test` / `unit` | Run unit tests                                    |
 

--- a/docs/dev/DEBUGGING.md
+++ b/docs/dev/DEBUGGING.md
@@ -2,7 +2,7 @@
 
 ## Using Visual Studio Code
 
-The most simplest way is to debug using the `Debug Mark Text` configuration. You can set breakpoints and use the `debugger` statement.
+The most simplest way is to debug using the `Debug MarkText` configuration. You can set breakpoints and use the `debugger` statement.
 
 **Prerequisites:**
 

--- a/docs/dev/INTERFACE.md
+++ b/docs/dev/INTERFACE.md
@@ -14,7 +14,7 @@ The titlebar is located at the top of the window and shows the current opened fi
 
 ### Sidebar
 
-The sidebar is an optional feature of Mark Text that contains three panels and has a variable width. The first pannel is a tree view of the opened root directory. The latter two are a folder searcher (find in files) that is powered by ripgrep and table of contents of the currently opened document.
+The sidebar is an optional feature of MarkText that contains three panels and has a variable width. The first pannel is a tree view of the opened root directory. The latter two are a folder searcher (find in files) that is powered by ripgrep and table of contents of the currently opened document.
 
 ### Editor
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,11 +1,11 @@
 # Developer Documentation
 
-Welcome to developer documentation of Mark Text.
+Welcome to developer documentation of MarkText.
 
 - [Project architecture](ARCHITECTURE.md)
 - [Build instructions](BUILD.md)
 - [Debugging](DEBUGGING.md)
 - [Interface](INTERFACE.md)
-- [Steps to release Mark Text](RELEASE.md)
+- [Steps to release MarkText](RELEASE.md)
 - [Prepare a hotfix](RELEASE_HOTFIX.md)
 - [Internal documentation](code/README.md)

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -1,4 +1,4 @@
-# Steps to release Mark Text
+# Steps to release MarkText
 
 - Create a release candidate
   - Create branch `release-v%version%`

--- a/docs/dev/RELEASE_HOTFIX.md
+++ b/docs/dev/RELEASE_HOTFIX.md
@@ -3,7 +3,7 @@
 - Create a hotfix branch: `git checkout -b hotfix-vX.Y.Z`
 - Make changes to the code and/or `cherry-pick` changes from another branch and commit changes.
 - Test the hotfix and binaries.
-- [Release](RELEASE.md) a new Mark Text version.
+- [Release](RELEASE.md) a new MarkText version.
 
 **How to cherry pick?**
 

--- a/docs/dev/code/README.md
+++ b/docs/dev/code/README.md
@@ -1,6 +1,6 @@
 # Internal Documentation
 
-WIP documentation of Mark Text internals.
+WIP documentation of MarkText internals.
 
 - [Block addition properties and its value](BLOCK_ADDITION_PROPERTY.md)
 - [Commands](COMMANDS.md)

--- a/docs/i18n/french.md
+++ b/docs/i18n/french.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="../../static/logo-small.png" alt="mark text" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20me?&hashtags=happyMarkText">
@@ -109,9 +109,9 @@
 
 ## Pourquoi écrire un nouvel éditeur?
 
-1. J'adore écrire. J'ai utilisé de nombreux éditeurs markdown et pourtant, aucun ne correspondait réellement à mes besoins. **Mark Text** utilise un DOM virtuel pour le rendu ce qui le rend très efficace. C'est aussi un outil open source pour tous les amoureux de l'écriture et du markdown.
-2. Comme mentionné **Mark Text** est et restera open source. Il est aussi espérer que des amoureux du markdown puissent participer au dévelopement du projet afin de rendre **Mark Text** un éditeur parmis les plus populaire.
-3. Il y a beaucoup d'éditeur markdown et chacun de ses éditeurs à ses propres caractéristiques mais il est aussi difficile de pouvoir satisfaire tout les besoins utilisateurs. J'espère que **Mark Text** pourra satisfaire vos besoins le plus possible. De plus **Mark Text** n'est pas parfait mais nous faisons de notre mieux pour aller dans cette direction.
+1. J'adore écrire. J'ai utilisé de nombreux éditeurs markdown et pourtant, aucun ne correspondait réellement à mes besoins. **MarkText** utilise un DOM virtuel pour le rendu ce qui le rend très efficace. C'est aussi un outil open source pour tous les amoureux de l'écriture et du markdown.
+2. Comme mentionné **MarkText** est et restera open source. Il est aussi espérer que des amoureux du markdown puissent participer au dévelopement du projet afin de rendre **MarkText** un éditeur parmis les plus populaire.
+3. Il y a beaucoup d'éditeur markdown et chacun de ses éditeurs à ses propres caractéristiques mais il est aussi difficile de pouvoir satisfaire tout les besoins utilisateurs. J'espère que **MarkText** pourra satisfaire vos besoins le plus possible. De plus **MarkText** n'est pas parfait mais nous faisons de notre mieux pour aller dans cette direction.
 
 ## Download and Install
 
@@ -125,7 +125,7 @@ Vous ne trouvez pas votre système? Aller sur la [page des releases](https://git
 
 Vous voulez voir une nouvelle feature dans la prochaine version? Consulté le [CHANGELOG](../../.github/CHANGELOG.md)
 
-Si vous êtes sur OS X, vous pouvez installer Mark Text via [**homebrew cask**](https://github.com/caskroom/homebrew-cask), pour commencer à utiliser Homebrew-Cask, vous avez seulement besoin d'avoir [Homebrew](https://brew.sh/) installer sur votre machine.
+Si vous êtes sur OS X, vous pouvez installer MarkText via [**homebrew cask**](https://github.com/caskroom/homebrew-cask), pour commencer à utiliser Homebrew-Cask, vous avez seulement besoin d'avoir [Homebrew](https://brew.sh/) installer sur votre machine.
 
 ```bash
 brew install --cask mark-text
@@ -135,7 +135,7 @@ brew install --cask mark-text
 
 #### macOS and Windows
 
-Télécharger et installer simplement Mark Text via le client d'installation.
+Télécharger et installer simplement MarkText via le client d'installation.
 
 #### Linux
 
@@ -143,13 +143,13 @@ Veuillez suivre [les instructions d'installations Linux](../../docs/LINUX.md).
 
 ## Development
 
-Si vous souhaiter participer à l'amélioration de **Mark Text**, référer vous au [instructions de dévelopement](../../CONTRIBUTING.md#build-instructions).
+Si vous souhaiter participer à l'amélioration de **MarkText**, référer vous au [instructions de dévelopement](../../CONTRIBUTING.md#build-instructions).
 
 Si vous avez des questions pendant votre utilisation, vous êtes les bienvenues pour ouvrir une issue, mais j'espère que vous suivrez le format requis. Bien sûr, si vous soumettez une PR directement, cela sera apprécié.
 
 ## Contribution
 
-**Mark Text** est en plein déveloment, prenez soin d'étudier le [guide de contribution](../../CONTRIBUTING.md) avant de faire une pull request. Vous souhaitez plus de fonctionnalités à Mark Text? Rendez-vous sur la [TODO LIST](../../.github/TODOLIST.md) pour ouvrir des issues.
+**MarkText** est en plein déveloment, prenez soin d'étudier le [guide de contribution](../../CONTRIBUTING.md) avant de faire une pull request. Vous souhaitez plus de fonctionnalités à MarkText? Rendez-vous sur la [TODO LIST](../../.github/TODOLIST.md) pour ouvrir des issues.
 
 ## Backers
 
@@ -167,9 +167,9 @@ Supporter ce projet en devenant sponsor de celui-ci. Votre logo sera affiché ic
 
 ## Contributors
 
-Merci à tous les contributeurs ayant déjà participé à Mark Text [[contributors](https://github.com/marktext/marktext/graphs/contributors)]
+Merci à tous les contributeurs ayant déjà participé à MarkText [[contributors](https://github.com/marktext/marktext/graphs/contributors)]
 
-Un remerciement spécial à @[Yasujizr](https://github.com/Yasujizr) qui est l'auteur du logo de Mark Text.
+Un remerciement spécial à @[Yasujizr](https://github.com/Yasujizr) qui est l'auteur du logo de MarkText.
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/i18n/ja.md
+++ b/docs/i18n/ja.md
@@ -1,6 +1,6 @@
-<p align="center"><img src="../../static/logo-small.png" alt="Mark Text" width="100" height="100"></p>
+<p align="center"><img src="../../static/logo-small.png" alt="MarkText" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
@@ -108,16 +108,16 @@
 
 <br />
 
-<h2 align="center">Mark Textへの支援</h2>
+<h2 align="center">MarkTextへの支援</h2>
 
-Mark Textは、MITライセンスのオープンソースプロジェクトであり、Githubリリースページからいつでも無料で最新のMark Textをダウンロードできます。Mark Textはまだ開発中のソフトウェアであり、開発を続けるためにはスポンサーからのご支援が必要です。どうかMark Textへのご支援をよろしくお願い申し上げます。
+MarkTextは、MITライセンスのオープンソースプロジェクトであり、Githubリリースページからいつでも無料で最新のMarkTextをダウンロードできます。MarkTextはまだ開発中のソフトウェアであり、開発を続けるためにはスポンサーからのご支援が必要です。どうかMarkTextへのご支援をよろしくお願い申し上げます。
 
 - Patreonを介して継続的ご支援をいただける場合は[こちら](https://www.patreon.com/ranluo)から、また、一時寄付金をいただける場合は[こちら](https://github.com/Jocs/sponsor.me)からお願いいたします。
 - Open Collectiveを介してご支援をいただける場合は[こちら](https://opencollective.com/marktext)をご利用ください。
 
 ##### PatreonとOpen Collectiveの違い
 
-Patreonを介した寄付は、Mark Textの開発および維持を行っているLuo Ran (@jocs)に直接届きます。Open Collectiveを介した寄付は、その額や出資者が公開されます。すべての出資金はMark Textの開発、維持、オンラインおよびオフラインでの活動、そしてその他の必要なリソースの入手に使われます。PatreonかOpen Collectiveかに関わらず、すべての出資者のお名前もしくは会社のロゴは、Mark Textの公式サイトおよびReadmeに掲載いたします。
+Patreonを介した寄付は、MarkTextの開発および維持を行っているLuo Ran (@jocs)に直接届きます。Open Collectiveを介した寄付は、その額や出資者が公開されます。すべての出資金はMarkTextの開発、維持、オンラインおよびオフラインでの活動、そしてその他の必要なリソースの入手に使われます。PatreonかOpen Collectiveかに関わらず、すべての出資者のお名前もしくは会社のロゴは、MarkTextの公式サイトおよびReadmeに掲載いたします。
 
 **Platinum Sponsors**
 
@@ -181,9 +181,9 @@ Patreonを介した寄付は、Mark Textの開発および維持を行ってい�
 
 ## 開発の意図
 
-1. 私は書くことが好きです。これまでに沢山のマークダウンエディタを使ってきましたが、まだ私の要望を完璧に満たすものを見つけられていません。致命的なバグに執筆を邪魔されたくないのです。**Mark Text**はページのレンダリングに仮想DOMを用いることで効率を向上させ、さらにオープンソースで提供しました。
-2. 上記の通り、**Mark Text**はオープンソースなので、誰でもソースコードをコントリビュートすることで開発に参加し、**Mark Text** をポピュラーなマークダウンエディタにしていくことができます。
-3. 特徴的な機能を備えたマークダウンエディタは既に沢山ありますが、全てのマークダウンユーザーの要望を満たすのは難しいです。まだまだ未熟ですが、**Mark Text** がマークダウンユーザーの要望を可能な限り叶えられるエディタになることを願っています。
+1. 私は書くことが好きです。これまでに沢山のマークダウンエディタを使ってきましたが、まだ私の要望を完璧に満たすものを見つけられていません。致命的なバグに執筆を邪魔されたくないのです。**MarkText**はページのレンダリングに仮想DOMを用いることで効率を向上させ、さらにオープンソースで提供しました。
+2. 上記の通り、**MarkText**はオープンソースなので、誰でもソースコードをコントリビュートすることで開発に参加し、**MarkText** をポピュラーなマークダウンエディタにしていくことができます。
+3. 特徴的な機能を備えたマークダウンエディタは既に沢山ありますが、全てのマークダウンユーザーの要望を満たすのは難しいです。まだまだ未熟ですが、**MarkText** がマークダウンユーザーの要望を可能な限り叶えられるエディタになることを願っています。
 
 <h2 id="download">ダウンロード</h2>
 
@@ -197,7 +197,7 @@ Patreonを介した寄付は、Mark Textの開発および維持を行ってい�
 
 #### macOS
 
-最新のMark Text(`marktext-%version%.dmg`)を[リリースページ](https://github.com/marktext/marktext/releases/latest)からダウンロードするか、[**homebrew cask**](https://github.com/caskroom/homebrew-cask)を用いてインストールしてください。Homebrew-Caskを使うためには、[Homebrew](https://brew.sh/)がインストールされている必要があります。
+最新のMarkText(`marktext-%version%.dmg`)を[リリースページ](https://github.com/marktext/marktext/releases/latest)からダウンロードするか、[**homebrew cask**](https://github.com/caskroom/homebrew-cask)を用いてインストールしてください。Homebrew-Caskを使うためには、[Homebrew](https://brew.sh/)がインストールされている必要があります。
 
 ```bash
 brew install --cask mark-text
@@ -205,7 +205,7 @@ brew install --cask mark-text
 
 #### Windows
 
-Mark Textをダウンロードして、セットアップウィザード(`marktext-setup-%version%.exe`)を介してインストールしてください。インストールの際、ユーザごとにインストールするか、グローバルにインストールするかを選択してください。
+MarkTextをダウンロードして、セットアップウィザード(`marktext-setup-%version%.exe`)を介してインストールしてください。インストールの際、ユーザごとにインストールするか、グローバルにインストールするかを選択してください。
 
 #### Linux
 
@@ -217,26 +217,26 @@ Linux、macOSおよびWindows用の全てのバイナリは、[リリースペ�
 
 <h2 id="development">開発</h2>
 
-**Mark Text** を自前でビルドしたい場合は、[build instructions](../../docs/dev/BUILD.md)を参照してください。
+**MarkText** を自前でビルドしたい場合は、[build instructions](../../docs/dev/BUILD.md)を参照してください。
 
 - [User documentation](../../docs/README.md)
 - [Developer documentation](../../docs/dev/README.md)
 
-**Mark Text**に関するご質問がありましたら、フォーマットを参考にissueを作成してください。もちろんプルリクエストを直接提出して頂いても構いません。ご協力ありがとうございます。
+**MarkText**に関するご質問がありましたら、フォーマットを参考にissueを作成してください。もちろんプルリクエストを直接提出して頂いても構いません。ご協力ありがとうございます。
 
 ## インテグレーション
 
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text): macOS向けのアプリであるAlfred Workflowです。Alfredを起動して、"mt"コマンドを入力することでファイルやフォルダをMark Textで開きます。
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text): macOS向けのアプリであるAlfred Workflowです。Alfredを起動して、"mt"コマンドを入力することでファイルやフォルダをMarkTextで開きます。
 
 <h2 id="contribution">コントリビューション</h2>
 
-Mark Textは開発の真っ最中です、プルリクエストを作成する場合は事前に [Contributing Guide](../../CONTRIBUTING.md) をご確認ください。Mark Textに追加したい新機能がある場合は、 [roadmap](https://github.com/marktext/marktext/projects)を参考にしてissueを作成してください。
+MarkTextは開発の真っ最中です、プルリクエストを作成する場合は事前に [Contributing Guide](../../CONTRIBUTING.md) をご確認ください。MarkTextに追加したい新機能がある場合は、 [roadmap](https://github.com/marktext/marktext/projects)を参考にしてissueを作成してください。
 
 ## コントリビューター
 
-Mark Textにコントリビュートしてくださった [[コントリビューター](https://github.com/marktext/marktext/graphs/contributors)] の皆さんに感謝を申し上げます。
+MarkTextにコントリビュートしてくださった [[コントリビューター](https://github.com/marktext/marktext/graphs/contributors)] の皆さんに感謝を申し上げます。
 
-Mark Textのロゴをデザインしてくださった @[Yasujizr](https://github.com/Yasujizr) に感謝を申し上げます。
+MarkTextのロゴをデザインしてくださった @[Yasujizr](https://github.com/Yasujizr) に感謝を申し上げます。
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/i18n/pl.md
+++ b/docs/i18n/pl.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="../../static/logo-small.png" alt="mark text" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fmarktext%2Fmarktext">
@@ -109,9 +109,9 @@
 
 ### Dlaczego kolejny edytor?
 
-1. Kocham pisać. Używałem wiele różnych edytorów markdown, ale wciąż nie ma takiego, który byłby w pełni zgodny z moimi oczekiwaniami. Nie lubię, kiedy pisanie przerywają mi niemożliwe do wytrzymania błędy. **Mark Text** używa wirtualnego DOM do wyrenderowania strony co sprawia, że jest bardzo wydajny. Program jest rozpowszechniany na licencji open source dla wszystkich przyjaciół kochających markdown i pisanie.
-2. Jak już zostało wspomniane powyżej, **Mark Text** będzie zawsze rozpowszechniany na licencji open source. Wierzymy, że wszyscy wielbiciele markdown dołożą swoją cegiełkę do kodów źródłowych programu i pomogą w rozwijaniu **Mark Text**.
-3. Istnieje wiele edytorów markdown i każdy z nich ma swoje cechy szczególne, jednak ciężko jest zaspokoić wszystkie potrzeby użytkowników. Wierzę, że **Mark Text** jest w stanie zaspokoić potrzeby jak największej grupy osób. Mimo iż najnowsza wersja **Mark Text** nie jest idealna, próbujemy stworzyć go tak doskonałym jak to jest tylko możliwe.
+1. Kocham pisać. Używałem wiele różnych edytorów markdown, ale wciąż nie ma takiego, który byłby w pełni zgodny z moimi oczekiwaniami. Nie lubię, kiedy pisanie przerywają mi niemożliwe do wytrzymania błędy. **MarkText** używa wirtualnego DOM do wyrenderowania strony co sprawia, że jest bardzo wydajny. Program jest rozpowszechniany na licencji open source dla wszystkich przyjaciół kochających markdown i pisanie.
+2. Jak już zostało wspomniane powyżej, **MarkText** będzie zawsze rozpowszechniany na licencji open source. Wierzymy, że wszyscy wielbiciele markdown dołożą swoją cegiełkę do kodów źródłowych programu i pomogą w rozwijaniu **MarkText**.
+3. Istnieje wiele edytorów markdown i każdy z nich ma swoje cechy szczególne, jednak ciężko jest zaspokoić wszystkie potrzeby użytkowników. Wierzę, że **MarkText** jest w stanie zaspokoić potrzeby jak największej grupy osób. Mimo iż najnowsza wersja **MarkText** nie jest idealna, próbujemy stworzyć go tak doskonałym jak to jest tylko możliwe.
 
 ### Instalacja
 
@@ -125,7 +125,7 @@ Nie znalazłeś swojego systemu? Przejdź do strony [release](https://github.com
 
 Chciałbyś zobaczyć jak nowe udogodnienia wprowadziła najnowsza wersja? Udaj się do [CHANGELOG](../../.github/CHANGELOG.md)
 
-Jeśli używasz systemu OS X, to możesz zainstalować Mark Text za pomocą [**homebrew cask**](https://github.com/caskroom/homebrew-cask). Aby zacząć korzystać z Homebrew-Cask potrzebujesz tylko [Homebrew](https://brew.sh/).
+Jeśli używasz systemu OS X, to możesz zainstalować MarkText za pomocą [**homebrew cask**](https://github.com/caskroom/homebrew-cask). Aby zacząć korzystać z Homebrew-Cask potrzebujesz tylko [Homebrew](https://brew.sh/).
 
 > brew install --cask mark-text
 
@@ -133,22 +133,22 @@ Jeśli używasz systemu OS X, to możesz zainstalować Mark Text za pomocą [**h
 
 ### Rozwój
 
-Jeżeli chciałbyś samodzielnie zbudować **Mark Text**:
+Jeżeli chciałbyś samodzielnie zbudować **MarkText**:
 
 - sklonuj to repozytorium.
 - uruchom komendę `npm install`
 - uruchom komendę `npm run build`
 - skopiuj zbudowaną aplikację do folderu Applications lub jeśli używasz systemu Windows uruchom instalator.
 
-W przypadku jakichkolwiek pytań podczas korzystania z **Mark Text** zaczęcamy do zgłoszenia problemu. Mamy nadzieję, że będziesz trzymał się ustalonego z góry formatu zgłaszania problemów. Wspaniale by było, jeżeli to właśnie ty naprawisz błąd i zgłosisz pull request.
+W przypadku jakichkolwiek pytań podczas korzystania z **MarkText** zaczęcamy do zgłoszenia problemu. Mamy nadzieję, że będziesz trzymał się ustalonego z góry formatu zgłaszania problemów. Wspaniale by było, jeżeli to właśnie ty naprawisz błąd i zgłosisz pull request.
 
 ## Udział w projekcie
 
-Mark Text jest w trakcie rozwijania. Upewnij się, że przeczytałeś [Contributing Guide](../../CONTRIBUTING.md) przed stworzeniem pull request. Chcesz dodać nowe udogodnienia do Mark Text? Udaj się do [TODO LIST](../../.github/TODOLIST.md)
+MarkText jest w trakcie rozwijania. Upewnij się, że przeczytałeś [Contributing Guide](../../CONTRIBUTING.md) przed stworzeniem pull request. Chcesz dodać nowe udogodnienia do MarkText? Udaj się do [TODO LIST](../../.github/TODOLIST.md)
 
-Dziękujemy wszystkim osobom, które już wzięły udział w projekcie Mark Text! Jeżeli już jesteś członkiem [contributors](https://github.com/marktext/marktext/graphs/contributors), otwórz pull request aby dodać twoje imię i zdjęcie do poniższej listy osób, które pomogły przy projekcie.
+Dziękujemy wszystkim osobom, które już wzięły udział w projekcie MarkText! Jeżeli już jesteś członkiem [contributors](https://github.com/marktext/marktext/graphs/contributors), otwórz pull request aby dodać twoje imię i zdjęcie do poniższej listy osób, które pomogły przy projekcie.
 
-Specjalne podziękowania dla @[Yasujizr](https://github.com/Yasujizr), który zaprojektował logo Mark Text.
+Specjalne podziękowania dla @[Yasujizr](https://github.com/Yasujizr), który zaprojektował logo MarkText.
 
 | [![Jocs](https://avatars0.githubusercontent.com/u/9712830?s=150&v=4)](https://github.com/Jocs) | [![ywwhack](https://avatars1.githubusercontent.com/u/8746197?s=150&v=4)](https://github.com/ywwhack) | [![notAlaanor](https://avatars1.githubusercontent.com/u/17591936?s=150&v=4)](https://github.com/notAlaanor) | [![fxha](https://avatars1.githubusercontent.com/u/22716132?s=150&v=4)](https://github.com/fxha) |
 |:----------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|

--- a/docs/i18n/pt.md
+++ b/docs/i18n/pt.md
@@ -1,6 +1,6 @@
-<p align="center"><img src="https://github.com/marktext/marktext/raw/develop/static/logo-small.png" alt="Mark Text" width="100" height="100"></p>
+<p align="center"><img src="https://github.com/marktext/marktext/raw/develop/static/logo-small.png" alt="MarkText" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
@@ -111,19 +111,19 @@
 
 <br />
 
-<h2 align="center">Dê apoio ao Mark Text</h2>
+<h2 align="center">Dê apoio ao MarkText</h2>
 
-Mark Text é um projeto com licença MIT (projetos de código aberto), e suas atualizações sempre estarão disponíveis gratuitamente na página de 'Releases' do Github. Mark Text ainda está em desenvolvimento e seu desenvolvimento é inseparável de todos os patrocinadores. Espero que você se junte a esse grupo:
+MarkText é um projeto com licença MIT (projetos de código aberto), e suas atualizações sempre estarão disponíveis gratuitamente na página de 'Releases' do Github. MarkText ainda está em desenvolvimento e seu desenvolvimento é inseparável de todos os patrocinadores. Espero que você se junte a esse grupo:
 
 - [Torne-se um apoiador ou patrocinador no Patreon](https://www.patreon.com/ranluo) or [One time donation](https://github.com/Jocs/sponsor.me)
 - [Seja um apoiador ou patrocinador no Open Collective](https://opencollective.com/marktext)
 
 ##### Qual é a diferença entre Patreon e Open Collective?
 
-**Patreon**: Os fundos serão patrocinados diretamente para Luo Ran (@jocs) que criou o Mark Text e continua a mantê-lo.
+**Patreon**: Os fundos serão patrocinados diretamente para Luo Ran (@jocs) que criou o MarkText e continua a mantê-lo.
 
-**Open Collective**: Todas as despesas são transparentes. Os fundos serão usados para o desenvolvimento e manutenção do Mark Text, financiando atividades online e offline e adquirindo outros recursos necessários.
-Nomes e logotipos de empresas de todos os patrocinadores (do Patreon e do Open Collective) aparecerão no site oficial do Mark Text e em seu arquivo README.md.
+**Open Collective**: Todas as despesas são transparentes. Os fundos serão usados para o desenvolvimento e manutenção do MarkText, financiando atividades online e offline e adquirindo outros recursos necessários.
+Nomes e logotipos de empresas de todos os patrocinadores (do Patreon e do Open Collective) aparecerão no site oficial do MarkText e em seu arquivo README.md.
 
 **Patrocinadores Especiais**
 
@@ -194,9 +194,9 @@ Nomes e logotipos de empresas de todos os patrocinadores (do Patreon e do Open C
 
 ## Por que criar outro editor?
 
-1. Amo escrever. Eu usei muitos editores de markdown, mas ainda não há um editor que possa atender totalmente às minhas necessidades. Não gosto de ser incomodado quando escrevo por algum bug insuportável. **Mark Text** usa DOM virtual para renderizar páginas, o que tem os benefícios adicionais de ser altamente eficiente e possui código aberto. Dessa forma, qualquer pessoa que adora marcação e escrita pode usar Mark Text.
-2. Conforme mencionado acima, **Mark Text** é totalmente gratuito e de código-fonte aberto e será para sempre. Esperamos que todos os amantes do markdown contribuam com seu próprio código e ajudem a desenvolver o **Mark Text**, tornando-o um editor de markdown popular.
-3. Existem muitos editores de markdown e todos têm seus próprios méritos, alguns têm recursos que outros não. É difícil satisfazer as necessidades de cada usuário, mas esperamos que **Mark Text** seja capaz de satisfazer cada usuário de Markdown tanto quanto possível. Embora o último **Mark Text** ainda não seja perfeito, vamos tentar fazer o melhor que pudermos.
+1. Amo escrever. Eu usei muitos editores de markdown, mas ainda não há um editor que possa atender totalmente às minhas necessidades. Não gosto de ser incomodado quando escrevo por algum bug insuportável. **MarkText** usa DOM virtual para renderizar páginas, o que tem os benefícios adicionais de ser altamente eficiente e possui código aberto. Dessa forma, qualquer pessoa que adora marcação e escrita pode usar MarkText.
+2. Conforme mencionado acima, **MarkText** é totalmente gratuito e de código-fonte aberto e será para sempre. Esperamos que todos os amantes do markdown contribuam com seu próprio código e ajudem a desenvolver o **MarkText**, tornando-o um editor de markdown popular.
+3. Existem muitos editores de markdown e todos têm seus próprios méritos, alguns têm recursos que outros não. É difícil satisfazer as necessidades de cada usuário, mas esperamos que **MarkText** seja capaz de satisfazer cada usuário de Markdown tanto quanto possível. Embora o último **MarkText** ainda não seja perfeito, vamos tentar fazer o melhor que pudermos.
 
 ## Download e Instalação
 
@@ -210,7 +210,7 @@ Quer ver os últimos recursos? Por favor acesse o [Histórico de Mudanças](.git
 
 #### macOS
 
-Você pode baixar o último `marktext-%version%.dmg` acessando [página de versões](https://github.com/marktext/marktext/releases/latest) ou instale o Mark Text usando [**homebrew cask**](https://github.com/caskroom/homebrew-cask). Para usar Homebrew-Cask você precisa ter o [Homebrew](https://brew.sh/) instalado.
+Você pode baixar o último `marktext-%version%.dmg` acessando [página de versões](https://github.com/marktext/marktext/releases/latest) ou instale o MarkText usando [**homebrew cask**](https://github.com/caskroom/homebrew-cask). Para usar Homebrew-Cask você precisa ter o [Homebrew](https://brew.sh/) instalado.
 
 ```bash
 brew install --cask mark-text
@@ -218,7 +218,7 @@ brew install --cask mark-text
 
 #### Windows
 
-Instale o Mark Text utilizando um gerenciador de instalações (`marktext-setup-%version%.exe`) e escolha para instalar para seu usuário ou em toda a máquina.
+Instale o MarkText utilizando um gerenciador de instalações (`marktext-setup-%version%.exe`) e escolha para instalar para seu usuário ou em toda a máquina.
 
 De forma alternativa, você pode instalar usando [Chocolatey](https://chocolatey.org/). Para usar Chocolatey você precisa de ter instalado [Chocolatey](https://chocolatey.org/install).
 
@@ -236,24 +236,24 @@ Todo o código-fonte para Linux, macOS and Windows pode ser baixado da [página 
 
 ## Desenvolvimento
 
-Se você deseja fazer sua própria build do **Mark Text**, dê uma lida no documento de [instruções de build](docs/dev/BUILD.md).
+Se você deseja fazer sua própria build do **MarkText**, dê uma lida no documento de [instruções de build](docs/dev/BUILD.md).
 
 - [Documentação do Usuário](docs/README.md)
 - [Documentação do Desenvolvedor](docs/dev/README.md)
 
-Se você ainda possui alguma dúvida sobre **Mark Text**, seja bem vindo para abrir uma issue. Ao fazer isso, use o formato padrão encontrado ao abrir uma 'issue'. Claro, se você enviar um PR diretamente, será muito apreciado.
+Se você ainda possui alguma dúvida sobre **MarkText**, seja bem vindo para abrir uma issue. Ao fazer isso, use o formato padrão encontrado ao abrir uma 'issue'. Claro, se você enviar um PR diretamente, será muito apreciado.
 
 ## Integrações
 
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text): Um fluxo de trabalho para o aplicativo Alfred do macOS: Use "mt" para abrir arquivos/pasta com Mark Text.
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text): Um fluxo de trabalho para o aplicativo Alfred do macOS: Use "mt" para abrir arquivos/pasta com MarkText.
 
 ## Contribuição
 
-Mark Text está em pleno desenvolvimento, certifique-se de ler o [guia de Contribuição](CONTRIBUTING.md) antes de fazer uma solicitação de PR. Quer adicionar alguns recursos ao Mark Text? Consulte nosso [roadmap](https://github.com/marktext/marktext/projects) and open issues.
+MarkText está em pleno desenvolvimento, certifique-se de ler o [guia de Contribuição](CONTRIBUTING.md) antes de fazer uma solicitação de PR. Quer adicionar alguns recursos ao MarkText? Consulte nosso [roadmap](https://github.com/marktext/marktext/projects) and open issues.
 
 ## Contribuidores
 
-Obrigado a todas as pessoas que já contribuíram para Mark Text[[contribuidores](https://github.com/marktext/marktext/graphs/contributors)]
+Obrigado a todas as pessoas que já contribuíram para MarkText[[contribuidores](https://github.com/marktext/marktext/graphs/contributors)]
 
 Um agradecimento especial ao @[Yasujizr](https://github.com/Yasujizr) por desenhar nossa Logo.
 

--- a/docs/i18n/spanish.md
+++ b/docs/i18n/spanish.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="../../static/logo-small.png" alt="mark text" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20me?&hashtags=happyMarkText">
@@ -109,9 +109,9 @@
 
 ## ¿Por qué hacer otro editor ?
 
-1. Me encanta escribir. He usado un montón de editores de markdown, y todavía no he encontrado ninguno que cumpla todas mis necesidades. No me gusta que me moleste ningún bug cuando escribo. **Mark Text** usa virtual DOM para renderizar páginas, la cual tiene el beneficio de ser muy eficiente y de código abierto. Así, a cualquiera que le guste escribir y use markdown puede usar Mark Text
-2. Como se ha mencionado arriba, **Mark Text** es de código abierto, y lo será para siempre. Esperamos que todos los amantes de markdown contribuyan y ayuden al desarrollo de **Mark Text**, para que sea popular.
-3. Hay muchos editores de markdown, y todos tienen sus méritos. Algunos tienen funcionalidades que otros no. Es difícil satisfacer los gustos de todo el mundo, pero esperamos que **Mark Text** cubra las necesidades de todos lo máximo posible. Aunque lo último de **Mark Text** no sea perfecto, lo damos todo para intentar que sea lo mejor
+1. Me encanta escribir. He usado un montón de editores de markdown, y todavía no he encontrado ninguno que cumpla todas mis necesidades. No me gusta que me moleste ningún bug cuando escribo. **MarkText** usa virtual DOM para renderizar páginas, la cual tiene el beneficio de ser muy eficiente y de código abierto. Así, a cualquiera que le guste escribir y use markdown puede usar MarkText
+2. Como se ha mencionado arriba, **MarkText** es de código abierto, y lo será para siempre. Esperamos que todos los amantes de markdown contribuyan y ayuden al desarrollo de **MarkText**, para que sea popular.
+3. Hay muchos editores de markdown, y todos tienen sus méritos. Algunos tienen funcionalidades que otros no. Es difícil satisfacer los gustos de todo el mundo, pero esperamos que **MarkText** cubra las necesidades de todos lo máximo posible. Aunque lo último de **MarkText** no sea perfecto, lo damos todo para intentar que sea lo mejor
 
 ## Descarga e instalación
 
@@ -142,15 +142,15 @@ Sigue las [instrucciones de instalación de Linux]	(../../docs/LINUX.md).
 
 ## Desarrollo
 
-Si quieres construir tú mismo **Mark Text**, por favor, sigue las  [instrucciones de desarrollo](../../CONTRIBUTING.md#build-instructions).
+Si quieres construir tú mismo **MarkText**, por favor, sigue las  [instrucciones de desarrollo](../../CONTRIBUTING.md#build-instructions).
 
-Si tienes dudas sobre **Mark Text**, puedes abrir un issue. Si lo haces, por favor, sigue el formato estándar. Por supuesto, apreciamos que mandes directamente un Pull Request
+Si tienes dudas sobre **MarkText**, puedes abrir un issue. Si lo haces, por favor, sigue el formato estándar. Por supuesto, apreciamos que mandes directamente un Pull Request
 
 ## Integración
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text): un workflow  para la aplicación de macOS Alfred: usa "mt" para abrir archivos/carpetas con Mark Text
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text): un workflow  para la aplicación de macOS Alfred: usa "mt" para abrir archivos/carpetas con MarkText
 ## Contribución
 
-**Mark Text** está en pleno desarrollo. Asegúrate de leer [la guía de contribución](../../CONTRIBUTING.md) antes de hacer un Pull Request. ¿Quieres añadir algunas funcionalidades? Échale un vistazo a la [TODO LIST](../../.github/TODOLIST.md) y abre issues.
+**MarkText** está en pleno desarrollo. Asegúrate de leer [la guía de contribución](../../CONTRIBUTING.md) antes de hacer un Pull Request. ¿Quieres añadir algunas funcionalidades? Échale un vistazo a la [TODO LIST](../../.github/TODOLIST.md) y abre issues.
 
 ## Backers
 
@@ -187,9 +187,9 @@ Apoya este proyecto convirtiéndote en un sponsor. Tu logo se verá aquí con un
 
 ## Contribuidores
 
-Gracias a todo el mundo que ha contribuido al desarrollo de Mark Text! [[contributors](https://github.com/marktext/marktext/graphs/contributors)]
+Gracias a todo el mundo que ha contribuido al desarrollo de MarkText! [[contributors](https://github.com/marktext/marktext/graphs/contributors)]
 
-Un especial agradecimiento a @[Yasujizr](https://github.com/Yasujizr) por hacer el logo de Mark Text.
+Un especial agradecimiento a @[Yasujizr](https://github.com/Yasujizr) por hacer el logo de MarkText.
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/i18n/tr.md
+++ b/docs/i18n/tr.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="../../static/logo-small.png" alt="mark text" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=Uygulama%20için%20ne%20demek%20istersiniz?&hashtags=happyMarkText">
@@ -111,18 +111,18 @@
 
 <br />
 
-<h2 align="center">Mark Text'e yardımda bulunma</h2>
+<h2 align="center">MarkText'e yardımda bulunma</h2>
 
-Mark Text, MIT lisanslı  ve açık kaynaklı bir projedir, ve en yeni versiyonu her zaman ücretsiz olarak GitHub'dan indirilebilir. Mark Text hâlâ geliştirme aşamasında, ve bu geliştirme sponsorları sayesinde mümkün oluyor. Sponsor olmak isterseniz:
+MarkText, MIT lisanslı  ve açık kaynaklı bir projedir, ve en yeni versiyonu her zaman ücretsiz olarak GitHub'dan indirilebilir. MarkText hâlâ geliştirme aşamasında, ve bu geliştirme sponsorları sayesinde mümkün oluyor. Sponsor olmak isterseniz:
 
 - [Become a backer or sponsor on Patreon](https://www.patreon.com/ranluo) or [One time donation](https://github.com/Jocs/sponsor.me)
 - [Become a backer or sponsor on Open Collective](https://opencollective.com/marktext)
 
 ##### Open Collective ve Patreon arasında ne fark var?
 
-Patreon: Tüm yardım direkt olarak Mark Text'i yapan ve sürdüren Luo Ran (@jocs)'a, gider.
-Open Collective: Bu platformda tüm masraf ve harcamalarımız şeffaftır. Para, Mark Text'in geliştirilmesi ve sürdürülmesi, çevrimiçi ve çevrimdışı aktiviteleri, ve gerekli kaynaklara erişimi için kullanılacaktır.
-Tüm sponsorlarımızın (hem Patreon hem Open Collective) isimleri ve logoları Mark Text'in resmi web sitesinde ve README.md dosyasında yer alır.
+Patreon: Tüm yardım direkt olarak MarkText'i yapan ve sürdüren Luo Ran (@jocs)'a, gider.
+Open Collective: Bu platformda tüm masraf ve harcamalarımız şeffaftır. Para, MarkText'in geliştirilmesi ve sürdürülmesi, çevrimiçi ve çevrimdışı aktiviteleri, ve gerekli kaynaklara erişimi için kullanılacaktır.
+Tüm sponsorlarımızın (hem Patreon hem Open Collective) isimleri ve logoları MarkText'in resmi web sitesinde ve README.md dosyasında yer alır.
 
 **Özel Sponsorlar**
 
@@ -193,9 +193,9 @@ Tüm sponsorlarımızın (hem Patreon hem Open Collective) isimleri ve logoları
 
 ## Neden başka bir editör?
 
-1. Yazmayı sevdiğimiz için. Birçok markdown editörü kullandık, ve hala benim gereksinimlerimi tam anlamı ile karşılayanı bir editör yok. Yazarken dayanılmaz bir bug ile uğraşmaktan hoşlanmıyorum. **Mark Text** sayfayı çizmek için virtual DOM kullanır, bu da hızlı ve açık kaynaklı olması gibi avantajlar sağlıyor. Bu yolla yazmayı ve markdown'u seven bütün herkes Mark Text kullanabilir.
-2. Yukarıda bahsettiğim gibi **Mark Text** daima açık kaynak olacak. Tüm markdown sevenlerin koda katkıda bulunmasını ve **Mark Text**'in daha popüler bir markdown editör olmasını ümit ediyorum.
-3. Birçok markdown editörü var, ve her biri kendi avantajlarına sahip. Tüm markdown kullanıcılarını tatmin etmek zor, ama biz **Mark Text** 'in markdown kullanıcılarının gereksinimlerini mümkün oldukça tatmin edebileceğini umuyoruz. **Mark Text** hala mükemmel değil, ancak biz elimizden geldiğince iyileştirmeye çalışıyoruz.
+1. Yazmayı sevdiğimiz için. Birçok markdown editörü kullandık, ve hala benim gereksinimlerimi tam anlamı ile karşılayanı bir editör yok. Yazarken dayanılmaz bir bug ile uğraşmaktan hoşlanmıyorum. **MarkText** sayfayı çizmek için virtual DOM kullanır, bu da hızlı ve açık kaynaklı olması gibi avantajlar sağlıyor. Bu yolla yazmayı ve markdown'u seven bütün herkes MarkText kullanabilir.
+2. Yukarıda bahsettiğim gibi **MarkText** daima açık kaynak olacak. Tüm markdown sevenlerin koda katkıda bulunmasını ve **MarkText**'in daha popüler bir markdown editör olmasını ümit ediyorum.
+3. Birçok markdown editörü var, ve her biri kendi avantajlarına sahip. Tüm markdown kullanıcılarını tatmin etmek zor, ama biz **MarkText** 'in markdown kullanıcılarının gereksinimlerini mümkün oldukça tatmin edebileceğini umuyoruz. **MarkText** hala mükemmel değil, ancak biz elimizden geldiğince iyileştirmeye çalışıyoruz.
 
 ## İndirme ve Kurulum
 
@@ -209,7 +209,7 @@ Son sürümde gelen değişiklikler için [CHANGELOG](.github/CHANGELOG.md)'a ba
 
 #### macOS
 
-Mark Text'i [indirmeler](https://github.com/marktext/marktext/releases/latest)'den`marktext-%sürüm%.dmg` olarak  indirebilir, ya da [**homebrew cask**](https://github.com/caskroom/homebrew-cask) yoluyla kurabilirsiniz. Homebrew-Cask kullanabilmek için [Homebrew](https://brew.sh/)'ün kurulu olması gerekir.
+MarkText'i [indirmeler](https://github.com/marktext/marktext/releases/latest)'den`marktext-%sürüm%.dmg` olarak  indirebilir, ya da [**homebrew cask**](https://github.com/caskroom/homebrew-cask) yoluyla kurabilirsiniz. Homebrew-Cask kullanabilmek için [Homebrew](https://brew.sh/)'ün kurulu olması gerekir.
 
 ```bash
 brew install --cask mark-text
@@ -219,7 +219,7 @@ brew install --cask mark-text
 
 (`marktext-setup-%version%.exe`) yükleyiciyi indirip çalıştırın.
 
-Veya, Mark Text'i [Chocolatey](https://chocolatey.org/) yoluyla kurun. Chocolatey kullanabilmek için [Chocolatey](https://chocolatey.org/install)'in kurulu olması gerekir.
+Veya, MarkText'i [Chocolatey](https://chocolatey.org/) yoluyla kurun. Chocolatey kullanabilmek için [Chocolatey](https://chocolatey.org/install)'in kurulu olması gerekir.
 
 ```bash
 choco install marktext
@@ -235,26 +235,26 @@ Tüm Linux, macOS ve Windows sürümleri [indirmeler](https://github.com/marktex
 
 ## Geliştirme
 
-Eğer **Mark Text** kendiniz derlemek isterseniz, lütfen [geliştirici dökümantasyonuna](../../CONTRIBUTING.md#build-instructions) bakın.
+Eğer **MarkText** kendiniz derlemek isterseniz, lütfen [geliştirici dökümantasyonuna](../../CONTRIBUTING.md#build-instructions) bakın.
 
 - [Kullanıcı dokümantasyonu](../README.md)
 - [Geliştirici dokümantasyonu](../dev/README.md)
 
-**Mark Text** hakkında sorularınız için issue açabilirsiniz. Lütfen standart formatı kullanın. Direkt olarak PR açmak tabiki hoş karşılanır.
+**MarkText** hakkında sorularınız için issue açabilirsiniz. Lütfen standart formatı kullanın. Direkt olarak PR açmak tabiki hoş karşılanır.
 
 ## Entegrasyonlar
 
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text): macOS Alfred uygulaması için bir iş akışı: Mark Text ile dosya/klasör açmak için "mt" kullanılır.
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text): macOS Alfred uygulaması için bir iş akışı: MarkText ile dosya/klasör açmak için "mt" kullanılır.
 
 ## Katkıda Bulunmak
 
-Mark Text geliştirme aşamasındadır. Lütfen pull request açmadan önce [Katkıda bulunma Rehberine](../../CONTRIBUTING.md) bakınız. Mark Text'e katkıda bulunmak için [roadmap](https://github.com/marktext/marktext/projects)'e bakınız.
+MarkText geliştirme aşamasındadır. Lütfen pull request açmadan önce [Katkıda bulunma Rehberine](../../CONTRIBUTING.md) bakınız. MarkText'e katkıda bulunmak için [roadmap](https://github.com/marktext/marktext/projects)'e bakınız.
 
 ## Destekçiler
 
 Tüm destekçilerimize teşekkürler! [[destekçiler](https://github.com/marktext/marktext/graphs/contributors)]
 
-Mark Text logosunu tasarlayan @[Yasujizr](https://github.com/Yasujizr)'a özel teşekkürler.
+MarkText logosunu tasarlayan @[Yasujizr](https://github.com/Yasujizr)'a özel teşekkürler.
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -1,6 +1,6 @@
-<p align="center"><img src="../../static/logo-small.png" alt="Mark Text" width="100" height="100"></p>
+<p align="center"><img src="../../static/logo-small.png" alt="MarkText" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
@@ -111,18 +111,18 @@
 
 <br />
 
-<h2 align="center">支持 Mark Text</h2>
+<h2 align="center">支持 MarkText</h2>
 
-Mark Text 是一个使用 MIT license 的开源项目，您将一直能够从 GitHub release 页面免费下载最新版本。Mark Text 仍然在开发中，它的发展离不开所有赞助者，希望您能加入他们的行列：
+MarkText 是一个使用 MIT license 的开源项目，您将一直能够从 GitHub release 页面免费下载最新版本。MarkText 仍然在开发中，它的发展离不开所有赞助者，希望您能加入他们的行列：
 
 - [在 Patreon 上成为支持者或赞助者](https://www.patreon.com/ranluo) 或 [一次性捐赠](https://github.com/Jocs/sponsor.me)
 - [在 Open Collective 上成为支持者或赞助者](https://opencollective.com/marktext)
 
 ##### Patreon 和 OpenCollective 有什么不同？
 
-在 Patreon 赞助：资金将直接赞助给创建并继续维护 Mark Text 的 Luo Ran (@jocs)。
-在 Open Collective 赞助：所有费用都是透明的，这些赞助资金将用于 Mark Text 的开发、维护、在线和离线活动以及一些必要的资源。
-所有赞助者（无论是在 Patreon 还是 Open Collective）的姓名或公司徽标将出现在 Mark Text 的官方网站和 README.md 文件中。
+在 Patreon 赞助：资金将直接赞助给创建并继续维护 MarkText 的 Luo Ran (@jocs)。
+在 Open Collective 赞助：所有费用都是透明的，这些赞助资金将用于 MarkText 的开发、维护、在线和离线活动以及一些必要的资源。
+所有赞助者（无论是在 Patreon 还是 Open Collective）的姓名或公司徽标将出现在 MarkText 的官方网站和 README.md 文件中。
 
 **特别赞助者**
 
@@ -193,9 +193,9 @@ Mark Text 是一个使用 MIT license 的开源项目，您将一直能够从 Gi
 
 ## 为什么要编写一个编辑器？
 
-1. 我爱写作。我曾经使用过很多 Markdown 编辑器，但还没有一个编辑器可以完全满足我的需求。我不喜欢当我写一些难以忍受的错误时会被打扰。**Mark Text** 使用 virtual DOM 来渲染页面，具有高效和开源的附加优势。这样，任何喜欢 Markdown 和写作的人都可以使用 Mark Text。
-2. 如上所述，**Mark Text** 是完全自由开源的，并且将永远是开源的。我们希望所有 Markdown 爱好者都可以贡献自己的代码，并帮助将 **Mark Text** 开发为流行的 Markdown 编辑器。
-3. Markdown 编辑器很多，各有优点，有一些拥有独特的特性。我们很难满足每个 Markdown 用户的需求，但是我们希望 **Mark Text** 能够尽可能满足每个 Markdown 用户的需求。尽管最新的 **Mark Text** 仍不完美，但我们将尽力使它尽可能地完善。
+1. 我爱写作。我曾经使用过很多 Markdown 编辑器，但还没有一个编辑器可以完全满足我的需求。我不喜欢当我写一些难以忍受的错误时会被打扰。**MarkText** 使用 virtual DOM 来渲染页面，具有高效和开源的附加优势。这样，任何喜欢 Markdown 和写作的人都可以使用 MarkText。
+2. 如上所述，**MarkText** 是完全自由开源的，并且将永远是开源的。我们希望所有 Markdown 爱好者都可以贡献自己的代码，并帮助将 **MarkText** 开发为流行的 Markdown 编辑器。
+3. Markdown 编辑器很多，各有优点，有一些拥有独特的特性。我们很难满足每个 Markdown 用户的需求，但是我们希望 **MarkText** 能够尽可能满足每个 Markdown 用户的需求。尽管最新的 **MarkText** 仍不完美，但我们将尽力使它尽可能地完善。
 
 ## 下载和安装
 
@@ -209,7 +209,7 @@ Mark Text 是一个使用 MIT license 的开源项目，您将一直能够从 Gi
 
 #### macOS
 
-您可以从 [release 页面](https://github.com/marktext/marktext/releases/latest)下载最新的 `marktext-%version%.dmg` 或者使用 [**homebrew cask**](https://github.com/caskroom/homebrew-cask) 安装 Mark Text。要使用 Homebrew-Cask，您只需要安装 [Homebrew](https://brew.sh/)。
+您可以从 [release 页面](https://github.com/marktext/marktext/releases/latest)下载最新的 `marktext-%version%.dmg` 或者使用 [**homebrew cask**](https://github.com/caskroom/homebrew-cask) 安装 MarkText。要使用 Homebrew-Cask，您只需要安装 [Homebrew](https://brew.sh/)。
 
 ```bash
 brew install --cask mark-text
@@ -217,9 +217,9 @@ brew install --cask mark-text
 
 #### Windows
 
-要想安装 Mark Text，只需下载并运行安装向导（`marktext-setup-％version％.exe`），然后选择为本用户安装还是为本计算机所有用户安装。
+要想安装 MarkText，只需下载并运行安装向导（`marktext-setup-％version％.exe`），然后选择为本用户安装还是为本计算机所有用户安装。
 
-另外，也可以使用 [Chocolatey](https://chocolatey.org/) 安装 Mark Text。要想使用 Chocolatey，您需要确保安装了 [Chocolatey](https://chocolatey.org/install)。
+另外，也可以使用 [Chocolatey](https://chocolatey.org/) 安装 MarkText。要想使用 Chocolatey，您需要确保安装了 [Chocolatey](https://chocolatey.org/install)。
 
 ```bash
 choco install marktext
@@ -235,26 +235,26 @@ choco install marktext
 
 ## 开发
 
-如果您想自己构建 **Mark Text**，请查看我们的[构建指南](../../docs/dev/BUILD.md)。
+如果您想自己构建 **MarkText**，请查看我们的[构建指南](../../docs/dev/BUILD.md)。
 
 - [用户文档](../../docs/README.md)
 - [开发者文档](../../docs/dev/README.md)
 
-如果您对 **Mark Text** 有任何疑问，欢迎写一个 issue。当这样做时，请使用打开 issue 时的默认格式。当然，如果您直接提交 PR，我们将不胜感激。
+如果您对 **MarkText** 有任何疑问，欢迎写一个 issue。当这样做时，请使用打开 issue 时的默认格式。当然，如果您直接提交 PR，我们将不胜感激。
 
 ## 集成
 
-- [Alfred 工作流](http://www.packal.org/workflow/mark-text)：macOS 应用程序 Alfred 的工作流：使用“mt”在文件或者文件夹下打开 Mark Text。
+- [Alfred 工作流](http://www.packal.org/workflow/mark-text)：macOS 应用程序 Alfred 的工作流：使用“mt”在文件或者文件夹下打开 MarkText。
 
 ## 贡献
 
-Mark Text 正在全面开发中，请确保在提出 PR 之前先阅读[贡献指南](../../CONTRIBUTING.md)。想要给 Mark Text 添加一些功能？请先看看 [roadmap](../../ROADMAP.md) 和开放的 issue。
+MarkText 正在全面开发中，请确保在提出 PR 之前先阅读[贡献指南](../../CONTRIBUTING.md)。想要给 MarkText 添加一些功能？请先看看 [roadmap](../../ROADMAP.md) 和开放的 issue。
 
 ## 贡献者
 
-感谢所有为 Mark Text 做出贡献的人[[贡献者](https://github.com/marktext/marktext/graphs/contributors)]
+感谢所有为 MarkText 做出贡献的人[[贡献者](https://github.com/marktext/marktext/graphs/contributors)]
 
-特别感谢设计了 Mark Text 图标的 @[Yasujizr](https://github.com/Yasujizr)。
+特别感谢设计了 MarkText 图标的 @[Yasujizr](https://github.com/Yasujizr)。
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/docs/i18n/zh_tw.md
+++ b/docs/i18n/zh_tw.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="../../static/logo-small.png" alt="mark text" width="100" height="100"></p>
 
-<h1 align="center">Mark Text</h1>
+<h1 align="center">MarkText</h1>
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
     <img src="https://img.shields.io/twitter/url/https/github.com/marktext/marktext.svg?style=for-the-badge" alt="twitter">
@@ -110,16 +110,16 @@
 <br />
 
 
-<h2 align="center">支援 Mark Text</h2>
+<h2 align="center">支援 MarkText</h2>
 
-Mark Text 是 MIT 許可的開源專案，你可以持續在 GitHub 發布頁面免費下載最新版本。Mark Text 仍然在開發中，其發展與所有贊助商都密不可分。我希望你加入他們的行列：
+MarkText 是 MIT 許可的開源專案，你可以持續在 GitHub 發布頁面免費下載最新版本。MarkText 仍然在開發中，其發展與所有贊助商都密不可分。我希望你加入他們的行列：
 
 - [Become a backer or sponsor on Patreon](https://www.patreon.com/ranluo) or [One time donation](https://github.com/Jocs/sponsor.me)
 - [Become a backer or sponsor on Open Collective](https://opencollective.com/marktext)
 
 ##### 使用 Patreon 和 OpenCollective 贊助有什麼不同？
 
-使用 Patreon 贊助，它將直接贊助给 Mark Text 的作者及維護者 Luo Ran (@jocs)。使用 Open Collective 贊助的所有費用都是公開的，這些贊助資金將用於 Mark Text 的開發、維護、線上和線下活動以及一些必要的資源（無論您是在 Patreon 還是 Open Collective 贊助）。您的姓名或公司logo將出現在 Mark Text 的 README 和官方網站上。
+使用 Patreon 贊助，它將直接贊助给 MarkText 的作者及維護者 Luo Ran (@jocs)。使用 Open Collective 贊助的所有費用都是公開的，這些贊助資金將用於 MarkText 的開發、維護、線上和線下活動以及一些必要的資源（無論您是在 Patreon 還是 Open Collective 贊助）。您的姓名或公司logo將出現在 MarkText 的 README 和官方網站上。
 
 **白金贊助商**
 
@@ -185,9 +185,9 @@ Mark Text 是 MIT 許可的開源專案，你可以持續在 GitHub 發布頁面
 ## 為什麼要另外寫一個編輯器？
 
 1. 我愛寫作。我曾經用過很多 Markdown 編輯器，但沒有一個編輯器可以滿足我的需求。我不喜歡在我寫作的時候被莫名其妙的bug干擾。
-**Mark Text** 使用 virtual DOM 來呈現畫面，擁有高效能和開源的附加優勢。任何喜歡 Markdown 和寫作的人都可以使用 Mark Text。
-2. 承上所述，**Mark Text** 是完全免費和開源的，且將永遠開源。我們希望所有 Markdown 愛好者都可以協助開發並貢獻自己的程式，讓 **Mark Text** 成為流行的 Markdown 編輯器。
-3. Markdown 編輯器很多，各有優點，有些則沒有。我們很難滿足所有 Markdown 用户的需求，但是我們希望 **Mark Text** 盡可能滿足每一個 Markdown 用户的需求。儘管最新的 **Mark Text** 仍不完美，但我們會盡力使它更加完善。
+**MarkText** 使用 virtual DOM 來呈現畫面，擁有高效能和開源的附加優勢。任何喜歡 Markdown 和寫作的人都可以使用 MarkText。
+2. 承上所述，**MarkText** 是完全免費和開源的，且將永遠開源。我們希望所有 Markdown 愛好者都可以協助開發並貢獻自己的程式，讓 **MarkText** 成為流行的 Markdown 編輯器。
+3. Markdown 編輯器很多，各有優點，有些則沒有。我們很難滿足所有 Markdown 用户的需求，但是我們希望 **MarkText** 盡可能滿足每一個 Markdown 用户的需求。儘管最新的 **MarkText** 仍不完美，但我們會盡力使它更加完善。
 
 ## 下載及安裝
 
@@ -201,7 +201,7 @@ Mark Text 是 MIT 許可的開源專案，你可以持續在 GitHub 發布頁面
 
 #### macOS
 
-你可以從 [release page](https://github.com/marktext/marktext/releases/latest) 下載最新的 `marktext-%version%.dmg` 或是使用 [**homebrew cask**](https://github.com/caskroom/homebrew-cask) 安裝 Mark Text。如果使用 Homebrew-Cask，您只需要安裝 [Homebrew](https://brew.sh/)。
+你可以從 [release page](https://github.com/marktext/marktext/releases/latest) 下載最新的 `marktext-%version%.dmg` 或是使用 [**homebrew cask**](https://github.com/caskroom/homebrew-cask) 安裝 MarkText。如果使用 Homebrew-Cask，您只需要安裝 [Homebrew](https://brew.sh/)。
 
 ```bash
 brew install --cask mark-text
@@ -209,7 +209,7 @@ brew install --cask mark-text
 
 #### Windows
 
-只需要透過安裝精靈 (`marktext-setup-％version％.exe`）下載並安裝 Mark Text，然後選擇替用户或是機器安裝。
+只需要透過安裝精靈 (`marktext-setup-％version％.exe`）下載並安裝 MarkText，然後選擇替用户或是機器安裝。
 
 #### Linux
 
@@ -221,23 +221,23 @@ brew install --cask mark-text
 
 ## 開發
 
-如果您想自己建置 **Mark Text**，請查看我們的 [developer documentation](../../.github.md#build-instructions).
+如果您想自己建置 **MarkText**，請查看我們的 [developer documentation](../../.github.md#build-instructions).
 
-如果您對 **Mark Text** 有任何疑問，歡迎開一個 issue，並使用開 issue 時的預設格式。當然您也可以直接提交 PR，我們將感激不盡。
+如果您對 **MarkText** 有任何疑問，歡迎開一個 issue，並使用開 issue 時的預設格式。當然您也可以直接提交 PR，我們將感激不盡。
 
 ## 整合
-- [Alfred Workflow](http://www.packal.org/workflow/mark-text)：macOS 應用程式 Alfred 的使用流程：使用 "mt" 在文件或者文件夾中打開 Mark Text。
+- [Alfred Workflow](http://www.packal.org/workflow/mark-text)：macOS 應用程式 Alfred 的使用流程：使用 "mt" 在文件或者文件夾中打開 MarkText。
 
 ## 貢獻
 
-Mark Text 正在全面開發中，請確保在提出 PR 之前先閱讀 [Contributing Guide](../../CONTRIBUTING.md) 想要给 Mark Text 新增一些功能嗎？請先看看 [ROADMAP](../../ROADMAP.md) 並創建一個 issue。
+MarkText 正在全面開發中，請確保在提出 PR 之前先閱讀 [Contributing Guide](../../CONTRIBUTING.md) 想要给 MarkText 新增一些功能嗎？請先看看 [ROADMAP](../../ROADMAP.md) 並創建一個 issue。
 
 ## 貢獻者
 
-感謝所有為 Mark Text 做出貢獻的人們
+感謝所有為 MarkText 做出貢獻的人們
 [[contributors](https://github.com/marktext/marktext/graphs/contributors)]
 
-特别感謝 @[Yasujizr](https://github.com/Yasujizr) 設計了一個 Logo 給 Mark Text。
+特别感謝 @[Yasujizr](https://github.com/Yasujizr) 設計了一個 Logo 給 MarkText。
 
 <a href="https://github.com/marktext/marktext/graphs/contributors"><img src="https://opencollective.com/marktext/contributors.svg?width=890" /></a>
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,4 +1,4 @@
-productName: "Mark Text"
+productName: "MarkText"
 appId: "com.github.marktext.marktext"
 
 asar: true
@@ -95,7 +95,7 @@ linux:
   artifactName: "marktext-${arch}.${ext}"
   executableName: "marktext"
   description: "A simple and elegant open-source markdown editor that focused on speed and usability."
-  maintainer: "Mark Text Contributors"
+  maintainer: "MarkText Contributors"
   category: "Office;TextEditor;Utility"
   mimeTypes:
   - "text/markdown"

--- a/resources/THIRD-PARTY-LICENSES.txt
+++ b/resources/THIRD-PARTY-LICENSES.txt
@@ -1,7 +1,7 @@
 # Third Party Notices
 -------------------------------------------------
 
-This file contains all third-party packages that are bundled and shipped with Mark Text.
+This file contains all third-party packages that are bundled and shipped with MarkText.
 
 -------------------------------------------------
 # Summary

--- a/resources/linux/marktext.appdata.xml
+++ b/resources/linux/marktext.appdata.xml
@@ -3,11 +3,11 @@
   <id>com.github.marktext.marktext</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
-  <name>Mark Text</name>
+  <name>MarkText</name>
   <summary>Next generation markdown editor</summary>
   <description>
     <p>
-      Mark Text is a free and open-source realtime preview markdown editor which support both CommonMark Spec and GitHub Flavored Markdown Spec. It is a concise text editor, dedicated to improving your writing efficiency.
+      MarkText is a free and open-source realtime preview markdown editor which support both CommonMark Spec and GitHub Flavored Markdown Spec. It is a concise text editor, dedicated to improving your writing efficiency.
     </p>
     <p>Features:</p>
     <ul>

--- a/resources/linux/marktext.desktop
+++ b/resources/linux/marktext.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Mark Text
+Name=MarkText
 Comment=Next generation markdown editor
 Exec=marktext %F
 Terminal=false

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Mark Text</title>
+    <title>MarkText</title>
     <style>
       html, body {
         margin: 0;

--- a/src/main/cli/index.js
+++ b/src/main/cli/index.js
@@ -12,7 +12,7 @@ const writeLine = s => write(s + '\n')
 const cli = () => {
   let argv = process.argv.slice(1)
   if (process.env.NODE_ENV === 'development') {
-    // Don't pass electron development arguments to Mark Text and change user data path.
+    // Don't pass electron development arguments to MarkText and change user data path.
     argv = ['--user-data-dir', path.join(getPath('appData'), 'marktext-dev')]
   }
 
@@ -36,7 +36,7 @@ const cli = () => {
   }
 
   if (args['--version']) {
-    writeLine(`Mark Text: ${global.MARKTEXT_VERSION_STRING}`)
+    writeLine(`MarkText: ${global.MARKTEXT_VERSION_STRING}`)
     writeLine(`Node.js: ${process.versions.node}`)
     writeLine(`Electron: ${process.versions.electron}`)
     writeLine(`Chromium: ${process.versions.chrome}`)

--- a/src/main/dataCenter/schema.json
+++ b/src/main/dataCenter/schema.json
@@ -8,7 +8,7 @@
     "type": "string"
   },
   "webImages": {
-    "description": "Images from web which you used in Mark Text",
+    "description": "Images from web which you used in MarkText",
     "type": "array"
   },
   "cloudImages": {

--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -41,7 +41,7 @@ const handleError = async (title, error, type) => {
   }
 
   if (EXIT_ON_ERROR) {
-    console.log('Mark Text was terminated due to an unexpected error (MARKTEXT_EXIT_ON_ERROR variable was set)!')
+    console.log('MarkText was terminated due to an unexpected error (MARKTEXT_EXIT_ON_ERROR variable was set)!')
     process.exit(1)
     // eslint, don't lie to me, the return statement is important!
     return // eslint-disable-line no-unreachable
@@ -86,7 +86,7 @@ ${title}.
 
 ### Version
 
-Mark Text: ${global.MARKTEXT_VERSION_STRING}
+MarkText: ${global.MARKTEXT_VERSION_STRING}
 Operating system: ${getOSInformation()}`)
         break
       }

--- a/src/main/filesystem/watcher.js
+++ b/src/main/filesystem/watcher.js
@@ -329,7 +329,7 @@ class Watcher {
   }
 
   /**
-   * Check whether we should ignore the current event because the file may be changed from Mark Text itself.
+   * Check whether we should ignore the current event because the file may be changed from MarkText itself.
    *
    * @param {number} winId
    * @param {string} pathname

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -42,16 +42,16 @@ if (args['--disable-gpu']) {
   app.disableHardwareAcceleration()
 }
 
-// Make Mark Text a single instance application.
+// Make MarkText a single instance application.
 if (!process.mas && process.env.NODE_ENV !== 'development') {
   const gotSingleInstanceLock = app.requestSingleInstanceLock()
   if (!gotSingleInstanceLock) {
-    process.stdout.write('Other Mark Text instance detected: exiting...\n')
+    process.stdout.write('Other MarkText instance detected: exiting...\n')
     app.exit()
   }
 }
 
-// Mark Text environment is configured successfully. You can now access paths, use the logger etc.
+// MarkText environment is configured successfully. You can now access paths, use the logger etc.
 // Create other instances that need access to the modules from above.
 let accessor = null
 try {
@@ -60,7 +60,7 @@ try {
   // Catch errors that may come from invalid configuration files like settings.
   const msgHint = err.message.includes('Config schema violation')
     ? 'This seems to be an issue with your configuration file(s). ' : ''
-  log.error(`Loading Mark Text failed during initialization! ${msgHint}`, err)
+  log.error(`Loading MarkText failed during initialization! ${msgHint}`, err)
 
   const EXIT_ON_ERROR = !!process.env.MARKTEXT_EXIT_ON_ERROR
   const SHOW_ERROR_DIALOG = !process.env.MARKTEXT_ERROR_INTERACTION

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -21,7 +21,7 @@ class Keybindings {
     this.configPath = path.join(userDataPath, 'keybindings.json')
 
     this.keys = new Map([
-      // Mark Text - macOS only
+      // MarkText - macOS only
       ['mt.hide', 'Command+H'],
       ['mt.hide-others', 'Command+Alt+H'],
 

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -112,7 +112,7 @@ const handleResponseForSave = async (e, { id, filename, markdown, pathname, opti
 
   // If the file doesn't exist on disk add it to the recently used documents later
   // and execute file from filesystem watcher for a short time. The file may exists
-  // on disk nevertheless but is already tracked by Mark Text.
+  // on disk nevertheless but is already tracked by MarkText.
   const alreadyExistOnDisk = !!pathname
 
   let filePath = pathname
@@ -241,7 +241,7 @@ ipcMain.on('mt::response-file-save-as', async (e, { id, filename, markdown, path
 
   // If the file doesn't exist on disk add it to the recently used documents later
   // and execute file from filesystem watcher for a short time. The file may exists
-  // on disk nevertheless but is already tracked by Mark Text.
+  // on disk nevertheless but is already tracked by MarkText.
   const alreadyExistOnDisk = !!pathname
 
   let { filePath, canceled } = await dialog.showSaveDialog(win, {

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -110,7 +110,7 @@ export default function () {
     helpMenu.submenu.push({
       type: 'separator'
     }, {
-      label: 'About Mark Text...',
+      label: 'About MarkText...',
       click (menuItem, browserWindow) {
         actions.showAboutDialog(browserWindow)
       }

--- a/src/main/menu/templates/marktext.js
+++ b/src/main/menu/templates/marktext.js
@@ -4,9 +4,9 @@ import * as actions from '../actions/marktext'
 
 export default function (keybindings) {
   return {
-    label: 'Mark Text',
+    label: 'MarkText',
     submenu: [{
-      label: 'About Mark Text',
+      label: 'About MarkText',
       click (menuItem, browserWindow) {
         showAboutDialog(browserWindow)
       }
@@ -30,7 +30,7 @@ export default function (keybindings) {
     }, {
       type: 'separator'
     }, {
-      label: 'Hide Mark Text',
+      label: 'Hide MarkText',
       accelerator: keybindings.getAccelerator('mt.hide'),
       role: 'hide'
     }, {
@@ -43,7 +43,7 @@ export default function (keybindings) {
     }, {
       type: 'separator'
     }, {
-      label: 'Quit Mark Text',
+      label: 'Quit MarkText',
       accelerator: keybindings.getAccelerator('file.quit'),
       click: app.quit
     }]

--- a/src/main/preferences/hunspell.js
+++ b/src/main/preferences/hunspell.js
@@ -13,7 +13,7 @@ export default async appDataPath => {
   const destPath = path.join(destDir, 'en-US.bdic')
 
   if (!await fs.exists(srcPath)) {
-    log.error('Error while installing Hunspell default dictionary. Mark Text resources are corrupted!')
+    log.error('Error while installing Hunspell default dictionary. MarkText resources are corrupted!')
     return
   }
 

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -52,7 +52,7 @@
     "default": "modified"
   },
   "startUpAction": {
-    "description": "General--The action after Mark Text startup, open the last edited content, open the specified folder or blank page",
+    "description": "General--The action after MarkText startup, open the last edited content, open the specified folder or blank page",
     "enum": [
       "folder",
       "lastState",
@@ -65,7 +65,7 @@
     "type": "string"
   },
   "language": {
-    "description": "General--The language Mark Text use.",
+    "description": "General--The language MarkText use.",
     "type": "string",
     "default": "en"
   },
@@ -245,7 +245,7 @@
     "default": "."
   },
   "preferHeadingStyle": {
-    "description": "Markdown--The preferred heading style in Mark Text",
+    "description": "Markdown--The preferred heading style in MarkText",
     "enum": [
       "atx",
       "setext"
@@ -308,7 +308,7 @@
     "default": "hand"
   },
   "theme": {
-    "description": "Theme--Select the theme used in Mark Text",
+    "description": "Theme--Select the theme used in MarkText",
     "type": "string",
     "default": "light"
   },

--- a/src/main/windows/base.js
+++ b/src/main/windows/base.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events'
 import { isLinux } from '../config'
 
 /**
- * A Mark Text window.
+ * A MarkText window.
  * @typedef {BaseWindow} IApplicationWindow
  * @property {number | null} id Identifier (= browserWindow.id) or null during initialization.
  * @property {Electron.BrowserWindow} browserWindow The browse window.

--- a/src/main/windows/editor.js
+++ b/src/main/windows/editor.js
@@ -117,7 +117,7 @@ class EditorWindow extends BaseWindow {
       const { response } = await dialog.showMessageBox(win, {
         type: 'warning',
         buttons: ['Close', 'Reload', 'Keep It Open'],
-        message: 'Mark Text has crashed',
+        message: 'MarkText has crashed',
         detail: msg
       })
 

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -272,7 +272,7 @@ export const MUYA_DEFAULT_OPTION = Object.freeze({
   autoCheck: false,
   // Whether we should set spellcheck attribute on our container to highlight misspelled words.
   // NOTE: The browser is not able to correct misspelled words words without a custom
-  // implementation like in Mark Text.
+  // implementation like in MarkText.
   spellcheckEnabled: false,
   // transform the image to local folder, cloud or just return the local path
   imageAction: null,
@@ -292,7 +292,7 @@ export const MUYA_DEFAULT_OPTION = Object.freeze({
 })
 
 // export const DIAGRAM_TEMPLATE = Object.freeze({
-//   'mermaid': `graph LR;\nYou-->|Mark Text|Me;`
+//   'mermaid': `graph LR;\nYou-->|MarkText|Me;`
 // })
 
 export const isOsx = window && window.navigator && /Mac/.test(window.navigator.platform)

--- a/src/muya/lib/contentState/clickCtrl.js
+++ b/src/muya/lib/contentState/clickCtrl.js
@@ -12,6 +12,9 @@ const clickCtrl = ContentState => {
       const lastBlock = this.getLastBlock()
       const archor = this.findOutMostBlock(lastBlock)
       const archorParagraph = document.querySelector(`#${archor.key}`)
+      if (archorParagraph === null) {
+        return
+      }
       const rect = archorParagraph.getBoundingClientRect()
       // If click below the last paragraph
       // and the last paragraph is not empty, create a new empty paragraph

--- a/src/muya/lib/contentState/index.js
+++ b/src/muya/lib/contentState/index.js
@@ -279,7 +279,7 @@ class ContentState {
   }
 
   /**
-   * A block in Mark Text present a paragraph(block syntax in GFM) or a line in paragraph.
+   * A block in MarkText present a paragraph(block syntax in GFM) or a line in paragraph.
    * a `span` block must in a `p block` or `pre block` and `p block`'s children must be `span` blocks.
    */
   createBlock (type = 'span', extras = {}) {

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -457,7 +457,7 @@ function getContainer (originContainer, options) {
   container.setAttribute('autocorrect', false)
   container.setAttribute('autocomplete', 'off')
   // NOTE: The browser is not able to correct misspelled words words without
-  // a custom implementation like in Mark Text.
+  // a custom implementation like in MarkText.
   container.setAttribute('spellcheck', !!spellcheckEnabled)
   container.appendChild(rootDom)
   originContainer.replaceWith(container)

--- a/src/muya/lib/parser/marked/lexer.js
+++ b/src/muya/lib/parser/marked/lexer.js
@@ -389,7 +389,7 @@ Lexer.prototype.token = function (src, top) {
             (isOrdered && newIsOrdered && bull.slice(-1) !== newBull.slice(-1)) ||
             (isOrdered !== newIsOrdered) ||
             // Changing to/from task list item from/to bullet, starts a new list(work for marktext issue #870)
-            // Because we distinguish between task list and bullet list in Mark Text,
+            // Because we distinguish between task list and bullet list in MarkText,
             // the parsing here is somewhat different from the commonmark Spec,
             // and the task list needs to be a separate list.
             (isTaskList !== newIsTaskListItem)

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -1,5 +1,5 @@
 /**
- * translate markdown format to content state used by Mark Text
+ * translate markdown format to content state used by MarkText
  * there is some difference when parse loose list item and tight lsit item.
  * Both of them add a p block in li block, use the CSS style to distinguish loose and tight.
  */

--- a/src/muya/package.json
+++ b/src/muya/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muya",
   "version": "0.1.2",
-  "description": "A browser based markdown editor that powers Mark Text",
+  "description": "A browser based markdown editor that powers MarkText",
   "main": "dist/muya.min.js",
   "scripts": {
     "test": "npm run test"

--- a/src/renderer/codeMirror/modes.js
+++ b/src/renderer/codeMirror/modes.js
@@ -167,6 +167,10 @@ const languages = [{
   mode: 'clike',
   mime: 'text/x-csharp'
 }, {
+  name: 'cs',
+  mode: 'clike',
+  mime: 'text/x-csharp'
+}, {
   name: 'rust',
   mode: 'rust',
   mime: 'text/x-rustsrc'

--- a/src/renderer/commands/index.js
+++ b/src/renderer/commands/index.js
@@ -677,29 +677,29 @@ const commands = [
   },
 
   // --------------------------------------------------------------------------
-  // Mark Text
+  // MarkText
 
   {
     id: 'file.preferences',
-    description: 'Mark Text: Preferences',
+    description: 'MarkText: Preferences',
     execute: async () => {
       ipcRenderer.send('mt::open-setting-window')
     }
   }, {
     id: 'file.quit',
-    description: 'Mark Text: Quit',
+    description: 'MarkText: Quit',
     execute: async () => {
       ipcRenderer.send('mt::app-try-quit')
     }
   }, {
     id: 'docs.user-guide',
-    description: 'Mark Text: End User Guide',
+    description: 'MarkText: End User Guide',
     execute: async () => {
       shell.openExternal('https://github.com/marktext/marktext/blob/develop/docs/README.md')
     }
   }, {
     id: 'docs.markdown-syntax',
-    description: 'Mark Text: Markdown Syntax Guide',
+    description: 'MarkText: Markdown Syntax Guide',
     execute: async () => {
       shell.openExternal('https://github.com/marktext/marktext/blob/develop/docs/MARKDOWN_SYNTAX.md')
     }
@@ -726,7 +726,7 @@ const commands = [
 if (isUpdatable()) {
   commands.push({
     id: 'file.check-update',
-    description: 'Mark Text: Check for Updates',
+    description: 'MarkText: Check for Updates',
     execute: async () => {
       ipcRenderer.send('mt::check-for-update')
     }

--- a/src/renderer/components/about/index.vue
+++ b/src/renderer/components/about/index.vue
@@ -33,9 +33,9 @@ import MarkTextLogo from '../../assets/images/logo.png'
 
 export default {
   data () {
-    this.name = 'Mark Text'
+    this.name = 'MarkText'
     this.copyright = `Copyright © 2017-${new Date().getFullYear()} Luo Ran`
-    this.copyrightContributors = `Copyright © 2018-${new Date().getFullYear()} Mark Text Contributors`
+    this.copyrightContributors = `Copyright © 2018-${new Date().getFullYear()} MarkText Contributors`
     this.logo = MarkTextLogo
     return {
       showAboutDialog: false

--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -172,7 +172,7 @@ export default {
 
       // TODO(perf): Create a copy of dom-autoscroller and just hook tabs-container to
       //   improve performance. Currently autoScroll is triggered when the mouse is moved
-      //   in Mark Text window.
+      //   in MarkText window.
 
       // Scroll when dragging a tab to the beginning or end of the tab container.
       this.autoScroller = autoScroll([tabs], {

--- a/src/renderer/components/import/index.vue
+++ b/src/renderer/components/import/index.vue
@@ -19,7 +19,7 @@
             <img :src="`${importIcon.url}`" alt="import file">
           </div>
           <div>Import or Open</div>
-          <p> Drop here to get you stuff into Mark Text</p>
+          <p> Drop here to get you stuff into MarkText</p>
         </div>
         <div class="file-list">
           <div>.md</div>

--- a/src/renderer/components/titleBar/index.vue
+++ b/src/renderer/components/titleBar/index.vue
@@ -9,7 +9,7 @@
       :class="[{ 'active': active }, { 'tabs-visible': showTabBar }, { 'frameless': titleBarStyle === 'custom' }, { 'isOsx': isOsx }]"
     >
       <div class="title" @dblclick.stop="toggleMaxmizeOnMacOS">
-        <span v-if="!filename">Mark Text</span>
+        <span v-if="!filename">MarkText</span>
         <span v-else>
           <span
             v-for="(path, index) of paths"
@@ -171,9 +171,9 @@ export default {
       const hasOpenFolder = this.project && this.project.name
       let title = ''
       if (value) {
-        title = hasOpenFolder ? `${value} - ${this.project.name}` : `${value} - Mark Text`
+        title = hasOpenFolder ? `${value} - ${this.project.name}` : `${value} - MarkText`
       } else {
-        title = hasOpenFolder ? this.project.name : 'Mark Text'
+        title = hasOpenFolder ? this.project.name : 'MarkText'
       }
 
       document.title = title

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -18,9 +18,9 @@ Vue.use(Vuex)
 // global states
 const state = {
   platform: process.platform, // platform of system `darwin` | `win32` | `linux`
-  appVersion: process.versions.MARKTEXT_VERSION_STRING, // Mark Text version string
+  appVersion: process.versions.MARKTEXT_VERSION_STRING, // MarkText version string
   windowActive: true, // whether current window is active or focused
-  init: false // whether Mark Text is initialized
+  init: false // whether MarkText is initialized
 }
 
 const getters = {}

--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -140,7 +140,7 @@ export const uploadImage = async (pathname, image, preferences) => {
 
     })
     const path = dayjs().format('YYYY/MM') + `/${dayjs().format('DD-HH-mm-ss')}-${filename}`
-    const message = `Upload by Mark Text at ${dayjs().format('YYYY-MM-DD HH:mm:ss')}`
+    const message = `Upload by MarkText at ${dayjs().format('YYYY-MM-DD HH:mm:ss')}`
     var payload = {
       owner,
       repo,

--- a/test/e2e/launch.spec.js
+++ b/test/e2e/launch.spec.js
@@ -1,7 +1,7 @@
 const { expect, test } = require('@playwright/test')
 const { launchElectron } = require('./helpers')
 
-test.describe('Check Launch Mark Text', async () => {
+test.describe('Check Launch MarkText', async () => {
   let app = null
   let page = null
 
@@ -15,8 +15,8 @@ test.describe('Check Launch Mark Text', async () => {
     await app.close()
   })
 
-  test('Empty Mark Text', async () => {
+  test('Empty MarkText', async () => {
     const title = await page.title()
-    expect(/^Mark Text|Untitled-1 - Mark Text$/.test(title)).toBeTruthy()
+    expect(/^MarkText|Untitled-1 - MarkText$/.test(title)).toBeTruthy()
   })
 })

--- a/test/specs/commonMark/compare.marked.md
+++ b/test/specs/commonMark/compare.marked.md
@@ -1,11 +1,11 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 80
-Mark Text failed examples count: 0
+MarkText failed examples count: 0
 
 **Example49**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -32,7 +32,7 @@ marked.js html
 
 **Example51**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -58,7 +58,7 @@ baz</em>
 
 **Example52**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -82,7 +82,7 @@ baz</em><br>====</p>
 
 **Example65**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -108,7 +108,7 @@ Bar</p>
 
 **Example164**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -137,7 +137,7 @@ marked.js html
 
 **Example169**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -158,7 +158,7 @@ marked.js html
 
 **Example171**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -179,7 +179,7 @@ marked.js html
 
 **Example206**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -210,7 +210,7 @@ bar</code></pre>
 
 **Example207**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -241,7 +241,7 @@ marked.js html
 
 **Example225**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -273,7 +273,7 @@ marked.js html
 
 **Example227**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -306,7 +306,7 @@ marked.js html
 
 **Example232**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -339,7 +339,7 @@ marked.js html
 
 **Example234**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -382,7 +382,7 @@ marked.js html
 
 **Example243**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -423,7 +423,7 @@ marked.js html
 
 **Example244**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -464,7 +464,7 @@ marked.js html
 
 **Example246**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -496,7 +496,7 @@ marked.js html
 
 **Example248**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -542,7 +542,7 @@ marked.js html
 
 **Example250**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -568,7 +568,7 @@ marked.js html
 
 **Example254**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -589,7 +589,7 @@ marked.js html
 
 **Example276**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -639,7 +639,7 @@ marked.js html
 
 **Example277**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -694,7 +694,7 @@ marked.js html
 
 **Example282**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -741,7 +741,7 @@ marked.js html
 
 **Example283**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -791,7 +791,7 @@ marked.js html
 
 **Example287**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -836,7 +836,7 @@ marked.js html
 
 **Example288**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -884,7 +884,7 @@ marked.js html
 
 **Example289**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -937,7 +937,7 @@ marked.js html
 
 **Example309**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -958,7 +958,7 @@ marked.js html
 
 **Example310**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -980,7 +980,7 @@ marked.js html
 
 **Example314**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1011,7 +1011,7 @@ marked.js html
 
 **Example318**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1030,7 +1030,7 @@ marked.js html
 
 **Example319**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1051,7 +1051,7 @@ marked.js html
 
 **Example320**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1073,7 +1073,7 @@ marked.js html
 
 **Example361**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1092,7 +1092,7 @@ marked.js html
 
 **Example387**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1111,7 +1111,7 @@ marked.js html
 
 **Example388**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1130,7 +1130,7 @@ marked.js html
 
 **Example407**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1149,7 +1149,7 @@ marked.js html
 
 **Example412**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1168,7 +1168,7 @@ marked.js html
 
 **Example415**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1187,7 +1187,7 @@ marked.js html
 
 **Example416**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1206,7 +1206,7 @@ marked.js html
 
 **Example424**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1225,7 +1225,7 @@ marked.js html
 
 **Example425**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1244,7 +1244,7 @@ marked.js html
 
 **Example442**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1263,7 +1263,7 @@ marked.js html
 
 **Example445**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1282,7 +1282,7 @@ marked.js html
 
 **Example446**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1301,7 +1301,7 @@ marked.js html
 
 **Example453**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1320,7 +1320,7 @@ marked.js html
 
 **Example454**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1339,7 +1339,7 @@ marked.js html
 
 **Example455**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1358,7 +1358,7 @@ marked.js html
 
 **Example456**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1377,7 +1377,7 @@ marked.js html
 
 **Example457**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1396,7 +1396,7 @@ marked.js html
 
 **Example458**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1415,7 +1415,7 @@ marked.js html
 
 **Example465**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1434,7 +1434,7 @@ marked.js html
 
 **Example466**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1453,7 +1453,7 @@ marked.js html
 
 **Example467**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1472,7 +1472,7 @@ marked.js html
 
 **Example470**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1491,7 +1491,7 @@ marked.js html
 
 **Example486**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1510,7 +1510,7 @@ marked.js html
 
 **Example489**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1529,7 +1529,7 @@ marked.js html
 
 **Example490**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1548,7 +1548,7 @@ marked.js html
 
 **Example491**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1575,7 +1575,7 @@ marked.js html
 
 **Example499**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1594,7 +1594,7 @@ marked.js html
 
 **Example503**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1613,7 +1613,7 @@ marked.js html
 
 **Example508**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1632,7 +1632,7 @@ marked.js html
 
 **Example514**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1651,7 +1651,7 @@ marked.js html
 
 **Example515**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1670,7 +1670,7 @@ marked.js html
 
 **Example516**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1689,7 +1689,7 @@ marked.js html
 
 **Example520**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1708,7 +1708,7 @@ marked.js html
 
 **Example522**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1727,7 +1727,7 @@ marked.js html
 
 **Example524**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1748,7 +1748,7 @@ marked.js html
 
 **Example528**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1769,7 +1769,7 @@ marked.js html
 
 **Example529**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1790,7 +1790,7 @@ marked.js html
 
 **Example532**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1811,7 +1811,7 @@ marked.js html
 
 **Example534**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1832,7 +1832,7 @@ marked.js html
 
 **Example569**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1853,7 +1853,7 @@ marked.js html
 
 **Example570**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1872,7 +1872,7 @@ marked.js html
 
 **Example571**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1891,7 +1891,7 @@ marked.js html
 
 **Example572**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1912,7 +1912,7 @@ marked.js html
 
 **Example573**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1933,7 +1933,7 @@ marked.js html
 
 **Example581**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1954,7 +1954,7 @@ marked.js html
 
 **Example585**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1975,7 +1975,7 @@ marked.js html
 
 **Example622**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content
@@ -1994,7 +1994,7 @@ marked.js html
 
 **Example623**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content

--- a/test/specs/commonMark/run.spec.js
+++ b/test/specs/commonMark/run.spec.js
@@ -91,7 +91,7 @@ export const writeResult = (version, specs, markedSpecs, type = 'commonmark') =>
   // compare with markedjs
   let compareResult = '## Compare with `marked.js`\n\n'
   compareResult += `Marked.js failed examples count: ${markedSpecs.filter(s => s.shouldFail).length}\n`
-  compareResult += `Mark Text failed examples count: ${failedCount}\n\n`
+  compareResult += `MarkText failed examples count: ${failedCount}\n\n`
   let count = 0
   specs.forEach((spec, i) => {
     if (spec.shouldFail !== markedSpecs[i].shouldFail) {
@@ -99,7 +99,7 @@ export const writeResult = (version, specs, markedSpecs, type = 'commonmark') =>
       const acturalHtml = marked(spec.markdown, MT_MARKED_OPTIONS)
 
       compareResult += `**Example${spec.example}**\n\n`
-      compareResult += `Mark Text ${spec.shouldFail ? 'fail' : 'success'} and marked.js ${markedSpecs[i].shouldFail ? 'fail' : 'success'}\n\n`
+      compareResult += `MarkText ${spec.shouldFail ? 'fail' : 'success'} and marked.js ${markedSpecs[i].shouldFail ? 'fail' : 'success'}\n\n`
       compareResult += '```markdown\n'
       compareResult += 'Markdown content\n'
       compareResult += `${spec.markdown.replace(/`/g, '\\`')}\n`

--- a/test/specs/gfm/compare.marked.md
+++ b/test/specs/gfm/compare.marked.md
@@ -1,11 +1,11 @@
 ## Compare with `marked.js`
 
 Marked.js failed examples count: 1
-Mark Text failed examples count: 0
+MarkText failed examples count: 0
 
 **Example653**
 
-Mark Text success and marked.js fail
+MarkText success and marked.js fail
 
 ```markdown
 Markdown content

--- a/tools/generateThirdPartyLicense.js
+++ b/tools/generateThirdPartyLicense.js
@@ -58,7 +58,7 @@ ${licenseText}
   const output = `# Third Party Notices
 -------------------------------------------------
 
-This file contains all third-party packages that are bundled and shipped with Mark Text.
+This file contains all third-party packages that are bundled and shipped with MarkText.
 
 -------------------------------------------------
 # Summary


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | As far as I've tested, no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2763
| License           | MIT

### Description

[Description of the bug or feature]

Literally just replaced all occurances of 'Mark Text' with 'MarkText' using sed.