### PR TITLE
fix: #2836 fix formula first render

### DIFF
--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -1,7 +1,7 @@
 import loadRenderer from '../../renderers'
 import { CLASS_OR_ID } from '../../config'
 import { conflict, mixins, camelToSnake } from '../../utils'
-import { patch, toVNode, toHTML, h } from './snabbdom'
+import { patch, toVNode, toHTML, h, addNStoVNodeChildren } from './snabbdom'
 import { beginRules } from '../rules'
 import renderInlines from './renderInlines'
 import renderBlock from './renderBlock'
@@ -175,7 +175,7 @@ class StateRender {
     const children = blocks.map(block => {
       return this.renderBlock(null, block, activeBlocks, matches, true)
     })
-
+    addNStoVNodeChildren(children)
     const newVdom = h(selector, children)
     const rootDom = document.querySelector(selector) || this.container
     const oldVdom = toVNode(rootDom)

--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -179,16 +179,8 @@ class StateRender {
     const newVdom = h(selector, children)
     const rootDom = document.querySelector(selector) || this.container
     const oldVdom = toVNode(rootDom)
+
     patch(oldVdom, newVdom)
-    // snabbdom 'patch' doesn't parse SVGs correctly, so we need to refresh the svg parentElement
-    // https://github.com/snabbdom/snabbdom/issues/388
-    const refreshSvgParent = (vDom) => {
-      if (vDom.children?.some(e => e.sel === 'svg')) {
-        const html = vDom.elm.innerHTML
-        vDom.elm.innerHTML = html
-      } else vDom.children?.forEach(v => refreshSvgParent(v))
-    }
-    refreshSvgParent(newVdom)
     this.renderMermaid()
     this.renderDiagram()
     this.codeCache.clear()

--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -179,8 +179,16 @@ class StateRender {
     const newVdom = h(selector, children)
     const rootDom = document.querySelector(selector) || this.container
     const oldVdom = toVNode(rootDom)
-
     patch(oldVdom, newVdom)
+    // snabbdom 'patch' doesn't parse SVGs correctly, so we need to refresh the svg parentElement
+    // https://github.com/snabbdom/snabbdom/issues/388
+    const refreshSvgParent = (vDom) => {
+      if (vDom.children?.some(e => e.sel === 'svg')) {
+        const html = vDom.elm.innerHTML
+        vDom.elm.innerHTML = html
+      } else vDom.children?.forEach(v => refreshSvgParent(v))
+    }
+    refreshSvgParent(newVdom)
     this.renderMermaid()
     this.renderDiagram()
     this.codeCache.clear()

--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -1,7 +1,7 @@
 import loadRenderer from '../../renderers'
 import { CLASS_OR_ID } from '../../config'
 import { conflict, mixins, camelToSnake } from '../../utils'
-import { patch, toVNode, toHTML, h, addNStoVNodeChildren } from './snabbdom'
+import { patch, toVNode, toHTML, h, addNStoVNodeSvgChildren } from './snabbdom'
 import { beginRules } from '../rules'
 import renderInlines from './renderInlines'
 import renderBlock from './renderBlock'
@@ -175,7 +175,7 @@ class StateRender {
     const children = blocks.map(block => {
       return this.renderBlock(null, block, activeBlocks, matches, true)
     })
-    addNStoVNodeChildren(children)
+    addNStoVNodeSvgChildren(children)
     const newVdom = h(selector, children)
     const rootDom = document.querySelector(selector) || this.container
     const oldVdom = toVNode(rootDom)

--- a/src/muya/lib/parser/render/snabbdom.js
+++ b/src/muya/lib/parser/render/snabbdom.js
@@ -21,15 +21,17 @@ export const htmlToVNode = html => { // helper function for convert html to vnod
 const addNS = ({ data, children, sel }) => {
   data.ns = 'http://www.w3.org/2000/svg'
   if (sel !== 'foreignObject' && children !== undefined) {
-    children.filter((vNode) => vNode.data).forEach(addNS)
+    for (const vNode of children) {
+      if (vNode.data === undefined) continue
+      addNS(vNode)
+    }
   }
 }
 
-export const addNStoVNodeChildren = (children = []) => {
-  children
-    .filter((vNode) => vNode.data)
-    .forEach((vNode) => {
-      addNStoVNodeChildren(vNode.children)
-      vNode.sel.startsWith('svg') && addNS(vNode)
-    })
+export const addNStoVNodeSvgChildren = (children = []) => {
+  for (const vNode of children) {
+    if (vNode.data === undefined) continue
+    if (vNode.sel.startsWith('svg')) addNS(vNode)
+    addNStoVNodeSvgChildren(vNode.children)
+  }
 }

--- a/src/muya/lib/parser/render/snabbdom.js
+++ b/src/muya/lib/parser/render/snabbdom.js
@@ -17,3 +17,19 @@ export const htmlToVNode = html => { // helper function for convert html to vnod
   wrapper.innerHTML = html
   return toVNode(wrapper).children
 }
+
+const addNS = ({ data, children, sel }) => {
+  data.ns = 'http://www.w3.org/2000/svg'
+  if (sel !== 'foreignObject' && children !== undefined) {
+    children.filter((vNode) => vNode.data).forEach(addNS)
+  }
+}
+
+export const addNStoVNodeChildren = (children = []) => {
+  children
+    .filter((vNode) => vNode.data)
+    .forEach((vNode) => {
+      addNStoVNodeChildren(vNode.children)
+      vNode.sel.startsWith('svg') && addNS(vNode)
+    })
+}


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | #2836
| License           | MIT

### Description

[Description of the bug or feature]
close #2836;
https://github.com/marktext/marktext/blob/4c517b163232af5649b7a26d4a5705e40bbe4817/src/muya/lib/parser/render/index.js#L183
the reason: snabbdom `patch` fn doesn't parse SVGs correctly , Related issue [#388](https://github.com/snabbdom/snabbdom/issues/388), i had tried update snabbdom to version 2.1.0, but didn't work.
so we need to refresh the svg , use innerHTML.
```js
patch(oldVdom, newVdom)
const refreshSvgParent = (vDom) => {
  if (vDom.children?.some(e => e.sel === 'svg')) {
    const html = vDom.elm.innerHTML
    vDom.elm.innerHTML = html
  } else vDom.children?.forEach(v => refreshSvgParent(v))
}
refreshSvgParent(newVdom)
```
**before-fix**
![before-fix](https://user-images.githubusercontent.com/91143836/148578140-05209f82-ac5e-4571-a62e-3de8adc0285f.gif)

**after-fix**
![after-fix](https://user-images.githubusercontent.com/91143836/148578178-71865c13-1ff9-46ab-bcaf-69c00537bfff.gif)

