### PR TITLE
Rearrange the buttons on the message box for unsaved files

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -161,23 +161,23 @@ const handleResponseForSave = async (e, { id, filename, markdown, pathname, opti
 const showUnsavedFilesMessage = async (win, files) => {
   const { response } = await dialog.showMessageBox(win, {
     type: 'warning',
-    buttons: ['Save', 'Cancel', 'Don\'t save'],
+    buttons: ['Save', 'Don\'t save', 'Cancel'],
     defaultId: 0,
     message: `Do you want to save the changes you made to ${files.length} ${files.length === 1 ? 'file' : 'files'}?\n\n${files.map(f => f.filename).join('\n')}`,
     detail: 'Your changes will be lost if you don\'t save them.',
-    cancelId: 1,
+    cancelId: 2,
     noLink: true
   })
 
   switch (response) {
-    case 2:
-      return { needSave: false }
     case 0:
       return new Promise((resolve, reject) => {
         setTimeout(() => {
           resolve({ needSave: true })
         })
       })
+    case 1:
+      return { needSave: false }
     default:
       return null
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

On the message box for unsaved files of Word and Notepad, from left to right are `Save`, `Don't Save`, `Cancel`. We've gotten used to arranging the buttons this way and I believe it is the best practice that we can follow.

![QQ截图20220808214858_1](https://user-images.githubusercontent.com/34790891/183444363-8a19e0ec-1d51-47b7-b575-768ff7369b50.png)

![QQ截图20220808222102](https://user-images.githubusercontent.com/34790891/183443813-ae4d5847-2fc2-43cd-8313-e9e1972b073e.png)