### PR TITLE
Add export PDF shortcut

### DIFF
--- a/docs/KEYBINDINGS_LINUX.md
+++ b/docs/KEYBINDINGS_LINUX.md
@@ -6,21 +6,22 @@ MarkText key bindings for Linux. Please see [general key bindings](KEYBINDINGS.m
 
 #### File menu
 
-| Id                  | Default                                       | Description                           |
-|:------------------- | --------------------------------------------- | ------------------------------------- |
-| `file.new-window`   | <kbd>Ctrl</kbd>+<kbd>N</kbd>                  | New window                            |
-| `file.new-tab`      | <kbd>Ctrl</kbd>+<kbd>T</kbd>                  | New tab                               |
-| `file.open-file`    | <kbd>Ctrl</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
-| `file.open-folder`  | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
-| `file.save`         | <kbd>Ctrl</kbd>+<kbd>S</kbd>                  | Save                                  |
-| `file.save-as`      | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
-| `file.move-file`    | -                                             | Move current file to another location |
-| `file.rename-file`  | -                                             | Rename current file                   |
-| `file.print`        | -                                             | Print current tab                     |
-| `file.preferences`  | <kbd>Ctrl</kbd>+<kbd>,</kbd>                  | Open settings window                  |
-| `file.close-tab`    | <kbd>Ctrl</kbd>+<kbd>W</kbd>                  | Close tab                             |
-| `file.close-window` | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
-| `file.quit`         | <kbd>Ctrl</kbd>+<kbd>Q</kbd>                  | Quit MarkText                         |
+| Id                     | Default                                       | Description                           |
+|:---------------------- | --------------------------------------------- | ------------------------------------- |
+| `file.new-window`      | <kbd>Ctrl</kbd>+<kbd>N</kbd>                  | New window                            |
+| `file.new-tab`         | <kbd>Ctrl</kbd>+<kbd>T</kbd>                  | New tab                               |
+| `file.open-file`       | <kbd>Ctrl</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
+| `file.open-folder`     | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
+| `file.save`            | <kbd>Ctrl</kbd>+<kbd>S</kbd>                  | Save                                  |
+| `file.save-as`         | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
+| `file.export-file.pdf` | <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>E</kbd>   | Export file as PDF                    |
+| `file.move-file`       | -                                             | Move current file to another location |
+| `file.rename-file`     | -                                             | Rename current file                   |
+| `file.print`           | -                                             | Print current tab                     |
+| `file.preferences`     | <kbd>Ctrl</kbd>+<kbd>,</kbd>                  | Open settings window                  |
+| `file.close-tab`       | <kbd>Ctrl</kbd>+<kbd>W</kbd>                  | Close tab                             |
+| `file.close-window`    | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
+| `file.quit`            | <kbd>Ctrl</kbd>+<kbd>Q</kbd>                  | Quit MarkText                         |
 
 #### Edit menu
 

--- a/docs/KEYBINDINGS_OSX.md
+++ b/docs/KEYBINDINGS_OSX.md
@@ -15,19 +15,20 @@ MarkText key bindings for macOS. Please see [general key bindings](KEYBINDINGS.m
 
 #### File menu
 
-| Id                  | Default                                          | Description                           |
-|:------------------- | ------------------------------------------------ | ------------------------------------- |
-| `file.new-window`   | <kbd>Command</kbd>+<kbd>N</kbd>                  | New window                            |
-| `file.new-tab`      | <kbd>Command</kbd>+<kbd>T</kbd>                  | New tab                               |
-| `file.open-file`    | <kbd>Command</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
-| `file.open-folder`  | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
-| `file.save`         | <kbd>Command</kbd>+<kbd>S</kbd>                  | Save                                  |
-| `file.save-as`      | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
-| `file.move-file`    | -                                                | Move current file to another location |
-| `file.rename-file`  | -                                                | Rename current file                   |
-| `file.print`        | -                                                | Print current tab                     |
-| `file.close-tab`    | <kbd>Command</kbd>+<kbd>W</kbd>                  | Close tab                             |
-| `file.close-window` | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
+| Id                     | Default                                          | Description                           |
+|:---------------------- | ------------------------------------------------ | ------------------------------------- |
+| `file.new-window`      | <kbd>Command</kbd>+<kbd>N</kbd>                  | New window                            |
+| `file.new-tab`         | <kbd>Command</kbd>+<kbd>T</kbd>                  | New tab                               |
+| `file.open-file`       | <kbd>Command</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
+| `file.open-folder`     | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
+| `file.save`            | <kbd>Command</kbd>+<kbd>S</kbd>                  | Save                                  |
+| `file.save-as`         | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
+| `file.export-file.pdf` | <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>E</kbd>      | Export file as PDF                    |
+| `file.move-file`       | -                                                | Move current file to another location |
+| `file.rename-file`     | -                                                | Rename current file                   |
+| `file.print`           | -                                                | Print current tab                     |
+| `file.close-tab`       | <kbd>Command</kbd>+<kbd>W</kbd>                  | Close tab                             |
+| `file.close-window`    | <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
 
 #### Edit menu
 

--- a/docs/KEYBINDINGS_WINDOWS.md
+++ b/docs/KEYBINDINGS_WINDOWS.md
@@ -6,21 +6,22 @@ MarkText key bindings for Windows. Please see [general key bindings](KEYBINDINGS
 
 #### File menu
 
-| Id                  | Default                                       | Description                           |
-|:------------------- | --------------------------------------------- | ------------------------------------- |
-| `file.new-window`   | <kbd>Ctrl</kbd>+<kbd>N</kbd>                  | New window                            |
-| `file.new-tab`      | <kbd>Ctrl</kbd>+<kbd>T</kbd>                  | New tab                               |
-| `file.open-file`    | <kbd>Ctrl</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
-| `file.open-folder`  | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
-| `file.save`         | <kbd>Ctrl</kbd>+<kbd>S</kbd>                  | Save                                  |
-| `file.save-as`      | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
-| `file.move-file`    | -                                             | Move current file to another location |
-| `file.rename-file`  | -                                             | Rename current file                   |
-| `file.print`        | -                                             | Print current tab                     |
-| `file.preferences`  | <kbd>Ctrl</kbd>+<kbd>,</kbd>                  | Open settings window                  |
-| `file.close-tab`    | <kbd>Ctrl</kbd>+<kbd>W</kbd>                  | Close tab                             |
-| `file.close-window` | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
-| `file.quit`         | <kbd>Ctrl</kbd>+<kbd>Q</kbd>                  | Quit MarkText                         |
+| Id                     | Default                                       | Description                           |
+|:---------------------- | --------------------------------------------- | ------------------------------------- |
+| `file.new-window`      | <kbd>Ctrl</kbd>+<kbd>N</kbd>                  | New window                            |
+| `file.new-tab`         | <kbd>Ctrl</kbd>+<kbd>T</kbd>                  | New tab                               |
+| `file.open-file`       | <kbd>Ctrl</kbd>+<kbd>O</kbd>                  | Open markdown file                    |
+| `file.open-folder`     | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>O</kbd> | Open folder                           |
+| `file.save`            | <kbd>Ctrl</kbd>+<kbd>S</kbd>                  | Save                                  |
+| `file.save-as`         | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> | Save as...                            |
+| `file.export-file.pdf` | <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>E</kbd>   | Export file as PDF                    |
+| `file.move-file`       | -                                             | Move current file to another location |
+| `file.rename-file`     | -                                             | Rename current file                   |
+| `file.print`           | -                                             | Print current tab                     |
+| `file.preferences`     | <kbd>Ctrl</kbd>+<kbd>,</kbd>                  | Open settings window                  |
+| `file.close-tab`       | <kbd>Ctrl</kbd>+<kbd>W</kbd>                  | Close tab                             |
+| `file.close-window`    | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd> | Close window                          |
+| `file.quit`            | <kbd>Ctrl</kbd>+<kbd>Q</kbd>                  | Quit MarkText                         |
 
 #### Edit menu
 

--- a/src/common/commands/constants.js
+++ b/src/common/commands/constants.js
@@ -35,6 +35,7 @@ const COMMANDS = Object.freeze({
   FILE_RENAME_FILE: 'file.rename-file',
   FILE_SAVE: 'file.save',
   FILE_SAVE_AS: 'file.save-as',
+  FILE_EXPORT_FILE_PDF: 'file.export-file.pdf',
   // FILE_TOGGLE_AUTO_SAVE: 'file.toggle-auto-save',
 
   FORMAT_CLEAR_FORMAT: 'format.clear-format',

--- a/src/main/keyboard/keybindingsDarwin.js
+++ b/src/main/keyboard/keybindingsDarwin.js
@@ -23,6 +23,9 @@ export default new Map([
   ['file.close-window', 'Command+Shift+W'],
   ['file.quit', 'Command+Q'],
 
+  // File > Export submenu
+  ['file.export-file.pdf', 'Ctrl+Alt+E'],
+
   // Edit menu
   ['edit.undo', 'Command+Z'],
   ['edit.redo', 'Command+Shift+Z'],

--- a/src/main/keyboard/keybindingsLinux.js
+++ b/src/main/keyboard/keybindingsLinux.js
@@ -27,6 +27,9 @@ export default new Map([
   ['file.close-window', 'Ctrl+Shift+W'],
   ['file.quit', 'Ctrl+Q'],
 
+  // File > Export submenu
+  ['file.export-file.pdf', 'Ctrl+Alt+E'],
+
   // Edit menu
   ['edit.undo', 'Ctrl+Z'],
   ['edit.redo', 'Ctrl+Shift+Z'],

--- a/src/main/keyboard/keybindingsWindows.js
+++ b/src/main/keyboard/keybindingsWindows.js
@@ -24,6 +24,9 @@ export default new Map([
   ['file.close-window', 'Ctrl+Shift+W'],
   ['file.quit', 'Ctrl+Q'],
 
+  // File > Export submenu
+  ['file.export-file.pdf', 'Ctrl+Alt+E'],
+
   // Edit menu
   ['edit.undo', 'Ctrl+Z'],
   ['edit.redo', 'Ctrl+Shift+Z'],

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -580,6 +580,12 @@ export const saveAs = win => {
   }
 }
 
+export const exportPDF = win => {
+  if (win && win.webContents) {
+    exportFile(win, 'pdf')
+  }
+}
+
 export const autoSave = (menuItem, browserWindow) => {
   const { checked } = menuItem
   ipcMain.emit('set-user-preference', { autoSave: checked })
@@ -620,4 +626,5 @@ export const loadFileCommands = commandManager => {
   commandManager.add(COMMANDS.FILE_RENAME_FILE, rename)
   commandManager.add(COMMANDS.FILE_SAVE, save)
   commandManager.add(COMMANDS.FILE_SAVE_AS, saveAs)
+  commandManager.add(COMMANDS.FILE_EXPORT_FILE_PDF, exportPDF)
 }

--- a/src/main/menu/templates/file.js
+++ b/src/main/menu/templates/file.js
@@ -126,6 +126,7 @@ export default function (keybindings, userPreference, recentlyUsedFiles) {
         }
       }, {
         label: 'PDF',
+        accelerator: keybindings.getAccelerator('file.export-file.pdf'),
         click (menuItem, browserWindow) {
           actions.exportFile(browserWindow, 'pdf')
         }

--- a/src/renderer/commands/descriptions.js
+++ b/src/renderer/commands/descriptions.js
@@ -111,6 +111,7 @@ const commandDescriptions = Object.freeze({
   'file.toggle-auto-save': 'File: Toggle Auto Save',
   'file.import-file': 'File: Import...',
   'file.export-file': 'File: Export...',
+  'file.export-file.pdf': 'File: Export as PDF...',
   'file.zoom': 'Window: Zoom...',
   'file.check-update': 'MarkText: Check for Updates...',
   'paragraph.reset-paragraph': 'Paragraph: Transform into Paragraph',


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3245
| License           | MIT

### Description

Enables user to set a shortcut for exporting directly to PDF
