### PR TITLE
fix: avoid reloading existing i18n locales

### DIFF
--- a/src/renderer/src/i18n/index.js
+++ b/src/renderer/src/i18n/index.js
@@ -54,7 +54,7 @@ export const t = (key, ...args) => {
 // Export language setter function
 export const setLanguage = (locale) => {
   if (!locale) return
-  if (!i18n.global.availableLocales.includes[locale]) {
+  if (!i18n.global.availableLocales.includes(locale)) {
     // Locale not yet available, need to get it from the main process
     const translation = window.i18nUtils.loadTranslations(locale)
     if (!translation) return // Failed to load locale file, error msg should be in the loadTranslations function

--- a/test/unit/specs/i18n.spec.js
+++ b/test/unit/specs/i18n.spec.js
@@ -1,0 +1,38 @@
+describe('renderer i18n language loading', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    window.i18nUtils = {
+      loadTranslations: vi.fn(locale => ({
+        locale,
+        menu: {
+          file: {
+            file: 'File'
+          }
+        }
+      }))
+    }
+  })
+
+  afterEach(() => {
+    delete window.i18nUtils
+  })
+
+  it('does not reload the default English locale', async() => {
+    const { setLanguage, getCurrentLanguage } = await import('../../../src/renderer/src/i18n')
+
+    setLanguage('en')
+
+    expect(window.i18nUtils.loadTranslations).not.toHaveBeenCalled()
+    expect(getCurrentLanguage()).to.equal('en')
+  })
+
+  it('loads an unavailable locale only once', async() => {
+    const { setLanguage } = await import('../../../src/renderer/src/i18n')
+
+    setLanguage('zh-CN')
+    setLanguage('zh-CN')
+
+    expect(window.i18nUtils.loadTranslations).toHaveBeenCalledTimes(1)
+    expect(window.i18nUtils.loadTranslations).toHaveBeenCalledWith('zh-CN')
+  })
+})


### PR DESCRIPTION
## Summary
- Fix renderer i18n locale availability check to call availableLocales.includes(locale) instead of indexing the method
- Add focused unit coverage for keeping the default English locale loaded and caching a dynamically loaded locale

This supports the menu localization work tracked in #138 by preventing existing locale messages from being treated as missing.

## Verification
- npx --yes pnpm@10.33.4 exec vitest run test/unit/specs/i18n.spec.js
- npx --yes pnpm@10.33.4 exec eslint src/renderer/src/i18n/index.js test/unit/specs/i18n.spec.js

Note: pnpm install --frozen-lockfile linked dependencies, but this Windows machine cannot complete postinstall because Visual Studio Build Tools are missing Spectre-mitigated libraries required for native-keymap rebuild.