### PR TITLE
fix: add pnpm-workspace.yaml to approve build scripts for native deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  ced: true
+  electron-winstaller: true
+  esbuild: true
+  keytar: true
+  native-keymap: true


### PR DESCRIPTION
## Summary

- pnpm 11 requires explicit approval of dependency build scripts via `allowBuilds` in `pnpm-workspace.yaml`
- Without this file, pnpm walks up to the parent directory and finds placeholder values, causing `ERR_PNPM_IGNORED_BUILDS` for `ced`, `esbuild`, `keytar`, `native-keymap`, and `electron-winstaller`
- Adds `pnpm-workspace.yaml` with `allowBuilds: true` for all five packages so `pnpm install` completes cleanly

## Test plan

- [x] Run `pnpm install` and verify no `ERR_PNPM_IGNORED_BUILDS` warning appears
- [x] Run `pnpm run dev` and verify the app starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)