### PR TITLE
Fix preference migrations

### DIFF
--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -120,7 +120,7 @@ function startMain () {
 
 function startElectron () {
   electronProcess = spawn(electron, [
-    '--inspect=5861',
+    '--inspect=5858',
     '--remote-debugging-port=8315',
     '--nolazy',
     path.join(__dirname, '../dist/electron/main.js')

--- a/docs/dev/DEBUGGING.md
+++ b/docs/dev/DEBUGGING.md
@@ -1,6 +1,6 @@
 # Debugging
 
-## Using Visual Studio Code
+## Use Visual Studio Code
 
 The most simplest way is to debug using the `Debug MarkText` configuration. You can set breakpoints and use the `debugger` statement.
 
@@ -8,6 +8,26 @@ The most simplest way is to debug using the `Debug MarkText` configuration. You 
 
 - [Debugger for Chrome](https://marketplace.visualstudio.com/itemdetails?itemName=msjsdiag.debugger-for-chrome)
 
-## Using Chrome Developer Tools
+## Use Chrome Developer Tools
 
-You can use the built-in developer tools via `View -> Toggle Developer Tools` in debug mode or connect via `chrome://inspect` using port `5861` for the main process and `8315` for the renderer process (`yarn run dev`).
+You can use the built-in developer tools via `View -> Toggle Developer Tools` in debug mode or connect via `chrome://inspect` using port `5858` for the main process and `8315` for the renderer process when launched via `yarn run dev`.
+
+### Debug built application
+
+You can use the default Electron command-line parameters to enable debug mode as described above.
+
+```shell
+$ marktext --inspect=5858 --remote-debugging-port=8315
+```
+
+## Debug slow startup performance
+
+Regardless of whether you are using the built or development version, you can use the [node-profiler](https://github.com/fxha/node-profiler) to analysis startup issues. Please follow the tool description for setup. Afterwards, launch the following commands in parallel (e.g. use three terminal windows and launch MarkText last).
+
+```shell
+$ node-profiler main
+$ node-profiler renderer
+$ marktext --inspect=5858 --remote-debugging-port=8315
+```
+
+After the successful launch of MarkText, press `Ctrl+C` on both `node-profiler` instances. The tools created two files named `main.cpuprofile` and `renderer.cpuprofile`. You can now analyse these files via *Chrome Developer Tools* or *Visual Studio Code*.

--- a/src/main/preferences/index.js
+++ b/src/main/preferences/index.js
@@ -64,19 +64,29 @@ class Preference extends EventEmitter {
       const defaultSettingKeys = Object.keys(defaultSettings)
 
       if (requiresUpdate) {
-        // remove outdated settings
+        // TODO(fxha): For performance reasons, we should try to replace 'electron-store' because
+        //   it does multiple blocking I/O calls when changing entries. There is no transaction or
+        //   async I/O available. The core reason we changed to it was JSON scheme validation.
+
+        // Remove outdated settings
         for (const key of userSettingKeys) {
           if (!defaultSettingKeys.includes(key)) {
             delete userSetting[key]
+            this.store.delete(key)
           }
         }
-        // add new setting options
+
+        // Add new setting options
+        let addedNewEntries = false
         for (const key in defaultSettings) {
           if (!userSettingKeys.includes(key)) {
+            addedNewEntries = true
             userSetting[key] = defaultSettings[key]
           }
         }
-        this.store.set(userSetting)
+        if (addedNewEntries) {
+          this.store.set(userSetting)
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| License           | MIT

### Description

Preference migrations were always applied because `store.set` didn't remove old entries. I also updated the debugging docs and will upload the `node-profiler` for automatic profiling soon.
