### PR TITLE
Avoid scrolling to cursor when Control/Alt/Shift/Escape is hit

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -54,7 +54,12 @@ export const EVENT_KEYS = Object.freeze(generateKeyHash([
   'ArrowLeft',
   'ArrowRight',
   'Tab',
-  'Escape'
+  'Escape',
+  'Control',
+  'Alt',
+  'Shift',
+  'PageUp',
+  'PageDown'
 ]))
 
 export const LOWERCASE_TAGS = Object.freeze(generateKeyHash([

--- a/src/muya/lib/eventHandler/keyboard.js
+++ b/src/muya/lib/eventHandler/keyboard.js
@@ -68,6 +68,10 @@ class Keyboard {
       ) {
         return
       }
+      if (event.key === EVENT_KEYS.Control || event.key === EVENT_KEYS.Alt || event.key === EVENT_KEYS.Escape || event.key === EVENT_KEYS.Shift || event.key === EVENT_KEYS.PageUp || event.key === EVENT_KEYS.PageDown) { // we don't want to focus on the cursor if the user just hits one of these keys. Other editors do not.
+       return
+      }
+
       // Cursor outside editor area or over not editable elements.
       if (event.target.closest('[contenteditable=false]')) {
         return


### PR DESCRIPTION
This behavior now matches other editors.
Fixes #3127

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | yes(technically but not expected behavior)
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #3127
| License           | MIT

### Description
Right now we scroll to the cursor when any key is hit.  In other editors hitting the system keys (control/shift/alt/escape) do not cause this to happen.  Do the same here.