### PR TITLE
fix: path.join args must be string type

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -154,7 +154,7 @@ export const uploadImage = async (pathname, image, preferences) => {
     if (typeof filepath !== 'string') {
       isPath = false
       const data = new Uint8Array(filepath)
-      filepath = path.join(tmpdir(), +new Date())
+      filepath = path.join(tmpdir(), +new Date() + '')
       await fs.writeFile(filepath, data)
     }
     if (uploader === 'picgo') {


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

When I debug uploading images using picgo, I found an error
in fileSystem.js(src/renderer/util/fileSystem.js)

![image](https://user-images.githubusercontent.com/44605072/187111741-44cb7a19-761d-4f4f-8a80-fe70359cf26c.png)

![image](https://user-images.githubusercontent.com/44605072/187111522-3d088a8b-d619-48d1-bdf4-4f467a2e7338.png)

path.join args must be string type

[Description of the bug or feature]
