### PR TITLE
fix: capitalize accelerator modifiers to fix custom keybindings

### DIFF
--- a/src/common/keybinding/index.js
+++ b/src/common/keybinding/index.js
@@ -1,6 +1,6 @@
 const isOsx = process.platform === 'darwin'
 
-// Map of lowercase modifier/key names to their canonical Electron accelerator form.
+// Map of lowercase modifier names to their canonical Electron accelerator form.
 const MODIFIER_CAPITALIZATION = {
   commandorcontrol: 'CommandOrControl',
   cmdorctrl: 'CmdOrCtrl',
@@ -18,7 +18,8 @@ const MODIFIER_CAPITALIZATION = {
 
 /**
  * Capitalize an accelerator string to match Electron's expected format.
- * e.g. "ctrl+alt+1" -> "Ctrl+Alt+1", "shift+a" -> "Shift+A"
+ * Only modifier names are capitalized; non-modifier key parts are preserved as-is.
+ * e.g. "ctrl+alt+1" -> "Ctrl+Alt+1", "shift+a" -> "Shift+a"
  *
  * @param {string} accelerator
  * @returns {string}

--- a/src/common/keybinding/index.js
+++ b/src/common/keybinding/index.js
@@ -1,5 +1,36 @@
 const isOsx = process.platform === 'darwin'
 
+// Map of lowercase modifier/key names to their canonical Electron accelerator form.
+const MODIFIER_CAPITALIZATION = {
+  commandorcontrol: 'CommandOrControl',
+  cmdorctrl: 'CmdOrCtrl',
+  command: 'Command',
+  control: 'Control',
+  ctrl: 'Ctrl',
+  cmd: 'Cmd',
+  alt: 'Alt',
+  option: 'Option',
+  altgr: 'AltGr',
+  shift: 'Shift',
+  meta: 'Meta',
+  super: 'Super'
+}
+
+/**
+ * Capitalize an accelerator string to match Electron's expected format.
+ * e.g. "ctrl+alt+1" -> "Ctrl+Alt+1", "shift+a" -> "Shift+A"
+ *
+ * @param {string} accelerator
+ * @returns {string}
+ */
+export const capitalizeAccelerator = accelerator => {
+  if (!accelerator) return accelerator
+  return accelerator.split('+').map(part => {
+    const lower = part.toLowerCase()
+    return MODIFIER_CAPITALIZATION[lower] || part
+  }).join('+')
+}
+
 const _normalizeAccelerator = accelerator => {
   return accelerator.toLowerCase()
     .replace('commandorcontrol', isOsx ? 'cmd' : 'ctrl')

--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -5,7 +5,7 @@ import path from 'path'
 import log from 'electron-log'
 import { electronLocalshortcut, isValidElectronAccelerator } from '@hfelix/electron-localshortcut'
 import { isFile2 } from 'common/filesystem'
-import { isEqualAccelerator } from 'common/keybinding'
+import { isEqualAccelerator, capitalizeAccelerator } from 'common/keybinding'
 import { isLinux, isOsx } from '../config'
 import { getKeyboardInfo, keyboardLayoutMonitor } from '../keyboard'
 import keybindingsDarwin from './keybindingsDarwin'
@@ -166,7 +166,9 @@ class Keybindings {
             // Unset key
             userAccelerators.set(key, '')
           } else if (isValidElectronAccelerator(value)) {
-            userAccelerators.set(key, value)
+            // Normalize modifier casing to match Electron's expected format.
+            // Handles legacy keybindings.json files that may contain lowercase modifiers (see #4123).
+            userAccelerators.set(key, capitalizeAccelerator(value))
           } else {
             console.error(`[WARNING] "${value}" is not a valid accelerator.`)
           }

--- a/src/renderer/prefComponents/keybindings/KeybindingConfigurator.js
+++ b/src/renderer/prefComponents/keybindings/KeybindingConfigurator.js
@@ -139,6 +139,10 @@ export default class KeybindingConfigurator {
   }
 
   _isDefaultBinding (id, accelerator) {
-    return this.defaultKeybindings.get(id) === accelerator
+    const defaultAccelerator = this.defaultKeybindings.get(id)
+    if (defaultAccelerator == null || accelerator == null) {
+      return defaultAccelerator === accelerator
+    }
+    return isEqualAccelerator(defaultAccelerator, accelerator)
   }
 }

--- a/src/renderer/prefComponents/keybindings/key-input-dialog.vue
+++ b/src/renderer/prefComponents/keybindings/key-input-dialog.vue
@@ -42,6 +42,7 @@ import {
   isValidElectronAccelerator,
   getAcceleratorFromKeyboardEvent
 } from '@hfelix/electron-localshortcut'
+import { capitalizeAccelerator } from 'common/keybinding'
 
 export default {
   data () {
@@ -105,6 +106,9 @@ export default {
       }
 
       const keybinding = getAcceleratorFromKeyboardEvent(event)
+      // Capitalize modifier names to match Electron's expected format (e.g. "ctrl+alt+1" -> "Ctrl+Alt+1").
+      // See: https://github.com/marktext/marktext/issues/4123
+      keybinding.accelerator = capitalizeAccelerator(keybinding.accelerator)
       this.currentKeybinding = keybinding
       // Verify whether the given key binding is valid for Electron.
       this.isKeybindingValid = keybinding.isValid && isValidElectronAccelerator(keybinding.accelerator)

--- a/test/unit/specs/capitalize-accelerator.spec.js
+++ b/test/unit/specs/capitalize-accelerator.spec.js
@@ -1,0 +1,83 @@
+import { capitalizeAccelerator } from 'common/keybinding'
+
+describe('capitalizeAccelerator', () => {
+  it('should capitalize single modifier + key', () => {
+    expect(capitalizeAccelerator('ctrl+a')).to.equal('Ctrl+a')
+  })
+
+  it('should capitalize multiple modifiers', () => {
+    expect(capitalizeAccelerator('ctrl+alt+1')).to.equal('Ctrl+Alt+1')
+  })
+
+  it('should capitalize ctrl+shift+key', () => {
+    expect(capitalizeAccelerator('ctrl+shift+z')).to.equal('Ctrl+Shift+z')
+  })
+
+  it('should preserve already-capitalized accelerators', () => {
+    expect(capitalizeAccelerator('Ctrl+Alt+1')).to.equal('Ctrl+Alt+1')
+  })
+
+  it('should handle CommandOrControl', () => {
+    expect(capitalizeAccelerator('commandorcontrol+s')).to.equal('CommandOrControl+s')
+  })
+
+  it('should handle CmdOrCtrl', () => {
+    expect(capitalizeAccelerator('cmdorctrl+n')).to.equal('CmdOrCtrl+n')
+  })
+
+  it('should handle Option modifier', () => {
+    expect(capitalizeAccelerator('option+a')).to.equal('Option+a')
+  })
+
+  it('should handle AltGr modifier', () => {
+    expect(capitalizeAccelerator('altgr+e')).to.equal('AltGr+e')
+  })
+
+  it('should handle Meta modifier', () => {
+    expect(capitalizeAccelerator('meta+x')).to.equal('Meta+x')
+  })
+
+  it('should handle Super modifier', () => {
+    expect(capitalizeAccelerator('super+l')).to.equal('Super+l')
+  })
+
+  it('should not alter non-modifier parts', () => {
+    expect(capitalizeAccelerator('ctrl+F5')).to.equal('Ctrl+F5')
+  })
+
+  it('should handle single key without modifier', () => {
+    expect(capitalizeAccelerator('F2')).to.equal('F2')
+  })
+
+  it('should return empty string for empty input', () => {
+    expect(capitalizeAccelerator('')).to.equal('')
+  })
+
+  it('should return null for null input', () => {
+    expect(capitalizeAccelerator(null)).to.equal(null)
+  })
+
+  it('should return undefined for undefined input', () => {
+    expect(capitalizeAccelerator(undefined)).to.equal(undefined)
+  })
+
+  it('should handle mixed case input', () => {
+    expect(capitalizeAccelerator('CTRL+ALT+a')).to.equal('Ctrl+Alt+a')
+  })
+
+  it('should handle three modifiers', () => {
+    expect(capitalizeAccelerator('ctrl+shift+alt+d')).to.equal('Ctrl+Shift+Alt+d')
+  })
+
+  it('should handle Command modifier', () => {
+    expect(capitalizeAccelerator('command+c')).to.equal('Command+c')
+  })
+
+  it('should handle Cmd modifier', () => {
+    expect(capitalizeAccelerator('cmd+v')).to.equal('Cmd+v')
+  })
+
+  it('should handle Control modifier (full word)', () => {
+    expect(capitalizeAccelerator('control+p')).to.equal('Control+p')
+  })
+})

--- a/test/unit/specs/capitalize-accelerator.spec.js
+++ b/test/unit/specs/capitalize-accelerator.spec.js
@@ -80,4 +80,25 @@ describe('capitalizeAccelerator', () => {
   it('should handle Control modifier (full word)', () => {
     expect(capitalizeAccelerator('control+p')).to.equal('Control+p')
   })
+
+  it('should handle single modifier without key', () => {
+    expect(capitalizeAccelerator('ctrl')).to.equal('Ctrl')
+  })
+
+  it('should handle modifier with Plus key', () => {
+    expect(capitalizeAccelerator('ctrl+Plus')).to.equal('Ctrl+Plus')
+  })
+
+  it('should preserve non-modifier special key names', () => {
+    expect(capitalizeAccelerator('ctrl+Space')).to.equal('Ctrl+Space')
+    expect(capitalizeAccelerator('ctrl+Tab')).to.equal('Ctrl+Tab')
+    expect(capitalizeAccelerator('ctrl+Backspace')).to.equal('Ctrl+Backspace')
+  })
+
+  it('should be idempotent (applying twice gives same result)', () => {
+    const input = 'ctrl+shift+alt+f5'
+    const once = capitalizeAccelerator(input)
+    const twice = capitalizeAccelerator(once)
+    expect(once).to.equal(twice)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #4123

- The keybinding preferences UI captures keyboard shortcuts via `getAcceleratorFromKeyboardEvent()` which returns lowercase modifier names (e.g. `ctrl+alt+1`), but Electron requires properly capitalized modifiers (e.g. `Ctrl+Alt+1`) to register shortcuts correctly.
- Add `capitalizeAccelerator()` utility to `src/common/keybinding/index.js` that normalizes modifier casing against a canonical map (Ctrl, Alt, Shift, Cmd, Meta, Super, AltGr, Option, CommandOrControl, CmdOrCtrl, Command, Control).
- Apply capitalization in `key-input-dialog.vue` immediately after capturing the accelerator, before saving.
- Fix `_isDefaultBinding` in `KeybindingConfigurator.js` to use `isEqualAccelerator` (case-insensitive) instead of strict equality, so re-entering a default binding is correctly recognized.

## Test plan

- [x] Add 21 unit tests for `capitalizeAccelerator()` covering all modifier names, mixed case, empty/null input, and multi-modifier combinations (`test/unit/specs/capitalize-accelerator.spec.js`)
- [ ] Manual: Open Preferences > Key Bindings, edit a binding (e.g. press Ctrl+Alt+1), verify it displays as `Ctrl+Alt+1` (not `ctrl+alt+1`)
- [ ] Manual: Save the binding, return to document, verify the shortcut works


🤖 Generated with [Claude Code](https://claude.com/claude-code)