### PR TITLE
Pasting html now properly transforms images as configured into local paths. Build instructions for windows updated fixes: #4149 #2510 #2105 #2462

### DIFF
--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -30,6 +30,13 @@ On Red Hat-based Linux: `sudo dnf install libX11-devel libxkbfile-devel libsecre
 
 - Windows 10 SDK (only needed before Windows 10)
 - Visual Studio 2019 (preferred)
+- Additional steps to fix gyp
+```
+$ npm install --global node-gyp@latest
+$ npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+$ node-gyp install
+$ python -m pip install setuptools
+```
 
 ### Let's build
 

--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -31,11 +31,11 @@ On Red Hat-based Linux: `sudo dnf install libX11-devel libxkbfile-devel libsecre
 - Windows 10 SDK (only needed before Windows 10)
 - Visual Studio 2019 (preferred)
 - Additional steps to fix gyp
-```
-$ npm install --global node-gyp@latest
-$ npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-$ node-gyp install
-$ python -m pip install setuptools
+ ```powershell
+   npm install --global node-gyp@latest
+   npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
+   node-gyp install
+   python -m pip install setuptools
 ```
 
 ### Let's build

--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -1,10 +1,50 @@
 
-import { PARAGRAPH_TYPES, PREVIEW_DOMPURIFY_CONFIG, HAS_TEXT_BLOCK_REG, IMAGE_EXT_REG, URL_REG } from '../config'
+import { PARAGRAPH_TYPES, PREVIEW_DOMPURIFY_CONFIG, HAS_TEXT_BLOCK_REG, IMAGE_EXT_REG, URL_REG, DATA_URL_REG } from '../config'
 import { sanitize, getUniqueId, getImageInfo as getImageSrc, getPageTitle } from '../utils'
 import { getImageInfo } from '../utils/getImageInfo'
 
 const LIST_REG = /ul|ol/
 const LINE_BREAKS_REG = /\n/
+const BLOB_URL_REG = /^blob:/i
+const MIME_EXTENSION_MAP = {
+  'image/jpeg': 'jpg',
+  'image/svg+xml': 'svg'
+}
+
+const getImageExtension = mimeType => {
+  const normalizedMimeType = mimeType ? mimeType.split(';')[0].toLowerCase() : ''
+  if (MIME_EXTENSION_MAP[normalizedMimeType]) {
+    return MIME_EXTENSION_MAP[normalizedMimeType]
+  }
+
+  const [, extension = 'png'] = normalizedMimeType.split('/')
+  return extension.split('+')[0] || 'png'
+}
+
+const getImageFileName = (mimeType, alt) => {
+  const extension = getImageExtension(mimeType)
+  const sanitizedAlt = alt && alt.trim()
+    ? alt.trim().replace(/[\\/:*?"<>|]+/g, '-')
+    : `pasted-image-${getUniqueId()}`
+
+  if (/\.[a-z\d]+$/i.test(sanitizedAlt)) {
+    return sanitizedAlt
+  }
+
+  return `${sanitizedAlt}.${extension}`
+}
+
+const createImageFileFromSource = async (src, alt = '') => {
+  const response = await window.fetch(src)
+  if (!response.ok) {
+    throw new Error(`Cannot fetch pasted image: ${response.status}`)
+  }
+
+  const blob = await response.blob()
+  const mimeType = blob.type || 'image/png'
+  const fileName = getImageFileName(mimeType, alt)
+  return new window.File([blob], fileName, { type: mimeType })
+}
 
 const pasteCtrl = ContentState => {
   // check paste type: `MERGE` or `NEWLINE`
@@ -121,9 +161,30 @@ const pasteCtrl = ContentState => {
         }
       }
     }
+    // ksksk
+    // copy images if needed
+    const images = Array.from(tempWrapper.querySelectorAll('img'))
+    for (const image of images) {
+      const src = image.getAttribute('src')
+      const alt = image.getAttribute('alt')
+      const img = document.createElement('img')
+      let imageSrc = src
+
+      if (src && (DATA_URL_REG.test(src) || URL_REG.test(src) || BLOB_URL_REG.test(src))) {
+        try {
+          const imageFile = await createImageFileFromSource(src, alt)
+          imageSrc = await this.muya.options.imageAction(imageFile, null, alt)
+        } catch (error) {
+          console.error('Unexpected error while saving pasted HTML image:', error)
+        }
+      }
+
+      img.src = imageSrc
+      img.alt = alt
+      image.replaceWith(img)
+    }
     return tempWrapper.innerHTML
   }
-
   ContentState.prototype.pasteImage = async function (event) {
     // Try to guess the clipboard file path.
     const imagePath = this.muya.options.clipboardFilePath()

--- a/src/muya/lib/contentState/pasteCtrl.js
+++ b/src/muya/lib/contentState/pasteCtrl.js
@@ -21,20 +21,20 @@ const getImageExtension = mimeType => {
   return extension.split('+')[0] || 'png'
 }
 
-const getImageFileName = (mimeType, alt) => {
+const getImageFileName = (mimeType, fname) => {
   const extension = getImageExtension(mimeType)
-  const sanitizedAlt = alt && alt.trim()
-    ? alt.trim().replace(/[\\/:*?"<>|]+/g, '-')
+  const sanitizedFileName = fname && fname.trim()
+    ? fname.trim().replace(/[\\/:*?"<>|]+/g, '-')
     : `pasted-image-${getUniqueId()}`
 
-  if (/\.[a-z\d]+$/i.test(sanitizedAlt)) {
-    return sanitizedAlt
+  if (/\.[a-z\d]+$/i.test(sanitizedFileName)) {
+    return sanitizedFileName
   }
 
-  return `${sanitizedAlt}.${extension}`
+  return `${sanitizedFileName}.${extension}`
 }
 
-const createImageFileFromSource = async (src, alt = '') => {
+const createImageFileFromSource = async (src, fname = '') => {
   const response = await window.fetch(src)
   if (!response.ok) {
     throw new Error(`Cannot fetch pasted image: ${response.status}`)
@@ -42,7 +42,7 @@ const createImageFileFromSource = async (src, alt = '') => {
 
   const blob = await response.blob()
   const mimeType = blob.type || 'image/png'
-  const fileName = getImageFileName(mimeType, alt)
+  const fileName = getImageFileName(mimeType, fname)
   return new window.File([blob], fileName, { type: mimeType })
 }
 
@@ -169,10 +169,11 @@ const pasteCtrl = ContentState => {
       const alt = image.getAttribute('alt')
       const img = document.createElement('img')
       let imageSrc = src
-
+      let fname = alt
       if (src && (DATA_URL_REG.test(src) || URL_REG.test(src) || BLOB_URL_REG.test(src))) {
+        if (URL_REG.test(src)) fname = src.split('/').pop().split('?')[0]
         try {
-          const imageFile = await createImageFileFromSource(src, alt)
+          const imageFile = await createImageFileFromSource(src, fname)
           imageSrc = await this.muya.options.imageAction(imageFile, null, alt)
         } catch (error) {
           console.error('Unexpected error while saving pasted HTML image:', error)


### PR DESCRIPTION
<!-- Please change the Answers in the table below
     to reflect the contents of your pull request. -->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | yes
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  not needed
| Fixed tickets     | Fixes #4149 #2510 #2105 #2462
| License           | MIT

### Description
Pasting html now properly transforms images as configured into local paths.
Build instructions for windows updated.
