### PR TITLE
Fix editor overflow

### DIFF
--- a/src/muya/themes/default.css
+++ b/src/muya/themes/default.css
@@ -131,6 +131,7 @@ kbd {
     margin: 0 auto;
     padding: 20px 50px 100px 50px;
     box-sizing: border-box;
+    cursor: text;
   }
 
   #ag-editor-id, [contenteditable] {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -1303,6 +1303,7 @@ export default {
     height: 100%;
     overflow: auto;
     box-sizing: border-box;
+    cursor: default;
   }
 
   .typewriter .editor-component {

--- a/src/renderer/components/editorWithTabs/index.vue
+++ b/src/renderer/components/editorWithTabs/index.vue
@@ -1,6 +1,7 @@
 <template>
     <div
       class="editor-with-tabs"
+      :style="{'max-width': showSideBar ? `calc(100vw - ${sideBarWidth}px` : '100vw' }"
     >
       <tabs v-show="showTabBar"></tabs>
       <div class="container">
@@ -22,6 +23,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import Tabs from './tabs.vue'
 import Editor from './editor.vue'
 import SourceCode from './sourceCode.vue'
@@ -61,6 +63,12 @@ export default {
     Editor,
     SourceCode,
     TabNotifications
+  },
+    computed: {
+    ...mapState({
+      showSideBar: state => state.layout.showSideBar,
+      sideBarWidth: state => state.layout.sideBarWidth
+    })
   }
 }
 </script>

--- a/src/renderer/components/editorWithTabs/tabs.vue
+++ b/src/renderer/components/editorWithTabs/tabs.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="editor-tabs"
-    :style="{'max-width': showSideBar ? `calc(100vw - ${sideBarWidth}px` : '100vw' }"
-  >
+  <div class="editor-tabs">
     <div
       class="scrollable-tabs"
       ref="tabContainer"
@@ -44,13 +41,13 @@
 </template>
 
 <script>
+import { shell, clipboard } from 'electron'
 import { mapState } from 'vuex'
 import autoScroll from 'dom-autoscroller'
 import dragula from 'dragula'
 import { tabsMixins } from '../../mixins'
 import { showContextMenu } from '../../contextMenu/tabs'
 import bus from '../../bus'
-import { shell, clipboard } from 'electron'
 
 export default {
   data () {
@@ -62,9 +59,7 @@ export default {
   computed: {
     ...mapState({
       currentFile: state => state.editor.currentFile,
-      tabs: state => state.editor.tabs,
-      showSideBar: state => state.layout.showSideBar,
-      sideBarWidth: state => state.layout.sideBarWidth
+      tabs: state => state.editor.tabs
     })
   },
   methods: {
@@ -100,9 +95,6 @@ export default {
     closeAll () {
       this.$store.dispatch('CLOSE_ALL_TABS')
     },
-    changeMaxWidth (width) {
-      this.$store.dispatch('CHANGE_SIDE_BAR_WIDTH', width)
-    },
     rename (tabId) {
       const tab = this.tabs.find(f => f.id === tabId)
       if (tab && tab.pathname) {
@@ -137,7 +129,6 @@ export default {
       bus.$on('TABS::rename', this.rename)
       bus.$on('TABS::copy-path', this.copyPath)
       bus.$on('TABS::show-in-folder', this.showInFolder)
-      bus.$on('EDITOR_TABS::change-max-width', this.changeMaxWidth)
     })
   },
   mounted () {

--- a/src/renderer/components/sideBar/index.vue
+++ b/src/renderer/components/sideBar/index.vue
@@ -53,7 +53,6 @@ import { sideBarIcons, sideBarBottomIcons } from './help'
 import Tree from './tree.vue'
 import SideBarSearch from './search.vue'
 import Toc from './toc.vue'
-import bus from '../../bus'
 import { mapState } from 'vuex'
 
 export default {
@@ -80,10 +79,9 @@ export default {
     }),
     finalSideBarWidth () {
       const { showSideBar, rightColumn, sideBarViewWidth } = this
-      let width = sideBarViewWidth
-      if (rightColumn === '') width = 45
-      if (!showSideBar) width -= 45
-      return width
+      if (!showSideBar) return 0
+      if (rightColumn === '') return 45
+      return sideBarViewWidth < 220 ? 220 : sideBarViewWidth
     }
   },
   created () {
@@ -121,10 +119,14 @@ export default {
     handleLeftIconClick (name) {
       if (this.rightColumn === name) {
         this.$store.commit('SET_LAYOUT', { rightColumn: '' })
-        bus.$emit('EDITOR_TABS::change-max-width', this.finalSideBarWidth)
+        this.$store.dispatch('CHANGE_SIDE_BAR_WIDTH', this.finalSideBarWidth)
       } else {
+        const needDispatch = this.rightColumn === ''
         this.$store.commit('SET_LAYOUT', { rightColumn: name })
         this.sideBarViewWidth = +this.sideBarWidth
+        if (needDispatch) {
+          this.$store.dispatch('CHANGE_SIDE_BAR_WIDTH', this.finalSideBarWidth)
+        }
       }
     },
     handleLeftBottomClick (name) {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | fixes #2019, fixes #2608
| License           | MIT

### Description

Fixed the editor overflow because the sidebar width was not added to the maximal width of the editor. I also changed the scrollbar cursor from text to default.
