### PR TITLE
fix(ipc): tighten three IPC channels + SET_IMAGE_FOLDER_PATH signature

### DIFF
--- a/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
+++ b/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
@@ -99,10 +99,9 @@ const openImageFolder = (): void => {
 }
 
 const modifyImageFolderPath = (value: string | undefined): void => {
-  // The store action's parameter is typed `string` but the IPC channel and
-  // runtime handler both accept `undefined` (the main process responds by
-  // opening a folder picker). Cast through to preserve that behavior.
-  preferenceStore.SET_IMAGE_FOLDER_PATH(value as string)
+  // Passing `undefined` is the documented way to ask the main process to
+  // open a folder picker (see `mt::ask-for-modify-image-folder-path`).
+  preferenceStore.SET_IMAGE_FOLDER_PATH(value)
 }
 
 const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {

--- a/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/src/renderer/src/prefComponents/keybindings/index.vue
@@ -113,20 +113,6 @@ import notice from '@/services/notification'
 import { Edit, RefreshRight, Delete } from '@element-plus/icons-vue'
 import { useI18n } from 'vue-i18n'
 
-// Shape returned by `mt::keybinding-get-keyboard-info`. The IPC contract
-// types `ret: unknown`, but the main-process handler returns the keyboard
-// layout descriptor expected by `@hfelix/electron-localshortcut`.
-interface KeyboardInfo {
-  layout: unknown
-  keymap: unknown
-}
-
-// Shape returned by `mt::keybinding-get-pref-keybindings` (same caveat).
-interface PrefKeybindings {
-  defaultKeybindings: Map<string, string>
-  userKeybindings: Map<string, string>
-}
-
 const { t, locale } = useI18n()
 
 const showDebugTools = ref<boolean>(false)
@@ -149,8 +135,7 @@ watch(locale, () => {
 onMounted(() => {
   window.electron.ipcRenderer
     .invoke('mt::keybinding-get-keyboard-info')
-    .then((info) => {
-      const { layout, keymap } = info as KeyboardInfo
+    .then(({ layout, keymap }) => {
       // Update the key mapper to prevent problems on non-US keyboards.
       setKeyboardLayout(layout, keymap)
     })
@@ -158,8 +143,7 @@ onMounted(() => {
 
   window.electron.ipcRenderer
     .invoke('mt::keybinding-get-pref-keybindings')
-    .then((bindings) => {
-      const { defaultKeybindings, userKeybindings } = bindings as PrefKeybindings
+    .then(({ defaultKeybindings, userKeybindings }) => {
       const configurator = new KeybindingConfigurator(defaultKeybindings, userKeybindings)
       keybindingConfigurator.value = configurator
       keybindingList.value = configurator.getKeybindings()

--- a/src/renderer/src/store/preferences.ts
+++ b/src/renderer/src/store/preferences.ts
@@ -310,7 +310,7 @@ export const usePreferencesStore = defineStore('preferences', {
       window.electron.ipcRenderer.send('mt::set-user-data', { [type]: value })
     },
 
-    SET_IMAGE_FOLDER_PATH(value: string): void {
+    SET_IMAGE_FOLDER_PATH(value?: string): void {
       window.electron.ipcRenderer.send('mt::ask-for-modify-image-folder-path', value)
     },
 

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -17,6 +17,7 @@
  *   3. Wire the caller via the typed preload bridge in src/preload/index.ts.
  */
 
+import type { IKeyboardLayoutInfo, IKeyboardMapping } from 'native-keymap'
 import type {
   MarkdownDocument,
   TabOptions,
@@ -61,8 +62,11 @@ export interface IpcInvokeChannels {
   'mt::i18n::is-supported': { args: [lang: string]; ret: boolean }
   'mt::i18n::load': { args: [language: string]; ret: Record<string, unknown> }
   'mt::i18n::supported': { args: []; ret: string[] }
-  'mt::keybinding-get-keyboard-info': { args: []; ret: unknown }
-  'mt::keybinding-get-pref-keybindings': { args: []; ret: unknown }
+  'mt::keybinding-get-keyboard-info': { args: []; ret: KeyboardInfo }
+  'mt::keybinding-get-pref-keybindings': {
+    args: []
+    ret: { defaultKeybindings: Map<string, string>; userKeybindings: Map<string, string> }
+  }
   'mt::keybinding-save-user-keybindings': { args: [bindings: unknown]; ret: boolean }
   'mt::paths::is-image': { args: [path: string]; ret: boolean }
   'mt::rg::start': { args: [req: unknown]; ret: { searchId: string } }
@@ -70,7 +74,7 @@ export interface IpcInvokeChannels {
   'mt::shell::open-path': { args: [fullPath: string]; ret: string }
   'mt::spellchecker-get-available-dictionaries': { args: []; ret: string[] }
   'mt::spellchecker-get-custom-dictionary-words': { args: []; ret: string[] }
-  'mt::spellchecker-remove-word': { args: [word: string]; ret: void }
+  'mt::spellchecker-remove-word': { args: [word: string]; ret: boolean }
   'mt::spellchecker-set-enabled': { args: [enabled: boolean]; ret: void }
   'mt::spellchecker-switch-language': { args: [language: string]; ret: void }
   'mt::uploader::upload': { args: [req: unknown]; ret: unknown }
@@ -286,6 +290,16 @@ export interface IpcMainEventChannels {
 // =================================================================
 // Auxiliary types
 // =================================================================
+
+/**
+ * Snapshot of the active OS keyboard layout, returned by
+ * `mt::keybinding-get-keyboard-info`. Mirrors the runtime shape produced
+ * by `native-keymap` (see `src/main/keyboard/index.ts#getKeyboardInfo`).
+ */
+export interface KeyboardInfo {
+  layout: IKeyboardLayoutInfo
+  keymap: IKeyboardMapping
+}
 
 export interface BootInfo {
   platform: NodeJS.Platform


### PR DESCRIPTION
## Summary

Small typing follow-up to the TypeScript migration (PRs #4250 / #4254). Four contracts had drifted from the runtime — they had been left as `unknown` / `void` / strict-`string` during the migration. This tightens them to match reality and drops the local `as` casts that drift had forced into renderer code.

### `src/shared/types/ipc.ts` — three channels

- **`mt::keybinding-get-keyboard-info`** — was `ret: unknown`. Main returns `{ layout, keymap }` from `native-keymap`. Introduces a `KeyboardInfo` aux type that mirrors `src/main/keyboard/index.ts#getKeyboardInfo`, re-exporting `IKeyboardLayoutInfo` / `IKeyboardMapping` as the field types.
- **`mt::keybinding-get-pref-keybindings`** — was `ret: unknown`. Main returns `{ defaultKeybindings: Map<string, string>; userKeybindings: Map<string, string> }` (see `src/main/app/index.ts:821-826`).
- **`mt::spellchecker-remove-word`** — was `ret: void`. The main handler in `src/main/spellchecker/index.ts` returns `boolean` (the result of `session.removeWordFromSpellCheckerDictionary`).

### `src/renderer/src/store/preferences.ts` — `SET_IMAGE_FOLDER_PATH`

- Was `(value: string)` but the underlying `mt::ask-for-modify-image-folder-path` channel is declared `[imagePath?: string]` — passing `undefined` is the documented way to ask main to open a folder picker. Loosened to `(value?: string)`.

### Renderer cleanups unblocked by the above

- `prefComponents/keybindings/index.vue` — drop the two local `KeyboardInfo` / `PrefKeybindings` interfaces and the `as` casts on the IPC results; destructure directly from the typed return.
- `prefComponents/image/components/folderSetting/index.vue` — drop the `value as string` cast on the optional-undefined path.

### Out of scope (noted, intentional)

- `components/exportSettings/index.vue` casts `window.marktext.paths` through `unknown` (same pattern in `util/pdf.ts`). Widening `src/types/global.d.ts` to expose `paths` typedly would balloon scope — left for a separate PR.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 550/550 passing
- [x] `pnpm lint` — 0 errors, 76 pre-existing `no-non-null-assertion` warnings unchanged
- [ ] Quick e2e smoke (preferences keybinding tab opens; image folder picker still works) — skipped because the worktree has known electron-launch timeout issues; pure type-level changes with no runtime semantics altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)