### PR TITLE
Fix picgo and cliScript uploader (marktext#2915)

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -149,12 +149,12 @@ export const uploadImage = async (pathname, image, preferences) => {
       })
   }
 
-  const uploadByCommand = async (uploader, filepath) => {
+  const uploadByCommand = async (uploader, filepath, suffix = '') => {
     let isPath = true
     if (typeof filepath !== 'string') {
       isPath = false
       const data = new Uint8Array(filepath)
-      filepath = path.join(tmpdir(), +new Date())
+      filepath = path.join(tmpdir(), +new Date() + suffix)
       await fs.writeFile(filepath, data)
     }
     if (uploader === 'picgo') {
@@ -224,7 +224,7 @@ export const uploadImage = async (pathname, image, preferences) => {
         switch (currentUploader) {
           case 'picgo':
           case 'cliScript':
-            uploadByCommand(currentUploader, reader.result)
+            uploadByCommand(currentUploader, reader.result, path.extname(image.name))
             break
           default:
             uploadByGithub(reader.result, image.name)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2915
| License           | MIT

### Description

While uploading image from paste board, function `uploadByCommand` get the raw image bin data from parameter `filepath`, and save it into a temp file in sys temp dir. 

1.path.join() require all string parameters but now a number provided, which raise a error and the error has been ignored (cause infinite loading)
2.Picgo upload image depends on suffix of the file.
