### PR TITLE
Ignore empty key bindings

### DIFF
--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -38,6 +38,9 @@ class Keybindings {
   registerKeyHandlers (win, acceleratorMap) {
     for (const item of acceleratorMap) {
       let { accelerator } = item
+      if (accelerator == null || accelerator === '') {
+        continue
+      }
 
       // Regisiter shortcuts on the BrowserWindow instead of using Chromium's native menu.
       // This makes it possible to receive key down events before Chromium/Electron and we


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Fixed tickets     | Fixes #3074
| License           | MIT

### Description

Fix regression that an empty shortcut will crash main process.
