### PR TITLE
Added support for image path variables (#2809)

### DIFF
--- a/src/main/dataCenter/index.js
+++ b/src/main/dataCenter/index.js
@@ -169,15 +169,15 @@ class DataCenter extends EventEmitter {
       win.webContents.send('mt::user-preference', userData)
     })
 
-    ipcMain.on('mt::ask-for-modify-image-folder-path', async (e, filePaths) => {
-      if (!filePaths[0]) {
+    ipcMain.on('mt::ask-for-modify-image-folder-path', async (e, filePath) => {
+      if (!filePath) {
         const win = BrowserWindow.fromWebContents(e.sender)
-        filePaths = (await dialog.showOpenDialog(win, {
+        filePath = (await dialog.showOpenDialog(win, {
           properties: ['openDirectory', 'createDirectory']
-        })).filePaths
+        })).filePaths[0]
       }
-      if (filePaths && filePaths[0]) {
-        this.setItem('imageFolderPath', filePaths[0])
+      if (filePath) {
+        this.setItem('imageFolderPath', filePath)
       }
     })
 

--- a/src/main/dataCenter/index.js
+++ b/src/main/dataCenter/index.js
@@ -169,15 +169,15 @@ class DataCenter extends EventEmitter {
       win.webContents.send('mt::user-preference', userData)
     })
 
-    ipcMain.on('mt::ask-for-modify-image-folder-path', async (e, filePath) => {
-      if (!filePath) {
+    ipcMain.on('mt::ask-for-modify-image-folder-path', async (e, imagePath) => {
+      if (!imagePath) {
         const win = BrowserWindow.fromWebContents(e.sender)
-        filePath = (await dialog.showOpenDialog(win, {
+        imagePath = (await dialog.showOpenDialog(win, {
           properties: ['openDirectory', 'createDirectory']
         })).filePaths[0]
       }
-      if (filePath) {
-        this.setItem('imageFolderPath', filePath)
+      if (imagePath) {
+        this.setItem('imageFolderPath', imagePath)
       }
     })
 

--- a/src/main/dataCenter/index.js
+++ b/src/main/dataCenter/index.js
@@ -169,11 +169,13 @@ class DataCenter extends EventEmitter {
       win.webContents.send('mt::user-preference', userData)
     })
 
-    ipcMain.on('mt::ask-for-modify-image-folder-path', async e => {
-      const win = BrowserWindow.fromWebContents(e.sender)
-      const { filePaths } = await dialog.showOpenDialog(win, {
-        properties: ['openDirectory', 'createDirectory']
-      })
+    ipcMain.on('mt::ask-for-modify-image-folder-path', async (e, filePaths) => {
+      if (!filePaths[0]) {
+        const win = BrowserWindow.fromWebContents(e.sender)
+        filePaths = (await dialog.showOpenDialog(win, {
+          properties: ['openDirectory', 'createDirectory']
+        })).filePaths
+      }
       if (filePaths && filePaths[0]) {
         this.setItem('imageFolderPath', filePaths[0])
       }

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -798,7 +798,7 @@ export default {
         }
       }
 
-      imageFolderPath = imageFolderPath.replace(/\${filename}/g, this.pathname)
+      resolvedImageFolderPath = imageFolderPath.replace(/\${filename}/g, this.pathname)
       let result = ''
       switch (imageInsertAction) {
         case 'upload': {
@@ -810,12 +810,12 @@ export default {
               type: 'info',
               message: err
             })
-            result = await moveImageToFolder(pathname, image, imageFolderPath)
+            result = await moveImageToFolder(pathname, image, resolvedImageFolderPath)
           }
           break
         }
         case 'folder': {
-          result = await moveImageToFolder(pathname, image, imageFolderPath)
+          result = await moveImageToFolder(pathname, image, resolvedImageFolderPath)
           if (cwd && imagePreferRelativeDirectory) {
             result = await moveToRelativeFolder(cwd, result, imageRelativeDirectoryName)
           }
@@ -826,7 +826,7 @@ export default {
             result = image
           } else {
             // Move image to image folder if it's Blob object.
-            result = await moveImageToFolder(pathname, image, imageFolderPath)
+            result = await moveImageToFolder(pathname, image, resolvedImageFolderPath)
 
             // Respect user preferences if file exist on disk.
             if (cwd && imagePreferRelativeDirectory) {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -158,7 +158,7 @@ export default {
       imageInsertAction: state => state.preferences.imageInsertAction,
       imagePreferRelativeDirectory: state => state.preferences.imagePreferRelativeDirectory,
       imageRelativeDirectoryName: state => state.preferences.imageRelativeDirectoryName,
-      imageFolderPath: state => state.preferences.imageFolderPath.replace(/\${filename}/g, this.currentFile),
+      imageFolderPath: state => state.preferences.imageFolderPath,
       theme: state => state.preferences.theme,
       sequenceTheme: state => state.preferences.sequenceTheme,
       hideScrollbar: state => state.preferences.hideScrollbar,
@@ -798,6 +798,7 @@ export default {
         }
       }
 
+      imageFolderPath = imageFolderPath.replace(/\${filename}/g, this.pathname)
       let result = ''
       switch (imageInsertAction) {
         case 'upload': {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -798,7 +798,7 @@ export default {
         }
       }
 
-      resolvedImageFolderPath = imageFolderPath.replace(/\${filename}/g, this.pathname)
+      const resolvedImageFolderPath = imageFolderPath.replace(/\${filename}/g, this.pathname)
       let result = ''
       switch (imageInsertAction) {
         case 'upload': {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -158,7 +158,7 @@ export default {
       imageInsertAction: state => state.preferences.imageInsertAction,
       imagePreferRelativeDirectory: state => state.preferences.imagePreferRelativeDirectory,
       imageRelativeDirectoryName: state => state.preferences.imageRelativeDirectoryName,
-      imageFolderPath: state => state.preferences.imageFolderPath,
+      imageFolderPath: state => state.preferences.imageFolderPath.replace(/\${filename}/g, this.currentFile),
       theme: state => state.preferences.theme,
       sequenceTheme: state => state.preferences.sequenceTheme,
       hideScrollbar: state => state.preferences.hideScrollbar,

--- a/src/renderer/prefComponents/image/index.vue
+++ b/src/renderer/prefComponents/image/index.vue
@@ -19,7 +19,7 @@
         description="Local image folder"
         :input="imageFolderPath"
         :regexValidator="/^(?:$|([a-zA-Z]:)?[\/\\].*$)/"
-        :defaultValue="FolderPathPlaceholder"
+        :defaultValue="folderPathPlaceholder"
         :onChange="value => modifyImageFolderPath(value)"
       ></text-box>
       <div>
@@ -75,7 +75,7 @@ export default {
         this.$store.dispatch('SET_SINGLE_PREFERENCE', { type, value })
       }
     },
-    FolderPathPlaceholder: {
+    folderPathPlaceholder: {
       get: function () {
         return this.$store.state.preferences.imageFolderPath || ''
       }

--- a/src/renderer/prefComponents/image/index.vue
+++ b/src/renderer/prefComponents/image/index.vue
@@ -15,10 +15,15 @@
     </section>
     <separator></separator>
     <section class="image-folder">
-      <div class="description">Local image folder</div>
-      <div class="path">{{imageFolderPath}}</div>
+      <text-box
+        description="Local image folder"
+        :input="imageFolderPath"
+        :regexValidator="/^(?:$|([a-zA-Z]:)?[\/\\].*$)/"
+        :defaultValue="FolderPathPlaceholder"
+        :onChange="value => modifyImageFolderPath(value)"
+      ></text-box>
       <div>
-        <el-button size="mini" @click="modifyImageFolderPath">Modify</el-button>
+        <el-button size="mini" @click="modifyImageFolderPath()">Modify</el-button>
         <el-button size="mini" @click="openImageFolder">Open Folder</el-button>
       </div>
       <bool
@@ -57,6 +62,7 @@ export default {
   },
   computed: {
     ...mapState({
+      imageFolderPath: state => state.preferences.imageFolderPath,
       imagePreferRelativeDirectory: state => state.preferences.imagePreferRelativeDirectory,
       imageRelativeDirectoryName: state => state.preferences.imageRelativeDirectoryName
     }),
@@ -69,9 +75,9 @@ export default {
         this.$store.dispatch('SET_SINGLE_PREFERENCE', { type, value })
       }
     },
-    imageFolderPath: {
+    FolderPathPlaceholder: {
       get: function () {
-        return this.$store.state.preferences.imageFolderPath
+        return this.$store.state.preferences.imageFolderPath || ''
       }
     },
     relativeDirectoryNamePlaceholder: {
@@ -84,8 +90,8 @@ export default {
     openImageFolder () {
       shell.openPath(this.imageFolderPath)
     },
-    modifyImageFolderPath () {
-      return this.$store.dispatch('SET_IMAGE_FOLDER_PATH')
+    modifyImageFolderPath (value) {
+      return this.$store.dispatch('SET_IMAGE_FOLDER_PATH', value)
     },
     onSelectChange (type, value) {
       this.$store.dispatch('SET_SINGLE_PREFERENCE', { type, value })
@@ -103,18 +109,6 @@ export default {
     & label {
       display: block;
       margin: 20px 0;
-    }
-  }
-  & .image-folder {
-    & div.description {
-      font-size: 14px;
-      color: var(--editorColor);
-    }
-    & div.path {
-      font-size: 14px;
-      color: var(--editorColor50);
-      margin-top: 15px;
-      margin-bottom: 15px;
     }
   }
 }

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -135,7 +135,7 @@ const actions = {
   },
 
   SET_IMAGE_FOLDER_PATH ({ commit }, value) {
-    ipcRenderer.send('mt::ask-for-modify-image-folder-path', [value])
+    ipcRenderer.send('mt::ask-for-modify-image-folder-path', value)
   },
 
   SELECT_DEFAULT_DIRECTORY_TO_OPEN ({ commit }) {

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -134,8 +134,8 @@ const actions = {
     ipcRenderer.send('mt::set-user-data', { [type]: value })
   },
 
-  SET_IMAGE_FOLDER_PATH ({ commit }) {
-    ipcRenderer.send('mt::ask-for-modify-image-folder-path')
+  SET_IMAGE_FOLDER_PATH ({ commit }, value) {
+    ipcRenderer.send('mt::ask-for-modify-image-folder-path', [value])
   },
 
   SELECT_DEFAULT_DIRECTORY_TO_OPEN ({ commit }) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2809
| Fixed tickets     | Fixes #2126
| Fixed tickets     | Fixes #2559
| License           | MIT

### Description

You can now use `${filename}` in Preferences -> Image -> Local image folder
This is simply regex replaced with the current fileName.
I've only tested this on Linux but it should work on windows/mac.