### PR TITLE
Add startup option for last folder or file opened

### DIFF
--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -15,7 +15,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | hideScrollbar          | Boolean | false         | Whether to hide scrollbars. Optional value: true, false                                                                                                    |
 | wordWrapInToc          | Boolean | false         | Whether to enable word wrap in TOC. Optional value: true, false                                                                                            |
 | fileSortBy             | String  | created       | Sort files in opened folder by `created` time, modified time and title.                                                                                    |
-| startUpAction          | String  | lastState     | The action after MarkText startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank` |
+| startUpAction          | String  | lastState     | The action on startup: open the last edited content, a folder, or blank page, optional value: `lastFolder`,`lastFile`,`lastFileOrFolder`,`folder`,`blank`  |
 | defaultDirectoryToOpen | String  | `""`          | The path that should be opened if `startUpAction=folder`.                                                                                                  |
 | language               | String  | en            | The language MarkText use.                                                                                                                                |
 

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -152,7 +152,7 @@ class App {
       theme
     } = preferences.getAll()
 
-    if (startUpAction === 'folder' && defaultDirectoryToOpen) {
+    if ((startUpAction === 'folder' || startUpAction === 'lastFolder' || startUpAction === 'lastFolder' || startUpAction === 'lastFileOrFolder') && defaultDirectoryToOpen) {
       const info = normalizeMarkdownPath(defaultDirectoryToOpen)
       if (info) {
         _openFilesCache.unshift(info)

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -59,7 +59,10 @@
     "enum": [
       "folder",
       "lastState",
-      "blank"
+      "blank",
+      "lastFolder",
+      "lastFile",
+      "lastFileOrFolder"
     ],
     "default": "blank"
   },

--- a/src/main/windows/editor.js
+++ b/src/main/windows/editor.js
@@ -299,6 +299,12 @@ class EditorWindow extends BaseWindow {
       this._openedRootDirectory = pathname
       ipcMain.emit('watcher-watch-directory', browserWindow, pathname)
       browserWindow.webContents.send('mt::open-directory', pathname)
+
+      const { preferences } = this._accessor
+      const startUpAction = preferences.getItem('startUpAction')
+      if (startUpAction === 'lastFolder' || startUpAction === 'lastFileOrFolder') {
+        preferences.setItem('defaultDirectoryToOpen', pathname)
+      }
     } else {
       this._directoryToOpen = pathname
     }
@@ -453,6 +459,11 @@ class EditorWindow extends BaseWindow {
 
     appMenu.addRecentlyUsedDocument(pathname)
     _openedFiles.push(pathname)
+    const { preferences } = this._accessor
+    const startUpAction = preferences.getItem('startUpAction') // do we want to cache this?
+    if (startUpAction === 'lastFile' || startUpAction === 'lastFileOrFolder') {
+      preferences.setItem('defaultDirectoryToOpen', pathname)
+    }
     browserWindow.webContents.send('mt::open-new-tab', rawDocument, options, selected)
   }
 

--- a/src/renderer/prefComponents/general/config.js
+++ b/src/renderer/prefComponents/general/config.js
@@ -62,3 +62,21 @@ export const languageOptions = [{
   label: 'English',
   value: 'en'
 }]
+
+export const startupOptions = [{
+  label: 'Open the default directory',
+  value: 'folder'
+}, {
+  label: 'Open a blank page',
+  value: 'blank'
+}, {
+  label: 'Open last opened directory',
+  value: 'lastFolder'
+}, {
+  label: 'Open last opened file',
+  value: 'lastFile'
+}, {
+  label: 'Open last opened file or directory',
+  value: 'lastFileOrFolder'
+}
+]

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -88,15 +88,14 @@
       </template>
       <template #children>
         <section class="startup-action-ctrl">
-          <el-radio-group v-model="startUpAction">
-            <!--
-              Hide "lastState" for now (#2064).
-            <el-radio class="ag-underdevelop" label="lastState">Restore last editor session</el-radio>
-            -->
-            <el-radio label="folder" style="margin-bottom: 10px;">Open the default directory<span>: {{defaultDirectoryToOpen}}</span></el-radio>
-            <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder</el-button>
-            <el-radio label="blank">Open a blank page</el-radio>
-          </el-radio-group>
+          Open File or Directory<span>: {{defaultDirectoryToOpen}}</span>
+          <el-button size="small" @click="selectDefaultDirectoryToOpen">Select Folder</el-button>
+          <cur-select
+          description="Action on startup"
+          :value="startUpAction"
+          :options="startupOptions"
+          :onChange="value => onSelectChange('startUpAction', value)"
+        ></cur-select>
         </section>
       </template>
     </compound>
@@ -131,7 +130,8 @@ import {
   titleBarStyleOptions,
   zoomOptions,
   fileSortByOptions,
-  languageOptions
+  languageOptions,
+  startupOptions
 } from './config'
 
 export default {
@@ -147,6 +147,7 @@ export default {
     this.zoomOptions = zoomOptions
     this.fileSortByOptions = fileSortByOptions
     this.languageOptions = languageOptions
+    this.startupOptions = startupOptions
     this.isOsx = isOsx
     return {}
   },


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes #386
| License           | MIT

### Description

Until sessions get here, a stopgap.  Ability to open last file or folder or either (although either is fairly pointless, how often do you open a folder and then not a file in it?)
