### PR TITLE
fix: word count tooltip not showing on macOS

### DIFF
--- a/src/renderer/src/components/titleBar/index.vue
+++ b/src/renderer/src/components/titleBar/index.vue
@@ -72,7 +72,6 @@
           <div
             v-if="wordCount"
             class="word-count"
-            :class="[{ 'title-no-drag': platform !== 'darwin' }]"
             @click.stop="handleWordClick"
           >
             <span class="text-center-vertical">{{ `${HASH[show].short} ${wordCount[show]}` }}</span>
@@ -397,6 +396,7 @@ div.title > span {
 }
 
 .word-count {
+  -webkit-app-region: no-drag;
   cursor: pointer;
   font-size: 14px;
   color: var(--editorColor30);


### PR DESCRIPTION
## Summary

- On macOS, the `.word-count` element in the title bar lacked `-webkit-app-region: no-drag`, so it remained inside the window drag region
- The OS intercepted `mouseenter`/`mouseleave` events for window dragging, preventing `el-tooltip` from triggering
- Previously the `no-drag` region was only applied via a template class binding on non-macOS platforms (`platform !== 'darwin'`)

**Fix:** Move `-webkit-app-region: no-drag` directly into the `.word-count` CSS rule so it applies on all platforms, and remove the now-redundant `:class` template binding.

## Test plan

- [x] Open MarkText on macOS and verify hovering over the word count in the title bar shows the tooltip with words / characters / paragraphs breakdown
- [x] Verify clicking the word count still cycles through counter types (W → P → C → A) on macOS
- [ ] Verify the same behaviour on Windows / Linux is unaffected
- [x] Verify window dragging from the title bar still works correctly (the small word-count area is no-drag; the rest of the bar remains draggable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)