### PR TITLE
Remember the file's scroll position as long as it stays open

### DIFF
--- a/docs/dev/code/renderer/editor.md
+++ b/docs/dev/code/renderer/editor.md
@@ -82,6 +82,7 @@ interface IDocumentState
     index: number
   },
   cursor: any,
+  firstViewportVisibleItem: any,
   wordCount: {
     paragraph: number,
     word: number,

--- a/src/muya/lib/contentState/index.js
+++ b/src/muya/lib/contentState/index.js
@@ -81,6 +81,7 @@ class ContentState {
     this._selectedImage = null
     this.dropAnchor = null
     this.prevCursor = null
+    this.firstViewportVisibleItem = null
     this.historyTimer = null
     this.history = new History(this)
     this.turndownConfig = Object.assign({}, DEFAULT_TURNDOWN_CONFIG, { bulletListMarker })
@@ -343,6 +344,43 @@ class ContentState {
 
   getCursor () {
     return this.cursor
+  }
+
+  getBlockKeyByIndex (index) {
+    let arr = index.split('.')
+    const travel = blocks => {
+      let pos = arr.shift()
+      let num = parseInt(pos)
+      if (num !== pos || Number.isInteger(num) === false) { return null }
+      pos = num
+      if (blocks.length <= pos) { return null }
+        let block = blocks[pos]
+      if (arr.length === 0) { return block.key } else { return travel(block.children) }
+    }
+    return travel(this.blocks)
+  }
+
+  getBlockIndex (key) {
+    if (!key) return null
+    let result = null
+    const travel = blocks => {
+      for (let index = 0; index < blocks.length; index++) {
+        const block = blocks[index]
+        if (block.key === key) {
+          result = `${index}`
+          return true
+        }
+        if (block.children.length) {
+          if (travel(block.children)) {
+            result = `${index}.${result}`
+            return true
+          }
+        }
+      }
+      return false
+    }
+    travel(this.blocks)
+    return result
   }
 
   getBlock (key) {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -111,6 +111,7 @@ import '@/assets/themes/codemirror/one-dark.css'
 // import 'view-image/lib/imgViewer.css'
 import CloseIcon from '@/assets/icons/close.svg'
 
+// Minus 67 here is the Y offset of the container itself, before we didn't include that in the scroll calculations, as we do now this keeps the actual Y offset the same
 const STANDAR_Y = 320
 
 export default {
@@ -501,8 +502,20 @@ export default {
     },
 
     currentFile: function (value, oldValue) {
+        if (this.sourceCode === false && oldValue && oldValue !== value) { // Cannot use the changed event above as it happens after we have switched to the new file
+          let firstViewportVisibleItem = this.getFirstElementInViewport()
+          if (firstViewportVisibleItem) { oldValue.firstViewportVisibleItem = 'M' + this.editor.contentState.getBlockIndex(firstViewportVisibleItem.id) } else { oldValue.firstViewportVisibleItem = 'Z' }// undefining if already set
+        }
+
       if (value && value !== oldValue) {
-        this.scrollToCursor(0)
+        if (this.sourceCode === false && value.firstViewportVisibleItem && value.firstViewportVisibleItem.startsWith('M')) {
+          let indexStr = value.firstViewportVisibleItem.substring(1)
+          this.$nextTick(() => {
+            let elemId = this.editor.contentState.getBlockKeyByIndex(indexStr)
+            if (!elemId) { return }
+            this.scrollToElement('#' + elemId, 15, true)
+          })
+        } else { this.scrollToCursor(0) }
         // Hide float tools if needed.
         this.editor && this.editor.hideAllFloatTools()
       }
@@ -690,7 +703,6 @@ export default {
       //
       //   this.setImageViewerVisible(true)
       // })
-
       this.editor.on('selectionChange', changes => {
         const { y } = changes.cursorCoords
         if (this.typewriter) {
@@ -1065,14 +1077,51 @@ export default {
       return this.scrollToElement(`#${slug}`)
     },
 
-    scrollToElement (selector) {
+    getFirstElementInViewport () {
+    let node = this.editor.container
+    if (node.childNodes.length === 0) { return null }
+    let offsetY = node.scrollTop
+    node = node.childNodes[0]// this gets us to the editors primary div
+    if (offsetY === 0) {
+      if (node.childNodes.length === 0) { return null }
+      return node.childNodes[0]
+    }
+
+    const nodeStack = []
+
+      while (node) {
+            // Only iterate over elements and text nodes
+            if (node.nodeType > 3) {
+              node = nodeStack.pop()
+              continue
+            }
+            if (node.offsetTop >= offsetY) { return node }
+
+            if (node.nodeType === 1) {
+                // this is an element
+                // add all its children to the stack
+                let i = node.childNodes.length - 1
+                while (i >= 0) {
+                  nodeStack.push(node.childNodes[i])
+                  i -= 1
+                }
+              }
+
+              node = nodeStack.pop()
+      }
+    },
+
+    scrollToElement (selector, duration = 300, dontAddStandardHeadroom = false) {
       // Scroll to search highlight word
       const { container } = this.editor
       const anchor = document.querySelector(selector)
       if (anchor) {
-        const { y } = anchor.getBoundingClientRect()
-        const DURATION = 300
-        animatedScrollTo(container, container.scrollTop + y - STANDAR_Y, DURATION)
+        const DURATION = duration
+        const anchorY = anchor.getBoundingClientRect().y
+        const containerY = container.getBoundingClientRect().y
+
+        const add = dontAddStandardHeadroom ? 0 : STANDAR_Y
+        animatedScrollTo(container, container.scrollTop + anchorY - containerY - add, DURATION)
       }
     },
 
@@ -1229,7 +1278,7 @@ export default {
         if (cursor) {
           editor.setMarkdown(markdown, cursor, true)
         } else {
-          editor.setMarkdown(markdown)
+          editor.setMarkdown(markdown, null, true)
         }
       }
     },

--- a/src/renderer/components/editorWithTabs/sourceCode.vue.orig
+++ b/src/renderer/components/editorWithTabs/sourceCode.vue.orig
@@ -14,7 +14,6 @@ import { adjustCursor, animatedScrollTo } from '../../util'
 import bus from '../../bus'
 import { oneDarkThemes, railscastsThemes } from '@/config'
 
-// Same as editor.vue
 const STANDAR_Y = 320
 
 export default {
@@ -47,16 +46,18 @@ export default {
 
   watch: {
     currentTab: function (value, oldValue) {
-      if (!this.sourceCode) { return }
-      // Don't need to worry about setting the line on the oldValue already did in prepareTabSwitch
+      if (! this.sourceCode)
+        return;
+      //Don't need to worry about setting the line on the oldValue already did in prepareTabSwitch
       if (value && value !== oldValue) {
-        if (value.firstViewportVisibleItem && value.firstViewportVisibleItem.startsWith('S')) {
-          let line = value.firstViewportVisibleItem.substring(1)
+        if (value.firstViewportVisibleItem && value.firstViewportVisibleItem.startsWith("S")){
+          let line = value.firstViewportVisibleItem.substring(1);
           this.$nextTick(() => {
-            this.scrollToLineNumberInViewport(line, 15, true)
-          })
+            this.scrollToLineNumberInViewport(line, 15,true);
+          });
         }
       }
+
     },
     textDirection: function (value, oldValue) {
       const { editor } = this
@@ -109,6 +110,14 @@ export default {
       bus.$on('file-changed', this.handleFileChange)
       bus.$on('selectAll', this.handleSelectAll)
       bus.$on('image-action', this.handleImageAction)
+      bus.$on('undo', this.handleUndo)
+      bus.$on('redo', this.handleRedo)
+      bus.$on('find', this.handleFind)
+      bus.$on('replace', this.handleReplace)
+      bus.$on('findNext', this.handleFindNext)
+      bus.$on('findPrev', this.handleFindPrev)
+      document.addEventListener('click', this.docClick)
+      document.addEventListener('keyup', this.docKeyup)
 
       setMode(editor, 'markdown')
       this.listenChange()
@@ -134,6 +143,14 @@ export default {
     bus.$off('file-changed', this.handleFileChange)
     bus.$off('selectAll', this.handleSelectAll)
     bus.$off('image-action', this.handleImageAction)
+    bus.$off('undo', this.handleUndo)
+    bus.$off('redo', this.handleRedo)
+    bus.$off('find', this.handleFind)
+    bus.$off('replace', this.handleReplace)
+    bus.$off('findNext', this.handleFindNext)
+    bus.$off('findPrev', this.handleFindPrev)
+    document.removeEventListener('click', this.docClick)
+    document.removeEventListener('keyup', this.docKeyup)
 
     const { editor } = this
     const { cursor, markdown } = this.getMarkdownAndCursor(editor)
@@ -252,10 +269,10 @@ export default {
     },
     // Commit changes from old tab. Problem: tab was already switched, so commit changes with old tab id.
     prepareTabSwitch () {
-      let firstViewportVisibleItem = 'S' + this.getFirstLineNumberInViewport()
-      if (this.sourceCode === false) { // this shouldn't happen
-        firstViewportVisibleItem = undefined
-      }
+
+      let firstViewportVisibleItem = "S" + this.getFirstLineNumberInViewport();
+      if (this.sourceCode == false)//this shouldn't happen
+        firstViewportVisibleItem = undefined;       
 
       if (this.commitTimer) clearTimeout(this.commitTimer)
       if (this.tabId) {
@@ -265,15 +282,64 @@ export default {
         this.tabId = null // invalidate tab id
       }
     },
-    scrollToLineNumberInViewport (line, duration = 300, dontAddStandardHeadroom = false) {
-      let pos = this.editor.charCoords({ line: line, ch: 0 }, 'local').top
-      const DURATION = duration
-      if (!dontAddStandardHeadroom) { pos -= STANDAR_Y }
+<<<<<<< HEAD
+    scrollToLineNumberInViewport(line, duration=300, dontAddStandardHeadroom=false){
+      let pos = this.editor.charCoords({line:line,ch:0},"local").top;
+      const DURATION = duration;
+      if (! dontAddStandardHeadroom)
+        pos -= STANDAR_Y;
       animatedScrollTo(this.$el, pos, DURATION)
     },
-    getFirstLineNumberInViewport () {
-      return this.editor.coordsChar({ left: 0, top: this.$el.scrollTop }, 'local').line
+    getFirstLineNumberInViewport(){
+      return this.editor.coordsChar({left:0,top:this.$el.scrollTop},"local").line;
     },
+=======
+    handleUndo () {
+      if (this.editor && this.sourceCode) {
+        this.editor.execCommand('undo')
+      }
+    },
+
+    handleRedo () {
+      if (this.editor && this.sourceCode) {
+        this.editor.execCommand('redo')
+      }
+    },
+    docKeyup (event) {
+      if (this.editor && this.sourceCode && event.key === 'Escape') {
+        this.editor.execCommand('clearSearch')
+      }
+    },
+
+    docClick () {
+      if (this.editor && this.sourceCode)
+      this.editor.execCommand('clearSearch')
+    },
+    handleFind () {
+       if (this.editor && this.sourceCode) {
+        this.editor.execCommand('findPersistent')
+      }
+    },
+
+    handleReplace () {
+       if (this.editor && this.sourceCode) {
+        this.editor.execCommand('replace')
+      }
+    },
+
+    handleFindNext () {
+      if (this.editor && this.sourceCode) {
+        this.editor.execCommand('findNext')
+      }
+    },
+
+    handleFindPrev () {
+      if (this.editor && this.sourceCode) {
+        this.editor.execCommand('findPrev')
+      }
+    },
+
+>>>>>>> sourcecode_editor_find_undo_redo_fixes
     handleSelectAll () {
       if (!this.sourceCode) {
         return

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -247,6 +247,11 @@ const mutations = {
       state.currentFile.history = history
     }
   },
+  SET_FIRST_VIS_ITEM (state, firstViewportVisibleItem) {
+    if (hasKeys(state.currentFile)) {
+      state.currentFile.firstViewportVisibleItem = firstViewportVisibleItem
+    }
+  },
   CLOSE_TABS (state, tabIdList) {
     if (!tabIdList || tabIdList.length === 0) return
 
@@ -922,7 +927,7 @@ const actions = {
 
   // Content change from realtime preview editor and source code editor
   // WORKAROUND: id is "muya" if changes come from muya and not source code editor! So we don't have to apply the workaround.
-  LISTEN_FOR_CONTENT_CHANGE ({ commit, dispatch, state, rootState }, { id, markdown, wordCount, cursor, history, toc }) {
+  LISTEN_FOR_CONTENT_CHANGE ({ commit, dispatch, state, rootState }, { id, markdown, wordCount, cursor, history, toc, firstViewportVisibleItem }) {
     const { autoSave } = rootState.preferences
     const {
       id: currentId,
@@ -952,6 +957,10 @@ const actions = {
           if (history) {
             tab.history = history
           }
+          // Set Line or First Visible Item Index
+          if (firstViewportVisibleItem) {
+            tab.firstViewportVisibleItem = firstViewportVisibleItem
+          }
           break
         }
       }
@@ -977,6 +986,9 @@ const actions = {
     // Set history
     if (history) {
       commit('SET_HISTORY', history)
+    }
+    if (firstViewportVisibleItem) {
+      commit('SET_FIRST_VIS_ITEM', firstViewportVisibleItem)
     }
     // Set toc
     if (toc && !equal(toc, listToc)) {


### PR DESCRIPTION
By default returns the user to the same scroll position on a document where they left off (except if changed to code editing before switching back, or vice versa). Only saved in memory could be added to future session saves for #998.

This fixes the calculation for scrollToElement but re-adjusts the scrollback so it looks the same to the user.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes (ish)
| New feature?      | yes
| Breaking changes? | kinda?
| Deprecations?     | no
| New tests added?  | probably should but didn't
| Fixed tickets     | fixes #2672 
| License           | MIT

### Description

If you are alt tabbing between documents for references it can be annoying to make sure your cursor is at the position for it to properly not change the view each time.

This code saves the users scroll position in a window so rather than returning them to where their cursor was when tabbing between windows we can return to the exact scroll they were at.  This is how most other applications behave.     The one time it doesn't work is if you switch to or from code mode before switching back to the tab.   In that situation it defaults back to last known cursor position (old behavior).

I looked at a good number of ways to save scroll position and didn't actually look at what other software does.  I think other software generally doesn't swap the views in the same way.  Originally I went with just saving the yOffset, however if you adjust the window in any way this would not be right (ie resize window, change font size, zoom, etc).  One could attempt to just invalidate the setting in these situations and revert to cursor position but it isn't great.   Instead I try to save out the content position.   In code editing mode this is the line number for the first line visible.  For normal muya (markdown) view I use the first visible 'block' on screen.  Technically this means for markdown there might be a slight jump the first time switching back to align with the top of the block.   In addition for code editor mode I don't track what character you are at, so with wordwrap it might scroll you back a bit.

Now for muya we don't technically have a way of identifying what block is at the top, and the only official indexing into a specific block is based on the hidden cursor markers.   To get around this I get the first dom element visually that is on screen and then use that ID to figure out what block it is.   As blocks are actually completely rebuilt each time the view is brought back using the block's id doesn't work.  Instead I store the relative index to the block. For this I added a new getBlockIndex function.  As the block can also have a parent block (and we don't want to just use the parent block as it might be starting at a much different position) it returns a nested index id in the form like "5.3.2.1"  which is the 6th top level block, the 4th child it has, the 3rd child of that block and finally the 2nd child of that.

This way even when the blocks are re-created we can identify it again by using getBlockKeyByIndex taking that string and getting the blocks id.  Then we can use our existing scroll to element with its ID to scroll to the right position. Note: A new parameter added to scrolltoElement to optionally not backscroll. 

 I didn't make a user setting for this, but it does break current behavior so maybe some users will want to turn it off.   Given it is what should be expected I figured it might be fine.   

This does fix a few bugs (ie cursor not being set properly when switching between code editor windows, but only the visibility issue not the re-selecting cursor bug).  

Now this code exploits a bit of a race condition.  Technically handleFileChange in editor.vue calls setCursor which would take you to the wrong spot in the file.  the currentFile watcher where I set the position in editor.vue uses a slight animation however so it happens after that call.  I am not sure how best to avoid that scrollToCursor call as im not sure if it is needed in other situations in that function.  

The code quality here could be higher, and it needs some test cases, but I ran out of time I could spend on this.   It seems to be working well and if I find otherwise will update.