### PR TITLE
Remove macos arm64 package

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,6 @@ Mark Text is now MarkText! We'd like to thank all contributors and users that ha
 - Added command-line image uploader.
 - Added regular expression group replacement to searcher.
 - Added PlantUML diagram support.
-- Added support for Apple M1 (arm64).
 - Added support for chemical equations in math mode.
 - Added automatic call to search for find-in-file when the pane is opened.
 - Open local non-markdown files in default application.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,12 @@ jobs:
           sha256sum build/marktext-*.rpm
         shell: bash
 
+      # shasum -a 256 build/marktext-arm64-mac.zip
+      # shasum -a 256 build/marktext-arm64.dmg
       - name: Calculate checksums
         if: runner.os == 'macOS'
         run: |
-          shasum -a 256 build/marktext-arm64-mac.zip
           shasum -a 256 build/marktext-x64-mac.zip
-          shasum -a 256 build/marktext-arm64.dmg
           shasum -a 256 build/marktext-x64.dmg
         shell: bash
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -80,9 +80,9 @@ mac:
   darkModeSupport: true
   target:
     - target: dmg
-      arch: [x64, arm64]
+      arch: [x64]
     - target: zip
-      arch: [x64, arm64]
+      arch: [x64]
 dmg:
   artifactName: "marktext-${arch}.${ext}"
   contents:


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| License           | MIT

### Description

Don't build macOS arm64 package because no one can install the built package.

See https://github.com/marktext/marktext/issues/2983#issuecomment-1031396465.
