### PR TITLE
fix: resolve Mermaid diagram rendering failure on Windows - #3606 

### DIFF
--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -1,6 +1,6 @@
 import loadRenderer from '../../renderers'
-import { CLASS_OR_ID, PREVIEW_DOMPURIFY_CONFIG } from '../../config'
-import { conflict, mixins, camelToSnake, sanitize } from '../../utils'
+import { CLASS_OR_ID } from '../../config'
+import { conflict, mixins, camelToSnake } from '../../utils'
 import { patch, toVNode, toHTML, h } from './snabbdom'
 import { beginRules } from '../rules'
 import renderInlines from './renderInlines'
@@ -114,10 +114,14 @@ class StateRender {
           continue
         }
         try {
-          mermaid.parse(code)
-          target.innerHTML = sanitize(code, PREVIEW_DOMPURIFY_CONFIG, true)
-          mermaid.init(undefined, target)
+          const id = `mermaid-${key.replace('#', '')}`
+          const { svg } = await mermaid.render(id, code)
+          target.innerHTML = svg
         } catch (err) {
+          const container = document.getElementById(`mermaid-${key.replace('#', '')}`)
+          if (container) {
+            container.remove()
+          }
           target.innerHTML = '< Invalid Mermaid Codes >'
           target.classList.add(CLASS_OR_ID.AG_MATH_ERROR)
         }

--- a/src/muya/lib/utils/exportHtml.js
+++ b/src/muya/lib/utils/exportHtml.js
@@ -29,24 +29,30 @@ class ExportHtml {
 
   async renderMermaid() {
     const codes = this.exportContainer.querySelectorAll('code.language-mermaid')
-    for (const code of codes) {
-      const preEle = code.parentNode
-      const mermaidContainer = document.createElement('div')
-      mermaidContainer.innerHTML = sanitize(
-        unescapeHTML(code.innerHTML),
-        EXPORT_DOMPURIFY_CONFIG,
-        true
-      )
-      mermaidContainer.classList.add('mermaid')
-      preEle.replaceWith(mermaidContainer)
-    }
     const mermaid = await loadRenderer('mermaid')
-    // We only export light theme, so set mermaid theme to `default`, in the future, we can choose whick theme to export.
     mermaid.initialize({
       securityLevel: 'strict',
       theme: 'default'
     })
-    mermaid.init(undefined, this.exportContainer.querySelectorAll('div.mermaid'))
+    let index = 0
+    for (const code of codes) {
+      const preEle = code.parentNode
+      const rawCode = unescapeHTML(code.innerHTML)
+      const mermaidContainer = document.createElement('div')
+      mermaidContainer.classList.add('mermaid')
+      preEle.replaceWith(mermaidContainer)
+      try {
+        const id = `mermaid-export-${index++}`
+        const { svg } = await mermaid.render(id, rawCode)
+        mermaidContainer.innerHTML = svg
+      } catch (err) {
+        const container = document.getElementById(`mermaid-export-${index - 1}`)
+        if (container) {
+          container.remove()
+        }
+        mermaidContainer.innerHTML = '< Invalid Diagram >'
+      }
+    }
     if (this.muya) {
       mermaid.initialize({
         securityLevel: 'strict',


### PR DESCRIPTION
Closes #3606

## Summary

Fix "Invalid Mermaid Codes" error when rendering Mermaid diagrams. The root cause is that the project uses Mermaid v11 (`^11.15.0`), but the rendering code still relies on deprecated APIs that have changed behavior in newer versions:

1. **`mermaid.parse(code)`** became asynchronous in v11 (returns `Promise<ParseResult>`), but was called synchronously, so parse errors were never properly caught and the code always fell into the catch block.
2. **`mermaid.init(undefined, target)`** was deprecated in v10 and has unstable behavior in v11 (internally calls `mermaid.run({ suppressErrors: true })`), which fails to render diagrams correctly.
3. The old workflow set `innerHTML` to the raw mermaid code text via `sanitize()`, then called `mermaid.init()` to render from the DOM — an unnecessary intermediate step that could break with certain mermaid syntax (e.g. HTML tags, frontmatter `---` blocks as reported in #3606).

This PR replaces the deprecated API calls with the recommended **`mermaid.render(id, code)`** (available since v10), which directly accepts a code string and returns the rendered SVG HTML, eliminating the fragile intermediate DOM step.

### Changes

- **`src/muya/lib/parser/render/index.js`** (editor rendering):
  
  - Replace `mermaid.parse()` + `mermaid.init()` with `await mermaid.render(id, code)`
  - Properly `await` the async `mermaid.render()` call
  - Clean up temporary DOM elements created by `mermaid.render()` on failure
  - Remove unused `sanitize` and `PREVIEW_DOMPURIFY_CONFIG` imports

- **`src/muya/lib/utils/exportHtml.js`** (HTML export rendering):
  
  - Replace `mermaid.init()` with `await mermaid.render(id, code)` for each diagram
  - Remove the unnecessary `sanitize()` call on the raw mermaid code before rendering
  - Add error handling with cleanup of temporary DOM elements on failure

## Type of change

- [x]  Bug fix (non-breaking, fixes an issue)
- [ ]  New feature (non-breaking, adds functionality)
- [ ]  Breaking change (causes existing functionality to change)
- [ ]  Documentation update

## Test plan

- [x]  Manually tested on: Windows

Test cases to verify:

1. Simple flowchart renders correctly: `graph LR; A-->B; B-->C;`
2. Mermaid code with HTML tags in labels (the original #3606 case) renders without "Invalid Mermaid Codes" error
3. Mermaid code with frontmatter `---` title block renders correctly
4. Invalid mermaid code shows "Invalid Mermaid Codes" error message instead of crashing
5. Export to HTML renders mermaid diagrams correctly
6. Switching between dark/default mermaid themes works

## Notes for reviewers

- `mermaid.render(id, code)` creates a temporary hidden `<div>` in the document body with the given `id` to render the SVG. If rendering fails, this element remains in the DOM and must be manually cleaned up — hence the `document.getElementById(id)?.remove()` in the catch block.
- The `id` parameter must be unique across the page. In the editor, we use `mermaid-${blockKey}`; in export, we use `mermaid-export-${index}`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).