### PR TITLE
Remove accelerator for heading size on Windows

### DIFF
--- a/docs/KEYBINDINGS_LINUX.md
+++ b/docs/KEYBINDINGS_LINUX.md
@@ -54,7 +54,7 @@ MarkText key bindings for Linux. Please see [general key bindings](KEYBINDINGS.m
 | `paragraph.heading-4`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>4</kbd> | Set line as heading 4                    |
 | `paragraph.heading-5`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>5</kbd> | Set line as heading 5                    |
 | `paragraph.heading-6`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>6</kbd> | Set line as heading 6                    |
-| `paragraph.upgrade-heading` | <kbd>Ctrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                        |
+| `paragraph.upgrade-heading` | <kbd>Ctrl</kbd>+<kbd>Plus</kbd>               | Upgrade a heading                        |
 | `paragraph.degrade-heading` | <kbd>Ctrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                        |
 | `paragraph.table`           | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> | Insert a table                           |
 | `paragraph.code-fence`      | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> | Insert a code block                      |

--- a/docs/KEYBINDINGS_OSX.md
+++ b/docs/KEYBINDINGS_OSX.md
@@ -62,7 +62,7 @@ MarkText key bindings for macOS. Please see [general key bindings](KEYBINDINGS.m
 | `paragraph.heading-4`       | <kbd>Command</kbd>+<kbd>4</kbd>                   | Set line as heading 4                    |
 | `paragraph.heading-5`       | <kbd>Command</kbd>+<kbd>5</kbd>                   | Set line as heading 5                    |
 | `paragraph.heading-6`       | <kbd>Command</kbd>+<kbd>6</kbd>                   | Set line as heading 6                    |
-| `paragraph.upgrade-heading` | <kbd>Command</kbd>+<kbd>=</kbd>                   | Upgrade a heading                        |
+| `paragraph.upgrade-heading` | <kbd>Command</kbd>+<kbd>Plus</kbd>                | Upgrade a heading                        |
 | `paragraph.degrade-heading` | <kbd>Command</kbd>+<kbd>-</kbd>                   | Degrade a heading                        |
 | `paragraph.table`           | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd>  | Insert a table                           |
 | `paragraph.code-fence`      | <kbd>Command</kbd>+<kbd>Option</kbd>+<kbd>C</kbd> | Insert a code block                      |

--- a/docs/KEYBINDINGS_WINDOWS.md
+++ b/docs/KEYBINDINGS_WINDOWS.md
@@ -54,7 +54,7 @@ MarkText key bindings for Windows. Please see [general key bindings](KEYBINDINGS
 | `paragraph.heading-4`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>4</kbd> | Set line as heading 4                    |
 | `paragraph.heading-5`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>5</kbd> | Set line as heading 5                    |
 | `paragraph.heading-6`       | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>6</kbd> | Set line as heading 6                    |
-| `paragraph.upgrade-heading` | <kbd>Ctrl</kbd>+<kbd>=</kbd>                  | Upgrade a heading                        |
+| `paragraph.upgrade-heading` | <kbd>Ctrl</kbd>+<kbd>Plus</kbd>               | Upgrade a heading                        |
 | `paragraph.degrade-heading` | <kbd>Ctrl</kbd>+<kbd>-</kbd>                  | Degrade a heading                        |
 | `paragraph.table`           | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> | Insert a table                           |
 | `paragraph.code-fence`      | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> | Insert a code block                      |

--- a/src/main/keyboard/keybindingsDarwin.js
+++ b/src/main/keyboard/keybindingsDarwin.js
@@ -50,7 +50,7 @@ export default new Map([
   ['paragraph.heading-4', 'Command+4'],
   ['paragraph.heading-5', 'Command+5'],
   ['paragraph.heading-6', 'Command+6'],
-  ['paragraph.upgrade-heading', 'Command+='],
+  ['paragraph.upgrade-heading', 'Command+Plus'],
   ['paragraph.degrade-heading', 'Command+-'],
   ['paragraph.table', 'Command+Shift+T'],
   ['paragraph.code-fence', 'Command+Option+C'],

--- a/src/main/keyboard/keybindingsLinux.js
+++ b/src/main/keyboard/keybindingsLinux.js
@@ -48,13 +48,13 @@ export default new Map([
   ['edit.screenshot', ''], // macOS only
 
   // Paragraph menu
-  ['paragraph.heading-1', 'Ctrl+Shift+1'],
-  ['paragraph.heading-2', 'Ctrl+Shift+2'],
-  ['paragraph.heading-3', 'Ctrl+Shift+3'],
-  ['paragraph.heading-4', 'Ctrl+Shift+4'],
-  ['paragraph.heading-5', 'Ctrl+Shift+5'],
-  ['paragraph.heading-6', 'Ctrl+Shift+6'],
-  ['paragraph.upgrade-heading', 'Ctrl+='],
+  ['paragraph.heading-1', 'Ctrl+Alt+1'],
+  ['paragraph.heading-2', 'Ctrl+Alt+2'],
+  ['paragraph.heading-3', 'Ctrl+Alt+3'],
+  ['paragraph.heading-4', 'Ctrl+Alt+4'],
+  ['paragraph.heading-5', 'Ctrl+Alt+5'],
+  ['paragraph.heading-6', 'Ctrl+Alt+6'],
+  ['paragraph.upgrade-heading', 'Ctrl+Plus'],
   ['paragraph.degrade-heading', 'Ctrl+-'],
   ['paragraph.table', 'Ctrl+Shift+T'],
   ['paragraph.code-fence', 'Ctrl+Shift+K'],

--- a/src/main/keyboard/keybindingsWindows.js
+++ b/src/main/keyboard/keybindingsWindows.js
@@ -45,13 +45,15 @@ export default new Map([
   ['edit.screenshot', ''], // macOS only
 
   // Paragraph menu
-  ['paragraph.heading-1', 'Ctrl+Shift+1'],
-  ['paragraph.heading-2', 'Ctrl+Shift+2'],
-  ['paragraph.heading-3', 'Ctrl+Shift+3'],
-  ['paragraph.heading-4', 'Ctrl+Shift+4'],
-  ['paragraph.heading-5', 'Ctrl+Shift+5'],
-  ['paragraph.heading-6', 'Ctrl+Shift+6'],
-  ['paragraph.upgrade-heading', 'Ctrl+='],
+  // NOTE: We cannot set a default value for heading size because `Ctrl+Alt` is an alias
+  //       to `AltGr` on Windows and `Ctrl+Shift+1` is mapped to the underlying character.
+  ['paragraph.heading-1', ''],
+  ['paragraph.heading-2', ''],
+  ['paragraph.heading-3', ''],
+  ['paragraph.heading-4', ''],
+  ['paragraph.heading-5', ''],
+  ['paragraph.heading-6', ''],
+  ['paragraph.upgrade-heading', 'Ctrl+Plus'],
   ['paragraph.degrade-heading', 'Ctrl+-'],
   ['paragraph.table', 'Ctrl+Shift+T'],
   ['paragraph.code-fence', 'Ctrl+Shift+K'],

--- a/src/renderer/commands/descriptions.js
+++ b/src/renderer/commands/descriptions.js
@@ -99,6 +99,12 @@ const commandDescriptions = Object.freeze({
   'tabs.switch-to-tenth': 'Misc: Switch tab to the 10st',
 
   // ============================================
+  // # Menu descriptions but not available as command
+  // #
+
+  'view.reload-images': 'View: Clear cache and reload images',
+
+  // ============================================
   // # Additional command descriptions
   // #
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Breaking changes? | yes
| Fixed tickets     | Closes #3038
| License           | MIT

### Description

- Mapped upgrade heading to `Ctrl+Plus` (`+`) - this will work after updating packages due to a bug in key mapper.
- Added description for reload images shortcut in settings

Changes because we map `Ctrl+Shift+1` to the underlying character due to compatibility issues with non-US keyboards:

- Removed heading size shortcuts on Windows because we cannot bind any default keys that are static across all key board layouts
- Changed heading size accelerators on Linux to `Ctrl+Alt+Digit0-6`

A user on Windows have to manually set the key bindings above, but this should be no problem with the reworked settings.
