### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 16
           check-latest: true
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get install -y icnsutils graphicsmagick xz-utils libx11-dev libxkbfile-dev gnome-keyring libsecret-1-dev libfontconfig-dev
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         id: cacheNodeModules
         with:
           path: ${{ github.workspace }}/node_modules
@@ -55,13 +55,13 @@ jobs:
             ${{ runner.os }}-node_modules-cache-v1-
 
       - name: Cache Electron
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.HOME }}/.cache/electron
           key: ${{ runner.os }}-electron-cache-v1-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
 
       - name: Cache Electron-Builder
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.HOME }}/.cache//electron-builder
           key: ${{ runner.os }}-electron-builder-cache-v1-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 16
           check-latest: true
@@ -114,7 +114,7 @@ jobs:
         shell: pwsh
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         id: cacheNodeModules
         with:
           path: ${{ github.workspace }}\node_modules
@@ -123,13 +123,13 @@ jobs:
             ${{ runner.os }}-node_modules-cache-v2-
 
       - name: Cache Electron
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.LOCALAPPDATA }}\electron\Cache
           key: ${{ runner.os }}-electron-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
 
       - name: Cache Electron-Builder
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.LOCALAPPDATA }}\electron-builder\cache
           key: ${{ runner.os }}-electron-builder-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 16
           check-latest: true
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y icnsutils graphicsmagick xz-utils libx11-dev libxkbfile-dev gnome-keyring libsecret-1-dev libfontconfig-dev rpm
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/node_modules
           key: ${{ runner.os }}-node_modules-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
@@ -49,13 +49,13 @@ jobs:
             ${{ runner.os }}-node_modules-cache-v2-
 
       - name: Cache Electron
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.HOME }}/.cache/electron
           key: ${{ runner.os }}-electron-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
 
       - name: Cache Electron-Builder
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.HOME }}/.cache//electron-builder
           key: ${{ runner.os }}-electron-builder-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
@@ -118,10 +118,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: 16
           check-latest: true
@@ -137,7 +137,7 @@ jobs:
         shell: pwsh
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}\node_modules
           key: ${{ runner.os }}-node_modules-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
@@ -145,13 +145,13 @@ jobs:
             ${{ runner.os }}-node_modules-cache-v2-
 
       - name: Cache Electron
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.LOCALAPPDATA }}\electron\Cache
           key: ${{ runner.os }}-electron-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}
 
       - name: Cache Electron-Builder
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ env.LOCALAPPDATA }}\electron-builder\cache
           key: ${{ runner.os }}-electron-builder-cache-v2-${{ hashFiles(format('{0}{1}', github.workspace, '\yarn.lock')) }}


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | Fixes # (none)
| License           | MIT

### Description

This PR updates outdated GitHub Action versions. The following actions were updated: actions/setup-node (v2 → v6), actions/cache (v2 → v5), actions/checkout (v2 → v6), and others.