### PR TITLE
fix-#3019: Workaround for post window shutdown exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "release:muya": "yarn run build:muya && cd src/muya && yarn publish",
     "rebuild": "electron-rebuild -f",
     "gen-third-party": "node tools/generateThirdPartyLicense.js",
-    "validate-licenses": "node tools/validateLicenses.js"
+    "validate-licenses": "node tools/validateLicenses.js",
+    "deobfuscateStackTrace": "node tools/deobfuscateStackTrace.js"
   },
   "dependencies": {
     "@electron/remote": "^2.0.4",
@@ -157,6 +158,7 @@
     "postcss-preset-env": "^7.2.3",
     "raw-loader": "^4.0.2",
     "require-dir": "^1.2.0",
+    "stacktrace-parser": "^0.1.10",
     "style-loader": "^3.3.1",
     "svg-sprite-loader": "^6.0.11",
     "svgo": "^2.8.0",

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -500,15 +500,31 @@ class AppMenu {
       this.updateLineEndingMenu(windowId, lineEnding)
     })
     ipcMain.on('mt::update-format-menu', (e, windowId, formats) => {
+      if (!this.has(windowId)) {
+        log.error(`UpdateApplicationMenu: Cannot find window menu for window id ${windowId}.`)
+        return
+      }
       updateFormatMenu(this.getWindowMenuById(windowId), formats)
     })
     ipcMain.on('mt::update-sidebar-menu', (e, windowId, value) => {
+      if (!this.has(windowId)) {
+        log.error(`UpdateApplicationMenu: Cannot find window menu for window id ${windowId}.`)
+        return
+      }
       updateSidebarMenu(this.getWindowMenuById(windowId), value)
     })
     ipcMain.on('mt::view-layout-changed', (e, windowId, viewSettings) => {
+      if (!this.has(windowId)) {
+        log.error(`UpdateApplicationMenu: Cannot find window menu for window id ${windowId}.`)
+        return
+      }
       viewLayoutChanged(this.getWindowMenuById(windowId), viewSettings)
     })
     ipcMain.on('mt::editor-selection-changed', (e, windowId, changes) => {
+      if (!this.has(windowId)) {
+        log.error(`UpdateApplicationMenu: Cannot find window menu for window id ${windowId}.`)
+        return
+      }
       updateSelectionMenus(this.getWindowMenuById(windowId), changes)
     })
 

--- a/tools/deobfuscateStackTrace.js
+++ b/tools/deobfuscateStackTrace.js
@@ -8,8 +8,17 @@ const spec = {
   '--map': String,
   '-m': '--map'
 }
-const args = arg(spec, { argv: process.argv.slice(1), permissive: false })
+const args = arg(spec, { argv: process.argv.slice(1), permissive: true })
 const mapPath = args['--map']
+
+if (!mapPath) {
+  console.log('ERROR: -m is a required argument.\n')
+  console.log('USAGE:\n  yarn deobfuscateStackTrace -m <path_to_source_map>')
+  process.exit(1)
+} else if (!fs.existsSync(mapPath)) {
+  console.log(`ERROR: Invalid source map path: "${mapPath}".`)
+  process.exit(1)
+}
 
 const deobfuscateStackTrace = stackTraceStr => {
   const smc = new sourceMap.SourceMapConsumer(fs.readFileSync(mapPath, 'utf8'))
@@ -38,6 +47,8 @@ const deobfuscateStackTrace = stackTraceStr => {
     }
   })
 }
+
+console.log('Please paste the stack trace and continue with double Enter:')
 
 const lines = []
 readline.createInterface({

--- a/tools/deobfuscateStackTrace.js
+++ b/tools/deobfuscateStackTrace.js
@@ -1,0 +1,53 @@
+const fs = require('fs')
+const readline = require('readline')
+const arg = require('arg')
+const sourceMap = require('source-map')
+const stackTraceParser = require('stacktrace-parser')
+
+const spec = {
+  '--map': String,
+  '-m': '--map'
+}
+const args = arg(spec, { argv: process.argv.slice(1), permissive: false })
+const mapPath = args['--map']
+
+const deobfuscateStackTrace = stackTraceStr => {
+  const smc = new sourceMap.SourceMapConsumer(fs.readFileSync(mapPath, 'utf8'))
+  const stack = stackTraceParser.parse(stackTraceStr)
+  if (stack.length === 0) {
+    throw new Error('Invalid stack trace.')
+  }
+
+  const errorMessage = stackTraceStr.split('\n').find(line => line.trim().length > 0)
+  if (errorMessage) {
+    console.log(errorMessage)
+  }
+
+  stack.forEach(({ methodName, lineNumber, column }) => {
+    try {
+      if (lineNumber == null || lineNumber < 1) {
+        console.log(`    at ${methodName || ''}`)
+      } else {
+        const pos = smc.originalPositionFor({ line: lineNumber, column })
+        if (pos && pos.line != null) {
+          console.log(`    at ${pos.name || ''} (${pos.source}:${pos.line}:${pos.column})`)
+        }
+      }
+    } catch (err) {
+      console.log(`    Failed to parse line ${lineNumber} on column ${column}.`)
+    }
+  })
+}
+
+const lines = []
+readline.createInterface({
+  input: process.stdin,
+  terminal: false
+}).on('line', line => {
+  if (!line || line === '') {
+    console.log('Deobfuscated stack trace:')
+    deobfuscateStackTrace(lines.join('\n'))
+    process.exit(0)
+  }
+  lines.push(line)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -11922,6 +11922,13 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 stat-mode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
@@ -12510,6 +12517,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-fest@^1.0.2:
   version "1.4.0"


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #3019
| License           | MIT

### Description

Add workaround for a post window shutdown exception that only occurs on macOS. Most likely due to the event loop queue.
