### PR TITLE
Fix wrong HTML escape in paste handler

### DIFF
--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -74,8 +74,7 @@ const pasteCtrl = ContentState => {
     }
 
     // Prevent XSS and sanitize HTML.
-    const { disableHtml } = this.muya.options
-    const sanitizedHtml = sanitize(html, PREVIEW_DOMPURIFY_CONFIG, disableHtml)
+    const sanitizedHtml = sanitize(html, PREVIEW_DOMPURIFY_CONFIG, false)
     const tempWrapper = document.createElement('div')
     tempWrapper.innerHTML = sanitizedHtml
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #2612
| License           | MIT

### Description

Fixed an issue that caused the paste handler to insert only HTML content because we set the wrong flag. All input was converted to HTML when both normal text and HTML was set in clipboard.
