### PR TITLE
Added Arch Linux to development dependencies in BUILD.md

### DIFF
--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -26,6 +26,8 @@ On Debian-based Linux: `sudo apt-get install libx11-dev libxkbfile-dev libsecret
 
 On Red Hat-based Linux: `sudo dnf install libX11-devel libxkbfile-devel libsecret-devel fontconfig-devel`
 
+On Arch Linux: `sudo pacman -S libx11 libxkbfile libsecret fontconfig`
+
 **Additional development dependencies on Windows:**
 
 - Windows 10 SDK (only needed before Windows 10)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #ticket number (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Added Arch Linux to development dependencies in BUILD.md

I just added the `sudo` commands for installing dependencies on the Arch Linux / Manjaro environment.