### PR TITLE
fix: prevent command injection in picgo upload (CWE-78)

### DIFF
--- a/src/renderer/util/fileSystem.js
+++ b/src/renderer/util/fileSystem.js
@@ -158,7 +158,7 @@ export const uploadImage = async (pathname, image, preferences) => {
       await fs.writeFile(filepath, data)
     }
     if (uploader === 'picgo') {
-      cp.exec(`picgo u "${filepath}"`, async (err, data) => {
+      cp.execFile('picgo', ['u', filepath], async (err, data) => {
         if (!isPath) {
           await fs.unlink(filepath)
         }


### PR DESCRIPTION
## Summary

The `uploadImage` function in `src/renderer/util/fileSystem.js` uses `cp.exec()` to invoke the `picgo` CLI, interpolating a file path into a shell command string:

```js
cp.exec(`picgo u "${filepath}"`, ...)
```

This is vulnerable to **OS command injection (CWE-78)**. If `filepath` contains shell metacharacters — such as `$(cmd)`, backticks, or double-quote escapes — an attacker can execute arbitrary commands on the user's system.

### Attack scenario

A user opens a crafted markdown file containing an image reference with a malicious filename (e.g., `img$(whoami).png` or a filename with embedded quotes and semicolons). When the user triggers image upload via the picgo uploader, the unsanitized filename is passed directly into a shell command. The double-quote wrapping in the original code does **not** prevent injection — characters like `"`, `$()`, and backticks can escape out of the quoted context.

## Fix

Replace `cp.exec()` with `cp.execFile()`, which passes arguments as an array and does **not** invoke a shell:

```js
cp.execFile('picgo', ['u', filepath], ...)
```

This eliminates the injection vector entirely — `filepath` is passed as a literal argument to the `picgo` binary, regardless of what characters it contains.

## Testing

- Verified the fix compiles and the argument structure matches Node.js `child_process.execFile` API.
- Confirmed that filenames with shell metacharacters (`$()`, backticks, double quotes, semicolons) are no longer interpreted by a shell.
- Confirmed no behavioral change for normal filenames — `execFile` invokes the same binary with the same arguments.

## Security analysis

Before submitting, we considered whether existing mitigations prevent exploitation. The double-quote wrapping around `filepath` in the original `exec()` call is the only defense, and it is insufficient: within double quotes, `$()`, backticks, and `"` itself are all still interpreted by the shell. While this is a desktop application (limiting remote attack surface), the realistic vector is a crafted markdown file shared with the user — a common scenario for a markdown editor. The fix from `exec` to `execFile` is the standard remediation for this class of vulnerability.

cc @lewiswigmore
