### PR TITLE
chore(eslint): ignore .claude/ worktree clones in lint runs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default [
   // 0. Global ignores (must be first)
   {
     ignores: [
+      '.claude/**',
       'out/**',
       'dist/**',
       'src/muya/lib/assets/libs/**',


### PR DESCRIPTION
## Summary

The Claude Code agent creates nested git worktrees under `.claude/worktrees/agent-*/`. Each is a full checkout of the project, so when a developer runs `pnpm lint` from the parent checkout, ESLint walks into every worktree as well as the real source — turning a normal lint run into one with 10+ duplicates of every file (and a flood of duplicate warnings).

CI never sees this because there are no nested worktrees in a CI checkout. Adding `.claude/**` to the global ignores at the top of `eslint.config.js` keeps local lint runs fast and accurate regardless of how many agent worktrees are present.

## Change

`eslint.config.js` — block 0 (global ignores): add `'.claude/**'`.

## Test plan

- [x] `pnpm lint` after the change reports the same 76 pre-existing `no-non-null-assertion` warnings, 0 errors.
- [x] No `.claude/**` paths show up in lint output from a checkout that contains nested worktrees.
- [x] No effect on CI lint (CI checkouts have no `.claude/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)