### PR TITLE
Fix invalid fallback accelerator warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,8 @@ jobs:
           key: ${{ runner.os }}-electron-builder-cache-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
 
       - name: Install dependencies
-        if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
+        # Windows worker fail sometimes because a module cannot be found.
+        # if: ${{ steps.cacheNodeModules.outputs.cache-hit != 'true' }}
         run: yarn install --check-files --frozen-lockfile
 
       - name: Lint

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -36,7 +36,7 @@ class Keybindings {
   getAccelerator (id) {
     const name = this.keys.get(id)
     if (!name) {
-      return ''
+      return null
     }
     return name
   }
@@ -146,7 +146,6 @@ class Keybindings {
 
   _loadLocalKeybindings () {
     if (global.MARKTEXT_SAFE_MODE || !isFile2(this.configPath)) {
-      console.log('Ignoring key bindings because safe mode is enabled.')
       return
     }
 

--- a/src/main/windows/setting.js
+++ b/src/main/windows/setting.js
@@ -85,13 +85,12 @@ class SettingWindow extends BaseWindow {
     win.loadURL(this._buildUrlString(this.id, env, preferences))
     win.setSheetOffset(TITLE_BAR_HEIGHT)
 
-    electronLocalshortcut.register(
-      win,
-      keybindings.getAccelerator('view.toggle-dev-tools'),
-      () => {
+    const devToolsAccelerator = keybindings.getAccelerator('view.toggle-dev-tools')
+    if (env.debug && devToolsAccelerator) {
+      electronLocalshortcut.register(win, devToolsAccelerator, () => {
         win.webContents.toggleDevTools()
-      }
-    )
+      })
+    }
     return win
   }
 }


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| License           | MIT

### Description

Fixed invalid fallback accelerator warning in Electron shortcut handler and try to solve Windows CI failure by always installing dependencies.
