### PR TITLE
Make native menu theme follow app theme

### DIFF
--- a/src/common/theme.js
+++ b/src/common/theme.js
@@ -1,0 +1,33 @@
+export const railscastsThemes = Object.freeze([
+  'dark',
+  'material-dark',
+  // New gogh dark themes
+  'dracula',
+  'nord',
+  'catppuccin-mocha',
+  'gruvbox-dark',
+  'tokyo-night',
+  'tokyo-night-storm',
+  'solarized-dark',
+  'ayu-dark',
+  'ayu-mirage',
+  'everforest-dark',
+  'rose-pine',
+  'rose-pine-moon',
+  'monokai-pro',
+  'synthwave-84',
+  'horizon-dark',
+  'palenight',
+  'oxocarbon-dark',
+  'kanagawa',
+  'nightfox',
+  'cyberdream'
+])
+
+export const oneDarkThemes = Object.freeze(['one-dark'])
+
+export const isDarkThemeId = theme => {
+  return typeof theme === 'string' && (
+    railscastsThemes.includes(theme) || oneDarkThemes.includes(theme)
+  )
+}

--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -18,6 +18,7 @@ import { WindowType } from '../windows/base'
 import EditorWindow from '../windows/editor'
 import SettingWindow from '../windows/setting'
 import { setLanguage } from '../i18n'
+import { getNativeThemeSource, isDarkApplicationTheme } from './nativeTheme'
 
 class App {
   /**
@@ -251,12 +252,10 @@ class App {
       }
     }
 
-    // Configure native theme to follow system preferences
-    // Setting themeSource to 'system' allows Electron to track system theme changes
-    nativeTheme.themeSource = 'system'
+    nativeTheme.themeSource = getNativeThemeSource({ followSystemTheme, theme })
 
     // Apply theme at startup if "Follow system theme" is enabled
-    const isDarkTheme = /dark/i.test(theme)
+    const isDarkTheme = isDarkApplicationTheme(theme)
     const systemIsDark = nativeTheme.shouldUseDarkColors
 
     if (followSystemTheme && isDarkTheme !== systemIsDark) {
@@ -268,6 +267,12 @@ class App {
     }
 
     ipcMain.on('broadcast-preferences-changed', (change) => {
+      const nextPreferences = {
+        ...preferences.getAll(),
+        ...change
+      }
+      nativeTheme.themeSource = getNativeThemeSource(nextPreferences)
+
       // When followSystemTheme is enabled, immediately switch to match system
       if (change.followSystemTheme === true) {
         const systemIsDark = nativeTheme.shouldUseDarkColors

--- a/src/main/app/nativeTheme.js
+++ b/src/main/app/nativeTheme.js
@@ -1,0 +1,36 @@
+const DARK_THEME_IDS = new Set([
+  'ayu-dark',
+  'ayu-mirage',
+  'catppuccin-mocha',
+  'cyberdream',
+  'dark',
+  'dracula',
+  'everforest-dark',
+  'gruvbox-dark',
+  'horizon-dark',
+  'kanagawa',
+  'material-dark',
+  'monokai-pro',
+  'nightfox',
+  'nord',
+  'one-dark',
+  'oxocarbon-dark',
+  'palenight',
+  'rose-pine',
+  'rose-pine-moon',
+  'solarized-dark',
+  'synthwave-84',
+  'tokyo-night',
+  'tokyo-night-storm'
+])
+
+export const isDarkApplicationTheme = (theme) => {
+  return typeof theme === 'string' && DARK_THEME_IDS.has(theme)
+}
+
+export const getNativeThemeSource = ({ followSystemTheme, theme }) => {
+  if (followSystemTheme) {
+    return 'system'
+  }
+  return isDarkApplicationTheme(theme) ? 'dark' : 'light'
+}

--- a/src/main/app/nativeTheme.js
+++ b/src/main/app/nativeTheme.js
@@ -1,31 +1,7 @@
-const DARK_THEME_IDS = new Set([
-  'ayu-dark',
-  'ayu-mirage',
-  'catppuccin-mocha',
-  'cyberdream',
-  'dark',
-  'dracula',
-  'everforest-dark',
-  'gruvbox-dark',
-  'horizon-dark',
-  'kanagawa',
-  'material-dark',
-  'monokai-pro',
-  'nightfox',
-  'nord',
-  'one-dark',
-  'oxocarbon-dark',
-  'palenight',
-  'rose-pine',
-  'rose-pine-moon',
-  'solarized-dark',
-  'synthwave-84',
-  'tokyo-night',
-  'tokyo-night-storm'
-])
+import { isDarkThemeId } from '../../common/theme'
 
 export const isDarkApplicationTheme = (theme) => {
-  return typeof theme === 'string' && DARK_THEME_IDS.has(theme)
+  return isDarkThemeId(theme)
 }
 
 export const getNativeThemeSource = ({ followSystemTheme, theme }) => {

--- a/src/renderer/src/config.js
+++ b/src/renderer/src/config.js
@@ -14,29 +14,4 @@ export const DEFAULT_STYLE = Object.freeze({
   theme: 'light'
 })
 
-export const railscastsThemes = Object.freeze([
-  'dark',
-  'material-dark',
-  // New gogh dark themes
-  'dracula',
-  'nord',
-  'catppuccin-mocha',
-  'gruvbox-dark',
-  'tokyo-night',
-  'tokyo-night-storm',
-  'solarized-dark',
-  'ayu-dark',
-  'ayu-mirage',
-  'everforest-dark',
-  'rose-pine',
-  'rose-pine-moon',
-  'monokai-pro',
-  'synthwave-84',
-  'horizon-dark',
-  'palenight',
-  'oxocarbon-dark',
-  'kanagawa',
-  'nightfox',
-  'cyberdream'
-])
-export const oneDarkThemes = Object.freeze(['one-dark'])
+export { railscastsThemes, oneDarkThemes } from '../../common/theme'

--- a/test/unit/specs/native-theme.spec.js
+++ b/test/unit/specs/native-theme.spec.js
@@ -1,4 +1,5 @@
 import { getNativeThemeSource, isDarkApplicationTheme } from 'main_renderer/app/nativeTheme'
+import { oneDarkThemes, railscastsThemes } from 'common/theme'
 
 describe('Native theme source', () => {
   it('follows the system when configured to do so', () => {
@@ -8,6 +9,13 @@ describe('Native theme source', () => {
 
   it('uses dark native menus for dark MarkText themes', () => {
     for (const theme of ['dark', 'dracula', 'nord', 'rose-pine', 'kanagawa', 'cyberdream']) {
+      expect(isDarkApplicationTheme(theme)).to.equal(true)
+      expect(getNativeThemeSource({ followSystemTheme: false, theme })).to.equal('dark')
+    }
+  })
+
+  it('uses the shared MarkText dark theme classification', () => {
+    for (const theme of [...railscastsThemes, ...oneDarkThemes]) {
       expect(isDarkApplicationTheme(theme)).to.equal(true)
       expect(getNativeThemeSource({ followSystemTheme: false, theme })).to.equal('dark')
     }

--- a/test/unit/specs/native-theme.spec.js
+++ b/test/unit/specs/native-theme.spec.js
@@ -1,0 +1,22 @@
+import { getNativeThemeSource, isDarkApplicationTheme } from 'main_renderer/app/nativeTheme'
+
+describe('Native theme source', () => {
+  it('follows the system when configured to do so', () => {
+    expect(getNativeThemeSource({ followSystemTheme: true, theme: 'dark' })).to.equal('system')
+    expect(getNativeThemeSource({ followSystemTheme: true, theme: 'light' })).to.equal('system')
+  })
+
+  it('uses dark native menus for dark MarkText themes', () => {
+    for (const theme of ['dark', 'dracula', 'nord', 'rose-pine', 'kanagawa', 'cyberdream']) {
+      expect(isDarkApplicationTheme(theme)).to.equal(true)
+      expect(getNativeThemeSource({ followSystemTheme: false, theme })).to.equal('dark')
+    }
+  })
+
+  it('uses light native menus for light MarkText themes', () => {
+    for (const theme of ['light', 'graphite', 'ulysses', 'tokyo-night-light', 'unknown-theme']) {
+      expect(isDarkApplicationTheme(theme)).to.equal(false)
+      expect(getNativeThemeSource({ followSystemTheme: false, theme })).to.equal('light')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- set Electron nativeTheme.themeSource from the selected MarkText theme when not following the system theme
- keep nativeTheme in system mode when Follow System Theme is enabled
- add unit coverage for light/dark native theme source selection

Fixes #533

## Validation
- npm test -- test/unit/specs/native-theme.spec.js
- npm run lint -- src/main/app/index.js src/main/app/nativeTheme.js test/unit/specs/native-theme.spec.js
- npm run build
- npm test (544 tests passed, but Vitest exits nonzero because of an existing Prism unhandled rejection from test/unit/specs/markdown-basic.spec.js)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#533: Custom application menu theme](https://oss.issuehunt.io/repos/110446844/issues/533)
---
</details>
<!-- /Issuehunt content-->