### PR TITLE
Add .mdx extension support

### DIFF
--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -81,7 +81,7 @@ These entires don't have a settings option and need to be changed manually.
 
 | Key                  | Type             | Default | Description                                                                                                                                                      |
 | -------------------- | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| searchExclusions     | Array of Strings | `[]`    | The filename exclusions for the file searcher. Default: `'*.markdown', '*.mdown', '*.mkdn', '*.md', '*.mkd', '*.mdwn', '*.mdtxt', '*.mdtext', '*.text', '*.txt'` |
+| searchExclusions     | Array of Strings | `[]`    | The filename exclusions for the file searcher. Default: `'*.markdown', '*.mdown', '*.mkdn', '*.md', '*.mkd', '*.mdwn', '*.mdtxt', '*.mdtext', '*.mdx', '*.text', '*.txt'` |
 | searchMaxFileSize    | String           | `""`    | The maximum file size to search in (e.g. 50K or 10MB). Default: unlimited                                                                                        |
 | searchIncludeHidden  | Boolean          | false   | Search hidden files and directories                                                                                                                              |
 | searchNoIgnore       | Boolean          | false   | Don't respect ignore files such as `.gitignore`.                                                                                                                 |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -60,6 +60,7 @@ fileAssociations:
   - "mdown"
   - "mdtxt"
   - "mdtext"
+  - "mdx"
   name: "Markdown"
   description: "Markdown document"
   role: "Editor"

--- a/src/common/filesystem/paths.js
+++ b/src/common/filesystem/paths.js
@@ -13,6 +13,7 @@ export const MARKDOWN_EXTENSIONS = Object.freeze([
   'mdwn',
   'mdtxt',
   'mdtext',
+  'mdx',
   'text',
   'txt'
 ])

--- a/src/muya/lib/utils/markdownFile.js
+++ b/src/muya/lib/utils/markdownFile.js
@@ -9,6 +9,7 @@ const MARKDOWN_EXTENSIONS = Object.freeze([
   'mdwn',
   'mdtxt',
   'mdtext',
+  'mdx',
   'text',
   'txt'
 ])


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #2109
| License           | MIT

### Description

Make it possible to open `.mdx` files which are Markdown files with the possibility of adding JavaScript (JSX) code. MDX is [already very widespread and is still gaining a lot of popularity](https://www.npmjs.com/package/@mdx-js/mdx).

The main effect this change has is that it displays files with the `.mdx` ending in the sidebar and allows them to be opened.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/198988/187423055-be96ed54-04ad-43d6-ae8d-3453b83d204b.png">

As the files are basically Markdown files, they are already displayed correctly. Any JSX inside of the files also already looks good and doesn't need any special treatment:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/198988/187422787-28f40b5b-619a-42c1-8d54-f6fae91c66b5.png">

Saving works perfectly fine.

This PR conflicts with and closes #3424 that was opened recently. It adds the `MDX` extension to a couple more places in the source code / docs.