### PR TITLE
Set .ag-hide to 'display: none' if possible

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -73,6 +73,10 @@ div.ag-show-quick-insert-hint p.ag-paragraph.ag-active > span.ag-paragraph-conte
   position: relative;
 }
 
+.ag-hide {
+  display: none;
+}
+
 .ag-atx-line:empty::after,
 .ag-thematic-break-line:empty::after,
 .ag-code-content:empty::after,
@@ -330,6 +334,7 @@ span.ag-math > .ag-math-render.ag-math-error {
 
 .ag-hide.ag-ruby,
 .ag-hide.ag-math {
+  display: inline-block;
   width: auto;
   height: auto;
 }
@@ -797,6 +802,7 @@ span.ag-emoji-marked-text {
 
 .ag-hide.ag-emoji-marked-text[data-emoji],
 .ag-hide.ag-html-escape[data-character] {
+  display: inline-block;
   overflow: visible;
   white-space: nowrap;
   color: transparent;
@@ -887,12 +893,15 @@ span.ag-warn.ag-emoji-marked-text {
   text-decoration: none;
 }
 
-.ag-hide, .ag-hide .ag-highlight, .ag-hide .ag-selection {
-  display: inline-block;
+.ag-hide, .ag-highlight, .ag-selection {
   width: 0;
   height: 0;
   overflow: hidden;
   vertical-align: middle;
+}
+
+.ag-highlight, .ag-selection {
+  display: inline-block;
 }
 
 .ag-inline-image,


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | fixes #3025, fixes #2459
| License           | MIT

### Description

`.ag-hide` is actually a confusing name because it sometimes shows the content as inline. I tested this with a few elements and it seemed to work. Hiding `ag-hide` elements will help to render the page correctly (#3025), but also prevent running into the Chromium freeze (#2459).
