### PR TITLE
fix: migrate jsconfig.json away from deprecated baseUrl (TS 6.0)

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "paths": {
-      "@/*": ["src/renderer/src/*"],
-      "common/*": ["src/common/*"],
-      "muya/*": ["src/muya/*"]
+      "@/*": ["./src/renderer/src/*"],
+      "common/*": ["./src/common/*"],
+      "muya/*": ["./src/muya/*"]
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "out"]
 }


### PR DESCRIPTION
## Summary

- Removes the deprecated `baseUrl` compiler option, which TypeScript 6.0 warns will stop working in TS 7.0 ([migration guide](https://aka.ms/ts6))
- Adds `moduleResolution: "bundler"` — the correct setting for Vite-based projects — and explicit `target`/`module: ESNext`
- Updates `paths` entries with `./` prefix as required when `baseUrl` is absent
- Adds `out/` to the `exclude` list (this is the electron-vite compiled output directory, already git-ignored)

## Test plan

- [x] Run `npx tsc --noEmit --project jsconfig.json` — should produce no errors
- [x] Open the project in VS Code / VSCodium and confirm path alias go-to-definition works for `@/`, `common/`, and `muya/` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)