### PR TITLE
Fix: "delete" shortcut on a selected image deletes the text after it (#2816)

### DIFF
--- a/src/muya/lib/contentState/copyCutCtrl.js
+++ b/src/muya/lib/contentState/copyCutCtrl.js
@@ -25,6 +25,7 @@ const copyCutCtrl = ContentState => {
         key,
         token
       })
+      this.selectedImage = null
       return
     }
     const { start, end } = selection.getCursorRange()

--- a/src/muya/lib/contentState/deleteCtrl.js
+++ b/src/muya/lib/contentState/deleteCtrl.js
@@ -3,6 +3,13 @@ import selection from '../selection'
 const deleteCtrl = ContentState => {
   // Handle `delete` keydown event on document.
   ContentState.prototype.docDeleteHandler = function (event) {
+    // handle delete selected image
+    const { selectedImage } = this
+    if (selectedImage) {
+      event.preventDefault()
+      this.selectedImage = null
+      return this.deleteImage(selectedImage)
+    }
     if (this.selectedTableCells) {
       event.preventDefault()
       return this.deleteSelectedTableCells()


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2816
| License           | MIT

### Description
Bug: The behavior of deleting the selected image was not fully implemented.
