### PR TITLE
Fix non-character key bindings and Alt+F4 on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@electron/remote": "^2.0.4",
-    "@hfelix/electron-localshortcut": "^4.0.0-rc.1",
+    "@hfelix/electron-localshortcut": "^4.0.0",
     "@hfelix/electron-spellchecker": "^2.0.0",
     "@marktext/file-icons": "^1.0.6",
     "@octokit/rest": "^18.12.0",

--- a/src/common/keybinding/index.js
+++ b/src/common/keybinding/index.js
@@ -23,7 +23,7 @@ export const isEqualAccelerator = (a, b) => {
 
   const partsA = a.split('+')
   const partsB = b.split('+')
-  if (partsA.length !== partsB.length || partsA.length <= 1) {
+  if (partsA.length !== partsB.length) {
     return false
   }
 

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -436,6 +436,20 @@ class AppMenu {
       },
       id: null
     })
+
+    if (isWindows) {
+      // WORKAROUND: Window close event isn't triggered on Windows if `setIgnoreMenuShortcuts(true)` is used (Electron#32674).
+      // NB: Remove this immediately if upstream is fixed because the event may be emitted twice.
+      shortcutMap.push({
+        accelerator: 'Alt+F4',
+        click: (menuItem, win) => {
+          if (win && !win.isDestroyed()) {
+            win.close()
+          }
+        },
+        id: null
+      })
+    }
   }
 
   _buildEditorMenu (createShortcutMap, recentUsedDocuments = null) {

--- a/test/unit/specs/match-electron-accelerator.spec.js
+++ b/test/unit/specs/match-electron-accelerator.spec.js
@@ -1,19 +1,23 @@
 import { isEqualAccelerator } from 'common/keybinding'
 
-const keys = [
+const characterKeys = [
   '0',
   '1',
   '9',
   'A',
+  'b',
   'G',
   'Z',
-  'F1',
-  'F5',
-  'F24',
   '~',
   '!',
   '@',
-  '#',
+  '#'
+]
+
+const nonCharacterKeys = [
+  'F1',
+  'F5',
+  'F24',
   'Plus',
   'Space',
   'Tab',
@@ -42,6 +46,8 @@ const keys = [
   'PrintScreen'
 ]
 
+const keys = [...characterKeys, ...nonCharacterKeys]
+
 const modifiers = [
   'Command',
   'Cmd',
@@ -54,6 +60,34 @@ const modifiers = [
   'AltGr',
   'Shift'
 ]
+
+describe('Test equal with non characte key', () => {
+  it('Match F2', () => {
+    expect(isEqualAccelerator('F2', 'F2')).to.equal(true)
+  })
+  it('Match F10', () => {
+    expect(isEqualAccelerator('F10', 'F10')).to.equal(true)
+  })
+  it('Match PageUp', () => {
+    expect(isEqualAccelerator('PageUp', 'PageUp')).to.equal(true)
+  })
+  it('Match Tab', () => {
+    expect(isEqualAccelerator('Tab', 'Tab')).to.equal(true)
+  })
+
+  it('Mismatch F2 and F3', () => {
+    expect(isEqualAccelerator('F2', 'F3')).to.equal(false)
+  })
+  it('Mismatch Left and Down', () => {
+    expect(isEqualAccelerator('Left', 'Down')).to.equal(false)
+  })
+  it('Mismatch F1 and 1', () => {
+    expect(isEqualAccelerator('F1', '1')).to.equal(false)
+  })
+  it('Mismatch F2 and Ctrl+F2', () => {
+    expect(isEqualAccelerator('F2', 'Ctrl+F2')).to.equal(false)
+  })
+})
 
 describe('Test equal with basis keys', () => {
   it('Match Ctrl+A', () => {
@@ -100,11 +134,21 @@ describe('Test invalid accelerator', () => {
   })
 })
 
-describe('Match all', () => {
+describe('Match combination for modifier and key', () => {
   modifiers.forEach(mod =>
     keys.forEach(key => {
       it(`Should match ${mod}+${key}`, () => {
         expect(isEqualAccelerator(`${mod}+${key}`, `${key}+${mod}`)).to.equal(true)
+      })
+    })
+  )
+})
+
+describe('Match non-character keys', () => {
+  nonCharacterKeys.forEach(nonCharacterKey =>
+    keys.forEach(key => {
+      it(`Should match ${nonCharacterKeys}`, () => {
+        expect(isEqualAccelerator(`${nonCharacterKeys}`, `${nonCharacterKeys}`)).to.equal(true)
       })
     })
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,10 +1789,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@hfelix/electron-localshortcut@^4.0.0-rc.1":
-  version "4.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@hfelix/electron-localshortcut/-/electron-localshortcut-4.0.0-rc.1.tgz#1d7801c32ddd2ad2785073b920dcd16f24c1e53a"
-  integrity sha512-rRiwMBPJkPe/aAuzjFcjuIokm8VsTTWsCPOHNsjrrLWhOy+/TCiwEmdspCguLt07e23oXMhbMLALE3N3NFJGTg==
+"@hfelix/electron-localshortcut@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@hfelix/electron-localshortcut/-/electron-localshortcut-4.0.0.tgz#3ccfdb60dbe966b0ed7aa9388b13a52072734e8d"
+  integrity sha512-FZ+d3/6h141WOXrCLYt+ZcwcHZIkGar4chTqfZgcI+2FoLR3CJSJuX0dG8PUvvJWCo404PNxiVCF4ZxLOqpn8w==
   dependencies:
     debug "^4.3.3"
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | #2964
| License           | MIT

### Description

- Fix `Alt+F4` on Windows (https://github.com/electron/electron/issues/32674)
- Allow non-character key bindings ([see here](https://github.com/fxha/electron-localshortcut/commit/d32301bcbb2f1816c97941d81bb1bb0b9bdfef5b#diff-6d209b42d78478cc98ad988200eb8df96290c6ba8940efba664a830eaec8e3f0))
