### PR TITLE
Normalize Codemirror cursor that start is always before end

### DIFF
--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -306,7 +306,9 @@ const inputCtrl = ContentState => {
       return
     }
 
-    const checkMarkedUpdate = /atxLine|paragraphContent|cellContent/.test(block.functionType) ? this.checkNeedRender() : false
+    const checkMarkedUpdate = /atxLine|paragraphContent|cellContent/.test(block.functionType)
+      ? this.checkNeedRender()
+      : false
     let inlineUpdatedBlock = null
     if (/atxLine|paragraphContent|cellContent|thematicBreakLine/.test(block.functionType)) {
       inlineUpdatedBlock = this.isCollapse() && this.checkInlineUpdate(block)

--- a/src/renderer/components/editorWithTabs/sourceCode.vue
+++ b/src/renderer/components/editorWithTabs/sourceCode.vue
@@ -222,15 +222,23 @@ export default {
       let focus = cm.getCursor('head')
       let anchor = cm.getCursor('anchor')
       const markdown = cm.getValue()
-      const adjCursor = cursor => {
+      const convertToMuyaCursor = cursor => {
         const line = cm.getLine(cursor.line)
         const preLine = cm.getLine(cursor.line - 1)
         const nextLine = cm.getLine(cursor.line + 1)
         return adjustCursor(cursor, preLine, line, nextLine)
       }
-      focus = adjCursor(focus)
-      anchor = adjCursor(anchor)
 
+      anchor = convertToMuyaCursor(anchor) // Selection start as Muya cursor
+      focus = convertToMuyaCursor(focus) // Selection end as Muya cursor
+
+      // Normalize cursor that `anchor` is always before `focus` because
+      // this is the expected behavior in Muya.
+      if (anchor && focus && anchor.line > focus.line) {
+        const tmpCursor = focus
+        focus = anchor
+        anchor = tmpCursor
+      }
       return { cursor: { focus, anchor }, markdown }
     },
     // Commit changes from old tab. Problem: tab was already switched, so commit changes with old tab id.

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -139,12 +139,12 @@ export const adjustCursor = (cursor, preline, line, nextline) => {
   if (/[*+-]\s.+/.test(line) && newCursor.ch <= 1) {
     newCursor.ch = 2
   }
+
   // Need to adjust the cursor when cursor at blank line or in a line contains HTML tag.
   // set the newCursor to null, the new cursor will at the last line of document.
   if (!/\S/.test(line) || /<\/?([a-zA-Z\d-]+)(?=\s|>).*>/.test(line)) {
     newCursor = null
   }
-
   return newCursor
 }
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| License           | MIT

### Description

Fixed an issue that resulted in an Muya crash because the Codemirror selection was in the wrong order. This PR normalize the cursor position that  `anchor` (start) is always before `focus` (end).

**Example:**

1. Select text from bottom to top in source-code mode
2. Switch to normal editor
3. Click in the editor or just press backspace
4. A lot of exceptions