### PR TITLE
fix: toc update when modifying headers (fix #2851, fix #2805, fix #2570)

### DIFF
--- a/src/muya/lib/contentState/tocCtrl.js
+++ b/src/muya/lib/contentState/tocCtrl.js
@@ -7,7 +7,7 @@ const tocCtrl = ContentState => {
       if (/^h\d$/.test(block.type)) {
         const { headingStyle, key, type } = block
         const { text } = block.children[0]
-        const content = headingStyle === 'setext' ? text.trim() : text.replace(/^ *#{1,6} {1,}/, '').trim()
+        const content = headingStyle === 'setext' ? text.trim() : text.replace(/^\s*#{1,6}\s{1,}/, '').trim()
         const lvl = +type.substring(1)
         const slug = key
         toc.push({


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | #2851 #2805
| License           | MIT

### Description
[Description of the bug or feature]
close #2851;
close #2805;
close #2570;
https://github.com/marktext/marktext/blob/4c517b163232af5649b7a26d4a5705e40bbe4817/src/muya/lib/contentState/tocCtrl.js#L10
the reason : this regex can't match the `U+00A0 No-Break Space (NBSP) Unicode Character`
e.g:
```js
const str1 = "## ss"
const str2 = "## ss"

console.log(str1.replace(/^ *#{1,6} {1,}/, '')) // ## ss
console.log(str2.replace(/^ *#{1,6} {1,}/, '')) // ss

console.log(str1.replace(/^\s*#{1,6}\s{1,}/, '')) // ss
console.log(str2.replace(/^\s*#{1,6}\s{1,}/, '')) // ss
```
