### PR TITLE
Update keybindingsWindows.js - set binding to file.print

### DIFF
--- a/src/main/keyboard/keybindingsWindows.js
+++ b/src/main/keyboard/keybindingsWindows.js
@@ -18,7 +18,7 @@ export default new Map([
   ['file.save-as', 'Ctrl+Shift+S'],
   ['file.move-file', ''],
   ['file.rename-file', ''],
-  ['file.print', ''],
+  ['file.print', 'Ctrl+P'],
   ['file.preferences', 'Ctrl+,'],
   ['file.close-tab', 'Ctrl+W'],
   ['file.close-window', 'Ctrl+Shift+W'],


### PR DESCRIPTION
In file.print on Windows, keybinding Ctrl+P is pretty common, so I mapped it.

<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes #3502 (set to none if no tickets are fixed, repeat template for each ticket fixed)
| License           | MIT

### Description

On Windows, for printing the common shortcut is Ctrl+P. This changes adds this shortcut to keybindings for Windows.