### PR TITLE
add .claude .agents to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ thumbs.db
 .idea
 .env
 .eslintcache
+.claude/
+.agents/
+.agent/


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

It's convenient to ignore common agent folders like '.claude' and '.agents'
