### PR TITLE
fix: Internal image cache isn't reset if failed to load (#3001)

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -994,7 +994,7 @@ span.ag-warn.ag-emoji-marked-text {
 
 .ag-inline-image.ag-image-loading {
   width: 400px;
-  height: 250px;
+  height: 50px;
   margin: 0 auto;
   vertical-align: bottom;
 }

--- a/src/muya/lib/parser/render/renderInlines/loadImageAsync.js
+++ b/src/muya/lib/parser/render/renderInlines/loadImageAsync.js
@@ -17,6 +17,10 @@ export default function loadImageAsync (imageInfo, attrs, className, imageClass)
       // We have a cached image, but force it to load.
       reload = true
     }
+    if (!imageInfo.isSuccess) {
+      // There is a chance that it will succeed in loading this time, so we will try to reload it.
+      reload = true
+    }
   } else {
     reload = true
   }


### PR DESCRIPTION
In the loadImageAsync function, images that failed last time will try to be reloaded.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3001
| License           | MIT
