### PR TITLE
Update `marktext` alias path

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,5 +18,5 @@ Usage: marktext [commands] [path ...]
 `marktext` should point to your installation of MarkText. The exact location will vary from platform to platform. On macOS, you can create a convenient alias like:
 
 ```sh
-alias marktext="/Applications/Mark\ Text.app/Contents/MacOS/Mark\ Text"
+alias marktext="/Applications/MarkText.app/Contents/MacOS/MarkText"
 ```


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

`docs/CLI.md` was outdated, so I updated the folder path

```sh
alias marktext="/Applications/MarkText.app/Contents/MacOS/MarkText"
```
