### PR TITLE
Add new documentation for Arch Linux user.

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -88,7 +88,7 @@ or `flatpak update` to update all installed flatpaks.
 
 The Arch User Repository also contains the packages:
 
-`marktext`, `marktext-bin`, `marktext-git` and `marktext-appimage`.
+`marktext`, `marktext-bin`, `marktext-git`, `marktext-appimage`, `electron15-bin`, and `ripgrep`.
 
 Install it via an AUR helper like `yay -S marktext` or with
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -88,7 +88,7 @@ or `flatpak update` to update all installed flatpaks.
 
 The Arch User Repository also contains the packages:
 
-`marktext`, `marktext-bin`, `marktext-git`, `marktext-appimage`, `electron15-bin`, and `ripgrep`.
+`marktext`, `marktext-bin`, `marktext-git`, `marktext-appimage`, `electron15-bin` and `ripgrep`.
 
 Install it via an AUR helper like `yay -S marktext` or with
 


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| New tests added?  | yes
| Add documentation | yes
| Fixed tickets     | Fixes #ticket number (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Description
Hello, sorry for my contribution which may still be very messy.

When I did the installation on Arch Linux, it required `electron15-bin` and `ripgrep` which is not available by default, here I only add documentation for users who have problems like me.
