### PR TITLE
Enable macOS arm64 build target

### DIFF
--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -159,8 +159,8 @@ function greeting () {
   const cols = process.stdout.columns
   let text = ''
 
-  if (cols > 104) text = 'electron-vue'
-  else if (cols > 76) text = 'electron-|vue'
+  if (cols > 104) text = 'building marktext'
+  else if (cols > 76) text = 'building|marktext'
   else text = false
 
   if (text) {
@@ -169,7 +169,9 @@ function greeting () {
       font: 'simple3d',
       space: false
     })
-  } else console.log(chalk.yellow.bold('\n  electron-vue'))
+  } else {
+    console.log(chalk.yellow.bold('\n  building marktext'))
+  }
   console.log(chalk.blue('  getting ready...') + '\n')
 }
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,32 +58,33 @@ fileAssociations:
   description: "Markdown document"
   role: "Editor"
   icon: "../resources/icons/md.icns"
-dmg:
-  artifactName: "marktext.${ext}"
-  contents:
-  - x: 410
-    y: 150
-    type: "link"
-    path: "/Applications"
-  - x: 130
-    y: 150
-    type: "file"
 mac:
   artifactName: "marktext-mac.${ext}"
   icon: "resources/icons/icon.icns"
   darkModeSupport: true
+  target:
+    - target: dmg
+      arch: [x64, arm64]
+    - target: zip
+      arch: [x64, arm64]
+dmg:
+  artifactName: "marktext.${ext}"
+  contents:
+  - x: 410
+    y: 240
+    type: "link"
+    path: "/Applications"
+  - x: 130
+    y: 240
+    type: "file"
 win:
   artifactName: "marktext-${arch}-win.${ext}"
   icon: "resources/icons/icon.ico"
   target:
   - target: "nsis"
-    arch:
-    - "ia32"
-    - "x64"
+    arch: [ia32, x64]
   - target: "zip"
-    arch:
-    - "ia32"
-    - "x64"
+    arch: [ia32, x64]
   requestedExecutionLevel: "asInvoker"
 nsis:
   artifactName: "marktext-setup.${ext}"


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Fixed tickets     | Closes #2435
| License           | MIT

### Description

Added an additional installer for macOS arm64 (Apple M1). This may breaks the existing update process on macOS but I'm unsure about it.
