### PR TITLE
Remove debug info from ripgrep [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
 
+      - name: Strip ripgrep on Linux
+        if: runner.os == 'Linux'
+        run: strip node_modules/vscode-ripgrep/bin/rg
+
       - name: Lint
         run: |
           yarn run lint


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

Downstream fix for https://github.com/microsoft/ripgrep-prebuilt/issues/15 to remove debug information from ripgrep on Linux.

- Size before ~40MB
- Normally/after: 5MB
