### PR TITLE
docs: expand CLAUDE.md with single-test recipes and dev script catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,8 @@
-# MarkText — CLAUDE.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+# MarkText
 
 ## Project Overview
 
@@ -61,15 +65,28 @@ dist/          Packaged installers from electron-builder (git-ignored)
 ## Development Workflow
 
 ```bash
-# Install dependencies
+# Install dependencies (runs scripts/postinstall.js automatically)
 pnpm install
 
 # Run in development mode
 # Renderer hot-reloads automatically; press Ctrl+R to reload main/preload after edits
 pnpm run dev
 
+# Preview the last electron-vite build (no rebuild). PERF_TESTING=true is set automatically.
+pnpm run start
+
+# Build without packaging — fast path for verifying the renderer/main compile
+pnpm run build:unpack
+
+# Auto-format the repo with Prettier (separate from `lint`, which only checks)
+pnpm run format
+
 # Minify locale files (required for production builds, skip during dev)
 pnpm run minify-locales
+
+# Performance debugging — exposes a Node inspector on :5858 against the previewed build
+pnpm run perf:inspect       # attach when ready
+pnpm run perf:inspect-brk   # break on first line
 ```
 
 ## Build Commands
@@ -89,6 +106,14 @@ pnpm run test          # All unit tests (Vitest)
 pnpm run test:unit     # Unit tests only
 pnpm run test:e2e      # End-to-end tests (Playwright)
 pnpm run lint          # ESLint (run before committing; not currently enforced by CI)
+
+# Run a single Vitest file or test name
+pnpm exec vitest run test/unit/path/to/file.spec.js
+pnpm exec vitest run -t 'partial test name'
+
+# Run a single Playwright spec or a named test
+pnpm exec playwright test test/e2e/path/to/file.spec.js
+pnpm exec playwright test -g 'partial test name'
 ```
 
 ## Code Style
@@ -133,6 +158,19 @@ Muya  (src/muya/)
 Most IPC channels between main and renderer use the `mt::` prefix (e.g. `mt::open-new-tab`, `mt::file-saved`). Some internal channels do not follow this convention (e.g. `language-changed`).
 
 See `docs/dev/IPC.md` for conventions and examples.
+
+## Further Reading
+
+`docs/dev/` contains the deeper developer documentation referenced by this guide:
+
+- `ARCHITECTURE.md` — process/module layering beyond the summary above
+- `BUILD.md` — full platform build prerequisites (including the Arch Linux deps added recently)
+- `DEBUGGING.md` — attaching debuggers to main/renderer processes
+- `INTERFACE.md` — Muya and renderer public interfaces
+- `IPC.md` — full IPC channel catalog and `mt::` conventions
+- `LINUX_DEV.md` — Linux-specific dev environment setup
+- `PERFORMANCE.md` — perf measurement workflow (pairs with `pnpm run perf:inspect`)
+- `RELEASE.md` / `RELEASE_HOTFIX.md` — release process
 
 ## Important Build Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ dist/          Packaged installers from electron-builder (git-ignored)
 pnpm install
 
 # Run in development mode
-# Renderer hot-reloads automatically; press Ctrl+R to reload main/preload after edits
+# Renderer hot-reloads automatically. Pressing Ctrl+R in the dev window reloads
+# the renderer (which re-runs the preload script); changes to the main process
+# require restarting `pnpm run dev`.
 pnpm run dev
 
 # Preview the last electron-vite build (no rebuild). PERF_TESTING=true is set automatically.
@@ -107,12 +109,12 @@ pnpm run test:unit     # Unit tests only
 pnpm run test:e2e      # End-to-end tests (Playwright)
 pnpm run lint          # ESLint (run before committing; not currently enforced by CI)
 
-# Run a single Vitest file or test name
-pnpm exec vitest run test/unit/path/to/file.spec.js
+# Run a single Vitest file or test name (specs live under test/unit/specs/)
+pnpm exec vitest run test/unit/specs/markdown-basic.spec.js
 pnpm exec vitest run -t 'partial test name'
 
-# Run a single Playwright spec or a named test
-pnpm exec playwright test test/e2e/path/to/file.spec.js
+# Run a single Playwright spec or a named test (specs live directly under test/e2e/)
+pnpm exec playwright test test/e2e/launch.spec.js
 pnpm exec playwright test -g 'partial test name'
 ```
 
@@ -177,7 +179,7 @@ See `docs/dev/IPC.md` for conventions and examples.
 - **CommonJS vs ESM**: `main` and `preload` compile to CommonJS; `renderer` is ESM-only. Do not use `require()` in renderer code.
 - **Minify locales**: `pnpm run minify-locales` must run before production builds. It is included in `build:win/mac/linux` but not in `dev`.
 - **Native modules**: After changing Electron version, run `pnpm run rebuild-native` (`electron-rebuild -f`).
-- **Hot reload**: Only the renderer process hot-reloads in dev mode. After editing `main/` or `preload/` source, press `Ctrl+R` in the development window.
+- **Hot reload**: The renderer hot-reloads via Vite HMR. `Ctrl+R` in the dev window reloads the renderer and re-runs the preload script. Changes to `main/` source are NOT picked up by a window reload — restart `pnpm run dev` to pick them up.
 - **Path aliases** (defined in `electron.vite.config.js`): `@` → `src/renderer/src`, `common` → `src/common`, `muya` → `src/muya`. Imports from muya therefore look like `muya/lib/...`.
 
 ## Contribution


### PR DESCRIPTION
## Summary
- Adds the standard Claude Code preamble required by `/init` so future Claude Code sessions recognize the file.
- Documents existing-but-undocumented npm scripts: `format`, `start`, `build:unpack`, `perf:inspect`, `perf:inspect-brk`.
- Adds single-file / single-test invocations for Vitest and Playwright (`pnpm exec vitest run -t '…'`, `pnpm exec playwright test -g '…'`).
- Adds a "Further Reading" section linking the existing docs under `docs/dev/` (ARCHITECTURE, BUILD, DEBUGGING, INTERFACE, IPC, LINUX_DEV, PERFORMANCE, RELEASE).

No code changes — `CLAUDE.md` only.

## Test plan
- [x] `CLAUDE.md` renders correctly on GitHub
- [x] All referenced scripts exist in `package.json`
- [x] All referenced files exist under `docs/dev/`