### PR TITLE
Fix code intellisense and Vetur

### DIFF
--- a/src/main/jsconfig.json
+++ b/src/main/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "paths": {
+      "common/*": ["../common/*"]
+    }
+  },
+  "include": ["."]
+}

--- a/src/renderer/jsconfig.json
+++ b/src/renderer/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2020",
+    "paths": {
+      "common/*": ["../common/*"],
+      "muya/*": ["../muya/*"],
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["."]
+}

--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  projects: [
+    {
+      root: './src/renderer',
+      package: '../../package.json',
+      tsconfig: './jsconfig.json'
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

Fix code intellisense and Vetur by adding `jsconfig.js` for main and renderer.

I'm unsure about the target but it should be at least `es2020` because we build against node v16.
