### PR TITLE
fix: search group

### DIFF
--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -77,7 +77,7 @@ function startRenderer () {
           watch: false
         }
       ],
-      onBeforeSetupMiddleware ({ app, middleware}) {
+      onBeforeSetupMiddleware ({ app, middleware }) {
         app.use(hotMiddleware)
         middleware.waitUntilValid(() => {
           resolve()

--- a/src/muya/lib/contentState/searchCtrl.js
+++ b/src/muya/lib/contentState/searchCtrl.js
@@ -35,7 +35,6 @@ const matchString = (text, value, options) => {
 
 const searchCtrl = ContentState => {
   ContentState.prototype.buildRegexValue = function (match, value) {
-    // TODO: Needed to handle great than 10?
     const groups = value.match(/(?<!\\)\$\d/g)
 
     if (Array.isArray(groups) && groups.length) {

--- a/src/muya/lib/contentState/searchCtrl.js
+++ b/src/muya/lib/contentState/searchCtrl.js
@@ -35,15 +35,20 @@ const matchString = (text, value, options) => {
 
 const searchCtrl = ContentState => {
   ContentState.prototype.buildRegexValue = function (match, value) {
-    const groups = value.match(/\$(\d)*/g)
-    if (groups) {
-      for (const regexGroup of groups) {
-        const groupIndex = regexGroup[1] - 1
-        if (groupIndex < match.subMatches.length) {
-          value = value.replace(regexGroup, match.subMatches[groupIndex])
+    // TODO: Needed to handle great than 10?
+    const groups = value.match(/(?<!\\)\$\d/g)
+
+    if (Array.isArray(groups) && groups.length) {
+      for (const group of groups) {
+        const index = parseInt(group.replace(/^\$/, ''))
+        if (index === 0) {
+          value = value.replace(group, match.match)
+        } else if (index > 0 && index <= match.subMatches.length) {
+          value = value.replace(group, match.subMatches[index - 1])
         }
       }
     }
+
     return value
   }
 
@@ -55,15 +60,16 @@ const searchCtrl = ContentState => {
   }
 
   ContentState.prototype.replace = function (replaceValue, opt = { isSingle: true }) {
-    const { isSingle } = opt
+    const { isSingle, isRegexp } = opt
     delete opt.isSingle
     const searchOptions = Object.assign({}, defaultSearchOption, opt)
     const { matches, value, index } = this.searchMatches
     if (matches.length) {
-      if (opt.isRegexp) {
+      if (isRegexp) {
         replaceValue = this.buildRegexValue(matches[index], replaceValue)
       }
       if (isSingle) {
+        // replace single
         this.replaceOne(matches[index], replaceValue)
       } else {
         // replace all
@@ -119,12 +125,13 @@ const searchCtrl = ContentState => {
 
         if (text && typeof text === 'string') {
           const strMatches = matchString(text, value, options)
-          matches.push(...strMatches.map(m => {
+          matches.push(...strMatches.map(({ index, match, subMatches }) => {
             return {
               key,
-              start: m.index,
-              end: m.index + m.match.length,
-              subMatches: m.subMatches
+              start: index,
+              end: index + match.length,
+              match,
+              subMatches
             }
           }))
         }


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | yes/not needed
| Fixed tickets     | Fixes 
| License           | MIT

### Description

- Support `$0` to present all the match.
-  Escape `$` inside the replacement; use look-behind to ignore escaped character (\$).

BTY, still not support `$10` which is greater than 9, @fxha do you is it necessary to support it?
