### PR TITLE
Do not use Cmd+Tab as a keybind on macOS.

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -143,8 +143,8 @@ Here is an example:
 
 | Id                       | Default                                              | Description                  |
 | ------------------------ | ---------------------------------------------------- | ---------------------------- |
-| `tabs.cycle-forward`     | <kbd>CmdOrCtrl</kbd>+<kbd>Tab</kbd>                  | Cycle through tabs           |
-| `tabs.cycle-backward`    | <kbd>CmdOrCtrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> | Cycle backwards through tabs |
+| `tabs.cycle-forward`     | <kbd>Ctrl</kbd>+<kbd>Tab</kbd>                       | Cycle through tabs           |
+| `tabs.cycle-backward`    | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd>      | Cycle backwards through tabs |
 | `tabs.switch-to-left`    | <kbd>CmdOrCtrl</kbd>+<kbd>PageUp</kbd>               | Switch tab to the left       |
 | `tabs.switch-to-right`   | <kbd>CmdOrCtrl</kbd>+<kbd>PageDown</kbd>             | Switch tab to the right      |
 | `tabs.switch-to-first`   | <kbd>Alt</kbd>+<kbd>1</kbd>                          | Switch tab to the 1st        |

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -108,8 +108,8 @@ class Keybindings {
       ['view.dev-reload', 'CmdOrCtrl+R'],
 
       // Misc
-      ['tabs.cycle-forward', 'CmdOrCtrl+Tab'],
-      ['tabs.cycle-backward', 'CmdOrCtrl+Shift+Tab'],
+      ['tabs.cycle-forward', 'Ctrl+Tab'],
+      ['tabs.cycle-backward', 'Ctrl+Shift+Tab'],
       ['tabs.switch-to-left', 'CmdOrCtrl+PageUp'],
       ['tabs.switch-to-right', 'CmdOrCtrl+PageDown'],
       ['tabs.switch-to-first', `${tabSwitchBaseStroke}+1`],


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes none
| License           | MIT

### Description

Changes the default tab cycle keybinds from `CmdOrCtrl+...+Tab` to `Ctrl+...+Tab` (for cycle forward and backward) for expected behaviour on macOS.

#### Rationale:

On macOS, the keybind Cmd+Tab is used to cycle between windows (similar to Alt+Tab on Windows). Therefore, the default keybind of `CmdOrCtrl+Tab` is non-functional (as far as I can tell) on macOS as the window manager steals the key combination before Mark Text sees it. This PR changes the keybind to the expected out-of-the-box behaviour. I fixed this with `keybindings.json` for myself, but as this behaviour seems broken/unintended, thought it might be worth a PR; feel free to close if there's a reason it's currently `CmdOrCtrl`.
