### PR TITLE
Document that Python 3.12+ requires `pip install setuptools`

### DIFF
--- a/docs/dev/BUILD.md
+++ b/docs/dev/BUILD.md
@@ -11,7 +11,7 @@ git clone https://github.com/marktext/marktext.git
 Before you can get started developing, you need set up your build environment:
 
 - Node.js `>=v16` but `<v17` and yarn
-- Python `>=v3.6` for node-gyp
+- Python `>=v3.6` for node-gyp; Python `>=v3.12` requires `setuptools` (`pip install setuptools`)
 - C++ compiler and development tools
 - Build is supported on Linux, macOS and Windows
 


### PR DESCRIPTION
| Q                 | A              |
| ----------------- | -------------- |
| Bug fix?          | yes            |
| New feature?      | no             |
| Breaking changes? | no             |
| Deprecations?     | no             |
| New tests added?  | not needed     |
| Fixed tickets     | none           |
| License           | MIT            |

### Description

`yarn install` fails with Python 3.12+ because `node-gyp` (v9, bundled with Node 16's npm) invokes `gyp_main.py`, which depends on `distutils` — a module removed from the Python standard library in Python 3.12 ([PEP 632](https://peps.python.org/pep-0632/)). The failure manifests as a traceback in the `fontmanager-redux` native addon build step:

```
gyp info find Python using Python version 3.13.13 found at ".../.venv/bin/python3"
Traceback (most recent call last):
  File ".../node-gyp/gyp/gyp_main.py", line 42, in <module>
    import gyp
```

**Fix:** Document that Python `>=3.12` users must install `setuptools` before running `yarn install`. The `setuptools` package ships a `distutils` compatibility shim that satisfies `node-gyp`'s requirement.

```bash
pip install setuptools
yarn install
```

Updated `docs/dev/BUILD.md` Prerequisites section to reflect this requirement.
