### PR TITLE
fix: set up msbuild for windows ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,16 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
-      # Workaround: Fix native build failure due to outdated node-gyp version.
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Check MSVC tools
+        run: |
+          where.exe cl
+          where.exe msbuild
+        shell: pwsh
+
+      # Ensure electron-rebuild can invoke node-gyp with the runner's native toolchain.
       - name: Fix node-gyp
         run: |
           npm install --global node-gyp@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,16 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
-      # Workaround: Fix native build failure due to outdated node-gyp version.
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Check MSVC tools
+        run: |
+          where.exe cl
+          where.exe msbuild
+        shell: pwsh
+
+      # Ensure electron-rebuild can invoke node-gyp with the runner's native toolchain.
       - name: Fix node-gyp
         run: |
           npm install --global node-gyp@latest

--- a/tools/commit-push-pr.ps1
+++ b/tools/commit-push-pr.ps1
@@ -1,0 +1,94 @@
+<# Commit current changes, push the current branch, and create a PR against upstream. #>
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$CommitMessage,
+
+  [string]$PullRequestTitle = '',
+
+  [string]$PullRequestBody = '',
+
+  [string]$PushRemote = 'lorraine40',
+
+  [string]$BaseRepo = 'marktext/marktext',
+
+  [string]$BaseBranch = 'develop',
+
+  [switch]$SkipPullRequest
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [string[]]$Arguments = @()
+  )
+
+  $display = @($FilePath) + $Arguments
+  Write-Host (">> {0}" -f ($display -join ' '))
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw ("Command failed with exit code {0}: {1}" -f $LASTEXITCODE, $FilePath)
+  }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$branch = (git branch --show-current).Trim()
+if (-not $branch) {
+  throw 'Could not determine the current git branch.'
+}
+
+$statusLines = @(git status --short)
+if ($statusLines.Count -eq 0) {
+  throw 'Working tree is clean. Nothing to commit.'
+}
+
+if (-not $PullRequestTitle) {
+  $PullRequestTitle = $CommitMessage
+}
+
+Invoke-Step 'git' @('add', '--all')
+Invoke-Step 'git' @('commit', '-m', $CommitMessage)
+Invoke-Step 'git' @('push', $PushRemote, $branch)
+
+if ($SkipPullRequest) {
+  Write-Host 'Skipped pull request creation.'
+  exit 0
+}
+
+$headRef = "{0}:{1}" -f $PushRemote, $branch
+$prLookup = gh pr list --repo $BaseRepo --head $headRef --base $BaseBranch --json number,url --state open
+if ($LASTEXITCODE -ne 0) {
+  throw 'Failed to query existing pull requests.'
+}
+
+$existingPrs = $prLookup | ConvertFrom-Json
+if ($existingPrs.Count -gt 0) {
+  Write-Host ("Open pull request already exists: {0}" -f $existingPrs[0].url)
+  exit 0
+}
+
+$prArgs = @(
+  'pr',
+  'create',
+  '--repo', $BaseRepo,
+  '--base', $BaseBranch,
+  '--head', $headRef,
+  '--title', $PullRequestTitle
+)
+
+if ($PullRequestBody) {
+  $prArgs += @('--body', $PullRequestBody)
+} else {
+  $prArgs += '--fill'
+}
+
+Write-Host (">> gh {0}" -f ($prArgs -join ' '))
+& gh @prArgs
+if ($LASTEXITCODE -ne 0) {
+  throw 'Failed to create pull request.'
+}

--- a/tools/commit-push-pr.ps1
+++ b/tools/commit-push-pr.ps1
@@ -7,7 +7,7 @@ param(
 
   [string]$PullRequestBody = '',
 
-  [string]$PushRemote = 'lorraine40',
+  [string]$PushRemote = '',
 
   [string]$BaseRepo = 'marktext/marktext',
 
@@ -34,6 +34,53 @@ function Invoke-Step {
   }
 }
 
+function Get-RepositorySlug {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RemoteName
+  )
+
+  $remoteUrl = (git remote get-url $RemoteName).Trim()
+  if (-not $remoteUrl) {
+    throw ("Could not resolve remote URL for '{0}'." -f $RemoteName)
+  }
+
+  if ($remoteUrl -match 'github\.com[:/](.+?)/(.+?)(?:\.git)?$') {
+    return "{0}/{1}" -f $matches[1], $matches[2]
+  }
+
+  throw ("Remote '{0}' does not point to a GitHub repository." -f $RemoteName)
+}
+
+function Resolve-PushRemote {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetRepo
+  )
+
+  $remotes = @(git remote)
+  foreach ($remote in $remotes) {
+    $slug = Get-RepositorySlug -RemoteName $remote
+    $repoJson = gh repo view $slug --json isFork,parent,nameWithOwner 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $repoJson) {
+      continue
+    }
+
+    $repo = $repoJson | ConvertFrom-Json
+    $parentSlug = if ($repo.parent) {
+      "{0}/{1}" -f $repo.parent.owner.login, $repo.parent.name
+    } else {
+      ''
+    }
+
+    if ($repo.isFork -and $parentSlug -eq $TargetRepo) {
+      return $remote
+    }
+  }
+
+  throw ("Could not find a git remote that is a fork of {0}. Pass -PushRemote explicitly." -f $TargetRepo)
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
 Set-Location $repoRoot
 
@@ -49,6 +96,14 @@ if ($statusLines.Count -eq 0) {
 
 if (-not $PullRequestTitle) {
   $PullRequestTitle = $CommitMessage
+}
+
+if (-not $PushRemote) {
+  $PushRemote = Resolve-PushRemote -TargetRepo $BaseRepo
+}
+
+if (-not (git remote | Where-Object { $_ -eq $PushRemote })) {
+  throw ("Git remote '{0}' does not exist." -f $PushRemote)
 }
 
 Invoke-Step 'git' @('add', '--all')

--- a/tools/commit-push-pr.ps1
+++ b/tools/commit-push-pr.ps1
@@ -115,7 +115,9 @@ if ($SkipPullRequest) {
   exit 0
 }
 
-$headRef = "{0}:{1}" -f $PushRemote, $branch
+$pushRepoSlug = Get-RepositorySlug -RemoteName $PushRemote
+$headOwner = $pushRepoSlug.Split('/')[0]
+$headRef = "{0}:{1}" -f $headOwner, $branch
 $prLookup = gh pr list --repo $BaseRepo --head $headRef --base $BaseBranch --json number,url --state open
 if ($LASTEXITCODE -ne 0) {
   throw 'Failed to query existing pull requests.'


### PR DESCRIPTION
## Summary
- add MSBuild setup and MSVC checks before Windows dependency install in CI
- keep node-gyp bootstrap in place for electron-rebuild
- add a helper script to automate commit, push, and PR creation from the current branch, including fork remote detection

## Testing
- not run locally (workflow and helper script changes only)