### PR TITLE
refactor(test): port specs to strict TS — drop @ts-nocheck, ESM imports (TS migration follow-up 3/6)

### DIFF
--- a/docs/dev/TYPESCRIPT.md
+++ b/docs/dev/TYPESCRIPT.md
@@ -160,8 +160,12 @@ These items are tracked as follow-up PRs:
 2. **All `.vue` SFCs** — remove `// @ts-nocheck` from `<script setup
    lang="ts">` blocks, type `defineProps`/`defineEmits`, fix
    ~20 errors per file.
-3. **Test specs** — remove `// @ts-nocheck` from `test/unit/specs/*.spec.ts`
-   and `test/e2e/*.spec.ts`, convert CommonJS `require()` to ESM `import`.
+3. ~~**Test specs** — remove `// @ts-nocheck` from `test/unit/specs/*.spec.ts`
+   and `test/e2e/*.spec.ts`, convert CommonJS `require()` to ESM `import`.~~
+   **Done.** Every spec uses ESM `import { test, expect } from
+   '@playwright/test'` / `import { describe, it, expect } from 'vitest'`
+   and is type-checked. `test/e2e/helpers.ts` is fully typed; vitest specs
+   import their globals explicitly.
 4. **`@typescript-eslint/no-explicit-any`** — currently `warn` in
    `eslint.config.js`. Tighten to `error` after the per-file
    `// @ts-nocheck` opt-outs above have been removed and the remaining

--- a/test/e2e/command-palette.spec.ts
+++ b/test/e2e/command-palette.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, sendIpcToRenderer } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, sendIpcToRenderer } from './helpers'
 
 test.describe('Command palette', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# Palette\n')

--- a/test/e2e/context-isolation.spec.ts
+++ b/test/e2e/context-isolation.spec.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchElectron } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
 
 // Asserts the renderer is actually sandboxed: contextIsolation: true,
 // nodeIntegration: false, sandbox: true. If any of these regress, the bridge
@@ -9,8 +8,8 @@ const { launchElectron } = require('./helpers')
 // test is the canary.
 
 test.describe('Renderer sandboxing', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const { app: electronApp, page: firstPage } = await launchElectron()

--- a/test/e2e/editor-input.spec.ts
+++ b/test/e2e/editor-input.spec.ts
@@ -1,17 +1,16 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const {
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
   launchWithMarkdown,
   getMarkdownContent,
   enterSourceMode,
   exitSourceMode,
   typeIntoEditor
-} = require('./helpers')
+} from './helpers'
 
 test.describe('Editor input and source-mode roundtrip', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# Hello\n\nStarting paragraph.\n')
@@ -31,9 +30,12 @@ test.describe('Editor input and source-mode roundtrip', () => {
 
   test('Toggling source mode preserves content', async() => {
     await enterSourceMode(page, app)
-    const md = await page.evaluate(() =>
-      document.querySelector('.source-code .CodeMirror').CodeMirror.getValue()
-    )
+    const md = await page.evaluate(() => {
+      const cm = document.querySelector('.source-code .CodeMirror') as
+        | (Element & { CodeMirror: { getValue(): string } })
+        | null
+      return cm ? cm.CodeMirror.getValue() : ''
+    })
     expect(md).toContain('# Hello')
     await exitSourceMode(page, app)
     const stillThere = await page.locator('.editor-component').isVisible()

--- a/test/e2e/find-replace.spec.ts
+++ b/test/e2e/find-replace.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, sendIpcToRenderer, focusEditor } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, sendIpcToRenderer, focusEditor } from './helpers'
 
 test.describe('Find bar', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown(

--- a/test/e2e/fixture-render.spec.ts
+++ b/test/e2e/fixture-render.spec.ts
@@ -1,12 +1,13 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithDoc } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithDoc } from './helpers'
 
-const runFixture = (name, relativePath, assertion) => {
+type FixtureAssertion = (ctx: { page: Page }) => Promise<void>
+
+const runFixture = (name: string, relativePath: string, assertion: FixtureAssertion): void => {
   test.describe(`Fixture: ${name}`, () => {
-    let app = null
-    let page = null
+    let app: ElectronApplication | null = null
+    let page: Page
 
     test.beforeAll(async() => {
       const launched = await launchWithDoc(relativePath)

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -1,18 +1,16 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const { _electron } = require('playwright')
+import { _electron, type ElectronApplication, type Page } from 'playwright'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 
 const projectRoot = path.resolve(__dirname, '../..')
 
-const getDateAsFilename = () => {
+const getDateAsFilename = (): string => {
   const date = new Date()
   return '' + date.getFullYear() + (date.getMonth() + 1) + date.getDay()
 }
 
-const getTempPath = (suffix = '') => {
+const getTempPath = (suffix = ''): string => {
   const name =
     'marktext-e2etest-' +
     getDateAsFilename() +
@@ -22,7 +20,7 @@ const getTempPath = (suffix = '') => {
   return path.join(os.tmpdir(), name)
 }
 
-const getElectronPath = () => {
+export const getElectronPath = (): string => {
   if (process.platform === 'win32') {
     return path.resolve(path.join('node_modules', '.bin', 'electron.cmd'))
   }
@@ -33,8 +31,8 @@ const getElectronPath = () => {
 
 // Track every temp directory we create so we can sweep them on process exit
 // (Playwright workers persist across specs but die when the run ends).
-const createdTempDirs = new Set()
-const trackTempDir = (dir) => {
+const createdTempDirs = new Set<string>()
+const trackTempDir = (dir: string): string => {
   createdTempDirs.add(dir)
   return dir
 }
@@ -48,7 +46,12 @@ process.on('exit', () => {
   }
 })
 
-const launchElectron = async(userArgs) => {
+export interface LaunchResult {
+  app: ElectronApplication
+  page: Page
+}
+
+export const launchElectron = async(userArgs?: string[]): Promise<LaunchResult> => {
   userArgs = userArgs || []
   const executablePath = getElectronPath()
   // Pass project root as entry so Electron reads package.json and getAppPath() returns project root.
@@ -68,7 +71,10 @@ const launchElectron = async(userArgs) => {
   return { app, page }
 }
 
-const waitForMenuReady = async(app, timeout = 10000) => {
+export const waitForMenuReady = async(
+  app: ElectronApplication,
+  timeout = 10000
+): Promise<void> => {
   const deadline = Date.now() + timeout
   while (Date.now() < deadline) {
     const ready = await app.evaluate(({ Menu }) => !!Menu.getApplicationMenu())
@@ -78,7 +84,7 @@ const waitForMenuReady = async(app, timeout = 10000) => {
   throw new Error('Application menu was not built within timeout')
 }
 
-const clickMenuById = async(app, id) => {
+export const clickMenuById = async(app: ElectronApplication, id: string): Promise<void> => {
   await app.evaluate(({ Menu, BrowserWindow }, menuId) => {
     const menu = Menu.getApplicationMenu()
     if (!menu) throw new Error('Application menu is not built yet')
@@ -102,7 +108,7 @@ const clickMenuById = async(app, id) => {
   }, id)
 }
 
-const waitForEditor = async(page, timeout = 15000) => {
+export const waitForEditor = async(page: Page, timeout = 15000): Promise<void> => {
   await page.waitForSelector('.editor-component', { state: 'attached', timeout })
   await page.waitForFunction(
     () => {
@@ -114,14 +120,16 @@ const waitForEditor = async(page, timeout = 15000) => {
   )
 }
 
-const enterSourceMode = async(page, app) => {
+export const enterSourceMode = async(page: Page, app: ElectronApplication): Promise<void> => {
   const already = await page.evaluate(() => !!document.querySelector('.source-code .CodeMirror'))
   if (already) return
   await clickMenuById(app, 'sourceCodeModeMenuItem')
   await page.waitForSelector('.source-code .CodeMirror', { state: 'attached', timeout: 10000 })
   await page.waitForFunction(
     () => {
-      const cm = document.querySelector('.source-code .CodeMirror')
+      const cm = document.querySelector('.source-code .CodeMirror') as
+        | (Element & { CodeMirror?: unknown })
+        | null
       return cm && cm.CodeMirror
     },
     null,
@@ -129,7 +137,7 @@ const enterSourceMode = async(page, app) => {
   )
 }
 
-const exitSourceMode = async(page, app) => {
+export const exitSourceMode = async(page: Page, app: ElectronApplication): Promise<void> => {
   const inSource = await page.evaluate(() => !!document.querySelector('.source-code .CodeMirror'))
   if (!inSource) return
   await clickMenuById(app, 'sourceCodeModeMenuItem')
@@ -138,20 +146,25 @@ const exitSourceMode = async(page, app) => {
   })
 }
 
-const getMarkdownContent = async(page, app) => {
+export const getMarkdownContent = async(
+  page: Page,
+  app: ElectronApplication
+): Promise<string> => {
   const wasInSource = await page.evaluate(
     () => !!document.querySelector('.source-code .CodeMirror')
   )
   if (!wasInSource) await enterSourceMode(page, app)
   const value = await page.evaluate(() => {
-    const cm = document.querySelector('.source-code .CodeMirror')
+    const cm = document.querySelector('.source-code .CodeMirror') as
+      | (Element & { CodeMirror?: { getValue(): string } })
+      | null
     return cm && cm.CodeMirror ? cm.CodeMirror.getValue() : ''
   })
   if (!wasInSource) await exitSourceMode(page, app)
   return value
 }
 
-const typeIntoEditor = async(page, text) => {
+export const typeIntoEditor = async(page: Page, text: string): Promise<void> => {
   await page.click('.editor-component', { timeout: 5000 })
   await page.keyboard.type(text, { delay: 0 })
 }
@@ -159,24 +172,25 @@ const typeIntoEditor = async(page, text) => {
 // Muya validates selections via `node.closest('span.ag-paragraph')` — the inner
 // span that wraps editable text. Selecting the outer <p class="ag-paragraph">
 // or its contents fails validation, so we always target the inner span.
-const focusEditor = async(page) => {
+export const focusEditor = async(page: Page): Promise<void> => {
   await page.evaluate(() => {
-    const root = document.querySelector('.editor-component')
+    const root = document.querySelector('.editor-component') as HTMLElement | null
     if (!root) return false
     root.focus()
     const spans = root.querySelectorAll('span.ag-paragraph')
-    let target = null
+    let target: Element | null = null
     for (const span of spans) {
       if (span.textContent && span.textContent.trim().length > 0) {
         target = span
         break
       }
     }
-    target = target || spans[0]
+    target = target || spans[0] || null
     if (!target) return false
     const range = document.createRange()
     range.selectNodeContents(target)
     const sel = window.getSelection()
+    if (!sel) return false
     sel.removeAllRanges()
     sel.addRange(range)
     document.dispatchEvent(new Event('selectionchange'))
@@ -186,25 +200,26 @@ const focusEditor = async(page) => {
   await page.waitForTimeout(150)
 }
 
-const placeCaretInEditor = async(page) => {
+export const placeCaretInEditor = async(page: Page): Promise<void> => {
   await page.evaluate(() => {
-    const root = document.querySelector('.editor-component')
+    const root = document.querySelector('.editor-component') as HTMLElement | null
     if (!root) return
     root.focus()
     const spans = root.querySelectorAll('span.ag-paragraph')
-    let target = null
+    let target: Element | null = null
     for (const span of spans) {
       if (span.textContent && span.textContent.trim().length > 0) {
         target = span
         break
       }
     }
-    target = target || spans[0]
+    target = target || spans[0] || null
     if (!target) return
     const range = document.createRange()
     range.selectNodeContents(target)
     range.collapse(false)
     const sel = window.getSelection()
+    if (!sel) return
     sel.removeAllRanges()
     sel.addRange(range)
     document.dispatchEvent(new Event('selectionchange'))
@@ -212,16 +227,22 @@ const placeCaretInEditor = async(page) => {
   await page.waitForTimeout(150)
 }
 
-const setSourceMarkdown = async(page, app, markdown) => {
+export const setSourceMarkdown = async(
+  page: Page,
+  app: ElectronApplication,
+  markdown: string
+): Promise<void> => {
   await enterSourceMode(page, app)
   await page.evaluate((value) => {
-    const cm = document.querySelector('.source-code .CodeMirror')
+    const cm = document.querySelector('.source-code .CodeMirror') as
+      | (Element & { CodeMirror?: { setValue(v: string): void } })
+      | null
     if (cm && cm.CodeMirror) cm.CodeMirror.setValue(value)
   }, markdown)
   await exitSourceMode(page, app)
 }
 
-const writeTempMarkdown = (content) => {
+const writeTempMarkdown = (content: string): string => {
   const dir = trackTempDir(getTempPath('-doc'))
   fs.mkdirSync(dir, { recursive: true })
   const filePath = path.join(dir, 'note.md')
@@ -229,14 +250,18 @@ const writeTempMarkdown = (content) => {
   return filePath
 }
 
-const launchWithDoc = async(relativeFixture) => {
+export const launchWithDoc = async(relativeFixture: string): Promise<LaunchResult> => {
   const { app, page } = await launchElectron([relativeFixture])
   await waitForEditor(page)
   await waitForMenuReady(app)
   return { app, page }
 }
 
-const launchWithMarkdown = async(markdown = '') => {
+export interface LaunchWithMarkdownResult extends LaunchResult {
+  filePath: string
+}
+
+export const launchWithMarkdown = async(markdown = ''): Promise<LaunchWithMarkdownResult> => {
   const filePath = writeTempMarkdown(markdown)
   const { app, page } = await launchElectron([filePath])
   await waitForEditor(page)
@@ -244,7 +269,11 @@ const launchWithMarkdown = async(markdown = '') => {
   return { app, page, filePath }
 }
 
-const sendIpcToRenderer = async(app, channel, ...args) => {
+export const sendIpcToRenderer = async(
+  app: ElectronApplication,
+  channel: string,
+  ...args: unknown[]
+): Promise<void> => {
   await app.evaluate(
     ({ BrowserWindow }, payload) => {
       const win = BrowserWindow.getAllWindows()[0]
@@ -252,22 +281,4 @@ const sendIpcToRenderer = async(app, channel, ...args) => {
     },
     { channel, args }
   )
-}
-
-module.exports = {
-  getElectronPath,
-  launchElectron,
-  launchWithDoc,
-  launchWithMarkdown,
-  waitForEditor,
-  waitForMenuReady,
-  clickMenuById,
-  enterSourceMode,
-  exitSourceMode,
-  getMarkdownContent,
-  typeIntoEditor,
-  focusEditor,
-  placeCaretInEditor,
-  setSourceMarkdown,
-  sendIpcToRenderer
 }

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -7,7 +7,7 @@ const projectRoot = path.resolve(__dirname, '../..')
 
 const getDateAsFilename = (): string => {
   const date = new Date()
-  return '' + date.getFullYear() + (date.getMonth() + 1) + date.getDay()
+  return '' + date.getFullYear() + (date.getMonth() + 1) + date.getDate()
 }
 
 const getTempPath = (suffix = ''): string => {

--- a/test/e2e/inline-format.spec.ts
+++ b/test/e2e/inline-format.spec.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, clickMenuById } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, clickMenuById } from './helpers'
 
 // Note: applying inline format marks (bold/italic/etc.) requires a live Muya
 // selection driven by user gestures. Setting DOM selection from outside the
@@ -24,8 +23,8 @@ const formatMenuIds = [
 ]
 
 test.describe('Inline format menu wiring', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('format wiring target\n')

--- a/test/e2e/launch.spec.ts
+++ b/test/e2e/launch.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchElectron } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
 
 test.describe('Check Launch MarkText', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const { app: electronApp, page: firstPage } = await launchElectron()

--- a/test/e2e/layout-toggles.spec.ts
+++ b/test/e2e/layout-toggles.spec.ts
@@ -1,15 +1,14 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, clickMenuById } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, clickMenuById } from './helpers'
 
 // Wait until a `v-show`-toggled element's visibility differs from `wasVisible`.
 // A missing element counts as "not visible", so the change-detection logic
 // stays consistent whether v-show clears the inline style or unmounts the node.
-const waitForVisibilityFlip = (page, selector, wasVisible) =>
+const waitForVisibilityFlip = (page: Page, selector: string, wasVisible: boolean) =>
   page.waitForFunction(
     ({ sel, prior }) => {
-      const el = document.querySelector(sel)
+      const el = document.querySelector(sel) as HTMLElement | null
       const visible = !!(el && el.style.display !== 'none' && el.offsetParent !== null)
       return visible !== prior
     },
@@ -18,8 +17,8 @@ const waitForVisibilityFlip = (page, selector, wasVisible) =>
   )
 
 test.describe('Layout panel toggles', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# Layout\n\n## Section A\n\n## Section B\n')
@@ -58,7 +57,7 @@ test.describe('Layout panel toggles', () => {
       await clickMenuById(app, 'sideBarMenuItem')
       await page.waitForFunction(
         () => {
-          const el = document.querySelector('.side-bar')
+          const el = document.querySelector('.side-bar') as HTMLElement | null
           return el && el.offsetParent !== null
         },
         null,

--- a/test/e2e/menu-sanity.spec.ts
+++ b/test/e2e/menu-sanity.spec.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchElectron, waitForMenuReady } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication } from 'playwright'
+import { launchElectron, waitForMenuReady } from './helpers'
 
 test.describe('Application menu wiring', () => {
-  let app = null
+  let app: ElectronApplication
 
   test.beforeAll(async() => {
     const { app: electronApp } = await launchElectron()
@@ -18,7 +17,8 @@ test.describe('Application menu wiring', () => {
 
   test('Top-level menu has the expected categories', async() => {
     const labels = await app.evaluate(({ Menu }) => {
-      return Menu.getApplicationMenu().items.map((i) => i.label)
+      const menu = Menu.getApplicationMenu()
+      return menu ? menu.items.map((i) => i.label) : []
     })
     expect(labels.length).toBeGreaterThanOrEqual(5)
   })
@@ -59,6 +59,7 @@ test.describe('Application menu wiring', () => {
     ]
     const present = await app.evaluate(({ Menu }, ids) => {
       const menu = Menu.getApplicationMenu()
+      if (!menu) return ids.map(() => false)
       return ids.map((id) => !!menu.getMenuItemById(id))
     }, expected)
     expected.forEach((id, idx) => {

--- a/test/e2e/paragraph-blocks.spec.ts
+++ b/test/e2e/paragraph-blocks.spec.ts
@@ -1,21 +1,20 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const {
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
   launchWithMarkdown,
   clickMenuById,
   setSourceMarkdown,
   placeCaretInEditor
-} = require('./helpers')
+} from './helpers'
 
-const resetTo = async(page, app, text) => {
+const resetTo = async(page: Page, app: ElectronApplication, text: string) => {
   await setSourceMarkdown(page, app, text + '\n')
   await placeCaretInEditor(page)
 }
 
 test.describe('Paragraph block transforms', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('seed paragraph\n')

--- a/test/e2e/plantuml.spec.ts
+++ b/test/e2e/plantuml.spec.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, focusEditor } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, focusEditor } from './helpers'
 
 // Validates the pako-based encoder that replaced Node zlib in
 // src/muya/lib/parser/render/plantuml.js. The encoded payload is what shows
@@ -11,8 +10,8 @@ const { launchWithMarkdown, focusEditor } = require('./helpers')
 const PLANTUML_DOC = '# plantuml smoke\n\n```plantuml\n@startuml\nA -> B\n@enduml\n```\n'
 
 test.describe('PlantUML render via pako', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown(PLANTUML_DOC)

--- a/test/e2e/ripgrep-search.spec.ts
+++ b/test/e2e/ripgrep-search.spec.ts
@@ -1,17 +1,16 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const { expect, test } = require('@playwright/test')
-const { launchElectron } = require('./helpers')
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
 
 // End-to-end smoke for the streaming ripgrep IPC (mt::rg::start /
 // mt::rg::match / mt::rg::done). Writes a small fixture tree, drives the
 // search directly through window.ripgrep so we don't depend on the sidebar
 // being open + focused, and asserts results stream back to the renderer.
 
-const writeFixtureTree = () => {
+const writeFixtureTree = (): string => {
   const dir = path.join(os.tmpdir(), 'mt-rg-' + Math.random().toString(36).slice(2, 8))
   fs.mkdirSync(dir, { recursive: true })
   fs.writeFileSync(path.join(dir, 'one.md'), '# Hello\n\nmagic-needle-XYZ in body.\n')
@@ -21,9 +20,9 @@ const writeFixtureTree = () => {
 }
 
 test.describe('Ripgrep IPC streaming', () => {
-  let app = null
-  let page = null
-  let fixtureDir = null
+  let app: ElectronApplication
+  let page: Page
+  let fixtureDir: string | null = null
 
   test.beforeAll(async() => {
     fixtureDir = writeFixtureTree()
@@ -42,22 +41,28 @@ test.describe('Ripgrep IPC streaming', () => {
   })
 
   test('text search streams matches and resolves', async() => {
-    const matches = await page.evaluate((directory) => {
-      return new Promise((resolve, reject) => {
+    interface RgMatch {
+      filePath: string
+    }
+    const matches = await page.evaluate<RgMatch[], string>((directory) => {
+      return new Promise<RgMatch[]>((resolve, reject) => {
         const searchId = 'rg-test-' + Math.random().toString(36).slice(2, 8)
-        const captured = []
-        const offMatch = window.ripgrep.onMatch((p) => {
-          if (p?.searchId === searchId) captured.push(p.payload)
+        const captured: RgMatch[] = []
+        const offMatch = window.ripgrep.onMatch((raw) => {
+          const p = raw as { searchId?: string; payload?: RgMatch }
+          if (p?.searchId === searchId && p.payload) captured.push(p.payload)
         })
         const cleanup = () => offMatch()
-        const offDone = window.ripgrep.onDone((p) => {
+        const offDone = window.ripgrep.onDone((raw) => {
+          const p = raw as { searchId?: string }
           if (p?.searchId !== searchId) return
           cleanup()
           offDone()
           offError()
           resolve(captured)
         })
-        const offError = window.ripgrep.onError((p) => {
+        const offError = window.ripgrep.onError((raw) => {
+          const p = raw as { searchId?: string; error?: string }
           if (p?.searchId !== searchId) return
           cleanup()
           offDone()
@@ -74,7 +79,7 @@ test.describe('Ripgrep IPC streaming', () => {
           })
           .catch(reject)
       })
-    }, fixtureDir)
+    }, fixtureDir as string)
 
     expect(matches.length).toBeGreaterThanOrEqual(2)
     const paths = matches.map((m) => m.filePath).sort()
@@ -83,21 +88,24 @@ test.describe('Ripgrep IPC streaming', () => {
   })
 
   test('file search (--files) streams paths', async() => {
-    const files = await page.evaluate((directory) => {
-      return new Promise((resolve, reject) => {
+    const files = await page.evaluate<string[], string>((directory) => {
+      return new Promise<string[]>((resolve, reject) => {
         const searchId = 'fs-test-' + Math.random().toString(36).slice(2, 8)
-        const seen = []
-        const offMatch = window.ripgrep.onMatch((p) => {
+        const seen: string[] = []
+        const offMatch = window.ripgrep.onMatch((raw) => {
+          const p = raw as { searchId?: string; payload?: unknown }
           if (p?.searchId === searchId && typeof p.payload === 'string') seen.push(p.payload)
         })
-        const offDone = window.ripgrep.onDone((p) => {
+        const offDone = window.ripgrep.onDone((raw) => {
+          const p = raw as { searchId?: string }
           if (p?.searchId !== searchId) return
           offMatch()
           offDone()
           offError()
           resolve(seen)
         })
-        const offError = window.ripgrep.onError((p) => {
+        const offError = window.ripgrep.onError((raw) => {
+          const p = raw as { searchId?: string; error?: string }
           if (p?.searchId !== searchId) return
           offMatch()
           offDone()
@@ -114,7 +122,7 @@ test.describe('Ripgrep IPC streaming', () => {
           })
           .catch(reject)
       })
-    }, fixtureDir)
+    }, fixtureDir as string)
 
     expect(files.length).toBeGreaterThanOrEqual(3)
   })

--- a/test/e2e/source-math.spec.ts
+++ b/test/e2e/source-math.spec.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, enterSourceMode } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, enterSourceMode } from './helpers'
 
 // Regression test for https://github.com/marktext/marktext/issues/4121
 // Underscores inside inline math (`$...$`) and block math (`$$...$$`) must
@@ -18,10 +17,18 @@ const FIXTURE = [
   ''
 ].join('\n')
 
-const readSourceState = async(page) => {
+interface CMInstance {
+  lastLine(): number
+  getLine(n: number): string
+  getTokenAt(pos: { line: number; ch: number }, precise?: boolean): unknown
+}
+
+const readSourceState = async(page: Page) => {
   await page.waitForFunction(
     () => {
-      const root = document.querySelector('.source-code .CodeMirror')
+      const root = document.querySelector('.source-code .CodeMirror') as
+        | (Element & { CodeMirror?: CMInstance })
+        | null
       if (!root || !root.CodeMirror) return false
       const cm = root.CodeMirror
       const last = cm.lastLine()
@@ -43,8 +50,8 @@ const readSourceState = async(page) => {
 }
 
 test.describe('Source view: math tokenization (#4121)', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown(FIXTURE)
@@ -76,6 +83,7 @@ test.describe('Source view: math tokenization (#4121)', () => {
     // so any `$` after the second one must not start an unbounded math span.
     const lastLineHasMath = await page.evaluate(() => {
       const root = document.querySelector('.source-code .CodeMirror')
+      if (!root) return false
       const spans = root.querySelectorAll('.cm-math-inline, .cm-math-block')
       for (const span of spans) {
         if (span.textContent && span.textContent.includes('only')) return true

--- a/test/e2e/tabs.spec.ts
+++ b/test/e2e/tabs.spec.ts
@@ -1,13 +1,12 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, sendIpcToRenderer } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, sendIpcToRenderer } from './helpers'
 
 const tabSelector = '.tabs-container > li'
 
 test.describe('Tab management', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# Tab base\n')

--- a/test/e2e/themes.spec.ts
+++ b/test/e2e/themes.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, clickMenuById } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, clickMenuById } from './helpers'
 
 test.describe('Theme switching', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# Theme test\n\nHello theme world.\n')

--- a/test/e2e/view-modes.spec.ts
+++ b/test/e2e/view-modes.spec.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchWithMarkdown, clickMenuById } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, clickMenuById } from './helpers'
 
 test.describe('View modes', () => {
-  let app = null
-  let page = null
+  let app: ElectronApplication
+  let page: Page
 
   test.beforeAll(async() => {
     const launched = await launchWithMarkdown('# View modes\n\nBody.\n')
@@ -22,7 +21,10 @@ test.describe('View modes', () => {
     await expect(page.locator('.editor-wrapper')).toHaveClass(/(^|\s)focus(\s|$)/)
     await clickMenuById(app, 'focusModeMenuItem')
     await page.waitForFunction(
-      () => !document.querySelector('.editor-wrapper').classList.contains('focus'),
+      () => {
+        const el = document.querySelector('.editor-wrapper')
+        return !el || !el.classList.contains('focus')
+      },
       null,
       { timeout: 5000 }
     )
@@ -33,7 +35,10 @@ test.describe('View modes', () => {
     await expect(page.locator('.editor-wrapper')).toHaveClass(/(^|\s)typewriter(\s|$)/)
     await clickMenuById(app, 'typewriterModeMenuItem')
     await page.waitForFunction(
-      () => !document.querySelector('.editor-wrapper').classList.contains('typewriter'),
+      () => {
+        const el = document.querySelector('.editor-wrapper')
+        return !el || !el.classList.contains('typewriter')
+      },
       null,
       { timeout: 5000 }
     )

--- a/test/e2e/xss.spec.ts
+++ b/test/e2e/xss.spec.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
-// @ts-nocheck
-const { expect, test } = require('@playwright/test')
-const { launchElectron } = require('./helpers')
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
 
 test.describe('Test XSS Vulnerabilities', () => {
-  let app = null
+  let app: ElectronApplication
 
-  let page = null
+  let page: Page
 
   test.beforeAll(async() => {
     const { app: electronApp, page: firstPage } = await launchElectron(['test/e2e/data/xss.md'])

--- a/test/unit/markdown.ts
+++ b/test/unit/markdown.ts
@@ -1,9 +1,7 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 import fs from 'fs'
 import path from 'path'
 
-const loadMarkdownContent = (pathname) => {
+const loadMarkdownContent = (pathname: string): string => {
   // Load file and ensure LF line endings.
   return fs
     .readFileSync(path.resolve('test/unit/data', pathname), 'utf-8')

--- a/test/unit/specs/export-markdown.spec.ts
+++ b/test/unit/specs/export-markdown.spec.ts
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import ExportMarkdown from '../../../src/muya/lib/utils/exportMarkdown'
+import { describe, it, expect, beforeEach } from 'vitest'
+import ExportMarkdown from 'muya/lib/utils/exportMarkdown'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TableBlock = Record<string, any>
 
 // Build a minimal table block structure that ExportMarkdown.normalizeTable expects.
-const makeTableBlock = (headerCells, bodyRows) => {
-  const makeCell = (text, type = 'td', align = '') => ({
+const makeTableBlock = (headerCells: string[], bodyRows: string[][]): TableBlock => {
+  const makeCell = (text: string, type = 'td', align = ''): TableBlock => ({
     type,
     align,
     children: [{ text }]
@@ -34,7 +36,8 @@ const makeTableBlock = (headerCells, bodyRows) => {
 }
 
 describe('ExportMarkdown.normalizeTable', () => {
-  let exporter
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let exporter: any
 
   beforeEach(() => {
     exporter = new ExportMarkdown([])

--- a/test/unit/specs/extract-word.spec.ts
+++ b/test/unit/specs/extract-word.spec.ts
@@ -1,6 +1,11 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import { extractWord } from '../../../src/muya/lib/marktext/spellchecker.js'
+import { describe, it, expect } from 'vitest'
+import { extractWord } from 'muya/lib/marktext/spellchecker.js'
+
+interface WordResult {
+  left: number
+  right: number
+  word: string
+}
 
 const basicCheck = 'Lorem ipsum dolor'
 const basicText =
@@ -10,11 +15,15 @@ const basicMdText =
 const nonAscii =
   '虥諰 鯦鯢鯡 媓幁惁 墏, 邆錉霋 鱐鱍鱕 銪 鈌鈅, 韎餀 骱 噮噦噞 虥諰諨 樆樦潏 蝺 嬔嬚嬞 脬舑莕 騩鰒...'
 
-const buildResult = (left, right, word) => {
+const buildResult = (left: number, right: number, word: string): WordResult => {
   return { left, right, word }
 }
 
-const test = (text, offset, expectedWord) => {
+const test = (
+  text: string | null,
+  offset: number | undefined,
+  expectedWord: WordResult | null
+): void => {
   const wordInfo = extractWord(text, offset)
   if (expectedWord === null) {
     expect(wordInfo).to.equal(null)

--- a/test/unit/specs/i18n.spec.ts
+++ b/test/unit/specs/i18n.spec.ts
@@ -1,10 +1,18 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+
+interface MockI18nUtils {
+  loadTranslations: Mock
+}
+
+// Window.i18nUtils is required in the runtime contextBridge typing, but in
+// this unit test we install a mock with `vi.fn` and remove it between specs.
+const win = window as unknown as { i18nUtils?: MockI18nUtils }
+
 describe('renderer i18n language loading', () => {
   beforeEach(() => {
     vi.resetModules()
-    window.i18nUtils = {
-      loadTranslations: vi.fn((locale) => ({
+    win.i18nUtils = {
+      loadTranslations: vi.fn((locale: string) => ({
         locale,
         menu: {
           file: {
@@ -16,7 +24,7 @@ describe('renderer i18n language loading', () => {
   })
 
   afterEach(() => {
-    delete window.i18nUtils
+    delete win.i18nUtils
   })
 
   it('does not reload the default English locale', async() => {
@@ -24,7 +32,7 @@ describe('renderer i18n language loading', () => {
 
     setLanguage('en')
 
-    expect(window.i18nUtils.loadTranslations).not.toHaveBeenCalled()
+    expect(win.i18nUtils!.loadTranslations).not.toHaveBeenCalled()
     expect(getCurrentLanguage()).to.equal('en')
   })
 
@@ -34,7 +42,7 @@ describe('renderer i18n language loading', () => {
     setLanguage('zh-CN')
     setLanguage('zh-CN')
 
-    expect(window.i18nUtils.loadTranslations).toHaveBeenCalledTimes(1)
-    expect(window.i18nUtils.loadTranslations).toHaveBeenCalledWith('zh-CN')
+    expect(win.i18nUtils!.loadTranslations).toHaveBeenCalledTimes(1)
+    expect(win.i18nUtils!.loadTranslations).toHaveBeenCalledWith('zh-CN')
   })
 })

--- a/test/unit/specs/markdown-basic.spec.ts
+++ b/test/unit/specs/markdown-basic.spec.ts
@@ -1,16 +1,28 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import ContentState from '../../../src/muya/lib/contentState'
-import EventCenter from '../../../src/muya/lib/eventHandler/event'
-import ExportMarkdown from '../../../src/muya/lib/utils/exportMarkdown'
-import { MUYA_DEFAULT_OPTION } from '../../../src/muya/lib/config'
+import { describe, it, expect } from 'vitest'
+import ContentState from 'muya/lib/contentState'
+import EventCenter from 'muya/lib/eventHandler/event'
+import ExportMarkdown from 'muya/lib/utils/exportMarkdown'
+import { MUYA_DEFAULT_OPTION } from 'muya/lib/config'
 import * as templates from '../markdown'
 
-const defaultOptions = { endOfLine: 'lf' }
-const defaultOptionsCrlf = Object.assign({}, defaultOptions, { endOfLine: 'crlf' })
+interface MuyaOptions {
+  endOfLine?: string
+  [key: string]: unknown
+}
 
-const createMuyaContext = (options) => {
-  const ctx = {}
+const defaultOptions: MuyaOptions = { endOfLine: 'lf' }
+const defaultOptionsCrlf: MuyaOptions = Object.assign({}, defaultOptions, { endOfLine: 'crlf' })
+
+interface MuyaCtx {
+  options: MuyaOptions
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  eventCenter: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  contentState: any
+}
+
+const createMuyaContext = (options: MuyaOptions): MuyaCtx => {
+  const ctx = {} as MuyaCtx
   ctx.options = Object.assign({}, MUYA_DEFAULT_OPTION, options)
   ctx.eventCenter = new EventCenter()
   ctx.contentState = new ContentState(ctx, ctx.options)
@@ -21,7 +33,7 @@ const createMuyaContext = (options) => {
 // Muya parser (Markdown to HTML to Markdown)
 //
 
-const verifyMarkdown = (markdown, options) => {
+const verifyMarkdown = (markdown: string, options: MuyaOptions): void => {
   const ctx = createMuyaContext(options)
   ctx.contentState.importMarkdown(markdown)
 

--- a/test/unit/specs/markdown-footnotes.spec.ts
+++ b/test/unit/specs/markdown-footnotes.spec.ts
@@ -1,8 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import { Lexer } from '../../../src/muya/lib/parser/marked'
+import { describe, it, expect } from 'vitest'
+import { Lexer } from 'muya/lib/parser/marked'
 
-const parseMarkdown = (markdown) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Token = Record<string, any>
+
+const parseMarkdown = (markdown: string): Token[] => {
   const lexer = new Lexer({
     disableInline: true,
     footnote: true
@@ -10,16 +12,16 @@ const parseMarkdown = (markdown) => {
   return lexer.lex(markdown)
 }
 
-const convertToken = (token) => {
-  const obj = {}
+const convertToken = (token: Token): Token => {
+  const obj: Token = {}
   for (const key of Object.keys(token)) {
     obj[key] = token[key]
   }
   return obj
 }
 
-const convertTokens = (tokenList) => {
-  const tokens = []
+const convertTokens = (tokenList: Token[]): Token[] => {
+  const tokens: Token[] = []
   for (const token of tokenList) {
     tokens.push(convertToken(token))
   }

--- a/test/unit/specs/markdown-list-indentation.spec.ts
+++ b/test/unit/specs/markdown-list-indentation.spec.ts
@@ -1,12 +1,20 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
-import ContentState from '../../../src/muya/lib/contentState'
-import EventCenter from '../../../src/muya/lib/eventHandler/event'
-import ExportMarkdown from '../../../src/muya/lib/utils/exportMarkdown'
-import { MUYA_DEFAULT_OPTION } from '../../../src/muya/lib/config'
+import { describe, it, expect } from 'vitest'
+import ContentState from 'muya/lib/contentState'
+import EventCenter from 'muya/lib/eventHandler/event'
+import ExportMarkdown from 'muya/lib/utils/exportMarkdown'
+import { MUYA_DEFAULT_OPTION } from 'muya/lib/config'
 
-const createMuyaContext = (listIndentation) => {
-  const ctx = {}
+interface MuyaCtx {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  eventCenter: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  contentState: any
+}
+
+const createMuyaContext = (listIndentation: number | string): MuyaCtx => {
+  const ctx = {} as MuyaCtx
   ctx.options = Object.assign({}, MUYA_DEFAULT_OPTION, { listIndentation })
   ctx.eventCenter = new EventCenter()
   ctx.contentState = new ContentState(ctx, ctx.options)
@@ -17,7 +25,11 @@ const createMuyaContext = (listIndentation) => {
 // Muya parser (Markdown to HTML to Markdown)
 //
 
-const verifyMarkdown = (expectedMarkdown, listIndentation, markdown = '') => {
+const verifyMarkdown = (
+  expectedMarkdown: string,
+  listIndentation: number | string,
+  markdown = ''
+): void => {
   if (!markdown) {
     markdown = `start
 

--- a/test/unit/specs/match-electron-accelerator.spec.ts
+++ b/test/unit/specs/match-electron-accelerator.spec.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+import { describe, it, expect } from 'vitest'
 import { isEqualAccelerator } from 'common/keybinding'
 
 const characterKeys = ['0', '1', '9', 'A', 'b', 'G', 'Z', '~', '!', '@', '#']

--- a/test/unit/specs/native-theme.spec.ts
+++ b/test/unit/specs/native-theme.spec.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+import { describe, it, expect } from 'vitest'
 import { getNativeThemeSource, isDarkApplicationTheme } from 'main_renderer/app/nativeTheme'
 import { oneDarkThemes, railscastsThemes } from 'common/theme'
 

--- a/test/unit/specs/slugger.spec.ts
+++ b/test/unit/specs/slugger.spec.ts
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
+import { describe, it, expect, beforeEach } from 'vitest'
 import Slugger from 'muya/lib/parser/marked/slugger'
 
 describe('Slugger', () => {
-  let slugger
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let slugger: any
 
   beforeEach(() => {
     slugger = new Slugger()

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,8 @@
       "@/*": ["./src/renderer/src/*"],
       "common/*": ["./src/common/*"],
       "muya/*": ["./src/muya/*"],
-      "@shared/*": ["./src/shared/*"]
+      "@shared/*": ["./src/shared/*"],
+      "main_renderer/*": ["./src/main/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Part 3/6 of the TypeScript migration deferred-work cleanup. Drops `// @ts-nocheck` from every test file and converts the Playwright e2e suite from CommonJS `require()` to ESM `import`.

### Changes (30 files)

- **`test/e2e/helpers.ts`** — converted to typed ESM, exporting `LaunchResult` / `LaunchWithMarkdownResult` and typed `ElectronApplication` / `Page` / `string` parameters across every helper.
- **17 e2e specs** — `require()` → `import`, dropped `// @ts-nocheck`, added `let app: ElectronApplication; let page: Page` typings.
- **9 unit specs + `test/unit/markdown.ts`** — dropped `// @ts-nocheck`, added explicit `import { describe, it, expect, ... } from 'vitest'`, switched relative `../../../src/muya/...` paths to the aliased `muya/lib/...` so they resolve against the ambient declarations in `src/types/muya.d.ts`.
- **`tsconfig.base.json`** — added `main_renderer/*` to `paths` (already in `vitest.config.ts`) so `native-theme.spec.ts` resolves `main_renderer/app/nativeTheme` under vue-tsc.
- **`docs/dev/TYPESCRIPT.md`** — marked item #3 in the deferred-work list as done.

### Specs that needed more than mechanical conversion

- `helpers.ts` — `enterSourceMode` / `getMarkdownContent` / `setSourceMarkdown` `page.evaluate` callbacks needed `Element & { CodeMirror?: ... }` casts; original code dereferenced `.CodeMirror` without a null guard.
- `ripgrep-search.spec.ts` — `window.ripgrep.onMatch/onDone/onError` payloads are typed `unknown` in `src/types/global.d.ts`, so the inline handlers needed local `{ searchId?: string; payload?: ... }` casts.
- `menu-sanity.spec.ts` / `source-math.spec.ts` / `view-modes.spec.ts` / `layout-toggles.spec.ts` — `page.evaluate` callbacks needed null-guards on `document.querySelector(...)` and `HTMLElement` casts for `.offsetParent` / `.style`.
- `i18n.spec.ts` — `window.i18nUtils` is declared *required* in `global.d.ts`; the spec installs a `vi.fn` mock in `beforeEach` and `delete`s it in `afterEach`, so we use a `win = window as unknown as { i18nUtils?: ... }` alias rather than augment the global Window.
- `markdown-basic.spec.ts` / `markdown-list-indentation.spec.ts` — `createMuyaContext` constructs a circular `{ ctx → contentState → ctx }` reference; kept the original mutation pattern but added an `as MuyaCtx` cast on the empty seed object.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 550/550 pass
- [x] `pnpm exec playwright test test/e2e/launch.spec.ts` — passes after `build:unpack`
- [ ] Full `pnpm test:e2e` to confirm no regressions in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)