### PR TITLE
Fixes #3718 Modify the pop-up conditions of muya-format-picker

### DIFF
--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -55,7 +55,8 @@ export const EVENT_KEYS = Object.freeze(generateKeyHash([
   'ArrowLeft',
   'ArrowRight',
   'Tab',
-  'Escape'
+  'Escape',
+  'Shift'
 ]))
 
 export const LOWERCASE_TAGS = Object.freeze(generateKeyHash([

--- a/src/muya/lib/eventHandler/keyboard.js
+++ b/src/muya/lib/eventHandler/keyboard.js
@@ -8,6 +8,7 @@ class Keyboard {
   constructor (muya) {
     this.muya = muya
     this.isComposed = false
+    this.isShiftDown = false
     this.shownFloat = new Set()
     this.recordIsComposed()
     this.dispatchEditorState()
@@ -187,6 +188,10 @@ class Keyboard {
         case EVENT_KEYS.Tab:
           contentState.tabHandler(event)
           break
+        case EVENT_KEYS.Shift:
+          eventCenter.dispatch('muya-format-picker', { reference: null })
+          this.isShiftDown = true
+          break
         default:
           break
       }
@@ -252,6 +257,10 @@ class Keyboard {
         })
       }
 
+      if (event.key === EVENT_KEYS.Shift) {
+        this.isShiftDown = false
+      }
+
       const { anchor, focus, start, end } = selection.getCursorRange()
       if (!anchor || !focus) {
         return
@@ -276,6 +285,7 @@ class Keyboard {
 
       const block = contentState.getBlock(anchor.key)
       if (
+        this.isShiftDown === false &&
         anchor.key === focus.key &&
         anchor.offset !== focus.offset &&
         block.functionType !== 'codeContent' &&


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes [#3718](https://github.com/marktext/marktext/issues/3718)
| License           | MIT

### Description

Before: When selecting the text by 'Shift' and 'Arrow keys', the 'muya-format-picker' that pop upon the selected text make it hard to continue selecting by 'Shift + ArrowUp' or 'Shift + ArrowDown' , while 'Shift + ArrowLeft' or 'Shift + ArrowRight' working still. 

So I modified the pop up logic of the 'muya-format-picker'. Add code to  check if the 'Shift' is still pressed. If so the 'muya-format-picker' won't pop up.

