### PR TITLE
fix: #2294 Focus find-in-folder search box; unfocus with ESC

### DIFF
--- a/src/renderer/components/search/index.vue
+++ b/src/renderer/components/search/index.vue
@@ -176,6 +176,7 @@ export default {
     bus.$on('findPrev', this.listenFindPrev)
     document.addEventListener('click', this.docClick)
     document.addEventListener('keyup', this.docKeyup)
+    bus.$on('search-blur', this.blurSearch)
   },
 
   beforeDestroy () {
@@ -185,6 +186,7 @@ export default {
     bus.$off('findPrev', this.listenFindPrev)
     document.removeEventListener('click', this.docClick)
     document.removeEventListener('keyup', this.docKeyup)
+    bus.$off('search-blur', this.blurSearch)
   },
 
   methods: {
@@ -225,6 +227,10 @@ export default {
 
     docClick () {
       if (!this.showSearch) return
+      this.emptySearch(true)
+    },
+
+    blurSearch () {
       this.emptySearch(true)
     },
 

--- a/src/renderer/components/sideBar/search.vue
+++ b/src/renderer/components/sideBar/search.vue
@@ -7,6 +7,7 @@
           type="text" v-model="keyword"
           placeholder="Search in folder..."
           @keyup="search"
+          ref="search"
         >
         <div class="controls">
           <span
@@ -125,14 +126,18 @@ export default {
   },
   watch: {
     showSideBar: function (value, oldValue) {
-      if (value && !oldValue && this.rightColumn === 'search') {
-        this.keyword = this.searchMatches.value
+      if (this.rightColumn === 'search') {
+        if (value && !oldValue) {
+          this.handleFindInFolder(false)
+        } else {
+          bus.$emit('search-blur')
+        }
       }
     }
   },
   created () {
     this.$nextTick(() => {
-      this.keyword = this.searchMatches.value
+      this.handleFindInFolder()
       bus.$on('findInFolder', this.handleFindInFolder)
       if (this.keyword.length > 0 && this.searcherRunning === false) {
         this.searcherRunning = true
@@ -316,8 +321,13 @@ export default {
     openFolder () {
       this.$store.dispatch('ASK_FOR_OPEN_PROJECT')
     },
-    handleFindInFolder () {
+    handleFindInFolder (focus = true) {
       this.keyword = this.searchMatches.value
+      if (focus) {
+        this.$nextTick(() => {
+          this.$refs.search.focus()
+        })
+      }
     }
   },
   destroyed () {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2294
| License           | MIT

### Description

This pull request changes the behavior of `Edit: Find in Folder`/(Ctrl+Shift+F) and `View: Toggle Sidebar`(Ctrl+J).

- On  `Find in Folder`: the search input is focused (whether the sidebar was previously open, closed or not yet created)
- On `Toggle Sidebar`: when closing the sidebar the search input is unfocused (blurred) if it had the focus.
- On `Escape`: the search input is unfocused (blurred) if it had the focus. 

When the search input get focused, the search keyword is emptied. Which is the same behavior as 'Edit: Find'(Ctrl+F).