### PR TITLE
Use glob expressions to filter files and folders

### DIFF
--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { isFile, isFile2, isSymbolicLink } from './index'
+import minimatch from 'minimatch'
 
 const isOsx = process.platform === 'darwin'
 
@@ -118,4 +119,20 @@ export const getResourcesPath = () => {
     resPath = path.join(resPath, '../../../../resources')
   }
   return resPath
+}
+
+/**
+ * Returns true if the pathname matches one of the exclude patterns.
+ *
+ * @param {string} pathname Path of file or directory
+ * @param {string} patterns Glob expressions
+ */
+export const checkPathExcludePattern = (pathname, patterns) => {
+  if (!pathname || typeof pathname !== 'string') return false
+  for (const pattern of patterns) {
+    if (minimatch(pathname, pattern, { matchBase: true })) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/main/filesystem/watcher.js
+++ b/src/main/filesystem/watcher.js
@@ -3,7 +3,7 @@ import fsPromises from 'fs/promises'
 import log from 'electron-log'
 import chokidar from 'chokidar'
 import { exists } from 'common/filesystem'
-import { hasMarkdownExtension } from 'common/filesystem/paths'
+import { hasMarkdownExtension, checkPathExcludePattern } from 'common/filesystem/paths'
 import { getUniqueId } from '../utils'
 import { loadMarkdownFile } from '../filesystem/markdown'
 import { isLinux, isOsx } from '../config'
@@ -157,6 +157,10 @@ class Watcher {
         }
 
         if (/(?:^|[/\\])(?:\..|node_modules|(?:.+\.asar))/.test(pathname)) {
+          return true
+        }
+
+        if (checkPathExcludePattern(pathname, this._preferences.getItem('treePathExcludePatterns'))) {
           return true
         }
         if (fileInfo.isDirectory()) {

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -71,6 +71,14 @@
           :onChange="value => onSelectChange('wordWrapInToc', value)"
         ></bool>
 
+        <text-box description='Patterns to exclude directorys or files'
+                  notes='Glob Patterns, Use "," to separate multiple pattern. Requires restart.'
+                  :input="projectPaths"
+                  :defaultValue="treePathExcludePatterns"
+                  :onChange="value => onSelectChange('treePathExcludePatterns',  value.split(','))"
+                  more="https://github.com/isaacs/minimatch"
+        ></text-box>
+
         <!-- TODO: The description is very bad and the entry isn't used by the editor. -->
         <cur-select
           description="Sort field for files in open folders"
@@ -125,6 +133,7 @@ import Range from '../common/range'
 import CurSelect from '../common/select'
 import Bool from '../common/bool'
 import Separator from '../common/separator'
+import textBox from '../common/textBox'
 import { isOsx } from '@/util'
 
 import {
@@ -140,7 +149,8 @@ export default {
     Bool,
     Range,
     CurSelect,
-    Separator
+    Separator,
+    textBox
   },
   data () {
     this.titleBarStyleOptions = titleBarStyleOptions
@@ -158,6 +168,7 @@ export default {
       defaultDirectoryToOpen: state => state.preferences.defaultDirectoryToOpen,
       openFilesInNewWindow: state => state.preferences.openFilesInNewWindow,
       openFolderInNewWindow: state => state.preferences.openFolderInNewWindow,
+      projectPaths: state => state.preferences.treePathExcludePatterns,
       zoom: state => state.preferences.zoom,
       hideScrollbar: state => state.preferences.hideScrollbar,
       wordWrapInToc: state => state.preferences.wordWrapInToc,

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -14,6 +14,7 @@ const state = {
   fileSortBy: 'created',
   startUpAction: 'lastState',
   defaultDirectoryToOpen: '',
+  treePathExcludePatterns: [],
   language: 'en',
 
   editorFontFamily: 'Open Sans',

--- a/static/preference.json
+++ b/static/preference.json
@@ -10,6 +10,7 @@
   "fileSortBy": "created",
   "startUpAction": "lastState",
   "defaultDirectoryToOpen": "",
+  "treePathExcludePatterns": [],
   "language": "en",
 
   "editorFontFamily": "Open Sans",


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none 
| License           | MIT

### Description

I added a feature to filter files and folders.

Sometimes we don't want certain files or folders displayed in the sidebar. It would look cleaner if we excluded them from the tree, such as the Image assets folders.

So I developed this feature. By configuring the glob patterns, users can exclude files or folders that they do not want to display. Use "," to separate multiple pattern.

Suppose my directory structure is as follows:
<img width="105" alt="expolre" src="https://user-images.githubusercontent.com/20969338/176999274-1f009066-218a-4fc2-be8d-5f189a57b76b.png">

The following three expressions are configured:
1. `**/*t/temp` to exclude the file or folder named `temp`  in base folder
2. `**/*temp.md` to exclude all files or folders whose names end with `temp.md`
3. `**/*.assets` to exclude all files or folders whose names end with `.assets`

Use "," to separate multiple pattern: `**/*t/temp,**/*temp.md,**/*.assets`

<img width="480" alt="config" src="https://user-images.githubusercontent.com/20969338/176999253-eb630d81-4d33-4bdc-b3dd-88b41d172cb0.png">

Finally we will see the following structure in the sidebar:

<img width="161" alt="tree" src="https://user-images.githubusercontent.com/20969338/176999279-eb943847-321e-4a22-ab2e-51117e1e9974.png">

The [minimatch](https://github.com/isaacs/minimatch) module is used to parse glob patterns.

