### PR TITLE
build(ts): enable exactOptionalPropertyTypes

### DIFF
--- a/docs/dev/TYPESCRIPT.md
+++ b/docs/dev/TYPESCRIPT.md
@@ -30,9 +30,6 @@ Relevant settings (`tsconfig.base.json`):
 - `strict: true` (every strict flag on)
 - `noUncheckedIndexedAccess: false` — too disruptive given existing
   index-access patterns (tabs, listToc)
-- `exactOptionalPropertyTypes: false` — kept off to keep the buffered-state
-  restore path (which carries optional fields through JSON serialization)
-  tolerant of `undefined` ≡ "key not present"
 - `allowJs: true, checkJs: false` — for `src/muya/` only (every other
   directory is now `.ts`)
 - `noEmit: true` — vue-tsc only type-checks; electron-vite handles the

--- a/src/main/app/env.ts
+++ b/src/main/app/env.ts
@@ -14,7 +14,7 @@ const patchEnvPath = (): void => {
 }
 
 export interface AppEnvironmentOptions {
-  userDataPath?: string
+  userDataPath?: string | undefined
   debug?: boolean
   isDevMode?: boolean
   verbose?: number | boolean

--- a/src/main/exceptionHandler.ts
+++ b/src/main/exceptionHandler.ts
@@ -68,7 +68,7 @@ const handleError = async(title: string, error: Error, type: ErrorType): Promise
       defaultId: 0,
       noLink: true,
       message: title,
-      detail: stack
+      ...(stack !== undefined && { detail: stack })
     })
 
     switch (response) {

--- a/src/main/filesystem/markdown.ts
+++ b/src/main/filesystem/markdown.ts
@@ -79,7 +79,7 @@ export const writeMarkdownFile = (
     content = convertLineEndings(content, lineEnding)
   }
 
-  const buffer = iconv.encode(content, encoding, { addBOM: isBom })
+  const buffer = iconv.encode(content, encoding, isBom !== undefined ? { addBOM: isBom } : {})
 
   // TODO(@fxha): "safeSaveDocuments" using temporary file and rename syscall.
   return writeFile(pathname, buffer, extension, undefined)

--- a/src/main/ipc/uploader.ts
+++ b/src/main/ipc/uploader.ts
@@ -121,11 +121,10 @@ const uploadByGithub = ({
       owner,
       repo,
       path: filePath,
-      branch,
+      ...(branch ? { branch } : {}),
       message,
       content
     }
-    if (!branch) delete payload.branch
     octokit.repos
       .createOrUpdateFileContents(payload)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -27,9 +27,11 @@ const buildMenu = (template: MenuTemplate | undefined, windowId: number): Menu =
     const id = item.id
     menu.append(
       new MenuItem({
-        label: item.label,
-        type: item.type as 'normal' | 'submenu' | 'checkbox' | 'radio' | undefined,
-        accelerator: item.accelerator,
+        ...(item.label !== undefined && { label: item.label }),
+        ...(item.type !== undefined && {
+          type: item.type as 'normal' | 'submenu' | 'checkbox' | 'radio'
+        }),
+        ...(item.accelerator !== undefined && { accelerator: item.accelerator }),
         enabled: item.enabled !== false,
         checked: !!item.checked,
         click: () => {
@@ -40,7 +42,9 @@ const buildMenu = (template: MenuTemplate | undefined, windowId: number): Menu =
             /* sender destroyed */
           }
         },
-        submenu: item.submenu ? buildMenu(item.submenu as MenuTemplateItem[], windowId) : undefined
+        ...(item.submenu
+          ? { submenu: buildMenu(item.submenu as MenuTemplateItem[], windowId) }
+          : {})
       })
     )
   }
@@ -99,8 +103,8 @@ export const registerWindowHandlers = (): void => {
       const menu = buildMenu(template, win.id)
       menu.popup({
         window: win,
-        x: position?.x,
-        y: position?.y,
+        ...(position?.x !== undefined && { x: position.x }),
+        ...(position?.y !== undefined && { y: position.y }),
         callback: () => {
           popups.delete(win.id)
           try {
@@ -122,7 +126,11 @@ export const registerWindowHandlers = (): void => {
     try {
       const appMenu = Menu.getApplicationMenu()
       if (!appMenu) return
-      appMenu.popup({ window: win, x: position?.x, y: position?.y })
+      appMenu.popup({
+        window: win,
+        ...(position?.x !== undefined && { x: position.x }),
+        ...(position?.y !== undefined && { y: position.y })
+      })
     } catch (err) {
       log.error('application menu popup failed:', err)
     }

--- a/src/main/keyboard/shortcutHandler.ts
+++ b/src/main/keyboard/shortcutHandler.ts
@@ -60,6 +60,20 @@ class Keybindings {
     return name
   }
 
+  /**
+   * Return a partial menu-item fragment with the `accelerator` key set
+   * when an accelerator is bound for `id`, or an empty object otherwise.
+   *
+   * Centralises the conditional spread required by
+   * `exactOptionalPropertyTypes: true` — Electron's
+   * `MenuItemConstructorOptions.accelerator` is `?: string`, which under
+   * that flag does not accept `undefined` as a value.
+   */
+  acceleratorFor(id: string): { accelerator: string } | Record<string, never> {
+    const name = this.keys.get(id)
+    return name ? { accelerator: name } : {}
+  }
+
   registerAccelerator(win: BrowserWindow, accelerator: string, callback: ShortcutCallback): void {
     if (!win || !accelerator || !callback) {
       throw new Error(`addKeyHandler: invalid arguments (accelerator="${accelerator}").`)

--- a/src/main/menu/actions/file.ts
+++ b/src/main/menu/actions/file.ts
@@ -98,9 +98,10 @@ const handleResponseForExport = async(e: IpcMainEvent, payload: ExportPayload): 
   }
 
   const defaultPath = path.join(dirname, `${nakedFilename}${extension}`)
+  const filters = getExportExtensionFilter(type)
   const { filePath, canceled } = await dialog.showSaveDialog(win, {
     defaultPath,
-    filters: getExportExtensionFilter(type)
+    ...(filters !== undefined && { filters })
   })
 
   if (filePath && !canceled) {

--- a/src/main/menu/templates/edit.ts
+++ b/src/main/menu/templates/edit.ts
@@ -11,14 +11,14 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     submenu: [
       {
         label: t('menu.edit.undo'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_UNDO) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_UNDO),
         click: (_menuItem, browserWindow) => {
           actions.editorUndo(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.redo'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_REDO) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_REDO),
         click: (_menuItem, browserWindow) => {
           actions.editorRedo(browserWindow as BrowserWindow | undefined)
         }
@@ -28,21 +28,21 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.cut'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_CUT) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_CUT),
         click(_menuItem, browserWindow) {
           actions.nativeCut(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.copy'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_COPY) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_COPY),
         click(_menuItem, browserWindow) {
           actions.nativeCopy(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.paste'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_PASTE) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_PASTE),
         click(_menuItem, browserWindow) {
           actions.nativePaste(browserWindow as BrowserWindow | undefined)
         }
@@ -52,21 +52,21 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.copyAsRich'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_COPY_AS_RICH) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_COPY_AS_RICH),
         click(_menuItem, browserWindow) {
           actions.editorCopyAsRich(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.copyAsHtml'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_COPY_AS_HTML) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_COPY_AS_HTML),
         click(_menuItem, browserWindow) {
           actions.editorCopyAsHtml(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.pasteAsPlainText'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_PASTE_AS_PLAINTEXT) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_PASTE_AS_PLAINTEXT),
         click(_menuItem, browserWindow) {
           actions.editorPasteAsPlainText(browserWindow as BrowserWindow | undefined)
         }
@@ -76,7 +76,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.selectAll'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_SELECT_ALL) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_SELECT_ALL),
         click(_menuItem, browserWindow) {
           actions.editorSelectAll(browserWindow as BrowserWindow | undefined)
         }
@@ -86,21 +86,21 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.duplicate'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_DUPLICATE) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_DUPLICATE),
         click(_menuItem, browserWindow) {
           actions.editorDuplicate(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.createParagraph'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_CREATE_PARAGRAPH) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_CREATE_PARAGRAPH),
         click(_menuItem, browserWindow) {
           actions.editorCreateParagraph(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.deleteParagraph'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_DELETE_PARAGRAPH) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_DELETE_PARAGRAPH),
         click(_menuItem, browserWindow) {
           actions.editorDeleteParagraph(browserWindow as BrowserWindow | undefined)
         }
@@ -110,28 +110,28 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.find'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_FIND) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_FIND),
         click(_menuItem, browserWindow) {
           actions.editorFind(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.findNext'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_FIND_NEXT) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_FIND_NEXT),
         click(_menuItem, browserWindow) {
           actions.editorFindNext(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.findPrevious'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_FIND_PREVIOUS) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_FIND_PREVIOUS),
         click(_menuItem, browserWindow) {
           actions.editorFindPrevious(browserWindow as BrowserWindow | undefined)
         }
       },
       {
         label: t('menu.edit.replace'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_REPLACE) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_REPLACE),
         click(_menuItem, browserWindow) {
           actions.editorReplace(browserWindow as BrowserWindow | undefined)
         }
@@ -141,7 +141,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.findInFolder'),
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_FIND_IN_FOLDER) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_FIND_IN_FOLDER),
         click(_menuItem, browserWindow) {
           actions.findInFolder(browserWindow as BrowserWindow | undefined)
         }
@@ -153,7 +153,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         label: t('menu.edit.screenshot'),
         id: 'screenshot',
         visible: isOsx,
-        accelerator: keybindings.getAccelerator(COMMANDS.EDIT_SCREENSHOT) ?? undefined,
+        ...keybindings.acceleratorFor(COMMANDS.EDIT_SCREENSHOT),
         click(_menuItem, browserWindow) {
           actions.screenshot(browserWindow as BrowserWindow | undefined)
         }

--- a/src/main/menu/templates/file.ts
+++ b/src/main/menu/templates/file.ts
@@ -15,14 +15,14 @@ export default function(
   const submenu: MenuItemConstructorOptions[] = [
     {
       label: t('menu.file.newTab'),
-      accelerator: keybindings.getAccelerator('file.new-tab') ?? undefined,
+      ...keybindings.acceleratorFor('file.new-tab'),
       click(_menuItem, browserWindow) {
         actions.newBlankTab(browserWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.file.newWindow'),
-      accelerator: keybindings.getAccelerator('file.new-window') ?? undefined,
+      ...keybindings.acceleratorFor('file.new-window'),
       click() {
         actions.newEditorWindow()
       }
@@ -32,14 +32,14 @@ export default function(
     },
     {
       label: t('menu.file.openFile'),
-      accelerator: keybindings.getAccelerator('file.open-file') ?? undefined,
+      ...keybindings.acceleratorFor('file.open-file'),
       click(_menuItem, browserWindow) {
         actions.openFile((browserWindow as BrowserWindow | undefined) ?? null)
       }
     },
     {
       label: t('menu.file.openFolder'),
-      accelerator: keybindings.getAccelerator('file.open-folder') ?? undefined,
+      ...keybindings.acceleratorFor('file.open-folder'),
       click(_menuItem, browserWindow) {
         actions.openFolder((browserWindow as BrowserWindow | undefined) ?? null)
       }
@@ -89,10 +89,10 @@ export default function(
       // ('recentDocuments' / 'clearRecentDocuments') in recent versions; the JS
       // original used lowercase. Cast to satisfy strict role typing while
       // preserving the original runtime string.
-      role: 'recentdocuments' as unknown as MenuItemConstructorOptions['role'],
+      role: 'recentdocuments' as unknown as NonNullable<MenuItemConstructorOptions['role']>,
       submenu: [
         {
-          role: 'clearrecentdocuments' as unknown as MenuItemConstructorOptions['role']
+          role: 'clearrecentdocuments' as unknown as NonNullable<MenuItemConstructorOptions['role']>
         }
       ]
     })
@@ -104,14 +104,14 @@ export default function(
     },
     {
       label: t('menu.file.save'),
-      accelerator: keybindings.getAccelerator('file.save') ?? undefined,
+      ...keybindings.acceleratorFor('file.save'),
       click(_menuItem, browserWindow) {
         actions.save(browserWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.file.saveAs'),
-      accelerator: keybindings.getAccelerator('file.save-as') ?? undefined,
+      ...keybindings.acceleratorFor('file.save-as'),
       click(_menuItem, browserWindow) {
         actions.saveAs(browserWindow as BrowserWindow | undefined)
       }
@@ -130,14 +130,14 @@ export default function(
     },
     {
       label: t('menu.file.moveTo'),
-      accelerator: keybindings.getAccelerator('file.move-file') ?? undefined,
+      ...keybindings.acceleratorFor('file.move-file'),
       click(_menuItem, browserWindow) {
         actions.moveTo(browserWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.file.rename'),
-      accelerator: keybindings.getAccelerator('file.rename-file') ?? undefined,
+      ...keybindings.acceleratorFor('file.rename-file'),
       click(_menuItem, browserWindow) {
         actions.rename(browserWindow as BrowserWindow | undefined)
       }
@@ -162,7 +162,7 @@ export default function(
         },
         {
           label: t('menu.file.exportPdf'),
-          accelerator: keybindings.getAccelerator('file.export-file.pdf') ?? undefined,
+          ...keybindings.acceleratorFor('file.export-file.pdf'),
           click(_menuItem, browserWindow) {
             actions.exportFile(browserWindow as BrowserWindow | undefined, 'pdf')
           }
@@ -171,7 +171,7 @@ export default function(
     },
     {
       label: t('menu.file.print'),
-      accelerator: keybindings.getAccelerator('file.print') ?? undefined,
+      ...keybindings.acceleratorFor('file.print'),
       click(_menuItem, browserWindow) {
         actions.printDocument(browserWindow as BrowserWindow | undefined)
       }
@@ -182,7 +182,7 @@ export default function(
     },
     {
       label: t('menu.file.preferences'),
-      accelerator: keybindings.getAccelerator('file.preferences') ?? undefined,
+      ...keybindings.acceleratorFor('file.preferences'),
       visible: !isOsx,
       click() {
         userSetting()
@@ -193,14 +193,14 @@ export default function(
     },
     {
       label: t('menu.file.closeTab'),
-      accelerator: keybindings.getAccelerator('file.close-tab') ?? undefined,
+      ...keybindings.acceleratorFor('file.close-tab'),
       click(_menuItem, browserWindow) {
         actions.closeTab(browserWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.file.closeWindow'),
-      accelerator: keybindings.getAccelerator('file.close-window') ?? undefined,
+      ...keybindings.acceleratorFor('file.close-window'),
       click(_menuItem, browserWindow) {
         actions.closeWindow(browserWindow as BrowserWindow | undefined)
       }
@@ -211,7 +211,7 @@ export default function(
     },
     {
       label: t('menu.file.quit'),
-      accelerator: keybindings.getAccelerator('file.quit') ?? undefined,
+      ...keybindings.acceleratorFor('file.quit'),
       visible: !isOsx,
       click: app.quit
     }

--- a/src/main/menu/templates/format.ts
+++ b/src/main/menu/templates/format.ts
@@ -12,7 +12,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'strongMenuItem',
         label: t('menu.format.bold'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.strong') ?? undefined,
+        ...keybindings.acceleratorFor('format.strong'),
         click(_menuItem, focusedWindow) {
           actions.strong(focusedWindow as BrowserWindow | undefined)
         }
@@ -21,7 +21,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'emphasisMenuItem',
         label: t('menu.format.italic'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.emphasis') ?? undefined,
+        ...keybindings.acceleratorFor('format.emphasis'),
         click(_menuItem, focusedWindow) {
           actions.emphasis(focusedWindow as BrowserWindow | undefined)
         }
@@ -30,7 +30,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'underlineMenuItem',
         label: t('menu.format.underline'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.underline') ?? undefined,
+        ...keybindings.acceleratorFor('format.underline'),
         click(_menuItem, focusedWindow) {
           actions.underline(focusedWindow as BrowserWindow | undefined)
         }
@@ -42,7 +42,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'superscriptMenuItem',
         label: t('menu.format.superscript'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.superscript') ?? undefined,
+        ...keybindings.acceleratorFor('format.superscript'),
         click(_menuItem, focusedWindow) {
           actions.superscript(focusedWindow as BrowserWindow | undefined)
         }
@@ -51,7 +51,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'subscriptMenuItem',
         label: t('menu.format.subscript'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.subscript') ?? undefined,
+        ...keybindings.acceleratorFor('format.subscript'),
         click(_menuItem, focusedWindow) {
           actions.subscript(focusedWindow as BrowserWindow | undefined)
         }
@@ -60,7 +60,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'highlightMenuItem',
         label: t('menu.format.highlight'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.highlight') ?? undefined,
+        ...keybindings.acceleratorFor('format.highlight'),
         click(_menuItem, focusedWindow) {
           actions.highlight(focusedWindow as BrowserWindow | undefined)
         }
@@ -72,7 +72,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'inlineCodeMenuItem',
         label: t('menu.format.inlineCode'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.inline-code') ?? undefined,
+        ...keybindings.acceleratorFor('format.inline-code'),
         click(_menuItem, focusedWindow) {
           actions.inlineCode(focusedWindow as BrowserWindow | undefined)
         }
@@ -81,7 +81,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'inlineMathMenuItem',
         label: t('menu.format.inlineMath'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.inline-math') ?? undefined,
+        ...keybindings.acceleratorFor('format.inline-math'),
         click(_menuItem, focusedWindow) {
           actions.inlineMath(focusedWindow as BrowserWindow | undefined)
         }
@@ -93,7 +93,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'strikeMenuItem',
         label: t('menu.format.strikethrough'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.strike') ?? undefined,
+        ...keybindings.acceleratorFor('format.strike'),
         click(_menuItem, focusedWindow) {
           actions.strikethrough(focusedWindow as BrowserWindow | undefined)
         }
@@ -102,7 +102,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'hyperlinkMenuItem',
         label: t('menu.format.hyperlink'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.hyperlink') ?? undefined,
+        ...keybindings.acceleratorFor('format.hyperlink'),
         click(_menuItem, focusedWindow) {
           actions.hyperlink(focusedWindow as BrowserWindow | undefined)
         }
@@ -111,7 +111,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'imageMenuItem',
         label: t('menu.format.image'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('format.image') ?? undefined,
+        ...keybindings.acceleratorFor('format.image'),
         click(_menuItem, focusedWindow) {
           actions.image(focusedWindow as BrowserWindow | undefined)
         }
@@ -121,7 +121,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.format.clearFormat'),
-        accelerator: keybindings.getAccelerator('format.clear-format') ?? undefined,
+        ...keybindings.acceleratorFor('format.clear-format'),
         click(_menuItem, focusedWindow) {
           actions.clearFormat(focusedWindow as BrowserWindow | undefined)
         }

--- a/src/main/menu/templates/marktext.ts
+++ b/src/main/menu/templates/marktext.ts
@@ -24,7 +24,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.marktext.preferences'),
-        accelerator: keybindings.getAccelerator('file.preferences') ?? undefined,
+        ...keybindings.acceleratorFor('file.preferences'),
         click() {
           actions.userSetting()
         }
@@ -42,14 +42,14 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.marktext.hide'),
-        accelerator: keybindings.getAccelerator('mt.hide') ?? undefined,
+        ...keybindings.acceleratorFor('mt.hide'),
         click() {
           actions.osxHide()
         }
       },
       {
         label: t('menu.marktext.hideOthers'),
-        accelerator: keybindings.getAccelerator('mt.hide-others') ?? undefined,
+        ...keybindings.acceleratorFor('mt.hide-others'),
         click() {
           actions.osxHideAll()
         }
@@ -65,7 +65,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.marktext.quit'),
-        accelerator: keybindings.getAccelerator('file.quit') ?? undefined,
+        ...keybindings.acceleratorFor('file.quit'),
         click: app.quit
       }
     ]

--- a/src/main/menu/templates/paragraph.ts
+++ b/src/main/menu/templates/paragraph.ts
@@ -12,7 +12,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading1MenuItem',
         label: t('menu.paragraph.heading1'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-1') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-1'),
         click(_menuItem, focusedWindow) {
           actions.heading1(focusedWindow as BrowserWindow | undefined)
         }
@@ -21,7 +21,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading2MenuItem',
         label: t('menu.paragraph.heading2'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-2') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-2'),
         click(_menuItem, focusedWindow) {
           actions.heading2(focusedWindow as BrowserWindow | undefined)
         }
@@ -30,7 +30,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading3MenuItem',
         label: t('menu.paragraph.heading3'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-3') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-3'),
         click(_menuItem, focusedWindow) {
           actions.heading3(focusedWindow as BrowserWindow | undefined)
         }
@@ -39,7 +39,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading4MenuItem',
         label: t('menu.paragraph.heading4'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-4') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-4'),
         click(_menuItem, focusedWindow) {
           actions.heading4(focusedWindow as BrowserWindow | undefined)
         }
@@ -48,7 +48,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading5MenuItem',
         label: t('menu.paragraph.heading5'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-5') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-5'),
         click(_menuItem, focusedWindow) {
           actions.heading5(focusedWindow as BrowserWindow | undefined)
         }
@@ -57,7 +57,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'heading6MenuItem',
         label: t('menu.paragraph.heading6'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.heading-6') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.heading-6'),
         click(_menuItem, focusedWindow) {
           actions.heading6(focusedWindow as BrowserWindow | undefined)
         }
@@ -68,7 +68,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       {
         id: 'upgradeHeadingMenuItem',
         label: t('menu.paragraph.promoteHeading'),
-        accelerator: keybindings.getAccelerator('paragraph.upgrade-heading') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.upgrade-heading'),
         click(_menuItem, focusedWindow) {
           actions.increaseHeading(focusedWindow as BrowserWindow | undefined)
         }
@@ -76,7 +76,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       {
         id: 'degradeHeadingMenuItem',
         label: t('menu.paragraph.demoteHeading'),
-        accelerator: keybindings.getAccelerator('paragraph.degrade-heading') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.degrade-heading'),
         click(_menuItem, focusedWindow) {
           actions.degradeHeading(focusedWindow as BrowserWindow | undefined)
         }
@@ -88,7 +88,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'tableMenuItem',
         label: t('menu.paragraph.table'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.table') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.table'),
         click(_menuItem, focusedWindow) {
           actions.table(focusedWindow as BrowserWindow | undefined)
         }
@@ -97,7 +97,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'codeFencesMenuItem',
         label: t('menu.paragraph.codeFences'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.code-fence') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.code-fence'),
         click(_menuItem, focusedWindow) {
           actions.codeFence(focusedWindow as BrowserWindow | undefined)
         }
@@ -106,7 +106,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'quoteBlockMenuItem',
         label: t('menu.paragraph.quoteBlock'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.quote-block') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.quote-block'),
         click(_menuItem, focusedWindow) {
           actions.quoteBlock(focusedWindow as BrowserWindow | undefined)
         }
@@ -115,7 +115,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'mathBlockMenuItem',
         label: t('menu.paragraph.mathBlock'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.math-formula') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.math-formula'),
         click(_menuItem, focusedWindow) {
           actions.mathFormula(focusedWindow as BrowserWindow | undefined)
         }
@@ -124,7 +124,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'htmlBlockMenuItem',
         label: t('menu.paragraph.htmlBlock'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.html-block') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.html-block'),
         click(_menuItem, focusedWindow) {
           actions.htmlBlock(focusedWindow as BrowserWindow | undefined)
         }
@@ -136,7 +136,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'orderListMenuItem',
         label: t('menu.paragraph.orderedList'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.order-list') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.order-list'),
         click(_menuItem, focusedWindow) {
           actions.orderedList(focusedWindow as BrowserWindow | undefined)
         }
@@ -145,7 +145,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'bulletListMenuItem',
         label: t('menu.paragraph.bulletList'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.bullet-list') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.bullet-list'),
         click(_menuItem, focusedWindow) {
           actions.bulletList(focusedWindow as BrowserWindow | undefined)
         }
@@ -154,7 +154,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'taskListMenuItem',
         label: t('menu.paragraph.taskList'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.task-list') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.task-list'),
         click(_menuItem, focusedWindow) {
           actions.taskList(focusedWindow as BrowserWindow | undefined)
         }
@@ -166,7 +166,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'looseListItemMenuItem',
         label: t('menu.paragraph.looseListItem'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.loose-list-item') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.loose-list-item'),
         click(_menuItem, focusedWindow) {
           actions.looseListItem(focusedWindow as BrowserWindow | undefined)
         }
@@ -178,7 +178,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'paragraphMenuItem',
         label: t('menu.paragraph.paragraph'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.paragraph') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.paragraph'),
         click(_menuItem, focusedWindow) {
           actions.paragraph(focusedWindow as BrowserWindow | undefined)
         }
@@ -187,7 +187,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'horizontalLineMenuItem',
         label: t('menu.paragraph.horizontalRule'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.horizontal-line') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.horizontal-line'),
         click(_menuItem, focusedWindow) {
           actions.horizontalLine(focusedWindow as BrowserWindow | undefined)
         }
@@ -196,7 +196,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         id: 'frontMatterMenuItem',
         label: t('menu.paragraph.frontMatter'),
         type: 'checkbox',
-        accelerator: keybindings.getAccelerator('paragraph.front-matter') ?? undefined,
+        ...keybindings.acceleratorFor('paragraph.front-matter'),
         click(_menuItem, focusedWindow) {
           actions.frontMatter(focusedWindow as BrowserWindow | undefined)
         }

--- a/src/main/menu/templates/prefEdit.ts
+++ b/src/main/menu/templates/prefEdit.ts
@@ -8,17 +8,17 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     submenu: [
       {
         label: t('menu.edit.cut'),
-        accelerator: keybindings.getAccelerator('edit.cut') ?? undefined,
+        ...keybindings.acceleratorFor('edit.cut'),
         role: 'cut'
       },
       {
         label: t('menu.edit.copy'),
-        accelerator: keybindings.getAccelerator('edit.copy') ?? undefined,
+        ...keybindings.acceleratorFor('edit.copy'),
         role: 'copy'
       },
       {
         label: t('menu.edit.paste'),
-        accelerator: keybindings.getAccelerator('edit.paste') ?? undefined,
+        ...keybindings.acceleratorFor('edit.paste'),
         role: 'paste'
       },
       {
@@ -26,7 +26,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       },
       {
         label: t('menu.edit.selectAll'),
-        accelerator: keybindings.getAccelerator('edit.select-all') ?? undefined,
+        ...keybindings.acceleratorFor('edit.select-all'),
         role: 'selectAll'
       }
     ]

--- a/src/main/menu/templates/view.ts
+++ b/src/main/menu/templates/view.ts
@@ -7,7 +7,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
   const submenu: MenuItemConstructorOptions[] = [
     {
       label: t('menu.view.commandPalette'),
-      accelerator: keybindings.getAccelerator('view.command-palette') ?? undefined,
+      ...keybindings.acceleratorFor('view.command-palette'),
       click(_menuItem, focusedWindow) {
         actions.showCommandPalette(focusedWindow as BrowserWindow | undefined)
       }
@@ -18,7 +18,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       id: 'sourceCodeModeMenuItem',
       label: t('menu.view.sourceCodeMode'),
-      accelerator: keybindings.getAccelerator('view.source-code-mode') ?? undefined,
+      ...keybindings.acceleratorFor('view.source-code-mode'),
       type: 'checkbox',
       checked: false,
       click(_item, focusedWindow) {
@@ -28,7 +28,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       id: 'typewriterModeMenuItem',
       label: t('menu.view.typewriterMode'),
-      accelerator: keybindings.getAccelerator('view.typewriter-mode') ?? undefined,
+      ...keybindings.acceleratorFor('view.typewriter-mode'),
       type: 'checkbox',
       checked: false,
       click(_item, focusedWindow) {
@@ -38,7 +38,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       id: 'focusModeMenuItem',
       label: t('menu.view.focusMode'),
-      accelerator: keybindings.getAccelerator('view.focus-mode') ?? undefined,
+      ...keybindings.acceleratorFor('view.focus-mode'),
       type: 'checkbox',
       checked: false,
       click(_item, focusedWindow) {
@@ -51,7 +51,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       label: t('menu.view.toggleSidebar'),
       id: 'sideBarMenuItem',
-      accelerator: keybindings.getAccelerator('view.toggle-sidebar') ?? undefined,
+      ...keybindings.acceleratorFor('view.toggle-sidebar'),
       type: 'checkbox',
       checked: false,
       click(_item, focusedWindow) {
@@ -61,7 +61,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       label: t('menu.view.toggleTabbar'),
       id: 'tabBarMenuItem',
-      accelerator: keybindings.getAccelerator('view.toggle-tabbar') ?? undefined,
+      ...keybindings.acceleratorFor('view.toggle-tabbar'),
       type: 'checkbox',
       checked: false,
       click(_item, focusedWindow) {
@@ -71,14 +71,14 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     {
       label: t('menu.view.toggleTableOfContents'),
       id: 'tocMenuItem',
-      accelerator: keybindings.getAccelerator('view.toggle-toc') ?? undefined,
+      ...keybindings.acceleratorFor('view.toggle-toc'),
       click(_, focusedWindow) {
         actions.showTableOfContents(focusedWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.view.reloadImages'),
-      accelerator: keybindings.getAccelerator('view.reload-images') ?? undefined,
+      ...keybindings.acceleratorFor('view.reload-images'),
       click(_item, focusedWindow) {
         actions.reloadImageCache(focusedWindow as BrowserWindow | undefined)
       }
@@ -96,14 +96,14 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     })
     submenu.push({
       label: t('menu.view.showDeveloperTools'),
-      accelerator: keybindings.getAccelerator('view.toggle-dev-tools') ?? undefined,
+      ...keybindings.acceleratorFor('view.toggle-dev-tools'),
       click(_item, win) {
         actions.debugToggleDevTools(win as BrowserWindow | undefined)
       }
     })
     submenu.push({
       label: t('menu.view.reloadWindow'),
-      accelerator: keybindings.getAccelerator('view.dev-reload') ?? undefined,
+      ...keybindings.acceleratorFor('view.dev-reload'),
       click(_item, focusedWindow) {
         actions.debugReloadWindow(focusedWindow as BrowserWindow | undefined)
       }

--- a/src/main/menu/templates/window.ts
+++ b/src/main/menu/templates/window.ts
@@ -9,7 +9,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
   const submenu: MenuItemConstructorOptions[] = [
     {
       label: t('menu.window.minimize'),
-      accelerator: keybindings.getAccelerator('window.minimize') ?? undefined,
+      ...keybindings.acceleratorFor('window.minimize'),
       click(_menuItem, browserWindow) {
         minimizeWindow(browserWindow as BrowserWindow | undefined)
       }
@@ -18,7 +18,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       id: 'alwaysOnTopMenuItem',
       label: t('menu.window.alwaysOnTop'),
       type: 'checkbox',
-      accelerator: keybindings.getAccelerator('window.toggle-always-on-top') ?? undefined,
+      ...keybindings.acceleratorFor('window.toggle-always-on-top'),
       click(_menuItem, browserWindow) {
         toggleAlwaysOnTop(browserWindow as BrowserWindow | undefined)
       }
@@ -28,14 +28,14 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     },
     {
       label: t('menu.window.zoomIn'),
-      accelerator: keybindings.getAccelerator('window.zoomIn') ?? undefined,
+      ...keybindings.acceleratorFor('window.zoomIn'),
       click(_menuItem, browserWindow) {
         zoomIn(browserWindow as BrowserWindow | undefined)
       }
     },
     {
       label: t('menu.window.zoomOut'),
-      accelerator: keybindings.getAccelerator('window.zoomOut') ?? undefined,
+      ...keybindings.acceleratorFor('window.zoomOut'),
       click(_menuItem, browserWindow) {
         zoomOut(browserWindow as BrowserWindow | undefined)
       }
@@ -45,7 +45,7 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
     },
     {
       label: t('menu.window.fullScreen'),
-      accelerator: keybindings.getAccelerator('window.toggle-full-screen') ?? undefined,
+      ...keybindings.acceleratorFor('window.toggle-full-screen'),
       click(_item, browserWindow) {
         if (browserWindow) {
           toggleFullScreen(browserWindow as BrowserWindow)

--- a/src/renderer/src/components/sideBar/tree.vue
+++ b/src/renderer/src/components/sideBar/tree.vue
@@ -87,7 +87,7 @@
       >
         <folder
           v-for="folder of projectTree.folders"
-          :key="folder.id"
+          :key="folder.id ?? folder.pathname"
           :folder="folder"
           :depth="depth"
         />
@@ -103,7 +103,7 @@
         >
         <file
           v-for="file of projectTree.files"
-          :key="file.id"
+          :key="file.id ?? file.pathname"
           :file="file"
           :depth="depth"
         />

--- a/src/renderer/src/components/sideBar/treeFolder.vue
+++ b/src/renderer/src/components/sideBar/treeFolder.vue
@@ -34,7 +34,7 @@
     >
       <tree-folder
         v-for="childFolder of folder.folders"
-        :key="childFolder.id"
+        :key="childFolder.id ?? childFolder.pathname"
         :folder="childFolder"
         :depth="depth + 1"
       />
@@ -49,7 +49,7 @@
       >
       <File
         v-for="file of folder.files"
-        :key="file.id"
+        :key="file.id ?? file.pathname"
         :file="file"
         :depth="depth + 1"
       />

--- a/src/renderer/src/components/titleBar/index.vue
+++ b/src/renderer/src/components/titleBar/index.vue
@@ -153,12 +153,12 @@ interface ProjectInfo {
 
 const props = defineProps<{
   project?: ProjectInfo | null
-  filename?: string
-  pathname?: string
+  filename?: string | undefined
+  pathname?: string | undefined
   active?: boolean
-  wordCount?: FileWordCount | null
+  wordCount?: FileWordCount | null | undefined
   platform?: string
-  isSaved?: boolean
+  isSaved?: boolean | undefined
 }>()
 
 const preferencesStore = usePreferencesStore()

--- a/src/renderer/src/contextMenu/popupMenu.ts
+++ b/src/renderer/src/contextMenu/popupMenu.ts
@@ -9,17 +9,17 @@ import type { MenuTemplate, MenuTemplateItem, MenuPopupPosition } from '@shared/
 export type MenuClickHandler = (payload: unknown) => void
 
 export interface ContextMenuItem {
-  id?: string
-  label?: string
+  id?: string | undefined
+  label?: string | undefined
   // Loose `string` here lets the menu factories emit plain `'separator'`
   // literals without `as const`. The serializer only special-cases 'separator'.
-  type?: string
-  accelerator?: string
-  enabled?: boolean
-  checked?: boolean
-  submenu?: ContextMenuItem[]
+  type?: string | undefined
+  accelerator?: string | undefined
+  enabled?: boolean | undefined
+  checked?: boolean | undefined
+  submenu?: ContextMenuItem[] | undefined
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  click?: (...args: any[]) => void
+  click?: ((...args: any[]) => void) | undefined
 }
 
 let nextId = 1

--- a/src/renderer/src/contextMenu/tabs/index.ts
+++ b/src/renderer/src/contextMenu/tabs/index.ts
@@ -11,9 +11,9 @@ import {
 import { popupContextMenu } from '../popupMenu'
 
 type MenuItemShape = {
-  type?: string
-  click?: (...args: unknown[]) => void
-  enabled?: boolean
+  type?: string | undefined
+  click?: ((...args: unknown[]) => void) | undefined
+  enabled?: boolean | undefined
   [key: string]: unknown
 }
 

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -33,10 +33,13 @@ bootstrapRenderer()
 // Create Vue app
 const app: App<Element> = createApp(Main)
 
-// Configure Element Plus with locale
-app.use(ElementPlus, {
-  locale: en
-})
+// Configure Element Plus with locale. Cast to `unknown` then the param type
+// because Element Plus's exported `Partial<ConfigProviderProps>` collapses
+// each prop to its full descriptor (with required `type` / `__epPropKey`)
+// under `exactOptionalPropertyTypes: true`, which doesn't match the runtime
+// value-shaped options bag.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use(ElementPlus, { locale: en } as any)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const envType = (window as any).marktext?.env?.type as string | undefined

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -5,7 +5,7 @@ import { usePreferencesStore } from './preferences'
 import { debouncedSendBufferedState } from './bufferedState'
 
 interface LayoutPartial {
-  rightColumn?: string
+  rightColumn?: string | undefined
   showSideBar?: boolean
   showTabBar?: boolean
   sideBarWidth?: number | string

--- a/src/shared/types/menu.ts
+++ b/src/shared/types/menu.ts
@@ -3,16 +3,16 @@
 // pulling Electron types into renderer-only consumers.
 
 export interface MenuTemplateItem {
-  id?: string
-  label?: string
-  type?: 'normal' | 'separator' | 'submenu' | 'checkbox' | 'radio'
-  accelerator?: string
-  enabled?: boolean
-  visible?: boolean
-  checked?: boolean
-  role?: string
-  click?: string
-  submenu?: MenuTemplateItem[]
+  id?: string | undefined
+  label?: string | undefined
+  type?: 'normal' | 'separator' | 'submenu' | 'checkbox' | 'radio' | undefined
+  accelerator?: string | undefined
+  enabled?: boolean | undefined
+  visible?: boolean | undefined
+  checked?: boolean | undefined
+  role?: string | undefined
+  click?: string | undefined
+  submenu?: MenuTemplateItem[] | undefined
   // Open shape — main-side menu builder occasionally tucks extra metadata in.
   [key: string]: unknown
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": false,
-    "exactOptionalPropertyTypes": false,
+    "exactOptionalPropertyTypes": true,
     "useDefineForClassFields": true,
 
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Flip `exactOptionalPropertyTypes` from `false` to `true` in `tsconfig.base.json` and fix the 97 new type errors that surface. The earlier blockers (the `currentFile: {}` sentinel and the buffered-state restoration path) are gone after PRs #4247–#4255, so the flag can finally come on.

## Fix-category breakdown

| Category | Count | Approach |
|---|---|---|
| Menu-template `accelerator: getAccelerator(id) ?? undefined` | 77 | New `Keybindings.acceleratorFor(id)` helper returning `{ accelerator } \| {}`, spread into each item |
| Cross-process menu shapes (`MenuTemplateItem`, `ContextMenuItem`, `MenuItemShape`) | 5 sites | Widen optional fields from `?: T` to `?: T \| undefined` — these IPC payloads treat `undefined` as "absent" by convention |
| Inline conditional spread on optional fields | 7 | Replace `field: maybeUndef` with `...(maybeUndef !== undefined && { field: maybeUndef })` (`detail`, `addBOM`, popup `x`/`y`, MenuItem fields, save-dialog `filters`, `branch`) |
| Vue `:key` bound to `string \| undefined` | 4 | Fall back to `pathname` so Vue receives a `PropertyKey` |
| TitleBar props sourced from `currentFile?.x` | 1 site (4 props) | Widen prop signatures to `?: T \| undefined` |
| Element Plus locale option | 1 | Cast to `any` — `Partial<ConfigProviderProps>` collapses to prop descriptors under the strict flag (library typing issue) |
| `AppEnvironmentOptions.userDataPath` | 1 | Widen to `string \| undefined` — same JSON-shape rationale |
| `templates/file.ts` role casts | 2 | Switch the cast target from `MenuItemConstructorOptions['role']` to `NonNullable<...>['role']` |

### Shared-type widenings

- `@shared/types/menu.MenuTemplateItem` — every optional field widened. Rationale: this is the IPC contract between renderer and main; both sides serialize the payload through `ipcRenderer.send` (which strips `undefined`), so `undefined ≡ "absent"` is the established contract.
- `ContextMenuItem` and `MenuItemShape` in `src/renderer/src/contextMenu/` — same rationale, these flow into the IPC layer above.
- `AppEnvironmentOptions.userDataPath` — value comes from CLI args (`as string | undefined`); the constructor treats undefined as "default user data path".

## Verification

- [x] `pnpm typecheck` — clean (was 97 errors before the fix-up)
- [x] `pnpm test:unit` — 550/550 pass
- [x] `pnpm lint` — 0 errors (warnings unchanged from baseline)
- [x] `pnpm test:e2e -g launch` — passes (after `pnpm build:unpack`)

## Test plan

- [ ] Open application: app menu shows correct accelerators next to items that have shortcuts bound, and items without bindings show no accelerator
- [ ] Right-click in sidebar: context menu items render with accelerators where defined
- [ ] Right-click a tab: context menu items reflect `enabled`/`disabled` state based on `pathname` presence
- [ ] Save markdown file with BOM encoding: BOM is written when `isBom` is true; no BOM when absent
- [ ] Configure GitHub uploader without a `branch` setting: upload still succeeds against the default branch