### PR TITLE
fix: skip conflict detection for unbound shortcuts in keybinding loader

### DIFF
--- a/src/main/keyboard/shortcutHandler.js
+++ b/src/main/keyboard/shortcutHandler.js
@@ -195,21 +195,25 @@ class Keybindings {
 
     // Check for duplicate shortcuts
     for (const [userKey, userValue] of userAccelerators) {
-      for (const [key, value] of accelerators) {
-        // This is a workaround to unset key bindings that the user used in `keybindings.json` before
-        // proper settings. Keep this for now, but add the ID to the users key binding that we show the
-        // right bindings in settings.
-        if (isEqualAccelerator(value, userValue)) {
-          // Unset default key
-          accelerators.set(key, '')
+      // Only search for conflicts when the user actually bound a key. Empty means "unbound"
+      // and would incorrectly match any other default-empty entry via isEqualAccelerator.
+      if (userValue) {
+        for (const [key, value] of accelerators) {
+          // This is a workaround to unset key bindings that the user used in `keybindings.json` before
+          // proper settings. Keep this for now, but add the ID to the users key binding that we show the
+          // right bindings in settings.
+          if (isEqualAccelerator(value, userValue)) {
+            // Unset default key
+            accelerators.set(key, '')
 
-          // This entry is actually unset because the user used the accelerator.
-          if (userAccelerators.get(key) == null) {
-            userAccelerators.set(key, '')
+            // This entry is actually unset because the user used the accelerator.
+            if (userAccelerators.get(key) == null) {
+              userAccelerators.set(key, '')
+            }
+
+            // A accelerator should only exist once in the default map.
+            break
           }
-
-          // A accelerator should only exist once in the default map.
-          break
         }
       }
       accelerators.set(userKey, userValue)


### PR DESCRIPTION
## Summary

- Fixes a bug in `_loadLocalKeybindings` where unbinding a shortcut (accelerator stored as `''`) caused `isEqualAccelerator('', '')` to return `true`, incorrectly matching the first default-empty system key (e.g. `mt.hide`, `file.move-file`)
- The spuriously matched key was then added to `userAccelerators` and re-processed mid-loop (JS `Map` `for...of` sees entries added during iteration), compounding the issue
- After restart, Settings > Keybindings would show those default-empty system shortcuts as if the user had deliberately unbound them

**Fix:** guard the inner conflict-detection loop with `if (userValue)` — an unbound key (empty string) cannot conflict with any existing binding and should skip that step entirely.

Closes #4165

## Test plan

- [ ] Open Settings > Keybindings, unbind one or more shortcuts (e.g. `file.save`), save
- [ ] Restart MarkText and reopen Settings > Keybindings
- [ ] Confirm that only the deliberately-unbound shortcuts appear as user-defined; default-empty system shortcuts (e.g. `mt.hide`) remain as default
- [ ] Confirm existing bound shortcuts still work correctly
- [ ] `pnpm run test:unit` passes (545 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)