### PR TITLE
Add architecture to artifact name on macOS [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,10 @@ jobs:
       - name: Calculate checksums
         if: runner.os == 'macOS'
         run: |
-          shasum -a 256 build/marktext-mac.zip
-          shasum -a 256 build/marktext.dmg
+          shasum -a 256 build/marktext-arm64-mac.zip
+          shasum -a 256 build/marktext-x64-mac.zip
+          shasum -a 256 build/marktext-arm64.dmg
+          shasum -a 256 build/marktext-x64.dmg
         shell: bash
 
   windows:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -60,7 +60,7 @@ fileAssociations:
   role: "Editor"
   icon: "../resources/icons/md.icns"
 mac:
-  artifactName: "marktext-mac.${ext}"
+  artifactName: "marktext-${arch}-mac.${ext}"
   icon: "resources/icons/icon.icns"
   darkModeSupport: true
   target:
@@ -69,7 +69,7 @@ mac:
     - target: zip
       arch: [x64, arm64]
 dmg:
-  artifactName: "marktext.${ext}"
+  artifactName: "marktext-${arch}.${ext}"
   contents:
   - x: 410
     y: 240


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

Fix same name for macOS arm64 and x64 setup.
