### PR TITLE
Remove expired "marktext.app" domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@
 <br>
 
 <div align="center">
-  <!-- Version -->
-  <a href="https://github.com/marktext/marktext">
-    <img src="https://badge.fury.io/gh/jocs%2Fmarktext.svg" alt="website">
-  </a>
   <!-- License -->
   <a href="LICENSE">
     <img src="https://img.shields.io/github/license/marktext/marktext.svg" alt="LICENSE">

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       Website
     </a>
     <span> | </span>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <div align="center">
   <!-- Version -->
-  <a href="https://marktext.github.io/website">
+  <a href="https://github.com/marktext/marktext">
     <img src="https://badge.fury.io/gh/jocs%2Fmarktext.svg" alt="website">
   </a>
   <!-- License -->

--- a/docs/i18n/ja.md
+++ b/docs/i18n/ja.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       ウェブサイト
     </a>
     <span> | </span>

--- a/docs/i18n/ko.md
+++ b/docs/i18n/ko.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       웹사이트
     </a>
     <span> | </span>

--- a/docs/i18n/pt.md
+++ b/docs/i18n/pt.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       Site
     </a>
     <span> | </span>

--- a/docs/i18n/tr.md
+++ b/docs/i18n/tr.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       Web sitesi
     </a>
      <span> | </span>

--- a/docs/i18n/zh_cn.md
+++ b/docs/i18n/zh_cn.md
@@ -47,7 +47,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       网站
     </a>
     <span> | </span>

--- a/docs/i18n/zh_tw.md
+++ b/docs/i18n/zh_tw.md
@@ -48,7 +48,7 @@
 
 <div align="center">
   <h3>
-    <a href="https://marktext.app">
+    <a href="https://github.com/marktext/marktext">
       官網
     </a>
     <span> | </span>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marktext",
   "version": "0.17.1",
-  "homepage": "https://marktext.app/",
+  "homepage": "https://github.com/marktext/marktext/",
   "description": "Next generation markdown editor",
   "license": "MIT",
   "main": "./dist/electron/main.js",

--- a/resources/linux/marktext.appdata.xml
+++ b/resources/linux/marktext.appdata.xml
@@ -19,7 +19,7 @@
       <li>Various edit modes and themes: source code mode, typewriter mode, focus mode</li>
     </ul>
   </description>
-  <url type="homepage">https://marktext.app/</url>
+  <url type="homepage">https://github.com/marktext/marktext/</url>
   <url type="bugtracker">https://github.com/marktext/marktext/issues</url>
   <screenshots>
     <screenshot type="default">

--- a/src/main/menu/templates/help.js
+++ b/src/main/menu/templates/help.js
@@ -68,7 +68,7 @@ export default function () {
     }, {
       label: 'Website...',
       click () {
-        shell.openExternal('https://marktext.app')
+        shell.openExternal('https://github.com/marktext/marktext')
       }
     }, {
       label: 'Watch on GitHub...',


### PR DESCRIPTION
This replaces marktext/marktext/pull/3349. It has the patch that @fxha asked me to apply in that PR. 

Domain name is being held hostage so URL no longer valid. See: #3348 and marktext/website#66

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description
The domain [marktext.app](https://marktext.app/) is for sale, presumably no longer controlled by the devs on this project. This doesn't fix the bug. A menu item in the application still links to the bad URL. But I don't know how to fix that. Maybe there are other places it needs to be removed or changed. 
