### PR TITLE
Invalidate CI cache and use async path exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,9 @@ jobs:
         id: cacheNodeModules
         with:
           path: ${{ github.workspace }}\node_modules
-          key: ${{ runner.os }}-node_modules-cache-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
+          key: ${{ runner.os }}-node_modules-cache-v1-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-cache-
+            ${{ runner.os }}-node_modules-cache-v1-
 
       - name: Cache Electron
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}\node_modules
-          key: ${{ runner.os }}-node_modules-cache-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
+          key: ${{ runner.os }}-node_modules-cache-v1-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-cache-
+            ${{ runner.os }}-node_modules-cache-v1-
 
       - name: Cache Electron
         uses: actions/cache@v2

--- a/src/common/filesystem/index.js
+++ b/src/common/filesystem/index.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import fsPromises from 'fs/promises'
 import path from 'path'
 
 /**
@@ -9,7 +10,8 @@ import path from 'path'
  */
 export const exists = async p => {
   try {
-    return fs.existsSync(p)
+    await fsPromises.access(p)
+    return true
   } catch (_) {
     return false
   }

--- a/src/main/preferences/hunspell.js
+++ b/src/main/preferences/hunspell.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import log from 'electron-log'
+import { exists } from 'common/filesystem'
 import { getResourcesPath } from 'common/filesystem/paths'
 
 // This is an asynchronous function to not block the process. The spell checker may be
@@ -12,12 +13,12 @@ export default async appDataPath => {
   const destDir = path.join(appDataPath, 'dictionaries')
   const destPath = path.join(destDir, 'en-US.bdic')
 
-  if (!fs.existsSync(srcPath)) {
-    log.error('Error while installing Hunspell default dictionary. Mark Text resources are corrupted!')
+  if (!await exists(srcPath)) {
+    log.error('Error while installing Hunspell default dictionary. MarkText resources are corrupted!')
     return
   }
 
-  if (!fs.existsSync(destPath)) {
+  if (!await exists(destPath)) {
     await fs.ensureDir(destDir)
     await fs.copy(srcPath, destPath)
   }


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

Try to fix CI on Windows by invalidating cache. I also reverted the synchronous path exists call from 478f1ca97a6208f334caa732cc9e30671cd3d800 because the API is used by the filesystem watcher.
