### PR TITLE
Fix korean input trigger keydown event twice (#2827)

### DIFF
--- a/src/renderer/components/sideBar/tree.vue
+++ b/src/renderer/components/sideBar/tree.vue
@@ -54,7 +54,7 @@
           :style="{'margin-left': `${depth * 5 + 15}px` }"
           ref="input"
           v-model="createName"
-          @keydown.enter="handleInputEnter"
+          @keypress.enter="handleInputEnter"
         >
         <file
           v-for="(file, index) of projectTree.files" :key="index + 'file'"
@@ -140,7 +140,7 @@ export default {
           this.$store.commit('SET_RENAME_CACHE', null)
         }
       })
-      document.addEventListener('keydown', event => {
+      document.addEventListener('keypress', event => {
         if (event.key === 'Escape') {
           this.$store.commit('CREATE_PATH', {})
           this.$store.commit('SET_RENAME_CACHE', null)

--- a/src/renderer/components/sideBar/treeFolder.vue
+++ b/src/renderer/components/sideBar/treeFolder.vue
@@ -37,7 +37,7 @@
         class="new-input"
         :style="{'margin-left': `${depth * 5 + 15}px` }"
         ref="input"
-        @keydown.enter="handleInputEnter"
+        @keypress.enter="handleInputEnter"
         v-model="createName"
       >
       <file


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2827 (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Description

I fixed #2827 issue, by replacing keydown with keypress. ( This solution does not affect other language. )

It is well known issue, keydown and keyup make event twice when using korean.

