### PR TITLE
fix: prevent querySelector crash on empty heading slug

### DIFF
--- a/src/muya/lib/contentState/tableDragBarCtrl.js
+++ b/src/muya/lib/contentState/tableDragBarCtrl.js
@@ -1,5 +1,7 @@
 const calculateAspects = (tableId, barType) => {
+  if (!tableId) return []
   const table = document.querySelector(`#${tableId}`)
+  if (!table) return []
   if (barType === 'bottom') {
     const firstRow = table.querySelector('tr')
     return Array.from(firstRow.children).map(cell => cell.clientWidth)
@@ -9,7 +11,9 @@ const calculateAspects = (tableId, barType) => {
 }
 
 export const getAllTableCells = tableId => {
+  if (!tableId) return []
   const table = document.querySelector(`#${tableId}`)
+  if (!table) return []
   const rows = table.querySelectorAll('tr')
   const cells = []
   for (const row of Array.from(rows)) {
@@ -37,7 +41,9 @@ export const getIndex = (barType, cell) => {
 }
 
 const getDragCells = (tableId, barType, index) => {
+  if (!tableId) return []
   const table = document.querySelector(`#${tableId}`)
+  if (!table) return []
   const dragCells = []
   if (barType === 'left') {
     if (index === 0) {

--- a/src/muya/lib/parser/marked/slugger.js
+++ b/src/muya/lib/parser/marked/slugger.js
@@ -24,6 +24,12 @@ Slugger.prototype.slug = function (value) {
     .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
     .replace(/\s/g, '-')
 
+  // Use a fallback slug when heading content is empty or contains only special characters.
+  // An empty slug would produce an invalid CSS selector '#'. See #4087.
+  if (!slug) {
+    slug = 'heading'
+  }
+
   if (this.seen.hasOwnProperty(slug)) {
     const originalSlug = slug
     do {

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -905,13 +905,20 @@ export default {
     },
 
     scrollToHeader (slug) {
+      if (!slug) return
       return this.scrollToElement(`#${slug}`)
     },
 
     scrollToElement (selector) {
       // Scroll to search highlight word
       const { container } = this.editor
-      const anchor = document.querySelector(selector)
+      let anchor
+      try {
+        anchor = document.querySelector(selector)
+      } catch (e) {
+        // Invalid CSS selector (e.g. '#' from an empty heading slug). See #4087.
+        return
+      }
       if (anchor) {
         const { y } = anchor.getBoundingClientRect()
         const DURATION = 300

--- a/test/unit/specs/slugger.spec.js
+++ b/test/unit/specs/slugger.spec.js
@@ -60,6 +60,37 @@ describe('Slugger', () => {
       expect(slugger.slug('heading')).to.equal('heading')
       expect(slugger.slug('')).to.equal('heading-1')
     })
+
+    it('should deduplicate when empty heading appears before real "heading"', () => {
+      expect(slugger.slug('')).to.equal('heading')
+      expect(slugger.slug('heading')).to.equal('heading-1')
+    })
+
+    it('should handle chained collisions with fallback slugs', () => {
+      expect(slugger.slug('')).to.equal('heading')
+      expect(slugger.slug('')).to.equal('heading-1')
+      expect(slugger.slug('heading-1')).to.equal('heading-1-1')
+    })
+  })
+
+  describe('unicode and emoji headings', () => {
+    it('should handle CJK characters', () => {
+      const slug = slugger.slug('你好世界')
+      expect(slug).to.be.a('string')
+      expect(slug.length).to.be.greaterThan(0)
+    })
+
+    it('should handle emoji-only heading', () => {
+      const slug = slugger.slug('🚀🎉')
+      expect(slug).to.be.a('string')
+      expect(slug.length).to.be.greaterThan(0)
+    })
+
+    it('should handle mixed ASCII and Unicode', () => {
+      const slug = slugger.slug('Hello 世界')
+      expect(slug).to.be.a('string')
+      expect(slug.length).to.be.greaterThan(0)
+    })
   })
 
   describe('deduplication', () => {

--- a/test/unit/specs/slugger.spec.js
+++ b/test/unit/specs/slugger.spec.js
@@ -1,0 +1,79 @@
+import Slugger from 'muya/lib/parser/marked/slugger'
+
+describe('Slugger', () => {
+  let slugger
+
+  beforeEach(() => {
+    slugger = new Slugger()
+  })
+
+  describe('basic slug generation', () => {
+    it('should generate a slug from plain text', () => {
+      expect(slugger.slug('Hello World')).to.equal('hello-world')
+    })
+
+    it('should convert to lowercase', () => {
+      expect(slugger.slug('HELLO')).to.equal('hello')
+    })
+
+    it('should replace spaces with hyphens', () => {
+      expect(slugger.slug('foo bar baz')).to.equal('foo-bar-baz')
+    })
+
+    it('should strip special characters', () => {
+      expect(slugger.slug('Hello, World!')).to.equal('hello-world')
+    })
+
+    it('should strip parentheses and brackets', () => {
+      expect(slugger.slug('Section (1) [intro]')).to.equal('section-1-intro')
+    })
+
+    it('should strip HTML tags', () => {
+      expect(slugger.slug('Hello <b>World</b>')).to.equal('hello-world')
+    })
+  })
+
+  describe('empty and special-character-only headings (#4087)', () => {
+    it('should return "heading" for empty string', () => {
+      expect(slugger.slug('')).to.equal('heading')
+    })
+
+    it('should return "heading" for whitespace-only input', () => {
+      expect(slugger.slug('   ')).to.equal('heading')
+    })
+
+    it('should return "heading" for input with only special characters', () => {
+      expect(slugger.slug('!@#$%^&*()')).to.equal('heading')
+    })
+
+    it('should return "heading" for input with only punctuation', () => {
+      expect(slugger.slug('.,;:!?')).to.equal('heading')
+    })
+
+    it('should deduplicate fallback headings', () => {
+      expect(slugger.slug('')).to.equal('heading')
+      expect(slugger.slug('')).to.equal('heading-1')
+      expect(slugger.slug('')).to.equal('heading-2')
+    })
+
+    it('should deduplicate when fallback collides with real heading', () => {
+      expect(slugger.slug('heading')).to.equal('heading')
+      expect(slugger.slug('')).to.equal('heading-1')
+    })
+  })
+
+  describe('deduplication', () => {
+    it('should append suffix for duplicate slugs', () => {
+      expect(slugger.slug('hello')).to.equal('hello')
+      expect(slugger.slug('hello')).to.equal('hello-1')
+      expect(slugger.slug('hello')).to.equal('hello-2')
+    })
+
+    it('should handle duplicates independently', () => {
+      expect(slugger.slug('foo')).to.equal('foo')
+      expect(slugger.slug('bar')).to.equal('bar')
+      expect(slugger.slug('foo')).to.equal('foo-1')
+      expect(slugger.slug('bar')).to.equal('bar-1')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4087
Also fixes #4092 (duplicate)

When a heading has no text content or contains only special characters, the slugger produces an empty slug. This causes `querySelector('#')` to throw `"Failed to execute 'querySelector': '#' is not a valid selector"`, crashing the renderer process.

**Changes:**

- **`slugger.js`**: Return fallback slug `'heading'` when content produces an empty slug (with deduplication support for multiple empty headings)
- **`editor.vue`**: Add empty-slug guard in `scrollToHeader` and wrap `querySelector` in try/catch in `scrollToElement`
- **`tableDragBarCtrl.js`**: Add null guards in `calculateAspects`, `getAllTableCells`, and `getDragCells` to prevent the same crash when table IDs are missing

## Test plan

- [x] Add 14 unit tests for `Slugger` covering normal slugs, empty strings, whitespace-only input, special-character-only input, fallback deduplication, and collision with real headings (`test/unit/specs/slugger.spec.js`)
- [ ] Manual: Create a heading with only special characters (e.g. `# !@#$%`), verify no crash
- [ ] Manual: Create an empty heading (`#` with no text), click it in the TOC sidebar, verify no crash
- [ ] Manual: Export a document with empty headings to PDF, verify no crash


🤖 Generated with [Claude Code](https://claude.com/claude-code)