### PR TITLE
Add menu i18n foundation

### DIFF
--- a/src/main/contextMenu/editor/index.js
+++ b/src/main/contextMenu/editor/index.js
@@ -1,18 +1,30 @@
 import { Menu, MenuItem } from 'electron'
 import {
-  CUT,
-  COPY,
-  PASTE,
-  COPY_AS_MARKDOWN,
-  COPY_AS_HTML,
-  PASTE_AS_PLAIN_TEXT,
   SEPARATOR,
-  INSERT_BEFORE,
-  INSERT_AFTER
+  copyAsHtmlMenuItem,
+  copyAsMarkdownMenuItem,
+  copyMenuItem,
+  cutMenuItem,
+  insertAfterMenuItem,
+  insertBeforeMenuItem,
+  pasteAsPlainTextMenuItem,
+  pasteMenuItem
 } from './menuItems'
 import spellcheckMenuBuilder from './spellcheck'
+import { createTranslator } from '../../i18n'
 
-const CONTEXT_ITEMS = [INSERT_BEFORE, INSERT_AFTER, SEPARATOR, CUT, COPY, PASTE, SEPARATOR, COPY_AS_MARKDOWN, COPY_AS_HTML, PASTE_AS_PLAIN_TEXT]
+const buildContextItems = t => [
+  insertBeforeMenuItem(t),
+  insertAfterMenuItem(t),
+  SEPARATOR,
+  cutMenuItem(t),
+  copyMenuItem(t),
+  pasteMenuItem(t),
+  SEPARATOR,
+  copyAsMarkdownMenuItem(t),
+  copyAsHtmlMenuItem(t),
+  pasteAsPlainTextMenuItem(t)
+]
 
 const isInsideEditor = params => {
   const { isEditable, editFlags, inputFieldType } = params
@@ -20,8 +32,9 @@ const isInsideEditor = params => {
   return isEditable && inputFieldType === 'none' && !!editFlags.canEditRichly
 }
 
-export const showEditorContextMenu = (win, event, params, isSpellcheckerEnabled) => {
+export const showEditorContextMenu = (win, event, params, isSpellcheckerEnabled, language = 'en') => {
   const { isEditable, hasImageContents, selectionText, editFlags, misspelledWord, dictionarySuggestions } = params
+  const t = createTranslator(language)
 
   // NOTE: We have to get the word suggestions from this event because `webFrame.getWordSuggestions` and
   //       `webFrame.isWordMisspelled` doesn't work on Windows (Electron#28684).
@@ -35,18 +48,21 @@ export const showEditorContextMenu = (win, event, params, isSpellcheckerEnabled)
 
     const menu = new Menu()
     if (isSpellcheckerEnabled) {
-      const spellingSubmenu = spellcheckMenuBuilder(isMisspelled, misspelledWord, dictionarySuggestions)
+      const spellingSubmenu = spellcheckMenuBuilder(isMisspelled, misspelledWord, dictionarySuggestions, t)
       menu.append(new MenuItem({
-        label: 'Spelling...',
+        label: t('Spelling...'),
         submenu: spellingSubmenu
       }))
       menu.append(new MenuItem(SEPARATOR))
     }
 
-    [CUT, COPY, COPY_AS_HTML, COPY_AS_MARKDOWN].forEach(item => {
-      item.enabled = canCopy
-    })
-    CONTEXT_ITEMS.forEach(item => {
+    const contextItems = buildContextItems(t)
+    contextItems
+      .filter(item => ['cutMenuItem', 'copyMenuItem', 'copyAsHtmlMenuItem', 'copyAsMarkdownMenuItem'].includes(item.id))
+      .forEach(item => {
+        item.enabled = canCopy
+      })
+    contextItems.forEach(item => {
       menu.append(new MenuItem(item))
     })
     menu.popup([{ window: win, x: event.clientX, y: event.clientY }])

--- a/src/main/contextMenu/editor/menuItems.js
+++ b/src/main/contextMenu/editor/menuItems.js
@@ -1,62 +1,62 @@
 // NOTE: This are mutable fields that may change at runtime.
 
-export const CUT = {
-  label: 'Cut',
+export const cutMenuItem = t => ({
+  label: t('Cut'),
   id: 'cutMenuItem',
   role: 'cut'
-}
+})
 
-export const COPY = {
-  label: 'Copy',
+export const copyMenuItem = t => ({
+  label: t('Copy'),
   id: 'copyMenuItem',
   role: 'copy'
-}
+})
 
-export const PASTE = {
-  label: 'Paste',
+export const pasteMenuItem = t => ({
+  label: t('Paste'),
   id: 'pasteMenuItem',
   role: 'paste'
-}
+})
 
-export const COPY_AS_MARKDOWN = {
-  label: 'Copy As Markdown',
+export const copyAsMarkdownMenuItem = t => ({
+  label: t('Copy As Markdown'),
   id: 'copyAsMarkdownMenuItem',
   click (menuItem, targetWindow) {
     targetWindow.webContents.send('mt::cm-copy-as-markdown')
   }
-}
+})
 
-export const COPY_AS_HTML = {
-  label: 'Copy As Html',
+export const copyAsHtmlMenuItem = t => ({
+  label: t('Copy As Html'),
   id: 'copyAsHtmlMenuItem',
   click (menuItem, targetWindow) {
     targetWindow.webContents.send('mt::cm-copy-as-html')
   }
-}
+})
 
-export const PASTE_AS_PLAIN_TEXT = {
-  label: 'Paste as Plain Text',
+export const pasteAsPlainTextMenuItem = t => ({
+  label: t('Paste as Plain Text'),
   id: 'pasteAsPlainTextMenuItem',
   click (menuItem, targetWindow) {
     targetWindow.webContents.send('mt::cm-paste-as-plain-text')
   }
-}
+})
 
-export const INSERT_BEFORE = {
-  label: 'Insert Paragraph Before',
+export const insertBeforeMenuItem = t => ({
+  label: t('Insert Paragraph Before'),
   id: 'insertParagraphBeforeMenuItem',
   click (menuItem, targetWindow) {
     targetWindow.webContents.send('mt::cm-insert-paragraph', 'before')
   }
-}
+})
 
-export const INSERT_AFTER = {
-  label: 'Insert Paragraph After',
+export const insertAfterMenuItem = t => ({
+  label: t('Insert Paragraph After'),
   id: 'insertParagraphAfterMenuItem',
   click (menuItem, targetWindow) {
     targetWindow.webContents.send('mt::cm-insert-paragraph', 'after')
   }
-}
+})
 
 export const SEPARATOR = {
   type: 'separator'

--- a/src/main/contextMenu/editor/spellcheck.js
+++ b/src/main/contextMenu/editor/spellcheck.js
@@ -12,11 +12,11 @@ import { SEPARATOR } from './menuItems'
  * @param {[string[]]} wordSuggestions Suggestions for `selectedWord`.
  * @returns {MenuItem[]}
  */
-export default (isMisspelled, misspelledWord, wordSuggestions) => {
+export default (isMisspelled, misspelledWord, wordSuggestions, t = label => label) => {
   const spellingSubmenu = []
 
   spellingSubmenu.push(new MenuItem({
-    label: 'Change Language...',
+    label: t('Change Language...'),
     // NB: On macOS the OS spell checker is used and will detect the language automatically.
     visible: !isOsx,
     click (menuItem, targetWindow) {
@@ -27,7 +27,7 @@ export default (isMisspelled, misspelledWord, wordSuggestions) => {
   // Handle misspelled word if wordSuggestions is set, otherwise word is correct.
   if (isMisspelled && misspelledWord && wordSuggestions) {
     spellingSubmenu.push({
-      label: 'Add to Dictionary',
+      label: t('Add to Dictionary'),
       click (menuItem, targetWindow) {
         if (!addToDictionary(targetWindow, misspelledWord)) {
           log.error(`Error while adding "${misspelledWord}" to dictionary.`)
@@ -54,7 +54,7 @@ export default (isMisspelled, misspelledWord, wordSuggestions) => {
     }
   } else {
     spellingSubmenu.push({
-      label: 'Edit Dictionary...',
+      label: t('Edit Dictionary...'),
       click (menuItem, targetWindow) {
         ipcMain.emit('app-create-settings-window', 'spelling')
       }

--- a/src/main/i18n.js
+++ b/src/main/i18n.js
@@ -1,0 +1,179 @@
+const DEFAULT_LANGUAGE = 'en'
+
+const LOCALES = {
+  'zh-CN': {
+    'About MarkText': '关于 MarkText',
+    'About MarkText...': '关于 MarkText...',
+    'Add to Dictionary': '添加到词典',
+    'Always on Top': '窗口置顶',
+    'Auto Save': '自动保存',
+    Bold: '加粗',
+    'Bring All to Front': '全部置于前面',
+    'Cadmium Light': '镉黄浅色',
+    'Carriage return and line feed (CRLF)': '回车换行 (CRLF)',
+    'Change Language...': '切换语言...',
+    'Changelog...': '更新日志...',
+    'Check for updates...': '检查更新...',
+    'Clear Formatting': '清除格式',
+    'Clear Recently Used': '清除最近使用',
+    'Close Tab': '关闭标签页',
+    'Close Window': '关闭窗口',
+    'Code Fences': '代码块',
+    'Command Palette...': '命令面板...',
+    Copy: '复制',
+    'Copy As Html': '复制为 HTML',
+    'Copy As Markdown': '复制为 Markdown',
+    'Copy as HTML': '复制为 HTML',
+    'Copy as Markdown': '复制为 Markdown',
+    'Create Paragraph': '创建段落',
+    Cut: '剪切',
+    Dark: '深色',
+    'Delete Paragraph': '删除段落',
+    'Demote Heading': '降低标题级别',
+    'Donate via Open Collective...': '通过 Open Collective 捐赠...',
+    Duplicate: '复制段落',
+    Edit: '编辑',
+    'Edit Dictionary...': '编辑词典...',
+    Export: '导出',
+    'Feedback via Twitter...': '通过 Twitter 反馈...',
+    File: '文件',
+    Find: '查找',
+    'Find Next': '查找下一个',
+    'Find Previous': '查找上一个',
+    'Find in Folder': '在文件夹中查找',
+    'Focus Mode': '专注模式',
+    'Follow us on Github...': '在 GitHub 上关注我们...',
+    'Follow us on Twitter...': '在 Twitter 上关注我们...',
+    Format: '格式',
+    'Front Matter': 'Front Matter',
+    'Graphite Light': '石墨浅色',
+    'Heading 1': '一级标题',
+    'Heading 2': '二级标题',
+    'Heading 3': '三级标题',
+    'Heading 4': '四级标题',
+    'Heading 5': '五级标题',
+    'Heading 6': '六级标题',
+    Help: '帮助',
+    'Hide MarkText': '隐藏 MarkText',
+    'Hide Others': '隐藏其他',
+    Highlight: '高亮',
+    'Horizontal Rule': '水平分割线',
+    'Html Block': 'HTML 块',
+    Hyperlink: '超链接',
+    Image: '图片',
+    'Import...': '导入...',
+    'Inline Code': '行内代码',
+    'Inline Math': '行内公式',
+    'Insert Paragraph After': '在后面插入段落',
+    'Insert Paragraph Before': '在前面插入段落',
+    Italic: '斜体',
+    'License...': '许可证...',
+    'Line Ending': '换行符',
+    'Line feed (LF)': '换行 (LF)',
+    'Loose List Item': '松散列表项',
+    'Markdown Reference...': 'Markdown 参考...',
+    'Material Dark': 'Material 深色',
+    'Math Block': '公式块',
+    Minimize: '最小化',
+    'Move To...': '移动到...',
+    'New Tab': '新建标签页',
+    'New Window': '新建窗口',
+    'One Dark': 'One Dark 深色',
+    'Open File...': '打开文件...',
+    'Open Folder...': '打开文件夹...',
+    'Open Recent': '打开最近使用',
+    'Ordered List': '有序列表',
+    Paragraph: '段落',
+    Paste: '粘贴',
+    'Paste As Plain Text': '粘贴为纯文本',
+    'Paste as Plain Text': '粘贴为纯文本',
+    Preferences: '偏好设置',
+    'Preferences...': '偏好设置...',
+    Print: '打印',
+    'Promote Heading': '提升标题级别',
+    'Quick Start...': '快速开始...',
+    Quit: '退出',
+    'Quit MarkText': '退出 MarkText',
+    'Quote Block': '引用块',
+    'Reload Images': '重新加载图片',
+    'Reload window': '重新加载窗口',
+    'Rename...': '重命名...',
+    Replace: '替换',
+    'Report Issue or Request Feature...': '报告问题或请求功能...',
+    Save: '保存',
+    'Save As...': '另存为...',
+    Screenshot: '截屏',
+    'Select All': '全选',
+    Services: '服务',
+    'Show All': '全部显示',
+    'Show Developer Tools': '显示开发者工具',
+    'Show Sidebar': '显示侧边栏',
+    'Show Tab Bar': '显示标签栏',
+    'Show in Full Screen': '全屏显示',
+    'Source Code Mode': '源代码模式',
+    'Spelling...': '拼写...',
+    Strikethrough: '删除线',
+    Subscript: '下标',
+    Superscript: '上标',
+    Table: '表格',
+    'Task List': '任务列表',
+    Theme: '主题',
+    'Toggle Table of Contents': '切换目录',
+    'Typewriter Mode': '打字机模式',
+    'Ulysses Light': 'Ulysses 浅色',
+    Underline: '下划线',
+    Undo: '撤销',
+    View: '视图',
+    'Watch on GitHub...': '在 GitHub 上关注项目...',
+    'Website...': '网站...',
+    Window: '窗口',
+    'Zoom In': '放大',
+    'Zoom Out': '缩小'
+  }
+}
+
+const stripMnemonic = label => label.replace(/&/g, '')
+
+export const normalizeLanguage = language => {
+  if (language === 'zh-CN' || language === 'zh') {
+    return 'zh-CN'
+  }
+  return DEFAULT_LANGUAGE
+}
+
+export const createTranslator = language => {
+  const messages = LOCALES[normalizeLanguage(language)]
+  return label => {
+    if (!label || !messages) {
+      return label
+    }
+
+    const cleanLabel = stripMnemonic(label)
+    const translated = messages[cleanLabel]
+    if (!translated) {
+      return label
+    }
+
+    return translated
+  }
+}
+
+export const translateMenuTemplate = (template, language) => {
+  const t = createTranslator(language)
+  const translateItem = item => {
+    if (item.label) {
+      item.label = t(item.label)
+    }
+    if (Array.isArray(item.submenu)) {
+      item.submenu.forEach(translateItem)
+    }
+    return item
+  }
+
+  if (Array.isArray(template)) {
+    template.forEach(translateItem)
+  } else if (template) {
+    translateItem(template)
+  }
+  return template
+}

--- a/src/main/menu/index.js
+++ b/src/main/menu/index.js
@@ -230,7 +230,7 @@ class AppMenu {
    *
    * @param {[string[]]} recentUsedDocuments
    */
-  updateAppMenu (recentUsedDocuments) {
+  updateAppMenu (recentUsedDocuments, language = null) {
     if (!recentUsedDocuments) {
       recentUsedDocuments = this.getRecentlyUsedDocuments()
     }
@@ -244,7 +244,7 @@ class AppMenu {
       const { menu: oldMenu, type } = value
       if (type !== MenuType.EDITOR) return
 
-      const { menu: newMenu } = this._buildEditorMenu(recentUsedDocuments)
+      const { menu: newMenu } = this._buildEditorMenu(recentUsedDocuments, language)
 
       // all other menu items are set automatically
       updateMenuItem(oldMenu, newMenu, 'sourceCodeModeMenuItem')
@@ -336,19 +336,34 @@ class AppMenu {
     })
   }
 
-  _buildEditorMenu (recentUsedDocuments = null) {
+  updateLanguageMenu = language => {
+    this.updateAppMenu(null, language)
+
+    this.windowMenus.forEach((value, key) => {
+      if (value.type !== MenuType.SETTINGS) return
+
+      const { menu } = this._buildSettingMenu(language)
+      value.menu = menu
+
+      if (this.activeWindowId === key) {
+        this._setApplicationMenu(menu)
+      }
+    })
+  }
+
+  _buildEditorMenu (recentUsedDocuments = null, language = null) {
     if (!recentUsedDocuments) {
       recentUsedDocuments = this.getRecentlyUsedDocuments()
     }
 
-    const menuTemplate = configureMenu(this._keybindings, this._preferences, recentUsedDocuments)
+    const menuTemplate = configureMenu(this._keybindings, this._preferences, recentUsedDocuments, language)
     const menu = Menu.buildFromTemplate(menuTemplate)
     return { menu, type: MenuType.EDITOR }
   }
 
-  _buildSettingMenu () {
+  _buildSettingMenu (language = null) {
     if (isOsx) {
-      const menuTemplate = configSettingMenu(this._keybindings)
+      const menuTemplate = configSettingMenu(this._keybindings, this._preferences, language)
       const menu = Menu.buildFromTemplate(menuTemplate)
       return { menu, type: MenuType.SETTINGS }
     }
@@ -414,6 +429,9 @@ class AppMenu {
       }
       if (prefs.autoSave !== undefined) {
         this.updateAutoSaveMenu(prefs.autoSave)
+      }
+      if (prefs.language !== undefined) {
+        this.updateLanguageMenu(prefs.language)
       }
     })
   }

--- a/src/main/menu/templates/index.js
+++ b/src/main/menu/templates/index.js
@@ -8,6 +8,7 @@ import window from './window'
 import paragraph from './paragraph'
 import format from './format'
 import theme from './theme'
+import { translateMenuTemplate } from '../../i18n'
 
 export dockMenu from './dock'
 
@@ -16,12 +17,13 @@ export dockMenu from './dock'
  *
  * @param {Keybindings} keybindings The keybindings instance
  */
-export const configSettingMenu = (keybindings) => {
-  return [
+export const configSettingMenu = (keybindings, preferences = null, language = null) => {
+  const menuTemplate = [
     ...(process.platform === 'darwin' ? [marktext(keybindings)] : []),
     prefEdit(keybindings),
     help()
   ]
+  return translateMenuTemplate(menuTemplate, language || (preferences && preferences.getItem('language')))
 }
 
 /**
@@ -31,8 +33,8 @@ export const configSettingMenu = (keybindings) => {
  * @param {Preference} preferences The preference instance.
  * @param {string[]} recentlyUsedFiles The recently used files.
  */
-export default function (keybindings, preferences, recentlyUsedFiles) {
-  return [
+export default function (keybindings, preferences, recentlyUsedFiles, language = null) {
+  const menuTemplate = [
     ...(process.platform === 'darwin' ? [marktext(keybindings)] : []),
     file(keybindings, preferences, recentlyUsedFiles),
     edit(keybindings),
@@ -43,4 +45,5 @@ export default function (keybindings, preferences, recentlyUsedFiles) {
     view(keybindings),
     help()
   ]
+  return translateMenuTemplate(menuTemplate, language || preferences.getItem('language'))
 }

--- a/src/main/windows/editor.js
+++ b/src/main/windows/editor.js
@@ -92,7 +92,7 @@ class EditorWindow extends BaseWindow {
     appMenu.addEditorMenu(win, { sourceCodeModeEnabled })
 
     win.webContents.on('context-menu', (event, params) => {
-      showEditorContextMenu(win, event, params, preferences.getItem('spellcheckerEnabled'))
+      showEditorContextMenu(win, event, params, preferences.getItem('spellcheckerEnabled'), preferences.getItem('language'))
     })
 
     win.webContents.once('did-finish-load', () => {

--- a/src/renderer/prefComponents/general/config.js
+++ b/src/renderer/prefComponents/general/config.js
@@ -61,4 +61,7 @@ export const fileSortByOptions = [{
 export const languageOptions = [{
   label: 'English',
   value: 'en'
+}, {
+  label: '简体中文',
+  value: 'zh-CN'
 }]

--- a/src/renderer/prefComponents/general/index.vue
+++ b/src/renderer/prefComponents/general/index.vue
@@ -111,7 +111,6 @@
           :value="language"
           :options="languageOptions"
           :onChange="value => onSelectChange('language', value)"
-          :disable="true"
         ></cur-select>
       </template>
     </compound>


### PR DESCRIPTION
## Summary
- add a small main-process i18n helper that localizes application menu templates from the existing `language` preference
- localize editor context menu and spell-check context menu labels through the same helper
- enable the existing General > User interface language selector with English and Simplified Chinese options

## Scope
This addresses part of #138 by preparing menu-level i18n only. It intentionally does not add a full app-wide translation framework or translate renderer content beyond enabling the existing language selector.

## Validation
- `yarn install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/eslint src/main/i18n.js src/main/menu/index.js src/main/menu/templates/index.js src/main/contextMenu/editor/index.js src/main/contextMenu/editor/menuItems.js src/main/contextMenu/editor/spellcheck.js src/main/windows/editor.js src/renderer/prefComponents/general/config.js src/renderer/prefComponents/general/index.vue`
- `git diff --check`
- localized menu helper assertions via Node dynamic import
- `yarn run pack:main`
- `yarn run pack:renderer`