### PR TITLE
Allow scrolling down even if no contents below

### DIFF
--- a/src/muya/themes/default.css
+++ b/src/muya/themes/default.css
@@ -132,7 +132,7 @@ kbd {
     padding: 20px 50px 100px 50px;
     box-sizing: border-box;
     cursor: text;
-    padding-buttom: 100vh;
+    padding-bottom: 100vh;
   }
 
   #ag-editor-id, [contenteditable] {

--- a/src/muya/themes/default.css
+++ b/src/muya/themes/default.css
@@ -132,6 +132,7 @@ kbd {
     padding: 20px 50px 100px 50px;
     box-sizing: border-box;
     cursor: text;
+    padding-buttom: 100vh;
   }
 
   #ag-editor-id, [contenteditable] {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Issue #3244 
| License           | MIT

### Description

This pull request adds a padding of one screen height at the bottom of editor container. This allows users to scoll down even if no contents below, so we don't need to fix our eyes on the very bottom of the screen when adding new lines. Many editors, such as VS Code or Sublime Text, already have this feature, so I belive it is nessery to add it.