### PR TITLE
Fixed colons being at end of hyperlinks #2096

### DIFF
--- a/src/muya/lib/parser/marked/inlineRules.js
+++ b/src/muya/lib/parser/marked/inlineRules.js
@@ -59,6 +59,11 @@ inline._escapes = /\\([!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~])/g
 inline._scheme = /[a-zA-Z][a-zA-Z0-9+.-]{1,31}/
 inline._email = /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+(@)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(?![-_])/
 inline.autolink = edit(inline.autolink)
+  stringLink = inline.autolink.source
+  if(stringLink[stringLink.length-1] == ':'){
+    stringLink.slice(0,-1)
+  }
+  inline.autolink = new RegExp(stringlink)
   .replace('scheme', inline._scheme)
   .replace('email', inline._email)
   .getRegex()
@@ -75,12 +80,22 @@ inline._href = /<(?:\\.|[^\n<>\\])+>|[^\s\x00-\x1f]*/ // eslint-disable-line no-
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/
 
 inline.link = edit(inline.link)
+  stringLink = inline.link.source
+  if(stringLink[stringLink.length-1] == ':'){
+    stringLink.slice(0,-1)
+  }
+  inline.link = new RegExp(stringlink)
   .replace('label', inline._label)
   .replace('href', inline._href)
   .replace('title', inline._title)
   .getRegex()
 
 inline.reflink = edit(inline.reflink)
+  stringLink = inline.reflink.source
+  if(stringLink[stringLink.length-1] == ':'){
+    stringLink.slice(0,-1)
+  }
+  inline.reflink = new RegExp(stringlink)
   .replace('label', inline._label)
   .getRegex()
 

--- a/src/muya/lib/parser/rules.js
+++ b/src/muya/lib/parser/rules.js
@@ -22,10 +22,6 @@ export const inlineRules = {
   auto_link: /^<(?:([a-zA-Z]{1}[a-zA-Z\d\+\.\-]{1,31}:[^ <>]*)|([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))>/,
   // (extended www autolink|extended url autolink|extended email autolink) the email regexp is the same as auto_link.
   auto_link_extension: /^(?:(www\.[a-z_-]+\.[a-z]{2,}(?::[0-9]{1,5})?(?:\/[\S]*)?)|(http(?:s)?:\/\/(?:[a-z0-9\-._~]+\.[a-z]{2,}|[0-9.]+|localhost|\[[a-f0-9.:]+\])(?::[0-9]{1,5})?(?:\/[\S]*)?)|([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))(?=\s|$)/,
-  link_string: auto_link_extension.toString(),
-  while(link_string.charAt(link_string.length - 1) != ':'){
-
-  },
   reference_link: /^\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   reference_image: /^\!\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   tail_header: /^(\s{1,}#{1,})(\s*)$/,

--- a/src/muya/lib/parser/rules.js
+++ b/src/muya/lib/parser/rules.js
@@ -22,6 +22,10 @@ export const inlineRules = {
   auto_link: /^<(?:([a-zA-Z]{1}[a-zA-Z\d\+\.\-]{1,31}:[^ <>]*)|([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))>/,
   // (extended www autolink|extended url autolink|extended email autolink) the email regexp is the same as auto_link.
   auto_link_extension: /^(?:(www\.[a-z_-]+\.[a-z]{2,}(?::[0-9]{1,5})?(?:\/[\S]*)?)|(http(?:s)?:\/\/(?:[a-z0-9\-._~]+\.[a-z]{2,}|[0-9.]+|localhost|\[[a-f0-9.:]+\])(?::[0-9]{1,5})?(?:\/[\S]*)?)|([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*))(?=\s|$)/,
+  link_string: auto_link_extension.toString(),
+  while(link_string.charAt(link_string.length - 1) != ':'){
+
+  },
   reference_link: /^\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   reference_image: /^\!\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
   tail_header: /^(\s{1,}#{1,})(\s*)$/,


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no (I don't know how but if told how to do so I would b happy to)
| Fixed tickets     | Fixes #2096 
| License           | MIT

### Description

[Description of the bug or feature]

Colon character was being included at the end of links which would cause them to not function correctly.

I fixed this by checking for the last character being a colon and deleting it if it was. 
I did this for the auto-link, normal link, and reference link.

This is my first contribution for a school assignment so I'm not particularly familiar with git and open source, so if there is anything else I need to do for this code to be added (like adding tests) please let me know how to do so and I will do it.
