### PR TITLE
feat: set default name of exported file to current filename

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -53,9 +53,9 @@ const handleResponseForExport = async (e, { type, content, pathname, title, page
   const win = BrowserWindow.fromWebContents(e.sender)
   const extension = EXTENSION_HASN[type]
   const dirname = pathname ? path.dirname(pathname) : getPath('documents')
-  let nakedFilename = title
+  let nakedFilename = pathname ? path.basename(pathname, '.md') : title
   if (!nakedFilename) {
-    nakedFilename = pathname ? path.basename(pathname, '.md') : 'Untitled'
+    nakedFilename = 'Untitled'
   }
 
   const defaultPath = path.join(dirname, `${nakedFilename}${extension}`)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2731
| License           | MIT

### Description
This changes the default name set when saving an exported file, defaulting to the name of .md file. If not available, it then defaults to the first header. Previously, this order was reversed, with the header being defaulted to before the filename.