### PR TITLE
feat: set image folder to .assets, create folder without filename ext…

### DIFF
--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -804,7 +804,7 @@ export default {
       const getResolvedImagePath = imagePath => {
         // Use filename only when the tab is saved on disk.
         const replacement = pathname ? filename : ''
-        return imagePath.replace(/\${filename}/g, replacement)
+        return imagePath.replace(/\${filename}/g, replacement.replace(/\.[^/.]+$/, ''))
       }
 
       const resolvedImageFolderPath = getResolvedImagePath(imageFolderPath)


### PR DESCRIPTION
…ension.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

[Description of the bug or feature]

Set relative image folder name: ${filename}.assets, And filename is foo.md
will create image folder,
Before: foo.md.assets
After: foo.assets