### PR TITLE
feat: Full WYSIWYG mode + live system theme following

### DIFF
--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -154,25 +154,54 @@ class App {
 
     // Set initial native theme for theme in preferences.
     const isDarkTheme = /dark/i.test(theme)
-    if (autoSwitchTheme === 0 && isDarkTheme !== nativeTheme.shouldUseDarkColors) {
+    if ((autoSwitchTheme === 0 || autoSwitchTheme === 1) && isDarkTheme !== nativeTheme.shouldUseDarkColors) {
       selectTheme(nativeTheme.shouldUseDarkColors ? 'dark' : 'light')
-      nativeTheme.themeSource = nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
+    }
+
+    // When following the system theme, keep themeSource as 'system' so Electron
+    // fires the 'updated' event on OS dark/light mode changes.
+    if (autoSwitchTheme === 1) {
+      nativeTheme.themeSource = 'system'
     } else {
       nativeTheme.themeSource = isDarkTheme ? 'dark' : 'light'
     }
 
     let isDarkMode = nativeTheme.shouldUseDarkColors
+    let isFollowingSystem = autoSwitchTheme === 1
+
     ipcMain.on('broadcast-preferences-changed', change => {
+      // Track autoSwitchTheme changes at runtime
+      if (change.autoSwitchTheme !== undefined) {
+        isFollowingSystem = change.autoSwitchTheme === 1
+        if (isFollowingSystem) {
+          nativeTheme.themeSource = 'system'
+          // Immediately sync to current system theme
+          const systemIsDark = nativeTheme.shouldUseDarkColors
+          if (systemIsDark !== isDarkMode) {
+            isDarkMode = systemIsDark
+            selectTheme(systemIsDark ? 'dark' : 'light')
+          }
+        }
+      }
       // Set Chromium's color for native elements after theme change.
       if (change.theme) {
         const isDarkTheme = /dark/i.test(change.theme)
         if (isDarkMode !== isDarkTheme) {
           isDarkMode = isDarkTheme
-          nativeTheme.themeSource = isDarkTheme ? 'dark' : 'light'
-        } else if (nativeTheme.themeSource === 'system') {
-          // Need to set dark or light theme because we set `system` to get the current system theme.
-          nativeTheme.themeSource = isDarkMode ? 'dark' : 'light'
+          if (!isFollowingSystem) {
+            nativeTheme.themeSource = isDarkTheme ? 'dark' : 'light'
+          }
         }
+      }
+    })
+
+    // Live-follow system theme changes (light/dark mode toggle in System Settings).
+    nativeTheme.on('updated', () => {
+      if (!isFollowingSystem) return
+      const systemIsDark = nativeTheme.shouldUseDarkColors
+      if (systemIsDark !== isDarkMode) {
+        isDarkMode = systemIsDark
+        selectTheme(systemIsDark ? 'dark' : 'light')
       }
     })
 

--- a/src/main/menu/actions/view.js
+++ b/src/main/menu/actions/view.js
@@ -68,6 +68,10 @@ export const toggleTypewriterMode = win => {
   toggleTypeMode(win, 'typewriter')
 }
 
+export const toggleFullWysiwyg = win => {
+  toggleTypeMode(win, 'fullWysiwyg')
+}
+
 export const reloadImageCache = win => {
   if (win && win.webContents) {
     win.webContents.send('mt::invalidate-image-cache')
@@ -129,6 +133,9 @@ export const viewLayoutChanged = (applicationMenu, changes) => {
         break
       case 'focus':
         changeMenuByName(focusModeMenuItemId, value)
+        break
+      case 'fullWysiwyg':
+        changeMenuByName('fullWysiwygMenuItem', value)
         break
     }
   }

--- a/src/main/menu/templates/view.js
+++ b/src/main/menu/templates/view.js
@@ -30,6 +30,14 @@ export default function (keybindings) {
         actions.toggleTypewriterMode(focusedWindow)
       }
     }, {
+      id: 'fullWysiwygMenuItem',
+      label: 'Full WYSIWYG Mode',
+      type: 'checkbox',
+      checked: false,
+      click (item, focusedWindow) {
+        actions.toggleFullWysiwyg(focusedWindow)
+      }
+    }, {
       id: 'focusModeMenuItem',
       label: 'Focus Mode',
       accelerator: keybindings.getAccelerator('view.focus-mode'),

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -317,7 +317,7 @@
   },
   "autoSwitchTheme": {
     "description": "Theme--Automatically adjust application theme according system.",
-    "default": 2,
+    "default": 1,
     "enum": [
       0,
       1,

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -290,7 +290,11 @@ export const MUYA_DEFAULT_OPTION = Object.freeze({
   isGitlabCompatibilityEnabled: false,
 
   // Whether HTML rendering is disabled or not.
-  disableHtml: true
+  disableHtml: true,
+
+  // Full WYSIWYG mode: never show raw markdown syntax to the user.
+  // The document renders like a word processor while saving as markdown.
+  fullWysiwyg: false
 })
 
 // export const DIAGRAM_TEMPLATE = Object.freeze({

--- a/src/muya/lib/contentState/backspaceCtrl.js
+++ b/src/muya/lib/contentState/backspaceCtrl.js
@@ -120,6 +120,26 @@ const backspaceCtrl = ContentState => {
       return
     }
 
+    // In full WYSIWYG mode, handle backspace at format boundaries.
+    // When cursor is at the start of a formatted span (e.g. just inside **bold**),
+    // remove the formatting instead of deleting a character.
+    if (this.muya.options.fullWysiwyg && start.key === end.key && start.offset === end.offset) {
+      const block = this.getBlock(start.key)
+      if (block && block.text) {
+        const tokens = tokenizer(block.text, { options: this.muya.options })
+        for (const token of tokens) {
+          if (!/strong|em|del|inline_code|inline_math/.test(token.type)) continue
+          const markerLen = (token.type === 'strong' || token.type === 'del') ? 2 : 1
+          // Cursor is right after the opening marker
+          if (start.offset === token.range.start + markerLen) {
+            event.preventDefault()
+            this.format(token.type) // Toggle format off
+            return this.partialRender()
+          }
+        }
+      }
+    }
+
     // handle delete selected image
     if (this.selectedImage) {
       event.preventDefault()

--- a/src/muya/lib/contentState/codeBlockCtrl.js
+++ b/src/muya/lib/contentState/codeBlockCtrl.js
@@ -93,6 +93,11 @@ const codeBlockCtrl = ContentState => {
    * [codeBlockUpdate if block updated to `pre` return true, else return false]
    */
   ContentState.prototype.codeBlockUpdate = function (block, code = '', lang) {
+    // In full WYSIWYG mode, don't auto-detect code fences from typing.
+    // Code blocks are created via toolbar or keyboard shortcuts (lang param).
+    if (!lang && this.muya.options.fullWysiwyg) {
+      return false
+    }
     if (block.type === 'span') {
       block = this.getParent(block)
     }

--- a/src/muya/lib/contentState/updateCtrl.js
+++ b/src/muya/lib/contentState/updateCtrl.js
@@ -22,6 +22,7 @@ const updateCtrl = ContentState => {
   }
 
   ContentState.prototype.checkNeedRender = function (cursor = this.cursor) {
+    if (this.muya.options.fullWysiwyg) return false
     const { labels } = this.stateRender
     const { start: cStart, end: cEnd, anchor, focus } = cursor
     const startBlock = this.getBlock(cStart ? cStart.key : anchor.key)
@@ -64,6 +65,11 @@ const updateCtrl = ContentState => {
    * block must be span block.
    */
   ContentState.prototype.checkInlineUpdate = function (block) {
+    // In full WYSIWYG mode, don't auto-transform typed markdown syntax into blocks.
+    // Users must use the toolbar or keyboard shortcuts to change block types.
+    if (this.muya.options.fullWysiwyg) {
+      return false
+    }
     // table cell can not have blocks in it
     if (/figure/.test(block.type)) {
       return false

--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -70,6 +70,9 @@ class StateRender {
   }
 
   getClassName (outerClass, block, token, cursor) {
+    if (this.muya.options.fullWysiwyg) {
+      return outerClass || CLASS_OR_ID.AG_HIDE
+    }
     return outerClass || (this.checkConflicted(block, token, cursor) ? CLASS_OR_ID.AG_GRAY : CLASS_OR_ID.AG_HIDE)
   }
 

--- a/src/renderer/components/editorWithTabs/editor.vue
+++ b/src/renderer/components/editorWithTabs/editor.vue
@@ -172,7 +172,9 @@ export default {
       // edit modes
       typewriter: state => state.preferences.typewriter,
       focus: state => state.preferences.focus,
-      sourceCode: state => state.preferences.sourceCode
+      sourceCode: state => state.preferences.sourceCode,
+
+      fullWysiwyg: state => state.preferences.fullWysiwyg
     })
   },
 
@@ -356,6 +358,16 @@ export default {
       }
     },
 
+    fullWysiwyg: function (value, oldValue) {
+      const { editor } = this
+      if (value !== oldValue && editor) {
+        editor.setOptions({
+          fullWysiwyg: value,
+          autoPairMarkdownSyntax: value ? false : this.autoPairMarkdownSyntax
+        }, true)
+      }
+    },
+
     hideLinkPopup: function (value, oldValue) {
       const { editor } = this
       if (value !== oldValue && editor) {
@@ -511,7 +523,6 @@ export default {
         markdown,
         preferLooseListItem,
         autoPairBracket,
-        autoPairMarkdownSyntax,
         trimUnnecessaryCodeBlockEmptyLines,
         autoPairQuote,
         bulletListMarker,
@@ -530,6 +541,8 @@ export default {
         hideLinkPopup,
         autoCheck,
         sequenceTheme,
+        fullWysiwyg: this.fullWysiwyg,
+        autoPairMarkdownSyntax: this.fullWysiwyg ? false : autoPairMarkdownSyntax,
         spellcheckEnabled: spellcheckerEnabled,
         imageAction: this.imageAction.bind(this),
         imagePathPicker: this.imagePathPicker.bind(this),
@@ -572,6 +585,7 @@ export default {
       bus.$on('print-service-clearup', this.handlePrintServiceClearup)
       bus.$on('paragraph', this.handleEditParagraph)
       bus.$on('format', this.handleInlineFormat)
+      bus.$on('insert-table', () => this.handleEditParagraph('table'))
       bus.$on('searchValue', this.handleSearch)
       bus.$on('replaceValue', this.handReplace)
       bus.$on('find-action', this.handleFindAction)
@@ -656,6 +670,7 @@ export default {
 
       this.editor.on('selectionFormats', formats => {
         this.$store.dispatch('SELECTION_FORMATS', formats)
+        bus.$emit('selectionFormats', formats)
       })
 
       document.addEventListener('keyup', this.keyup)

--- a/src/renderer/components/editorWithTabs/index.vue
+++ b/src/renderer/components/editorWithTabs/index.vue
@@ -4,6 +4,7 @@
       :style="{'max-width': showSideBar ? `calc(100vw - ${sideBarWidth}px` : '100vw' }"
     >
       <tabs v-show="showTabBar"></tabs>
+      <wysiwyg-toolbar></wysiwyg-toolbar>
       <div class="container">
         <editor
           :markdown="markdown"
@@ -28,6 +29,7 @@ import Tabs from './tabs.vue'
 import Editor from './editor.vue'
 import SourceCode from './sourceCode.vue'
 import TabNotifications from './notifications.vue'
+import WysiwygToolbar from './toolbar.vue'
 
 export default {
   props: {
@@ -62,7 +64,8 @@ export default {
     Tabs,
     Editor,
     SourceCode,
-    TabNotifications
+    TabNotifications,
+    WysiwygToolbar
   },
   computed: {
     ...mapState({

--- a/src/renderer/components/editorWithTabs/toolbar.vue
+++ b/src/renderer/components/editorWithTabs/toolbar.vue
@@ -1,129 +1,143 @@
 <template>
-  <div class="wysiwyg-toolbar" v-if="fullWysiwyg && !sourceCode">
+  <div class="wysiwyg-toolbar" v-if="fullWysiwyg">
+    <template v-if="!sourceCode">
+      <div class="toolbar-group">
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('strong') }"
+          title="Bold (Cmd+B)"
+          @click="applyFormat('strong')"
+        >
+          <strong>B</strong>
+        </button>
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('em') }"
+          title="Italic (Cmd+I)"
+          @click="applyFormat('em')"
+        >
+          <em>I</em>
+        </button>
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('u') }"
+          title="Underline (Cmd+U)"
+          @click="applyFormat('u')"
+        >
+          <u>U</u>
+        </button>
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('del') }"
+          title="Strikethrough (Cmd+D)"
+          @click="applyFormat('del')"
+        >
+          <del>S</del>
+        </button>
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('mark') }"
+          title="Highlight (Shift+Cmd+H)"
+          @click="applyFormat('mark')"
+        >
+          <span class="highlight-icon">H</span>
+        </button>
+        <button
+          class="toolbar-btn"
+          :class="{ active: isFormatActive('inline_code') }"
+          title="Inline Code (Cmd+`)"
+          @click="applyFormat('inline_code')"
+        >
+          <code>&lt;/&gt;</code>
+        </button>
+      </div>
+      <div class="toolbar-separator"></div>
+      <div class="toolbar-group">
+        <select
+          class="toolbar-select"
+          :value="currentBlockType"
+          @change="applyParagraph($event.target.value)"
+        >
+          <option value="paragraph">Paragraph</option>
+          <option value="heading 1">Heading 1</option>
+          <option value="heading 2">Heading 2</option>
+          <option value="heading 3">Heading 3</option>
+          <option value="heading 4">Heading 4</option>
+          <option value="heading 5">Heading 5</option>
+          <option value="heading 6">Heading 6</option>
+        </select>
+      </div>
+      <div class="toolbar-separator"></div>
+      <div class="toolbar-group">
+        <button
+          class="toolbar-btn"
+          title="Bullet List"
+          @click="applyParagraph('ul-bullet')"
+        >&#8226;</button>
+        <button
+          class="toolbar-btn"
+          title="Numbered List"
+          @click="applyParagraph('ol-order')"
+        >1.</button>
+        <button
+          class="toolbar-btn"
+          title="Task List"
+          @click="applyParagraph('ul-task')"
+        >&#9745;</button>
+        <button
+          class="toolbar-btn"
+          title="Block Quote"
+          @click="applyParagraph('blockquote')"
+        >&#8220;</button>
+      </div>
+      <div class="toolbar-separator"></div>
+      <div class="toolbar-group">
+        <button
+          class="toolbar-btn"
+          title="Insert Link (Cmd+L)"
+          @click="applyFormat('link')"
+        >&#128279;</button>
+        <button
+          class="toolbar-btn"
+          title="Insert Image (Shift+Cmd+I)"
+          @click="applyFormat('image')"
+        >&#128247;</button>
+        <button
+          class="toolbar-btn"
+          title="Insert Table"
+          @click="insertTable"
+        >&#9638;</button>
+        <button
+          class="toolbar-btn"
+          title="Code Block"
+          @click="applyParagraph('pre')"
+        >{ }</button>
+        <button
+          class="toolbar-btn"
+          title="Horizontal Rule"
+          @click="applyParagraph('hr')"
+        >&mdash;</button>
+      </div>
+      <div class="toolbar-separator"></div>
+      <div class="toolbar-group">
+        <button
+          class="toolbar-btn"
+          title="Clear Formatting (Shift+Cmd+R)"
+          @click="applyFormat('clear')"
+        >&#10006;</button>
+      </div>
+    </template>
+    <div class="toolbar-spacer"></div>
     <div class="toolbar-group">
       <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('strong') }"
-        title="Bold (Cmd+B)"
-        @click="applyFormat('strong')"
+        class="toolbar-btn toolbar-toggle"
+        :class="{ active: sourceCode }"
+        :title="sourceCode ? 'Switch to rendered view' : 'Switch to raw markdown'"
+        @click="toggleSourceCode"
       >
-        <strong>B</strong>
+        <span v-if="sourceCode" class="toggle-label">Raw</span>
+        <span v-else class="toggle-label">Raw</span>
       </button>
-      <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('em') }"
-        title="Italic (Cmd+I)"
-        @click="applyFormat('em')"
-      >
-        <em>I</em>
-      </button>
-      <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('u') }"
-        title="Underline (Cmd+U)"
-        @click="applyFormat('u')"
-      >
-        <u>U</u>
-      </button>
-      <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('del') }"
-        title="Strikethrough (Cmd+D)"
-        @click="applyFormat('del')"
-      >
-        <del>S</del>
-      </button>
-      <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('mark') }"
-        title="Highlight (Shift+Cmd+H)"
-        @click="applyFormat('mark')"
-      >
-        <span class="highlight-icon">H</span>
-      </button>
-      <button
-        class="toolbar-btn"
-        :class="{ active: isFormatActive('inline_code') }"
-        title="Inline Code (Cmd+`)"
-        @click="applyFormat('inline_code')"
-      >
-        <code>&lt;/&gt;</code>
-      </button>
-    </div>
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      <select
-        class="toolbar-select"
-        :value="currentBlockType"
-        @change="applyParagraph($event.target.value)"
-      >
-        <option value="paragraph">Paragraph</option>
-        <option value="heading 1">Heading 1</option>
-        <option value="heading 2">Heading 2</option>
-        <option value="heading 3">Heading 3</option>
-        <option value="heading 4">Heading 4</option>
-        <option value="heading 5">Heading 5</option>
-        <option value="heading 6">Heading 6</option>
-      </select>
-    </div>
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      <button
-        class="toolbar-btn"
-        title="Bullet List"
-        @click="applyParagraph('ul-bullet')"
-      >&#8226;</button>
-      <button
-        class="toolbar-btn"
-        title="Numbered List"
-        @click="applyParagraph('ol-order')"
-      >1.</button>
-      <button
-        class="toolbar-btn"
-        title="Task List"
-        @click="applyParagraph('ul-task')"
-      >&#9745;</button>
-      <button
-        class="toolbar-btn"
-        title="Block Quote"
-        @click="applyParagraph('blockquote')"
-      >&#8220;</button>
-    </div>
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      <button
-        class="toolbar-btn"
-        title="Insert Link (Cmd+L)"
-        @click="applyFormat('link')"
-      >&#128279;</button>
-      <button
-        class="toolbar-btn"
-        title="Insert Image (Shift+Cmd+I)"
-        @click="applyFormat('image')"
-      >&#128247;</button>
-      <button
-        class="toolbar-btn"
-        title="Insert Table"
-        @click="insertTable"
-      >&#9638;</button>
-      <button
-        class="toolbar-btn"
-        title="Code Block"
-        @click="applyParagraph('pre')"
-      >{ }</button>
-      <button
-        class="toolbar-btn"
-        title="Horizontal Rule"
-        @click="applyParagraph('hr')"
-      >&mdash;</button>
-    </div>
-    <div class="toolbar-separator"></div>
-    <div class="toolbar-group">
-      <button
-        class="toolbar-btn"
-        title="Clear Formatting (Shift+Cmd+R)"
-        @click="applyFormat('clear')"
-      >&#10006;</button>
     </div>
   </div>
 </template>
@@ -184,6 +198,10 @@ export default {
 
     insertTable () {
       bus.$emit('insert-table')
+    },
+
+    toggleSourceCode () {
+      bus.$emit('view:toggle-view-entry', 'sourceCode')
     }
   }
 }
@@ -270,5 +288,29 @@ export default {
     padding: 0 3px;
     border-radius: 2px;
     color: #333;
+  }
+
+  .toolbar-spacer {
+    flex: 1;
+  }
+
+  .toolbar-toggle {
+    width: auto;
+    padding: 0 8px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    opacity: 0.5;
+  }
+
+  .toolbar-toggle.active {
+    opacity: 1;
+    background: var(--themeColor, #409eff);
+    color: #fff;
+  }
+
+  .toggle-label {
+    pointer-events: none;
   }
 </style>

--- a/src/renderer/components/editorWithTabs/toolbar.vue
+++ b/src/renderer/components/editorWithTabs/toolbar.vue
@@ -1,0 +1,274 @@
+<template>
+  <div class="wysiwyg-toolbar" v-if="fullWysiwyg && !sourceCode">
+    <div class="toolbar-group">
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('strong') }"
+        title="Bold (Cmd+B)"
+        @click="applyFormat('strong')"
+      >
+        <strong>B</strong>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('em') }"
+        title="Italic (Cmd+I)"
+        @click="applyFormat('em')"
+      >
+        <em>I</em>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('u') }"
+        title="Underline (Cmd+U)"
+        @click="applyFormat('u')"
+      >
+        <u>U</u>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('del') }"
+        title="Strikethrough (Cmd+D)"
+        @click="applyFormat('del')"
+      >
+        <del>S</del>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('mark') }"
+        title="Highlight (Shift+Cmd+H)"
+        @click="applyFormat('mark')"
+      >
+        <span class="highlight-icon">H</span>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: isFormatActive('inline_code') }"
+        title="Inline Code (Cmd+`)"
+        @click="applyFormat('inline_code')"
+      >
+        <code>&lt;/&gt;</code>
+      </button>
+    </div>
+    <div class="toolbar-separator"></div>
+    <div class="toolbar-group">
+      <select
+        class="toolbar-select"
+        :value="currentBlockType"
+        @change="applyParagraph($event.target.value)"
+      >
+        <option value="paragraph">Paragraph</option>
+        <option value="heading 1">Heading 1</option>
+        <option value="heading 2">Heading 2</option>
+        <option value="heading 3">Heading 3</option>
+        <option value="heading 4">Heading 4</option>
+        <option value="heading 5">Heading 5</option>
+        <option value="heading 6">Heading 6</option>
+      </select>
+    </div>
+    <div class="toolbar-separator"></div>
+    <div class="toolbar-group">
+      <button
+        class="toolbar-btn"
+        title="Bullet List"
+        @click="applyParagraph('ul-bullet')"
+      >&#8226;</button>
+      <button
+        class="toolbar-btn"
+        title="Numbered List"
+        @click="applyParagraph('ol-order')"
+      >1.</button>
+      <button
+        class="toolbar-btn"
+        title="Task List"
+        @click="applyParagraph('ul-task')"
+      >&#9745;</button>
+      <button
+        class="toolbar-btn"
+        title="Block Quote"
+        @click="applyParagraph('blockquote')"
+      >&#8220;</button>
+    </div>
+    <div class="toolbar-separator"></div>
+    <div class="toolbar-group">
+      <button
+        class="toolbar-btn"
+        title="Insert Link (Cmd+L)"
+        @click="applyFormat('link')"
+      >&#128279;</button>
+      <button
+        class="toolbar-btn"
+        title="Insert Image (Shift+Cmd+I)"
+        @click="applyFormat('image')"
+      >&#128247;</button>
+      <button
+        class="toolbar-btn"
+        title="Insert Table"
+        @click="insertTable"
+      >&#9638;</button>
+      <button
+        class="toolbar-btn"
+        title="Code Block"
+        @click="applyParagraph('pre')"
+      >{ }</button>
+      <button
+        class="toolbar-btn"
+        title="Horizontal Rule"
+        @click="applyParagraph('hr')"
+      >&mdash;</button>
+    </div>
+    <div class="toolbar-separator"></div>
+    <div class="toolbar-group">
+      <button
+        class="toolbar-btn"
+        title="Clear Formatting (Shift+Cmd+R)"
+        @click="applyFormat('clear')"
+      >&#10006;</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import bus from '@/bus'
+
+export default {
+  data () {
+    return {
+      activeFormats: [],
+      currentBlockType: 'paragraph'
+    }
+  },
+
+  computed: {
+    ...mapState({
+      fullWysiwyg: state => state.preferences.fullWysiwyg,
+      sourceCode: state => state.preferences.sourceCode
+    })
+  },
+
+  created () {
+    bus.$on('selectionFormats', this.handleSelectionFormats)
+  },
+
+  beforeDestroy () {
+    bus.$off('selectionFormats', this.handleSelectionFormats)
+  },
+
+  methods: {
+    isFormatActive (type) {
+      return this.activeFormats.some(f => f.type === type || (f.type === 'html_tag' && f.tag === type))
+    },
+
+    handleSelectionFormats (formats) {
+      if (formats && formats.formats) {
+        this.activeFormats = formats.formats
+      }
+      if (formats && formats.block) {
+        const { type } = formats.block
+        if (/^h(\d)$/.test(type)) {
+          this.currentBlockType = `heading ${type.charAt(1)}`
+        } else {
+          this.currentBlockType = 'paragraph'
+        }
+      }
+    },
+
+    applyFormat (type) {
+      bus.$emit('format', type)
+    },
+
+    applyParagraph (type) {
+      bus.$emit('paragraph', type)
+    },
+
+    insertTable () {
+      bus.$emit('insert-table')
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .wysiwyg-toolbar {
+    display: flex;
+    align-items: center;
+    padding: 4px 12px;
+    border-bottom: 1px solid var(--floatBorderColor, #e5e5e5);
+    background: var(--editorBgColor, #fff);
+    flex-shrink: 0;
+    gap: 2px;
+    user-select: none;
+    -webkit-app-region: no-drag;
+    overflow-x: auto;
+  }
+
+  .toolbar-group {
+    display: flex;
+    align-items: center;
+    gap: 1px;
+  }
+
+  .toolbar-separator {
+    width: 1px;
+    height: 20px;
+    background: var(--floatBorderColor, #ddd);
+    margin: 0 6px;
+    flex-shrink: 0;
+  }
+
+  .toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--editorColor, #333);
+    font-size: 13px;
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.15s;
+  }
+
+  .toolbar-btn:hover {
+    background: var(--sideBarItemHoverBgColor, rgba(0,0,0,0.06));
+  }
+
+  .toolbar-btn.active {
+    background: var(--themeColor, #409eff);
+    color: #fff;
+  }
+
+  .toolbar-btn code {
+    font-size: 11px;
+    font-family: monospace;
+    background: none;
+    padding: 0;
+  }
+
+  .toolbar-select {
+    height: 28px;
+    border: 1px solid var(--floatBorderColor, #ddd);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--editorColor, #333);
+    font-size: 12px;
+    padding: 0 4px;
+    cursor: pointer;
+    outline: none;
+  }
+
+  .toolbar-select:focus {
+    border-color: var(--themeColor, #409eff);
+  }
+
+  .highlight-icon {
+    background: #fef3a7;
+    padding: 0 3px;
+    border-radius: 2px;
+    color: #333;
+  }
+</style>

--- a/src/renderer/prefComponents/theme/config.js
+++ b/src/renderer/prefComponents/theme/config.js
@@ -20,12 +20,12 @@ export const themes = [
 ]
 
 export const autoSwitchThemeOptions = [{
-  label: 'Adjust theme at startup', // Always
+  label: 'Adjust theme at startup',
   value: 0
-}, /* {
-  label: 'Only at runtime',
+}, {
+  label: 'Always follow system',
   value: 1
-}, */ {
+}, {
   label: 'Never',
   value: 2
 }]

--- a/src/renderer/store/preferences.js
+++ b/src/renderer/store/preferences.js
@@ -54,11 +54,14 @@ const state = {
   sequenceTheme: 'hand',
 
   theme: 'light',
-  autoSwitchTheme: 2,
+  autoSwitchTheme: 1,
 
   spellcheckerEnabled: false,
   spellcheckerNoUnderline: false,
   spellcheckerLanguage: 'en-US',
+
+  // Full WYSIWYG mode - hides all raw markdown syntax from the user
+  fullWysiwyg: false,
 
   // Default values that are overwritten with the entries below.
   sideBarVisibility: false,


### PR DESCRIPTION
## Summary

- **Full WYSIWYG mode** (View > Full WYSIWYG Mode): Hides all raw markdown syntax from the user. The document renders like a word processor while editing, with formatting done via toolbar/keyboard shortcuts. The underlying file remains standard markdown. Fully opt-in - existing behavior unchanged when off.

- **Live system theme following**: The app now tracks macOS dark/light mode changes in real-time instead of only at startup. Adds "Always follow system" option (new default) to the theme auto-switch dropdown. Previously the runtime option was commented out and `nativeTheme.themeSource` was locked to explicit values, preventing Electron from receiving OS theme change events.

### WYSIWYG details (commit 1)
- `getClassName()` always returns `AG_HIDE` when `fullWysiwyg` is enabled - all 30+ inline renderers automatically hide their syntax markers
- `checkNeedRender()` and `checkInlineUpdate()` short-circuit to prevent auto-transforms from typed markdown syntax
- `codeBlockUpdate()` skips auto-detection of typed fences (code blocks created via toolbar only)
- Format-boundary-aware backspace handling (backspace at start of bold removes formatting instead of deleting)
- New persistent formatting toolbar component with inline format buttons, block type dropdown, and insert controls
- `autoPairMarkdownSyntax` suppressed when WYSIWYG is active

### Theme details (commit 2)
- `nativeTheme.themeSource` set to `'system'` when following system theme, enabling the `updated` event
- `nativeTheme.on('updated')` listener calls `selectTheme()` on OS theme changes
- Handles runtime `autoSwitchTheme` preference changes
- Default changed from "Never" (2) to "Always follow system" (1)

## Test plan
- [ ] Enable Full WYSIWYG via View menu, open a markdown file with headings/bold/links/code - verify no raw syntax visible
- [ ] Click into formatted text - verify markers stay hidden (no `##` or `**` appearing)
- [ ] Use toolbar to apply bold, italic, heading changes - verify formatting applies correctly
- [ ] Type `#` or `**` in WYSIWYG mode - verify no auto-transform occurs
- [ ] Disable Full WYSIWYG mode - verify normal semi-WYSIWYG behavior returns
- [ ] Set theme to "Always follow system", toggle macOS dark mode - verify instant theme switch
- [ ] Set theme to "Never", toggle macOS dark mode - verify no theme change
- [ ] Verify undo/redo works correctly with toolbar-initiated format changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)