### PR TITLE
fix: #1250 ignore a tab key when choosing a candidate of letters by IME

### DIFF
--- a/src/muya/lib/contentState/tabCtrl.js
+++ b/src/muya/lib/contentState/tabCtrl.js
@@ -302,6 +302,11 @@ const tabCtrl = ContentState => {
     // disable tab focus
     event.preventDefault()
 
+    // skip subsequent processing if IME is working
+    if (event.isComposing) {
+      return
+    }
+
     const { start, end } = selection.getCursorRange()
     if (!start || !end) {
       return


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #1250 
| License           | MIT

### Description

Skip processing in `tabHandler` when choosing a candidate of letters by IME.