### PR TITLE
ci: replace manual test_pr with automated PR workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,20 @@
+name: Setup pnpm and Node.js
+description: Install pnpm, Node.js, and project dependencies (skips postinstall scripts)
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.21.1'
+        cache: 'pnpm'
+
+    - name: Install Dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --ignore-scripts
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,8 @@
-name: Manual PR Build
+name: PR Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: 'PR number to test'
-        required: true
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   run-on-pr-head:
@@ -35,11 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Fetch PR head
-        run: |
-          git fetch origin +refs/pull/${{ inputs.pr }}/head:refs/remotes/origin/pr/${{ inputs.pr }}
-          git checkout -qf refs/remotes/origin/pr/${{ inputs.pr }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -91,6 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: marktext-${{ matrix.name }}
+          retention-days: 30
           path: |
             dist/*.exe
             dist/*.zip
@@ -117,6 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const run_id = context.runId;
+            const pr_number = context.payload.pull_request.number;
             const { data } = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -134,7 +128,7 @@ jobs:
               }).join('\n');
 
               const body = [
-                `Build artifacts for PR #${{ inputs.pr }}:`,
+                `Build artifacts for PR #${pr_number}:`,
                 '',
                 `Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${run_id}`,
                 '',
@@ -151,14 +145,14 @@ jobs:
         uses: peter-evans/find-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ inputs.pr }}
+          issue-number: ${{ github.event.pull_request.number }}
           body-includes: 'Build artifacts for PR'
 
       - name: Post or update PR comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ inputs.pr }}
+          issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           body: ${{ steps.build.outputs.body }}
           edit-mode: replace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-on-pr-head:
     permissions:
@@ -98,6 +102,7 @@ jobs:
   comment-on-pr:
     name: Comment artifact links on PR
     needs: run-on-pr-head
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,24 +37,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.21.1
-          cache: 'pnpm'
-
       - name: Install Linux Build Dependencies
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install -y icnsutils graphicsmagick xz-utils libx11-dev libxkbfile-dev gnome-keyring libsecret-1-dev libfontconfig-dev rpm
 
-      # --ignore-scripts so we can set env vars before postinstall runs electron-rebuild
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup
 
       # Must be set before postinstall runs electron-rebuild
       - name: Set C++20 for MacOS

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,18 +10,9 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.21.1
-          cache: 'pnpm'
 
       - name: Install System Dependencies
         run: |
@@ -31,11 +22,7 @@ jobs:
             xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
             libdrm2 libgtk-3-0 libgbm1 libasound2t64
 
-      # --ignore-scripts so we can set env vars before postinstall runs electron-rebuild
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup
 
       # Run the full postinstall: Electron binary download, patch-package,
       # electron-rebuild, and minify-locales.
@@ -48,9 +35,6 @@ jobs:
 
       - name: Build app
         run: pnpm build
-
-      - name: Install Playwright dependencies
-        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E Tests
         run: xvfb-run --auto-servernum pnpm test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,9 @@ jobs:
           npm_config_user_agent: 'pnpm'
           USE_ELECTRON_CLANG: '0'
 
+      - name: Build app
+        run: pnpm build
+
       - name: Install Playwright dependencies
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,49 @@
+name: E2E Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.1
+          cache: 'pnpm'
+
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libx11-dev libxkbfile-dev libsecret-1-dev libfontconfig-dev \
+            xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+            libdrm2 libgtk-3-0 libgbm1 libasound2t64
+
+      # --ignore-scripts so we can set env vars before postinstall runs electron-rebuild
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run the full postinstall: Electron binary download, patch-package,
+      # electron-rebuild, and minify-locales.
+      - name: Run postinstall
+        run: node scripts/postinstall.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          npm_config_user_agent: 'pnpm'
+          USE_ELECTRON_CLANG: '0'
+
+      - name: Install Playwright dependencies
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E Tests
+        run: xvfb-run --auto-servernum pnpm test:e2e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,20 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.21.1
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup
 
       - name: Run ESLint
         run: pnpm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.1
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run ESLint
+        run: pnpm lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.21.1
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Unit Tests
+        run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,20 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.21.1
-          cache: 'pnpm'
-
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/setup
 
       - name: Run Unit Tests
         run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Rename `test_pr.yml` → `build.yml`, change trigger from `workflow_dispatch` to `pull_request` (`opened`/`synchronize`/`reopened`), and set artifact retention to 30 days
- Add `lint.yml`: runs ESLint (`pnpm lint`) on every PR
- Add `test.yml`: runs Vitest unit tests (`pnpm test`) on every PR
- Add `e2e.yml`: runs Playwright + Electron E2E tests (`pnpm test:e2e`) on every PR via `xvfb-run` on Linux

## Test plan

- [x] Open a PR targeting `develop` and verify all four workflows trigger automatically in the Checks panel
- [x] Push an update to the same PR and verify `synchronize` event re-triggers all workflows
- [x] Confirm build artifacts show a 30-day expiration on the Actions run page
- [x] Confirm the `comment-on-pr` job posts artifact links correctly in the PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)