### PR TITLE
Fix Failure when uploading clipboard images with PicGo （#3360）

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -154,7 +154,7 @@ export const uploadImage = async (pathname, image, preferences) => {
     if (typeof filepath !== 'string') {
       isPath = false
       const data = new Uint8Array(filepath)
-      filepath = path.join(tmpdir(), +new Date())
+      filepath = path.join(tmpdir(), +new Date() + ".png")
       await fs.writeFile(filepath, data)
     }
     if (uploader === 'picgo') {


### PR DESCRIPTION

| Q                 | A           |
| ----------------- | ----------- |
| Bug fix?          | yes         |
| New feature?      | no          |
| Breaking changes? | no          |
| Deprecations?     | no          |
| New tests added?  | not needed  |
| Fixed tickets     | Fixes #3360 |
| License           | MIT         |

### Description

Fix the situation that picgo uploading pictures from clipboard will keep spinning around and cannot upload successfully.
The reason for the error is that the clipboard image needs to be saved in a temporary file when uploading, but when calling string splicing, it tries to splice a number type into a string resulting in an error.
Even if the number is converted to a string type, when picgo uploads it does not recognize the MIME-Type due to the lack of a suffix, so picgo throws an exception.
A more complete solution is to get the MIME-TYPE of the image and convert it to the corresponding suffix. But here the fix directly adds a default suffix .png to the image, and after testing I found this to be the easiest and working solution.