### PR TITLE
mdx file extension support to write markdown contents

### DIFF
--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -14,7 +14,8 @@ export const MARKDOWN_EXTENSIONS = Object.freeze([
   'mdtxt',
   'mdtext',
   'text',
-  'txt'
+  'txt',
+  'mdx'
 ])
 
 export const MARKDOWN_INCLUSIONS = Object.freeze(MARKDOWN_EXTENSIONS.map(x => '*.' + x))


### PR DESCRIPTION
First of all, Thanks for this amazing application. It's a daily text editor for me. Really appricated it. 

**I actually never tried Electronjs before even once. Just tested it on Windows 64-bit OS. Hope there will be no issues**

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #ticket number (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Description

Marktext doesn't support opening `.mdx` file where it basically contains markdown contains except some javascript code which can be ignorable IMO.

