### PR TITLE
fix: escape HTML attributes in image tag construction to prevent XSS/RCE

### DIFF
--- a/src/muya/lib/contentState/imageCtrl.js
+++ b/src/muya/lib/contentState/imageCtrl.js
@@ -1,6 +1,16 @@
 import { URL_REG, DATA_URL_REG } from '../config'
 import { correctImageSrc } from '../utils/getImageInfo'
 
+// Escape special HTML characters in attribute values to prevent injection.
+const escapeHtmlAttr = (str) => {
+  if (typeof str !== 'string') return str
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 const imageCtrl = ContentState => {
   /**
    * insert inline image at the cursor position.
@@ -114,7 +124,7 @@ const imageCtrl = ContentState => {
       if (value && attr === 'src') {
         value = correctImageSrc(value)
       }
-      imageText += `${attr}="${value}" `
+      imageText += `${escapeHtmlAttr(attr)}="${escapeHtmlAttr(value)}" `
     }
     imageText = imageText.trim()
     imageText += '>'
@@ -156,7 +166,7 @@ const imageCtrl = ContentState => {
         if (value && attr === 'src') {
           value = correctImageSrc(value)
         }
-        imageText += `${attr}="${value}" `
+        imageText += `${escapeHtmlAttr(attr)}="${escapeHtmlAttr(value)}" `
       }
       imageText = imageText.trim()
       imageText += '>'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Breaking changes? | no
| Deprecations?     | no
| New tests added?  | not needed
| Fixed tickets     | none
| License           | MIT

### Description

MarkText constructs `<img>` tags by interpolating image attributes (src, alt, title, etc.) directly into an HTML string without escaping. Because MarkText runs with `nodeIntegration: true` and `contextIsolation: false`, any JavaScript that executes in the renderer process has full access to Node.js APIs. This means a crafted Markdown file can achieve **remote code execution** simply by being opened.

#### Vulnerability details

**CWE-79 (Cross-Site Scripting) → Remote Code Execution**

In `src/muya/lib/contentState/imageCtrl.js`, the `replaceImage` and `updateImage` code paths build image HTML like this:

```js
imageText += `${attr}="${value}" `
```

Neither `attr` nor `value` is escaped. A Markdown image with a crafted alt text or title can break out of the attribute context and inject arbitrary HTML attributes, including event handlers.

#### Proof of Concept

Create a file called `exploit.md` with the following content:

```markdown
![test" onerror="require('child_process').exec('calc')](invalid-url)
```

Open this file in MarkText. Because the `alt` attribute value `test" onerror="require('child_process').exec('calc')` is interpolated without escaping, the resulting HTML becomes:

```html
<img alt="test" onerror="require('child_process').exec('calc')" src="invalid-url" >
```

The image fails to load (`invalid-url`), `onerror` fires, and `calc.exe` (or any arbitrary command) executes. On macOS/Linux, substitute with `open /System/Applications/Calculator.app` or `xcalc`.

This works because MarkText's Electron renderer has `nodeIntegration: true`, so `require('child_process')` is available in the DOM context.

#### Fix

This PR adds an `escapeHtmlAttr` helper that escapes `&`, `"`, `<`, and `>` in both attribute names and values before they are interpolated into the HTML string. This prevents breaking out of the quoted attribute context.

The fix is applied at both call sites in `imageCtrl.js` (lines 127 and 169) where image HTML is constructed.

#### Testing

- Verified that the PoC above no longer triggers code execution after the fix — the `onerror` payload is rendered as literal text inside the `alt` attribute.
- Verified that normal images (local paths, URLs, data URIs, images with titles and alt text containing safe special characters like `&`) render correctly after escaping.
- Verified that the escaping function handles non-string inputs gracefully by returning them unchanged.

#### Adversarial review

Before submitting, we considered whether existing protections would prevent exploitation. MarkText does not use a Content Security Policy that blocks inline event handlers, and the Electron configuration (`nodeIntegration: true`, `contextIsolation: false`) means any injected JS runs with full Node.js privileges. The only precondition is that a user opens a malicious `.md` file, which is the core use case of the application — users routinely open Markdown files from external sources (downloads, git repos, shared documents). There is no sanitization layer between the Markdown parser output and the DOM insertion in this code path.