### PR TITLE
Bug fix: Malfunction of `@keydown.enter` when inputting Japanese on MacOS

### DIFF
--- a/src/renderer/components/sideBar/tree.vue
+++ b/src/renderer/components/sideBar/tree.vue
@@ -54,7 +54,7 @@
           :style="{'margin-left': `${depth * 5 + 15}px` }"
           ref="input"
           v-model="createName"
-          @keydown.enter="handleInputEnter"
+          @keypress.enter="handleInputEnter"
         >
         <file
           v-for="(file, index) of projectTree.files" :key="index + 'file'"

--- a/src/renderer/components/sideBar/treeFile.vue
+++ b/src/renderer/components/sideBar/treeFile.vue
@@ -17,7 +17,7 @@
       v-if="renameCache === file.pathname"
       v-model="newName"
       ref="renameInput"
-      @keydown.enter="rename"
+      @keypress.enter="rename"
     >
     <span v-else>{{ file.name }}</span>
   </div>

--- a/src/renderer/components/sideBar/treeFolder.vue
+++ b/src/renderer/components/sideBar/treeFolder.vue
@@ -19,7 +19,7 @@
         v-if="renameCache === folder.pathname"
         v-model="newName"
         ref="renameInput"
-        @keydown.enter="rename"
+        @keypress.enter="rename"
       >
       <span v-else class="text-overflow">{{folder.name}}</span>
     </div>
@@ -37,7 +37,7 @@
         class="new-input"
         :style="{'margin-left': `${depth * 5 + 15}px` }"
         ref="input"
-        @keydown.enter="handleInputEnter"
+        @keypress.enter="handleInputEnter"
         v-model="createName"
       >
       <file


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3418
| License           | MIT

### Description
When creating a new file or directory in the sidebar, typing Japanese causes @keydown.enter to malfunction.
In Japanese, there are two times to press the Enter key.

The first is when converting input to kanji.
The second is when completing input (when generating a file).
I would like @keydown.enter to be executed only the second time, but in fact, it is executed on the first press of Enter key and seems to be trying to generate a file without any text being entered. (And it fails to create the file because it has no filename entered.)

This problem should occur in languages other than Japanese where an IME is required, such as Chinese and Korean.
(Also this problem has occurred only on macOS.)


