### PR TITLE
Added option to jump-to-start on file open

### DIFF
--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -11,13 +11,14 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | titleBarStyle          | String  | custom        | The title bar style on Linux and Window: `custom` or `native`                                                                                              |
 | openFilesInNewWindow   | Boolean | false         | true, false                                                                                                                                                |
 | openFolderInNewWindow  | Boolean | false         | true, false                                                                                                                                                |
-| zoom                   | Number  | 1.0           | The zoom level. Between 0.5 and 2.0 inclusive.                                                                                              |
+| zoom                   | Number  | 1.0           | The zoom level. Between 0.5 and 2.0 inclusive.                                                                                                             |
 | hideScrollbar          | Boolean | false         | Whether to hide scrollbars. Optional value: true, false                                                                                                    |
+| jumpToStartOnLoad      | Boolean | false         | Jump to the start of the document on load (rather than end)                                                                                                |
 | wordWrapInToc          | Boolean | false         | Whether to enable word wrap in TOC. Optional value: true, false                                                                                            |
 | fileSortBy             | String  | created       | Sort files in opened folder by `created` time, modified time and title.                                                                                    |
-| startUpAction          | String  | lastState     | The action after MarkText startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank` |
+| startUpAction          | String  | lastState     | The action after MarkText startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank`   |
 | defaultDirectoryToOpen | String  | `""`          | The path that should be opened if `startUpAction=folder`.                                                                                                  |
-| language               | String  | en            | The language MarkText use.                                                                                                                                |
+| language               | String  | en            | The language MarkText use.                                                                                                                                 |
 
 #### Editor
 

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -40,6 +40,11 @@
     "type": "boolean",
     "default": false
   },
+  "jumpToStartOnLoad": {
+    "description": "General--Whether to jump to start (vs end) of document on load.",
+    "type": "boolean",
+    "default": false
+  },
   "wordWrapInToc": {
     "description": "General--Whether to enable word wrap in TOC.",
     "type": "boolean",

--- a/src/muya/lib/index.js
+++ b/src/muya/lib/index.js
@@ -165,7 +165,7 @@ class Muya {
     return this.contentState.getCodeMirrorCursor()
   }
 
-  setMarkdown (markdown, cursor, isRenderCursor = true) {
+  setMarkdown (markdown, cursor, isRenderCursor = true, setToStartNotEndIfNoCursor = false) {
     let newMarkdown = markdown
     let isValid = false
     if (cursor && cursor.anchor && cursor.focus) {
@@ -174,7 +174,7 @@ class Muya {
       isValid = cursorInfo.isValid
     }
     this.contentState.importMarkdown(newMarkdown)
-    this.contentState.importCursor(cursor && isValid)
+    this.contentState.importCursor(cursor && isValid, setToStartNotEndIfNoCursor)
     this.contentState.render(isRenderCursor)
     setTimeout(() => {
       this.dispatchChange()

--- a/src/muya/lib/utils/importMarkdown.js
+++ b/src/muya/lib/utils/importMarkdown.js
@@ -540,7 +540,7 @@ const importRegister = ContentState => {
     }
   }
 
-  ContentState.prototype.importCursor = function (hasCursor) {
+  ContentState.prototype.importCursor = function (hasCursor, setToStartNotEndIfNoCursor = false) {
     // set cursor
     const cursor = {
       anchor: null,
@@ -581,9 +581,9 @@ const importRegister = ContentState => {
     if (hasCursor) {
       travel(this.blocks)
     } else {
-      const lastBlock = this.getLastBlock()
-      const key = lastBlock.key
-      const offset = lastBlock.text.length
+      const jumpBlock = setToStartNotEndIfNoCursor ? this.getFirstBlock() : this.getLastBlock()
+      const key = jumpBlock.key
+      const offset = setToStartNotEndIfNoCursor ? 0 : jumpBlock.text.length
       cursor.anchor = { key, offset }
       cursor.focus = { key, offset }
     }

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -162,6 +162,7 @@ export default {
       theme: state => state.preferences.theme,
       sequenceTheme: state => state.preferences.sequenceTheme,
       hideScrollbar: state => state.preferences.hideScrollbar,
+      jumpToStartOnLoad: state => state.preferences.jumpToStartOnLoad,
       spellcheckerEnabled: state => state.preferences.spellcheckerEnabled,
       spellcheckerIsHunspell: state => state.preferences.spellcheckerIsHunspell,
       spellcheckerNoUnderline: state => state.preferences.spellcheckerNoUnderline,
@@ -408,6 +409,12 @@ export default {
           codeFontFamily: this.codeFontFamily,
           hideScrollbar: value
         })
+      }
+    },
+    jumpToStartOnLoad: function (value, oldValue) {
+      const { editor } = this
+      if (value !== oldValue && editor) {
+        editor.setOptions({ jumpToStartOnLoad: value })
       }
     },
 
@@ -1229,7 +1236,7 @@ export default {
         if (cursor) {
           editor.setMarkdown(markdown, cursor, true)
         } else {
-          editor.setMarkdown(markdown)
+          editor.setMarkdown(markdown, null, true, this.jumpToStartOnLoad)
         }
       }
     },
@@ -1243,7 +1250,7 @@ export default {
             editor.setHistory(history)
           }
           if (typeof markdown === 'string') {
-            editor.setMarkdown(markdown, cursor, renderCursor)
+            editor.setMarkdown(markdown, cursor, renderCursor, this.jumpToStartOnLoad)
           } else if (cursor) {
             editor.setCursor(cursor)
           }

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -41,6 +41,11 @@
           :bool="hideScrollbar"
           :onChange="value => onSelectChange('hideScrollbar', value)"
         ></bool>
+         <bool
+          description="Jump to start (vs end) on load"
+          :bool="jumpToStartOnLoad"
+          :onChange="value => onSelectChange('jumpToStartOnLoad', value)"
+        ></bool>
         <bool
           description="Open files in new window"
           :bool="openFilesInNewWindow"
@@ -158,6 +163,7 @@ export default {
       defaultDirectoryToOpen: state => state.preferences.defaultDirectoryToOpen,
       openFilesInNewWindow: state => state.preferences.openFilesInNewWindow,
       openFolderInNewWindow: state => state.preferences.openFolderInNewWindow,
+      jumpToStartOnLoad: state => state.preferences.jumpToStartOnLoad,
       zoom: state => state.preferences.zoom,
       hideScrollbar: state => state.preferences.hideScrollbar,
       wordWrapInToc: state => state.preferences.wordWrapInToc,

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -10,6 +10,7 @@ const state = {
   openFolderInNewWindow: false,
   zoom: 1.0,
   hideScrollbar: false,
+  jumpToStartOnLoad: false,
   wordWrapInToc: false,
   fileSortBy: 'created',
   startUpAction: 'lastState',

--- a/static/preference.json
+++ b/static/preference.json
@@ -6,6 +6,7 @@
   "openFolderInNewWindow": false,
   "zoom": 1.0,
   "hideScrollbar": false,
+  "jumpToStartOnLoad": false,
   "wordWrapInToc": false,
   "fileSortBy": "created",
   "startUpAction": "lastState",


### PR DESCRIPTION
closes #1407


| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #1407
| License           | MIT

### Description

Adds the option to default to the top of the file rather than the bottom on open.  