### PR TITLE
fix #3270: CRLF not processed when pasting in code block

### DIFF
--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -347,7 +347,7 @@ const pasteCtrl = ContentState => {
       const blockText = startBlock.text
       const prePartText = blockText.substring(0, start.offset)
       const postPartText = blockText.substring(end.offset)
-      startBlock.text = prePartText + text + postPartText
+      startBlock.text = prePartText + text.replace(/\r\n/g, '\n') + postPartText
       const { key } = startBlock
       const offset = start.offset + text.length
       this.cursor = {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? |no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3270 
| License           | MIT

### Description
in win10 endline default
我调试了源码，发现在代码块里粘贴的时候是以原格式粘贴，只有当做一个删除或者其他操作时才会把/r/n转为/n，我认为粘贴时应该对/r/n进行处理。
I debugged the source code and found that when pasting in the code block, it is pasted in the original format. Only when it is used as a deletion or other operation will /r/n be converted to /n. I think /r/n should be processed when pasting.

