### PR TITLE
Fix file executable check on win32 (marktext#3289)

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -241,7 +241,11 @@ export const uploadImage = async (pathname, image, preferences) => {
 export const isFileExecutableSync = (filepath) => {
   try {
     const stat = statSync(filepath)
-    return stat.isFile() && (stat.mode & (constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH)) !== 0
+    if (process.platform === 'win32') {
+      return stat.isFile()
+    } else {
+      return stat.isFile() && (stat.mode & (constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH)) !== 0
+    }
   } catch (err) {
     // err ignored
     return false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3289
| License           | MIT

### Description

The file executable check not work on Windows, resulting in the script path cannot be save while using command line script image uploader.
According to [nodejs doc](https://nodejs.org/api/fs.html#file-mode-constants), S_IXUSR, S_IXGRP, S_IXOTH are not available on Windows.
