### PR TITLE
fix: add confirmation dialog before opening local files via shell.openPath

### DIFF
--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -413,7 +413,7 @@ ipcMain.on('mt::ask-for-open-project-in-sidebar', async e => {
   }
 })
 
-ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
+ipcMain.on('mt::format-link-click', async (e, { data, dirname }) => {
   if (!data || (!data.href && !data.text)) {
     return
   }
@@ -445,7 +445,21 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }) => {
       const win = BrowserWindow.fromWebContents(e.sender)
       openFileOrFolder(win, pathname)
     } else {
-      shell.openPath(pathname)
+      // Require user confirmation before opening non-markdown files to prevent
+      // crafted documents from silently launching arbitrary local files.
+      const win = BrowserWindow.fromWebContents(e.sender)
+      const { response } = await dialog.showMessageBox(win, {
+        type: 'question',
+        buttons: ['Open', 'Cancel'],
+        defaultId: 1,
+        cancelId: 1,
+        message: 'Open external file?',
+        detail: `Do you want to open "${pathname}"?`,
+        noLink: true
+      })
+      if (response === 0) {
+        shell.openPath(pathname)
+      }
     }
   }
 })

--- a/src/main/menu/actions/file.js
+++ b/src/main/menu/actions/file.js
@@ -440,7 +440,7 @@ ipcMain.on('mt::format-link-click', async (e, { data, dirname }) => {
   }
 
   if (pathname) {
-    pathname = path.normalize(pathname)
+    pathname = normalizeAndResolvePath(pathname)
     if (isMarkdownFile(pathname)) {
       const win = BrowserWindow.fromWebContents(e.sender)
       openFileOrFolder(win, pathname)
@@ -448,17 +448,32 @@ ipcMain.on('mt::format-link-click', async (e, { data, dirname }) => {
       // Require user confirmation before opening non-markdown files to prevent
       // crafted documents from silently launching arbitrary local files.
       const win = BrowserWindow.fromWebContents(e.sender)
+      // Strip control characters (including newlines) from the displayed path
+      // so a crafted filename cannot produce a misleading multi-line dialog.
+      // eslint-disable-next-line no-control-regex
+      const displayPath = pathname.replace(/[\x00-\x1f\x7f]/g, '\uFFFD')
       const { response } = await dialog.showMessageBox(win, {
         type: 'question',
         buttons: ['Open', 'Cancel'],
         defaultId: 1,
         cancelId: 1,
         message: 'Open external file?',
-        detail: `Do you want to open "${pathname}"?`,
+        detail: `Do you want to open "${displayPath}"?`,
         noLink: true
       })
       if (response === 0) {
-        shell.openPath(pathname)
+        // shell.openPath resolves with an error string (empty on success).
+        const err = await shell.openPath(pathname)
+        if (err) {
+          dialog.showMessageBox(win, {
+            type: 'error',
+            buttons: ['OK'],
+            defaultId: 0,
+            message: 'Failed to open file',
+            detail: err,
+            noLink: true
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

When a user clicks a link inside a markdown document, MarkText resolves the link to a local file path and, for non-markdown files, passes it directly to `shell.openPath()` without any user confirmation. This means a crafted markdown document can silently open arbitrary local files — including executables or scripts — the moment a user clicks a link.

**Affected file:** `src/main/menu/actions/file.js` (the `mt::format-link-click` IPC handler)

## Vulnerability details

1. An attacker creates a markdown file containing a link like `[click here](../../path/to/malicious.exe)`.
2. The victim opens this `.md` file in MarkText.
3. When the victim clicks the link, the `mt::format-link-click` handler resolves it to an absolute path using the document's directory.
4. If the resolved path does not point to a markdown file, `shell.openPath(pathname)` is called immediately — the OS opens or executes the file with no prompt.

The precondition (opening a malicious `.md` file) does **not** itself grant code execution, so the link click is the critical step that escalates to arbitrary local file execution.

## Proof of concept

Create a file called `evil.md` with the following content:

```markdown
# Innocent-looking document

Please [click here for more details](../../../../../../usr/bin/xcalc)
```

Open `evil.md` in MarkText and click the link. On the current codebase, `xcalc` (or whatever the path points to) launches immediately without any user prompt. On Windows, this could point to a `.bat`, `.exe`, or `.cmd` file.

After this patch, the user sees a confirmation dialog showing the resolved path and must explicitly click "Open" to proceed.

## Fix description

This patch adds a confirmation dialog (`dialog.showMessageBox`) before calling `shell.openPath()` for non-markdown files. Specific changes:

- **Confirmation dialog:** The user sees the resolved file path and must click "Open" to proceed. The default button is "Cancel" (`defaultId: 1`) to prevent accidental confirmation via Enter key.
- **Path sanitization for display:** Control characters (including newlines) in the filename are replaced with U+FFFD before showing in the dialog, preventing a crafted filename from producing a misleading multi-line dialog that could trick the user into clicking "Open".
- **Path canonicalization:** Uses `normalizeAndResolvePath` instead of bare `path.normalize` for consistent path handling.
- **Error surfacing:** `shell.openPath` errors are now shown to the user instead of being silently swallowed.
- **Async handler:** The IPC handler is made `async` to support the awaitable dialog and `shell.openPath` calls.

This follows the same pattern used by VS Code and other Electron editors when handling external file opens from untrusted content.

## Testing

- Verified that markdown file links (`.md`) still open directly without a dialog (existing behavior preserved).
- Verified that non-markdown file links now show a confirmation dialog before opening.
- Verified that clicking "Cancel" prevents `shell.openPath()` from being called.
- Verified that clicking "Open" correctly opens the target file.
- Verified that filenames containing newlines or control characters display safely in the dialog.
- Confirmed the change is minimal: 1 file changed, 32 insertions, 3 deletions, with no unrelated modifications.

## Adversarial review

Before submitting, we considered whether existing protections would prevent exploitation. MarkText does not sandbox link handling or restrict `shell.openPath` targets — any file path the OS can resolve is opened. Electron's default security policies don't block `shell.openPath` calls from the main process. The only prerequisite is that the victim opens a crafted `.md` file and clicks a link, which is a realistic attack scenario for a markdown editor.