### PR TITLE
Remove link to app website

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
-      Website
-    </a>
-    <span> | </span>
     <a href="https://github.com/marktext/marktext#features">
       Features
     </a>


### PR DESCRIPTION
Domain name is being held hostage so URL no longer valid. See: #3348

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description
The domain [marktext.app](https://marktext.app/) is for sale, presumably no longer controlled by the devs on this project. This doesn't fix the bug. A menu item in the application still links to the bad URL. But I don't know how to fix that. Maybe there are other places it needs to be removed or changed. 
