### PR TITLE
fix: "BackSpace" shoutcut on a selected image deletes the whole line (#3080)

### DIFF
--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -103,9 +103,11 @@ const backspaceCtrl = ContentState => {
 
   ContentState.prototype.docBackspaceHandler = function (event) {
     // handle delete selected image
-    if (this.selectedImage) {
+    const { selectedImage } = this
+    if (selectedImage) {
       event.preventDefault()
-      return this.deleteImage(this.selectedImage)
+      this.selectedImage = null
+      return this.deleteImage(selectedImage)
     }
     if (this.selectedTableCells) {
       event.preventDefault()
@@ -115,15 +117,17 @@ const backspaceCtrl = ContentState => {
 
   ContentState.prototype.backspaceHandler = function (event) {
     const { start, end } = selection.getCursorRange()
+    const { selectedImage } = this
 
     if (!start || !end) {
       return
     }
 
     // handle delete selected image
-    if (this.selectedImage) {
+    if (selectedImage) {
       event.preventDefault()
-      return this.deleteImage(this.selectedImage)
+      this.selectedImage = null
+      return this.deleteImage(selectedImage)
     }
 
     // Handle select all content.

--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -103,11 +103,9 @@ const backspaceCtrl = ContentState => {
 
   ContentState.prototype.docBackspaceHandler = function (event) {
     // handle delete selected image
-    const { selectedImage } = this
-    if (selectedImage) {
+    if (this.selectedImage) {
       event.preventDefault()
-      this.selectedImage = null
-      return this.deleteImage(selectedImage)
+      return this.deleteImage(this.selectedImage)
     }
     if (this.selectedTableCells) {
       event.preventDefault()
@@ -117,17 +115,15 @@ const backspaceCtrl = ContentState => {
 
   ContentState.prototype.backspaceHandler = function (event) {
     const { start, end } = selection.getCursorRange()
-    const { selectedImage } = this
 
     if (!start || !end) {
       return
     }
 
     // handle delete selected image
-    if (selectedImage) {
+    if (this.selectedImage) {
       event.preventDefault()
-      this.selectedImage = null
-      return this.deleteImage(selectedImage)
+      return this.deleteImage(this.selectedImage)
     }
 
     // Handle select all content.

--- a/src/muya/lib/contentState/imageCtrl.js
+++ b/src/muya/lib/contentState/imageCtrl.js
@@ -169,6 +169,10 @@ const imageCtrl = ContentState => {
   }
 
   ContentState.prototype.deleteImage = function ({ key, token }) {
+    const { selectedImage } = this
+    if (selectedImage && (selectedImage.key === key)) {
+      this.selectedImage = null
+    }
     const block = this.getBlock(key)
     const oldText = block.text
     const { start, end } = token.range


### PR DESCRIPTION
After deleting an image, contentState.selectedImage still pointed to the deleted image.
It was necessary to assign null at each location.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3080
| License           | MIT

### Description

- Fixed forgetting to set selectedImage to null with the backspace key.
- Fixed forgetting to set selectedImage to null with the delete button on the image toolbar.
