### PR TITLE
i18n: translate sponsor section in all language READMEs

### DIFF
--- a/docs/i18n/README-ar.md
+++ b/docs/i18n/README-ar.md
@@ -104,11 +104,11 @@
 
 <h2 dir="rtl" align="center">دعم MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText هو محرر Markdown مفتوح المصدر يعتمد على دعم مجتمعه. إذا كان MarkText يُحسّن سير عملك، يُرجى التفكير في [دعم المشروع](https://github.com/sponsors/marktext). شكراً لجميع الداعمين ❤️
 
-**Special Sponsor**
+**الراعي المميز**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">استخرج نتائج Google ومحركات البحث الأخرى من خلال واجهة برمجية سريعة وسهلة وشاملة.</a>
 
 ## لقطة شاشة
 

--- a/docs/i18n/README-ar.md
+++ b/docs/i18n/README-ar.md
@@ -104,11 +104,15 @@
 
 <h2 dir="rtl" align="center">دعم MarkText</h2>
 
+<div dir="rtl">
+
 MarkText هو محرر Markdown مفتوح المصدر يعتمد على دعم مجتمعه. إذا كان MarkText يُحسّن سير عملك، يُرجى التفكير في [دعم المشروع](https://github.com/sponsors/marktext). شكراً لجميع الداعمين ❤️
 
 **الراعي المميز**
 
 <a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">استخرج نتائج Google ومحركات البحث الأخرى من خلال واجهة برمجية سريعة وسهلة وشاملة.</a>
+
+</div>
 
 ## لقطة شاشة
 

--- a/docs/i18n/README-ar.md
+++ b/docs/i18n/README-ar.md
@@ -104,15 +104,11 @@
 
 <h2 dir="rtl" align="center">دعم MarkText</h2>
 
-<div dir="rtl">
-
 MarkText هو محرر Markdown مفتوح المصدر يعتمد على دعم مجتمعه. إذا كان MarkText يُحسّن سير عملك، يُرجى التفكير في [دعم المشروع](https://github.com/sponsors/marktext). شكراً لجميع الداعمين ❤️
 
 **الراعي المميز**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">استخرج نتائج Google ومحركات البحث الأخرى من خلال واجهة برمجية سريعة وسهلة وشاملة.</a>
-
-</div>
+<a dir="rtl" href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">استخرج نتائج Google ومحركات البحث الأخرى من خلال واجهة برمجية سريعة وسهلة وشاملة.</a>
 
 ## لقطة شاشة
 

--- a/docs/i18n/README-de.md
+++ b/docs/i18n/README-de.md
@@ -104,11 +104,11 @@
 
 <h2 align="center">MarkText unterstützen</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText ist ein Open-Source-Markdown-Editor, der von seiner Community unterstützt wird. Wenn MarkText Ihren Workflow verbessert, erwägen Sie bitte, [das Projekt zu sponsern](https://github.com/sponsors/marktext). Vielen Dank an alle Sponsoren ❤️
 
-**Special Sponsor**
+**Besonderer Sponsor**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Extrahieren Sie Daten von Google und anderen Suchmaschinen über unsere schnelle, einfache und vollständige API.</a>
 
 ## Screenshot
 

--- a/docs/i18n/README-es.md
+++ b/docs/i18n/README-es.md
@@ -104,11 +104,11 @@
 
 <h2 align="center">Apoyando a MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText es un editor de Markdown de código abierto impulsado por el apoyo de su comunidad. Si MarkText mejora tu flujo de trabajo, considera [patrocinar el proyecto](https://github.com/sponsors/marktext). Gracias a todos los patrocinadores ❤️
 
-**Special Sponsor**
+**Patrocinador Especial**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Extrae resultados de Google y otros motores de búsqueda con nuestra API rápida, sencilla y completa.</a>
 
 ## Capturas de pantalla
 

--- a/docs/i18n/README-fr.md
+++ b/docs/i18n/README-fr.md
@@ -104,11 +104,11 @@
 
 <h2 align="center">Soutenir MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText est un éditeur Markdown open-source soutenu par sa communauté. Si MarkText améliore votre flux de travail, pensez à [soutenir le projet](https://github.com/sponsors/marktext). Merci à tous les sponsors ❤️
 
-**Special Sponsor**
+**Sponsor Spécial**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Extrayez les résultats de Google et d'autres moteurs de recherche grâce à notre API rapide, facile et complète.</a>
 
 ## Captures d'écran
 

--- a/docs/i18n/README-jp.md
+++ b/docs/i18n/README-jp.md
@@ -105,11 +105,11 @@
 
 <h2 align="center">MarkText を支援する</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText はコミュニティの支援によって成り立つオープンソースの Markdown エディターです。MarkText があなたのワークフローを改善するなら、[プロジェクトへのスポンサー](https://github.com/sponsors/marktext)をご検討ください。すべてのスポンサーに感謝します ❤️
 
-**Special Sponsor**
+**スペシャルスポンサー**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">高速で使いやすく完全な API で Google や他の検索エンジンからデータを取得できます。</a>
 
 ## スクリーンショット
 

--- a/docs/i18n/README-kr.md
+++ b/docs/i18n/README-kr.md
@@ -105,11 +105,11 @@
 
 <h2 align="center">MarkText 지원</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText는 커뮤니티의 지원으로 운영되는 오픈소스 Markdown 편집기입니다. MarkText가 작업 흐름을 개선한다면 [프로젝트 후원](https://github.com/sponsors/marktext)을 고려해 주세요. 모든 후원자 여러분께 감사드립니다 ❤️
 
-**Special Sponsor**
+**특별 후원사**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">빠르고 쉬우며 완전한 API로 Google 및 기타 검색 엔진에서 데이터를 수집하세요.</a>
 
 ## 스크린샷
 

--- a/docs/i18n/README-pt.md
+++ b/docs/i18n/README-pt.md
@@ -104,11 +104,11 @@
 
 <h2 align="center">Apoiando o MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText é um editor Markdown de código aberto impulsionado pelo apoio de sua comunidade. Se o MarkText melhora seu fluxo de trabalho, considere [patrocinar o projeto](https://github.com/sponsors/marktext). Obrigado a todos os patrocinadores ❤️
 
-**Special Sponsor**
+**Patrocinador Especial**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Extraia dados do Google e de outros mecanismos de busca com nossa API rápida, fácil e completa.</a>
 
 ## Capturas de tela
 

--- a/docs/i18n/README-tr.md
+++ b/docs/i18n/README-tr.md
@@ -105,11 +105,11 @@
 
 <h2 align="center">MarkText'e Destek Olun</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText, topluluğunun desteğiyle hayata geçirilmiş açık kaynaklı bir Markdown editörüdür. MarkText iş akışınızı iyileştiriyorsa, lütfen [projeye destek olmayı](https://github.com/sponsors/marktext) düşünün. Tüm destekçilere teşekkürler ❤️
 
-**Special Sponsor**
+**Özel Destekçi**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Hızlı, kolay ve kapsamlı API'miz ile Google ve diğer arama motorlarından veri çekin.</a>
 
 ## Ekran Görüntüsü
 

--- a/docs/i18n/README-zh_cn.md
+++ b/docs/i18n/README-zh_cn.md
@@ -105,11 +105,11 @@
 
 <h2 align="center">支持 MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText 是一款由社区支持驱动的开源 Markdown 编辑器。如果 MarkText 改善了您的工作流程，请考虑[赞助本项目](https://github.com/sponsors/marktext)。感谢所有赞助者 ❤️
 
-**Special Sponsor**
+**特别赞助商**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">通过我们快速、便捷且完整的 API 抓取 Google 及其他搜索引擎的数据。</a>
 
 ## 截图
 

--- a/docs/i18n/README-zh_tw.md
+++ b/docs/i18n/README-zh_tw.md
@@ -105,11 +105,11 @@
 
 <h2 align="center">支持 MarkText</h2>
 
-MarkText is an open-source Markdown editor powered by the support of its community. If MarkText improves your workflow, please consider [sponsoring the project](https://github.com/sponsors/marktext). Thank you to all the sponsors ❤️
+MarkText 是一款由社群支持驅動的開源 Markdown 編輯器。如果 MarkText 改善了您的工作流程，請考慮[贊助本專案](https://github.com/sponsors/marktext)。感謝所有贊助者 ❤️
 
-**Special Sponsor**
+**特別贊助商**
 
-<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">Scrape Google and other search engines from our fast, easy, and complete API.</a>
+<a href="https://serpapi.com/?utm_source=marktext"><img src="../assets/sponsors/serpapi.png" width="150">透過我們快速、便捷且完整的 API 抓取 Google 及其他搜尋引擎的資料。</a>
 
 ## 截圖
 


### PR DESCRIPTION
## Summary

- Translated the sponsor section body text, **Special Sponsor** label, and SerpAPI description from English into each file's target language
- Affected files: `README-ar.md`, `README-de.md`, `README-es.md`, `README-fr.md`, `README-jp.md`, `README-kr.md`, `README-pt.md`, `README-tr.md`, `README-zh_cn.md`, `README-zh_tw.md`

| File | Language | Key translations |
|------|----------|-----------------|
| README-ar.md | Arabic | الراعي المميز |
| README-de.md | German | Besonderer Sponsor |
| README-es.md | Spanish | Patrocinador Especial |
| README-fr.md | French | Sponsor Spécial |
| README-jp.md | Japanese | スペシャルスポンサー |
| README-kr.md | Korean | 특별 후원사 |
| README-pt.md | Portuguese | Patrocinador Especial |
| README-tr.md | Turkish | Özel Destekçi |
| README-zh_cn.md | Simplified Chinese | 特别赞助商 |
| README-zh_tw.md | Traditional Chinese | 特別贊助商 |

## Test plan

- [x] Verify each README renders correctly on GitHub
- [x] Confirm translations are natural in each target language

🤖 Generated with [Claude Code](https://claude.com/claude-code)