### PR TITLE
fix: use default font smoothing

### DIFF
--- a/src/muya/lib/assets/styles/index.css
+++ b/src/muya/lib/assets/styles/index.css
@@ -22,7 +22,7 @@
 }
 
 html {
-  -webkit-font-smoothing: antialiased;
+  -webkit-font-smoothing: auto;
 }
 
 pre {


### PR DESCRIPTION
## Summary
- Restores the browser default font smoothing for Muya instead of forcing grayscale \\-webkit-font-smoothing: antialiased\\.
- Addresses blurry editor text reported in #430, especially on standard-DPI displays where subpixel antialiasing matters.

Fixes #430.

## Verification
- \\git diff --check\\`n- \\
px --yes prettier@3.8.3 --check src/muya/lib/assets/styles/index.css\\ reports the existing CSS file is not formatted under current Prettier rules; this patch only changes the smoothing value and avoids rewriting the file.