### PR TITLE
fix clickable HTML links on Windows (#3015)

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -415,12 +415,17 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
     return
   }
 
-  const href = data.href || data.text
-  if (URL_REG.test(href)) {
-    shell.openExternal(href)
+  const urlCandidate = data.href || data.text
+  if (URL_REG.test(urlCandidate)) {
+    shell.openExternal(urlCandidate)
     return
-  } else if (/^[a-z0-9]+:\/\//i.test(href)) {
+  } else if (/^[a-z0-9]+:\/\//i.test(urlCandidate)) {
     // Prevent other URLs.
+    return
+  }
+
+  const href = data.href
+  if (!href) {
     return
   }
 
@@ -432,6 +437,7 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
   }
 
   if (pathname) {
+    pathname = path.normalize(pathname)
     if (isMarkdownFile(pathname)) {
       const win = BrowserWindow.fromWebContents(e.sender)
       openFileOrFolder(win, pathname)

--- a/src/muya/lib/utils/markdownFile.js
+++ b/src/muya/lib/utils/markdownFile.js
@@ -1,0 +1,24 @@
+// __MARKTEXT_ONLY__
+
+const MARKDOWN_EXTENSIONS = Object.freeze([
+  'markdown',
+  'mdown',
+  'mkdn',
+  'md',
+  'mkd',
+  'mdwn',
+  'mdtxt',
+  'mdtext',
+  'text',
+  'txt'
+])
+
+/**
+ * Returns true if the filename matches one of the markdown extensions allowed in MarkText.
+ *
+ * @param {string} filename Path or filename
+ */
+export const hasMarkdownExtension = filename => {
+  if (!filename || typeof filename !== 'string') return false
+  return MARKDOWN_EXTENSIONS.some(ext => filename.toLowerCase().endsWith(`.${ext}`))
+}

--- a/src/muya/lib/utils/url.js
+++ b/src/muya/lib/utils/url.js
@@ -1,8 +1,22 @@
 import { isValidAttribute } from '../utils/dompurify'
+import { isWin } from '../config' // __MARKTEXT_PATCH__
+import { hasMarkdownExtension } from './markdownFile' // __MARKTEXT_PATCH__
 
 export const sanitizeHyperlink = rawLink => {
-  if (rawLink && typeof rawLink === 'string' && isValidAttribute('a', 'href', rawLink)) {
-    return rawLink
+  if (rawLink && typeof rawLink === 'string') {
+    if (isValidAttribute('a', 'href', rawLink)) {
+      return rawLink
+    }
+
+    // __MARKTEXT_PATCH__
+    if (isWin && /^[a-zA-Z]:[/\\].+/.test(rawLink) && hasMarkdownExtension(rawLink)) {
+      // Create and try UNC path on Windows because "C:\file.md" isn't allowed.
+      const uncPath = `\\\\?\\${rawLink}`
+      if (isValidAttribute('a', 'href', uncPath)) {
+        return uncPath
+      }
+    }
+    // END __MARKTEXT_PATCH__
   }
   return ''
 }


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #3015
| License           | MIT

### Description

Fixed clickable HTML links (`<a href="C:\a.md">foo</a>`) on Windows because the `href` was filtered out by dompurify. This PR applies a patch to Muya to map paths like `C:\foo\bar\doc.md` to an UNC path `\\\\?\\C:\foo\bar\doc.md` on Windows that is allowed by the validator.


