### PR TITLE
fix: fix new line page scroll (fix #2541, fix #2470)

### DIFF
--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -168,9 +168,10 @@ export const animatedScrollTo = function (element, to, duration, callback) {
 
   const animateScroll = function () {
     const now = +new Date()
-    const val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration))
-
-    element.scrollTop = val
+    if (duration > 0) {
+      const val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration))
+      element.scrollTop = val
+    }
 
     if (now > animationStart + duration) {
       element.scrollTop = to

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -154,7 +154,7 @@ export const animatedScrollTo = function (element, to, duration, callback) {
   const animationStart = +new Date()
 
   // Prevent animation on small steps or duration is 0
-  if (duration === 0 || Math.abs(change) <= 6) {
+  if (Math.abs(change) <= 6 || duration === 0) {
     element.scrollTop = to
     return
   }

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -153,8 +153,8 @@ export const animatedScrollTo = function (element, to, duration, callback) {
   const change = to - start
   const animationStart = +new Date()
 
-  // Prevent animation on small steps
-  if (Math.abs(change) <= 6) {
+  // Prevent animation on small steps or duration is 0
+  if (duration === 0 || Math.abs(change) <= 6) {
     element.scrollTop = to
     return
   }
@@ -168,10 +168,9 @@ export const animatedScrollTo = function (element, to, duration, callback) {
 
   const animateScroll = function () {
     const now = +new Date()
-    if (duration > 0) {
-      const val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration))
-      element.scrollTop = val
-    }
+    const val = Math.floor(easeInOutQuad(now - animationStart, start, change, duration))
+
+    element.scrollTop = val
 
     if (now > animationStart + duration) {
       element.scrollTop = to


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2541 Fixes #2470
| License           | MIT

### Description
close #2541;
close #2470;

https://github.com/marktext/marktext/blob/4c517b163232af5649b7a26d4a5705e40bbe4817/src/renderer/util/index.js#L151-L186

in `animatedScrollTo` fn, if the duration arg is 0 , the `easeInOutQuad` will always return NaN/-Infinity
```js
element.scrollTop = val // val NaN / -Infinity  equal  element.scrollTop = 0;
```
so the page will scroll from the page start(0) , cause the 'blink'.

