### PR TITLE
fix(source-view): stop styling math subscripts as emphasis (#4121)

### DIFF
--- a/src/renderer/src/codeMirror/index.js
+++ b/src/renderer/src/codeMirror/index.js
@@ -8,6 +8,7 @@ import codeMirror from 'codemirror/lib/codemirror'
 import loadmode from './loadmode'
 import overlayMode from './overlayMode'
 import multiplexMode from './mltiplexMode'
+import registerMarkdownMathMode from './markdownMathMode'
 import languages from './modes'
 import 'codemirror/lib/codemirror.css'
 import './index.css'
@@ -16,6 +17,7 @@ import 'codemirror/theme/railscasts.css'
 loadmode(codeMirror)
 overlayMode(codeMirror)
 multiplexMode(codeMirror)
+registerMarkdownMathMode(codeMirror)
 window.CodeMirror = codeMirror
 
 const modes = codeMirror.modeInfo

--- a/src/renderer/src/codeMirror/markdownMathMode.js
+++ b/src/renderer/src/codeMirror/markdownMathMode.js
@@ -1,0 +1,48 @@
+// CodeMirror "markdown-math" — a Markdown mode that delegates the contents of
+// `$...$` (inline) and `$$...$$` (block) math spans to the stex (LaTeX) mode.
+// Without this wrapper the plain Markdown mode highlights `_` as emphasis
+// delimiters even inside math, producing spurious italics for subscript
+// expressions like `$\text{F}_\text{A} = \text{F}_\text{B}$` in the source
+// view. See https://github.com/marktext/marktext/issues/4121.
+//
+// Both inner modes must be loaded eagerly here so that `getMode` resolves
+// them synchronously at the time the wrapper is instantiated.
+import 'codemirror/mode/markdown/markdown'
+import 'codemirror/mode/stex/stex'
+
+const registerMarkdownMathMode = (CodeMirror) => {
+  if (CodeMirror.modes && Object.prototype.hasOwnProperty.call(CodeMirror.modes, 'markdown-math')) {
+    return
+  }
+
+  CodeMirror.defineMode('markdown-math', function(config) {
+    const markdownMode = CodeMirror.getMode(config, {
+      name: 'markdown',
+      fencedCodeBlocks: true,
+      strikethrough: true,
+      taskLists: true
+    })
+    const stexMode = CodeMirror.getMode(config, 'stex')
+
+    // `$$` must come before `$` so the longer delimiter is matched first.
+    return CodeMirror.multiplexingMode(
+      markdownMode,
+      {
+        open: '$$',
+        close: '$$',
+        mode: stexMode,
+        delimStyle: 'formatting formatting-math formatting-math-block math-block',
+        innerStyle: 'math math-block'
+      },
+      {
+        open: '$',
+        close: '$',
+        mode: stexMode,
+        delimStyle: 'formatting formatting-math formatting-math-inline math-inline',
+        innerStyle: 'math math-inline'
+      }
+    )
+  })
+}
+
+export default registerMarkdownMathMode

--- a/src/renderer/src/codeMirror/markdownMathMode.js
+++ b/src/renderer/src/codeMirror/markdownMathMode.js
@@ -1,14 +1,27 @@
-// CodeMirror "markdown-math" — a Markdown mode that delegates the contents of
-// `$...$` (inline) and `$$...$$` (block) math spans to the stex (LaTeX) mode.
-// Without this wrapper the plain Markdown mode highlights `_` as emphasis
-// delimiters even inside math, producing spurious italics for subscript
-// expressions like `$\text{F}_\text{A} = \text{F}_\text{B}$` in the source
-// view. See https://github.com/marktext/marktext/issues/4121.
+// CodeMirror "markdown-math" — a GFM-flavoured Markdown mode that delegates
+// the contents of `$...$` (inline) and `$$...$$` (block) math spans to the
+// stex (LaTeX) mode. Without this wrapper the standard markdown mode highlights
+// `_` as emphasis delimiters even inside math, producing spurious italics for
+// subscript expressions like `$\text{F}_\text{A} = \text{F}_\text{B}$` in the
+// source view. See https://github.com/marktext/marktext/issues/4121.
 //
-// Both inner modes must be loaded eagerly here so that `getMode` resolves
-// them synchronously at the time the wrapper is instantiated.
+// The outer mode is `gfm` to preserve the tables / autolinks / task lists
+// styling the previous `setMode(cm, 'markdown')` call resolved to via
+// `codeMirror/modes.js` (which maps "markdown" → `gfm` / `text/x-gfm`).
+//
+// All inner modes are loaded eagerly so `getMode` resolves synchronously at
+// the time the wrapper is instantiated. `gfm` itself depends on `markdown`.
 import 'codemirror/mode/markdown/markdown'
+import 'codemirror/mode/gfm/gfm'
 import 'codemirror/mode/stex/stex'
+
+// Open guard for inline `$…$`. Mirrors Muya's `inline_math` rule
+// (`src/muya/lib/parser/rules.js`): require non-empty content with no inner
+// `$`, last char before the closer not being `\`, and the closing `$` not
+// followed by another `$` (which would be block math). This stops a single
+// stray `$` (e.g. "$5 owed") from flipping the inner mode on forever and keeps
+// the source-view tokenization aligned with the inline parse.
+const INLINE_MATH_OPEN = /\$(?!\$)(?=[^$\n]*?[^$\\]\$(?!\$))/
 
 const registerMarkdownMathMode = (CodeMirror) => {
   if (CodeMirror.modes && Object.prototype.hasOwnProperty.call(CodeMirror.modes, 'markdown-math')) {
@@ -16,8 +29,8 @@ const registerMarkdownMathMode = (CodeMirror) => {
   }
 
   CodeMirror.defineMode('markdown-math', function(config) {
-    const markdownMode = CodeMirror.getMode(config, {
-      name: 'markdown',
+    const gfmMode = CodeMirror.getMode(config, {
+      name: 'gfm',
       fencedCodeBlocks: true,
       strikethrough: true,
       taskLists: true
@@ -25,8 +38,11 @@ const registerMarkdownMathMode = (CodeMirror) => {
     const stexMode = CodeMirror.getMode(config, 'stex')
 
     // `$$` must come before `$` so the longer delimiter is matched first.
+    // Block math (`$$…$$`) intentionally has no lookahead guard: a matching
+    // closer typically lives on a later line, which CodeMirror's per-line
+    // tokenizer cannot see from the opener.
     return CodeMirror.multiplexingMode(
-      markdownMode,
+      gfmMode,
       {
         open: '$$',
         close: '$$',
@@ -35,7 +51,7 @@ const registerMarkdownMathMode = (CodeMirror) => {
         innerStyle: 'math math-block'
       },
       {
-        open: '$',
+        open: INLINE_MATH_OPEN,
         close: '$',
         mode: stexMode,
         delimStyle: 'formatting formatting-math formatting-math-inline math-inline',

--- a/src/renderer/src/components/editorWithTabs/sourceCode.vue
+++ b/src/renderer/src/components/editorWithTabs/sourceCode.vue
@@ -10,7 +10,7 @@ import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { usePreferencesStore } from '@/store/preferences'
 import { storeToRefs } from 'pinia'
-import codeMirror, { setMode, setCursorAtFirstLine, setTextDirection } from '../../codeMirror'
+import codeMirror, { setCursorAtFirstLine, setTextDirection } from '../../codeMirror'
 import { wordCount as getWordCount } from 'muya/lib/utils'
 import { adjustCursor } from '../../util'
 import bus from '../../bus'
@@ -304,7 +304,10 @@ onMounted(() => {
   // See https://github.com/codemirror/codemirror5/issues/6886 - hence, we need to use a local variable first.
   const codeMirrorInstance = codeMirror(container, codeMirrorConfig)
 
-  setMode(codeMirrorInstance, 'markdown')
+  // `markdown-math` wraps the standard Markdown mode and delegates `$...$` and
+  // `$$...$$` spans to stex so subscript underscores in math do not flip the
+  // outer mode into emphasis. See src/renderer/src/codeMirror/markdownMathMode.js.
+  codeMirrorInstance.setOption('mode', 'markdown-math')
 
   codeMirrorInstance.on('contextmenu', (cm, event) => {
     event.preventDefault()

--- a/test/e2e/source-math.spec.js
+++ b/test/e2e/source-math.spec.js
@@ -1,0 +1,47 @@
+const { expect, test } = require('@playwright/test')
+const { launchWithMarkdown, enterSourceMode } = require('./helpers')
+
+// Regression test for https://github.com/marktext/marktext/issues/4121
+// Underscores inside inline math (`$...$`) and block math (`$$...$$`) must
+// not be highlighted as Markdown emphasis in the source view: in math mode
+// they are subscript operators, not italic delimiters.
+test.describe('Source view: inline math tokenization (#4121)', () => {
+  let app = null
+  let page = null
+
+  test.beforeAll(async() => {
+    const md = '$\\text{F}_\\text{A} = \\text{F}_\\text{B}$ vs. $F_A = F_B$\n'
+    const launched = await launchWithMarkdown(md)
+    app = launched.app
+    page = launched.page
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('underscores inside $...$ are not styled as Markdown emphasis', async() => {
+    await enterSourceMode(page, app)
+
+    // Force the entire document to be tokenized so that off-screen lines have
+    // their highlight classes flushed to the DOM (defensive — the spec body
+    // here is only one line but viewport-driven rendering is brittle).
+    await page.waitForFunction(() => {
+      const root = document.querySelector('.source-code .CodeMirror')
+      if (!root || !root.CodeMirror) return false
+      const cm = root.CodeMirror
+      // Eagerly retokenize through line 0 to ensure highlight classes land.
+      cm.getTokenAt({ line: 0, ch: cm.getLine(0).length }, true)
+      return true
+    }, null, { timeout: 5000 })
+
+    const emTexts = await page.evaluate(() => {
+      const spans = document.querySelectorAll('.source-code .CodeMirror .cm-em')
+      return Array.from(spans).map((s) => s.textContent)
+    })
+
+    // There is no Markdown emphasis (`_word_` or `*word*`) outside of the
+    // math spans in our fixture, so any .cm-em span proves the bug.
+    expect(emTexts).toEqual([])
+  })
+})

--- a/test/e2e/source-math.spec.js
+++ b/test/e2e/source-math.spec.js
@@ -5,15 +5,45 @@ const { launchWithMarkdown, enterSourceMode } = require('./helpers')
 // Underscores inside inline math (`$...$`) and block math (`$$...$$`) must
 // not be highlighted as Markdown emphasis in the source view: in math mode
 // they are subscript operators, not italic delimiters.
-test.describe('Source view: inline math tokenization (#4121)', () => {
+const FIXTURE = [
+  '$\\text{F}_\\text{A} = \\text{F}_\\text{B}$ vs. $F_A = F_B$',
+  '',
+  '$$',
+  '\\sum_{i=1}^{n} a_{i} = b_{i}',
+  '$$',
+  '',
+  'I owe $5 and you owe $10 only.',
+  ''
+].join('\n')
+
+const readSourceState = async(page) => {
+  await page.waitForFunction(() => {
+    const root = document.querySelector('.source-code .CodeMirror')
+    if (!root || !root.CodeMirror) return false
+    const cm = root.CodeMirror
+    const last = cm.lastLine()
+    cm.getTokenAt({ line: last, ch: cm.getLine(last).length }, true)
+    return true
+  }, null, { timeout: 5000 })
+
+  return page.evaluate(() => {
+    const emTexts = Array.from(document.querySelectorAll('.source-code .CodeMirror .cm-em'))
+      .map((s) => s.textContent)
+    const mathInline = document.querySelectorAll('.source-code .CodeMirror .cm-math-inline').length
+    const mathBlock = document.querySelectorAll('.source-code .CodeMirror .cm-math-block').length
+    return { emTexts, mathInline, mathBlock }
+  })
+}
+
+test.describe('Source view: math tokenization (#4121)', () => {
   let app = null
   let page = null
 
   test.beforeAll(async() => {
-    const md = '$\\text{F}_\\text{A} = \\text{F}_\\text{B}$ vs. $F_A = F_B$\n'
-    const launched = await launchWithMarkdown(md)
+    const launched = await launchWithMarkdown(FIXTURE)
     app = launched.app
     page = launched.page
+    await enterSourceMode(page, app)
   })
 
   test.afterAll(async() => {
@@ -21,27 +51,30 @@ test.describe('Source view: inline math tokenization (#4121)', () => {
   })
 
   test('underscores inside $...$ are not styled as Markdown emphasis', async() => {
-    await enterSourceMode(page, app)
-
-    // Force the entire document to be tokenized so that off-screen lines have
-    // their highlight classes flushed to the DOM (defensive — the spec body
-    // here is only one line but viewport-driven rendering is brittle).
-    await page.waitForFunction(() => {
-      const root = document.querySelector('.source-code .CodeMirror')
-      if (!root || !root.CodeMirror) return false
-      const cm = root.CodeMirror
-      // Eagerly retokenize through line 0 to ensure highlight classes land.
-      cm.getTokenAt({ line: 0, ch: cm.getLine(0).length }, true)
-      return true
-    }, null, { timeout: 5000 })
-
-    const emTexts = await page.evaluate(() => {
-      const spans = document.querySelectorAll('.source-code .CodeMirror .cm-em')
-      return Array.from(spans).map((s) => s.textContent)
-    })
-
-    // There is no Markdown emphasis (`_word_` or `*word*`) outside of the
-    // math spans in our fixture, so any .cm-em span proves the bug.
+    const { emTexts, mathInline } = await readSourceState(page)
+    // There is no Markdown emphasis (`_word_` or `*word*`) outside math in the
+    // fixture, so any `.cm-em` span proves the bug.
     expect(emTexts).toEqual([])
+    // And the inline-math regions must actually be classified as math.
+    expect(mathInline).toBeGreaterThan(0)
+  })
+
+  test('underscores inside $$...$$ block math are not styled as emphasis', async() => {
+    const { mathBlock } = await readSourceState(page)
+    expect(mathBlock).toBeGreaterThan(0)
+  })
+
+  test('a lone $ followed by no closing $ does not enter math mode', async() => {
+    // The fixture's last paragraph has `$5 ... $10 only.` (no third $),
+    // so any `$` after the second one must not start an unbounded math span.
+    const lastLineHasMath = await page.evaluate(() => {
+      const root = document.querySelector('.source-code .CodeMirror')
+      const spans = root.querySelectorAll('.cm-math-inline, .cm-math-block')
+      for (const span of spans) {
+        if (span.textContent && span.textContent.includes('only')) return true
+      }
+      return false
+    })
+    expect(lastLineHasMath).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- In the source view the standard CodeMirror markdown mode treats `_` as an emphasis delimiter even inside `$...$` / `$$...$$`, so subscripts in expressions like `$\text{F}_\text{A} = \text{F}_\text{B}$` rendered with spurious italics (#4121).
- Wrap the markdown mode with `multiplexingMode` and delegate inline/block math spans to the existing `stex` mode so underscores keep their math semantics.
- Add a Playwright regression spec that loads the issue's fixture, switches to source mode, and asserts no `.cm-em` spans remain.

## Implementation notes

- New `src/renderer/src/codeMirror/markdownMathMode.js` defines a `markdown-math` mode (markdown outer + stex for `$$…$$` and `$…$`).
- Registered once in `codeMirror/index.js` after `multiplexMode(codeMirror)`.
- `sourceCode.vue` now sets `mode = 'markdown-math'` directly; the `setMode` helper is no longer needed here.

## Test plan

- [x] `pnpm exec playwright test test/e2e/source-math.spec.js` — fails before the fix, passes after.
- [x] `pnpm exec playwright test test/e2e/editor-input.spec.js test/e2e/view-modes.spec.js` — existing source-mode coverage still green.
- [x] `pnpm run lint`.
- [x] Manual smoke: open a doc with `$F_A = F_B$` and toggle source view — no italic styling inside the math span.

Closes #4121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)