### PR TITLE
fix(i18n): capitalize GitHub in English and Portuguese locale strings

### DIFF
--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -392,7 +392,7 @@
     "title": "Send us feedback via tweet",
     "feelingsQuestion": "What's your experience feelings?",
     "feedbackQuestion": "Tell us your feedback?",
-    "reportViaGithub": "Report bug or feature request via github",
+    "reportViaGithub": "Report bug or feature request via GitHub",
     "tweet": "Tweet"
   },
   "preferences": {

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -393,7 +393,7 @@
     "title": "Envie-nos feedback via tweet",
     "feelingsQuestion": "Qual é a sua experiência?",
     "feedbackQuestion": "Conte-nos seu feedback?",
-    "reportViaGithub": "Reportar bug ou solicitação de recurso via github",
+    "reportViaGithub": "Reportar bug ou solicitação de recurso via GitHub",
     "tweet": "Tweet"
   },
   "preferences": {


### PR DESCRIPTION
**Changes:**

- `en.json`: `"Report bug or feature request via github"` → `"Report bug or feature request via GitHub"`
- `pt.json`: `"Reportar bug ou solicitação de recurso via github"` → `"Reportar bug ou solicitação de recurso via GitHub"`

Other locales (zh-CN, zh-TW, de, es, fr, ja, ko) already use the correct capitalization.

---
Co-Authored-By: AtomCode (deepseek-v4-flash) <noreply@atomgit.com>