### PR TITLE
fix: avoid false "unsaved" prompt when closing file opened from search without editing

### DIFF
--- a/src/renderer/store/editor.js
+++ b/src/renderer/store/editor.js
@@ -193,6 +193,11 @@ const mutations = {
       state.currentFile.isSaved = status
     }
   },
+  CLEAR_IGNORE_NEXT_CONTENT_CHANGE_FOR_SAVE_STATUS (state) {
+    if (hasKeys(state.currentFile)) {
+      state.currentFile.ignoreNextContentChangeForSaveStatus = false
+    }
+  },
   SET_SAVE_STATUS_WHEN_REMOVE (state, { pathname }) {
     state.tabs.forEach(f => {
       if (f.pathname === pathname) {
@@ -868,6 +873,9 @@ const actions = {
 
     const { markdown, isMixedLineEndings } = markdownDocument
     const docState = createDocumentState(Object.assign(markdownDocument, options))
+    // Ignore the first content change from Muya after setMarkdown (e.g. open from search).
+    // Muya re-serializes content and may differ from disk, which would wrongly set isSaved = false.
+    docState.ignoreNextContentChangeForSaveStatus = true
     const { id, cursor } = docState
 
     if (selected) {
@@ -957,22 +965,34 @@ const actions = {
       commit('SET_TOC', toc)
     }
 
-    // Change save status/save to file only when the markdown changed!
-    if (markdown !== oldMarkdown) {
-      commit('SET_SAVE_STATUS', false)
+    // Change save status/save to file only when the markdown actually changed.
+    // Compare normalized form so that programmatic setMarkdown (e.g. open from search)
+    // which only differs in trailing newlines won't be treated as user edit.
+    const oldMarkdownNormalized = adjustTrailingNewlines(oldMarkdown, trimTrailingNewline)
+    if (markdown !== oldMarkdownNormalized) {
+      // Skip setting unsaved when this change came from programmatic setMarkdown (open from search).
+      // Muya's setMarkdown triggers dispatchChange with re-serialized content that can differ from disk.
+      if (state.currentFile.ignoreNextContentChangeForSaveStatus) {
+        commit('CLEAR_IGNORE_NEXT_CONTENT_CHANGE_FOR_SAVE_STATUS')
+      } else {
+        commit('SET_SAVE_STATUS', false)
 
-      // Save file is auto save is enable and file exist on disk.
-      if (pathname && autoSave) {
-        const options = getOptionsFromState(state.currentFile)
-        dispatch('HANDLE_AUTO_SAVE', {
-          id: currentId,
-          filename,
-          pathname,
-          markdown,
-          options
-        })
+        // Save file is auto save is enable and file exist on disk.
+        if (pathname && autoSave) {
+          const options = getOptionsFromState(state.currentFile)
+          dispatch('HANDLE_AUTO_SAVE', {
+            id: currentId,
+            filename,
+            pathname,
+            markdown,
+            options
+          })
+        }
       }
     }
+    // Always clear so that the flag only protects the very first change; otherwise when the
+    // first change had same content we would never clear and would wrongly ignore a later edit.
+    commit('CLEAR_IGNORE_NEXT_CONTENT_CHANGE_FOR_SAVE_STATUS')
   },
 
   HANDLE_AUTO_SAVE ({ commit, state, rootState }, { id, filename, pathname, markdown, options }) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

**Problem**  
After opening a folder containing files in the editor, if you open a file via the global search on the left, close it without making any edits, a prompt "Do you want to save changes?" will still pop up. The tab was incorrectly marked as unsaved because Muya's `setMarkdown()` triggers a `change` event with re-serialized content that can differ from the on-disk content (e.g. trailing newlines, line endings).

**Solution**  
1. **Normalized comparison**  
   When deciding whether content changed, compare both the incoming markdown and the previous markdown using the same trailing-newline normalization (`adjustTrailingNewlines`), so purely normalization differences do not set `isSaved = false`.

2. **Ignore first content change after opening**  
   For tabs created via `NEW_TAB_WITH_CONTENT` (e.g. open from search or file tree), set a flag `ignoreNextContentChangeForSaveStatus` so the first `change` event from Muya after `setMarkdown()` is not treated as a user edit. The flag is always cleared after handling each content change so subsequent real edits are still detected.

**Files changed**  
- `src/renderer/store/editor.js`: added mutation `CLEAR_IGNORE_NEXT_CONTENT_CHANGE_FOR_SAVE_STATUS`; set `ignoreNextContentChangeForSaveStatus` in `NEW_TAB_WITH_CONTENT`; in `LISTEN_FOR_CONTENT_CHANGE`, compare using normalized old markdown and skip setting unsaved when the flag is set; clear the flag after every content change.

---

### 中文说明

**问题**  
在编辑器中打开一个拥有文件的文件夹后，通过左侧全局搜索打开文件后，未做任何编辑直接关闭，仍会弹出「是否保存更改」的提示。原因是 Muya 的 `setMarkdown()` 会触发一次 `change` 事件，其内容为重新序列化后的 markdown，与磁盘内容可能不完全一致（如末尾换行、换行符等），导致被误判为未保存。

**修复**  
1. **归一化后再比较**  
   判断内容是否变化时，对「当前内容」和「打开时的内容」都做相同的末尾换行归一化再比较，避免仅因归一化差异被标为未保存。  
2. **打开后忽略第一次 content change**  
   对通过 `NEW_TAB_WITH_CONTENT` 打开的标签（如从搜索/文件树打开），设置 `ignoreNextContentChangeForSaveStatus`，使 Muya 在 `setMarkdown()` 之后触发的第一次 `change` 不视为用户编辑。每次处理 content change 后都会清除该标记，确保之后的真实编辑仍会被正确标为未保存。

**涉及文件**  
- `src/renderer/store/editor.js`：新增 mutation、在打开带内容的 tab 时设标记、在 content change 中做归一化比较与“忽略首次”逻辑，并在每次处理完后清除标记。