### PR TITLE
Fix partialRender cursor if the block was already removed from state

### DIFF
--- a/src/muya/lib/contentState/index.js
+++ b/src/muya/lib/contentState/index.js
@@ -246,13 +246,26 @@ class ContentState {
     matches.forEach((m, i) => {
       m.active = i === index
     })
-    const startIndex = startKey ? blocks.findIndex(block => block.key === startKey) : 0
-    const endIndex = endKey ? blocks.findIndex(block => block.key === endKey) + 1 : blocks.length
-    const needRenderBlocks = blocks.slice(startIndex, endIndex)
+
+    // The `endKey` may already be removed from blocks if range was selected via keyboard (GH#1854).
+    let startIndex = startKey ? blocks.findIndex(block => block.key === startKey) : 0
+    if (startIndex === -1) {
+      startIndex = 0
+    }
+
+    let endIndex = blocks.length
+    if (endKey) {
+      const tmpEndIndex = blocks.findIndex(block => block.key === endKey)
+      if (tmpEndIndex >= 0) {
+        endIndex = tmpEndIndex + 1
+      }
+    }
+
+    const blocksToRender = blocks.slice(startIndex, endIndex)
 
     this.setNextRenderRange()
     this.stateRender.collectLabels(blocks)
-    this.stateRender.partialRender(needRenderBlocks, activeBlocks, matches, startKey, endKey)
+    this.stateRender.partialRender(blocksToRender, activeBlocks, matches, startKey, endKey)
     if (isRenderCursor) {
       this.setCursor()
     } else {

--- a/src/muya/lib/contentState/inputCtrl.js
+++ b/src/muya/lib/contentState/inputCtrl.js
@@ -100,6 +100,7 @@ const inputCtrl = ContentState => {
     if (!start || !end) {
       return
     }
+
     const { start: oldStart, end: oldEnd } = this.cursor
     const key = start.key
     const block = this.getBlock(key)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #1854
| License           | MIT

### Description

Fixed the linked issue. The cursor may be in an invalid position because the underlying block was already removed. This was the case when selecting multiple blocks with the keyboard but not by mouse. In this case, we start a full render from the given start because the ending is unknown. It seems that the mouse selection doesn't update the cursor while selecting multiple blocks but the keyboard after each line.
