### PR TITLE
fix:  upload failure with github (#3588)

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -227,12 +227,11 @@ export const uploadImage = async (pathname, image, preferences) => {
             uploadByCommand(currentUploader, reader.result)
             break
           default:
-            uploadByGithub(reader.result, image.name)
+            uploadByGithub(Buffer.from(reader.result).toString('base64'), image.name)
         }
       }
 
-      const readerFunction = currentUploader !== 'github' ? 'readAsArrayBuffer' : 'readAsDataURL'
-      reader[readerFunction](image)
+      reader.readAsArrayBuffer(image)
     }
   }
   return promise


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not 
| Fixed tickets     | Fixes #3588
| License           | MIT

### Description

when you use github as your uploader , if you paste a image  and upload to github , it will appear error (HttpError: content is not valid Base64) , because the api readAsDataURL will return a base64 with some prefix like 'data:image/png;base64,' and the prefix isn't need
