### PR TITLE
fix: #4153 suppress EPIPE crash in main process

### DIFF
--- a/src/main/exceptionHandler.js
+++ b/src/main/exceptionHandler.js
@@ -99,6 +99,11 @@ Operating system: ${getOSInformation()}`)
 }
 
 const setupExceptionHandler = () => {
+  // Suppress EPIPE errors when electron-log writes to a closed pipe.
+  const ignoreEpipe = err => { if (err.code !== 'EPIPE') throw err }
+  process.stdout.on('error', ignoreEpipe)
+  process.stderr.on('error', ignoreEpipe)
+
   // main process error handler
   process.on('uncaughtException', error => {
     handleError(ERROR_MSG_MAIN, error, 'main')


### PR DESCRIPTION
## Summary

Fixes #4153

`electron-log`'s console transport crashes the main process with an `EPIPE` error when writing to a closed stdout/stderr pipe. This adds error handlers to suppress `EPIPE` while re-throwing all other errors.

### Changes

- **`src/main/exceptionHandler.js`** — Add `process.stdout` / `process.stderr` error handlers that ignore `EPIPE`

## Test plan

- [ ] Launch and use MarkText normally → no EPIPE crash dialog
- [ ] Other uncaught errors still show the error dialog as before