### PR TITLE
Fixes: grammar, spelling, readability + [BUG]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # MarkText Contributing Guide
 
-We are really excited that you are interested in contributing to MarkText :tada:. Before submitting your contribution though, please make sure to take a moment and read through the following guidelines.
+We are really excited that you are interested in contributing to MarkText :tada:. Before submitting your contribution, please make sure to take a moment and read through the following guidelines.
 
 - [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 - [Philosophy](#philosophy)
@@ -14,46 +14,49 @@ We are really excited that you are interested in contributing to MarkText :tada:
 
 ## Philosophy
 
-MarkText is still in development, many things will change and features will be added but our philosophy is to keep things clean, simple and minimal. For example our side bar and tabs: these two panels provide a lot of functionality but don't disturb the user if it's need it. We'll add more and more features, maybe extended it by plugins, that can be activated via settings to improve MarkText. So we allow everyone to customize MarkText for their needs and provide a minimal default interface.
+🔑 Our philosophy is to keep things clean, simple and minimal. 
+MarkText is constantly changing and we want these improvements to align with our philosphy. For example, look at the side bar and tabs; these two panels provide awesome functionality *and* aren't distracting to the user. We'll continue adding more features (like plugins) that can be activated via 'settings' to improve MarkText. This will allow everyone to customize MarkText for their needs and provide a minimal default interface.
 
-## Issue reporting guidelines
+## Issue Reporting Guidelines
 
-Please search for similar issues before opening an issue and always follow the [issue template](.github/ISSUE_TEMPLATE.md). Please provide a detailed description of the problem in your PR and live demo or screenshots are preferred.
+Please search for similar issues before opening an issue and always follow the [issue template](.github/ISSUE_TEMPLATE/). Please review the following Pull Request guidelines before making your own PR. 
 
-## Pull request guidelines
+## Pull Request Guidelines
+
+**In *all* Pull Requests:** provide a detailed description of the problem, as well as a demonstration with screen recordings and/or screenshots.
 
 Please make sure the following is done before submitting a PR:
 
 - Submit PRs directly to the `develop` branch.
 - Reference the related issue in the PR comment.
-- Utilize JSDoc for better code documentation.
+- Utilize [JSDoc](https://github.com/jsdoc/jsdoc) for better code documentation.
 - Ensure all tests pass.
-- Please lint (`yarn run lint`) and test your PR before submitting.
+- Please lint (`yarn run lint`) your PR.
 - All PRs need to pass the **CI** before merged. If it fails, please try to solve the issue(s) and feel free to ask for any help.
 
 If you add new feature:
 
 - Open a suggestion issue first.
-- Provide convincing reason to add this feature.
-- Then submit your PR.
+- Provide your reasoning on why you want to add this feature.
+- Submit your PR.
 
 If you fix a bug:
 
 - If you are resolving a special issue, please add `fix: #<issue number> <short message>` in your PR title (e.g.`fix: #3899 update entities encoding/decoding`).
-- Provide a detailed description of the bug in your PR and/or link to the issue. You can also include screenshots.
+- Provide a detailed description of the bug in your PR and/or link to the issue. 
 
 ### Where should I start?
 
-A good way to start to find an issue flagged as a `bug`, `help wanted` or `feature request`. The `good first issue` issues are good for newcomers. Please discuss the solution for larger issues first and after the final solution is approved by the MarkText members, you can submit/work on the PR. For small changes you can directly open a PR.
+A good way to start is to find an [issue](https://github.com/marktext/marktext/issues) labeled as `bug`, `help wanted` or `feature request`. The `good first issue` issues are good for newcomers. Please discuss the solution for larger issues first and after the final solution is approved by the MarkText members, you can submit/work on the PR. For small changes you can directly open a PR.
 
 Other ways to help:
 
 - Documentation
 - Translation (currently unavailable)
-- Design icons and logos and improve the UI
-- Help to test MarkText
-- Help to answer issues or discuss changes and features.
-- Let us know you opinion about MarkText, missing features and report bugs and problems. :+1: features you like and discuss with us about upcoming changes and features.
+- Design icons and logos
+- Improve the UI
+- Write tests for MarkText
+- Share your thoughts! We want to hear about features you think are missing, any bugs you find, and why you :heart: MarkText.
 
 ## Quick start
 
@@ -71,19 +74,19 @@ If there are conflicts or you want to update your local branch, please do the fo
 2. `git rebase upstream/develop`
 3. Please [resolve](https://help.github.com/articles/resolving-merge-conflicts-after-a-git-rebase/) all conflicts and force push your feature branch: `git push -f`
 
-### Build instructions
+### Build Instructions
 
-Please see [here](docs/dev/BUILD.md) for build instructions.
+🔗 [Build Instructions](docs/dev/BUILD.md)
 
-### Style guide
+### Style Guide
 
 You can run ESLint (`yarn run lint`) to help you to follow the style guide.
 
 - ES6 and "best practices"
 - 2 space indent
 - no semicolons
-- JSDoc for documentation
+- documentation: [JSDoc](https://github.com/jsdoc/jsdoc) 
 
-## Developer documentation
+## Developer Documentation
 
-Please see [here](docs/dev/README.md) for more details.
+Please [click here](docs/dev/README.md) for more details.


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

[BUG]: outdated, missing, and/or broken links.
- The 'issue template' was linked to an old version. 
- 'JSDoc' was referenced, but not linked.
- Added a link to MarkText's 'issues' page for quick access in the "where should I start?" section. 
- Other: did some proofreading, edits, etc. to improve readability & appear more professional.