### PR TITLE
Support slug/fragment navigation/linking (both internal and to relative documents), fix broken relative links with slugs on them

### DIFF
--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -465,17 +465,30 @@ class App {
     ipcMain.on('app-create-settings-window', () => {
       this._openSettingsWindow()
     })
-
-    ipcMain.on('app-open-file-by-id', (windowId, filePath) => {
+    ipcMain.on('scroll-to-header-by-name', (windowId, slug) => {
+      let editor = this._windowManager.get(windowId)
+      const win = editor.browserWindow
+      win.webContents.send('mt::scroll-to-header-by-name', slug)
+    })
+    ipcMain.on('app-open-file-by-id', (windowId, filePath, slug) => {
       const openFilesInNewWindow = this._accessor.preferences.getItem('openFilesInNewWindow')
+      let editor = null
       if (openFilesInNewWindow) {
         this._createEditorWindow(null, [filePath])
       } else {
-        const editor = this._windowManager.get(windowId)
+        editor = this._windowManager.get(windowId)
         if (editor) {
           editor.openTab(filePath, {}, true)
         }
       }
+      if (!slug) { return }
+
+      if (!editor) { editor = this._windowManager.get(windowId) }
+      if (!editor) { return }
+      const win = editor.browserWindow
+
+      // probably should pass this further down but at least createEditorWindow isn't setup great for taking params.
+      setTimeout(() => win.webContents.send('mt::scroll-to-header-by-name', slug), 250)
     })
     ipcMain.on('app-open-files-by-id', (windowId, fileList) => {
       const openFilesInNewWindow = this._accessor.preferences.getItem('openFilesInNewWindow')

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -414,8 +414,25 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
   if (!data || (!data.href && !data.text)) {
     return
   }
+  let parsedUrl = null
+  let slug = null
 
-  const urlCandidate = data.href || data.text
+  let urlCandidate = data.href || data.text
+  if (typeof (urlCandidate) === 'string') {
+    try {
+      parsedUrl = new URL(urlCandidate, 'b:/fake/')
+      if (parsedUrl.protocol === 'b:') { // seems like a local file
+        if (parsedUrl.hash) {
+          slug = parsedUrl.hash.substring(1)
+          if (urlCandidate.endsWith(parsedUrl.hash)) {
+            urlCandidate = urlCandidate.substring(0, urlCandidate.length - parsedUrl.hash.length)
+          }
+        }
+      }
+    } catch {
+
+    }
+  }
   if (URL_REG.test(urlCandidate)) {
     shell.openExternal(urlCandidate)
     return
@@ -424,8 +441,12 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
     return
   }
 
-  const href = data.href
+  const href = urlCandidate
   if (!href) {
+    if (slug) {
+      const win = BrowserWindow.fromWebContents(e.sender)
+      gotoSlug(win, slug)
+    }
     return
   }
 
@@ -440,7 +461,7 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
     pathname = path.normalize(pathname)
     if (isMarkdownFile(pathname)) {
       const win = BrowserWindow.fromWebContents(e.sender)
-      openFileOrFolder(win, pathname)
+      openFileOrFolder(win, pathname, slug)
     } else {
       shell.openPath(pathname)
     }
@@ -530,11 +551,13 @@ export const openFolder = async win => {
     openFileOrFolder(win, filePaths[0])
   }
 }
-
-export const openFileOrFolder = (win, pathname) => {
+export const gotoSlug = (win, slug) => {
+    ipcMain.emit('scroll-to-header-by-name', win.id, slug)
+}
+export const openFileOrFolder = (win, pathname, slug) => {
   const resolvedPath = normalizeAndResolvePath(pathname)
   if (isFile(resolvedPath)) {
-    ipcMain.emit('app-open-file-by-id', win.id, resolvedPath)
+    ipcMain.emit('app-open-file-by-id', win.id, resolvedPath, slug)
   } else if (isDirectory(resolvedPath)) {
     ipcMain.emit('app-open-directory-by-id', win.id, resolvedPath)
   } else {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -650,6 +650,7 @@ export default {
       bus.$on('deleteParagraph', this.handleParagraph)
       bus.$on('insertParagraph', this.handleInsertParagraph)
       bus.$on('scroll-to-header', this.scrollToHeader)
+      bus.$on('scroll-to-header-by-name', this.scrollToHeaderByName)
       bus.$on('screenshot-captured', this.handleScreenShot)
       bus.$on('switch-spellchecker-language', this.switchSpellcheckLanguage)
 
@@ -1064,6 +1065,16 @@ export default {
     scrollToHeader (slug) {
       return this.scrollToElement(`#${slug}`)
     },
+    tocNameToSlugName (slug) {
+      return slug.toLowerCase().replace(/[^a-zA-Z0-9 ]/g, '').replace(/\s+/g, '-')
+    },
+    scrollToHeaderByName (slug) {
+      this.editor.contentState.getTOC().forEach(item => {
+        if (this.tocNameToSlugName(item.content) === slug) {
+          this.scrollToHeader(item.slug)
+        }
+      })
+    },
 
     scrollToElement (selector) {
       // Scroll to search highlight word
@@ -1299,6 +1310,7 @@ export default {
     bus.$off('deleteParagraph', this.handleParagraph)
     bus.$off('insertParagraph', this.handleInsertParagraph)
     bus.$off('scroll-to-header', this.scrollToHeader)
+    bus.$off('scroll-to-header-by-name', this.scrollToHeaderByName)
     bus.$off('screenshot-captured', this.handleScreenShot)
     bus.$off('switch-spellchecker-language', this.switchSpellcheckLanguage)
 

--- a/src/renderer/pages/app.vue
+++ b/src/renderer/pages/app.vue
@@ -139,6 +139,7 @@ export default {
     dispatch('LISTEN_FOR_UPDATE')
     // module: editor
     dispatch('LISTEN_SCREEN_SHOT')
+    dispatch('LISTEN_SCROLL_TO_HEADER')
     dispatch('ASK_FOR_USER_PREFERENCE')
     dispatch('LISTEN_TOGGLE_VIEW')
     dispatch('LISTEN_FOR_CLOSE')

--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -344,6 +344,11 @@ const actions = {
       bus.$emit('screenshot-captured')
     })
   },
+  LISTEN_SCROLL_TO_HEADER ({ commit }) {
+    ipcRenderer.on('mt::scroll-to-header-by-name', (e, slug) => {
+      bus.$emit('scroll-to-header-by-name', slug)
+    })
+  },
 
   // image path auto complement
   ASK_FOR_IMAGE_AUTO_PATH ({ commit, state }, src) {


### PR DESCRIPTION

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | no
| Fixed tickets     | Fixes yep
| License           | MIT
Fixes #3135
Fixes #2474
Fixes #2473
Fixes #2469

### Description

#3135 was a bit annoying, would not open local files if they had a slug on the end of the navigation link.   Went to clean that up, but then.... 

Navigation to headers for both inside the same document and on another relative/local document.

Note, I am using the TOC parsing here and right now it only uses the header names.   This means if you are using a custom header ID it will not work.  It would not be that hard to add (in TOC parsing we just need to store one additional param).  You can still open the document, it just won't scroll to it properly.

Note, bit of a hack on actually doing the slug navigation for a new document. As the new document in a new window call wasn't going to easily take a slug param I don't wait until the document opens to scroll to the slug.  Instead I just setTimeout for 250 ms and hope its enough time 😅