### PR TITLE
fix(renderer): editor fills width when sidebar collapses to icon strip

### DIFF
--- a/src/renderer/src/components/editorWithTabs/index.vue
+++ b/src/renderer/src/components/editorWithTabs/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="editor-with-tabs"
-    :style="{ 'max-width': showSideBar ? `calc(100vw - ${sideBarWidth}px` : '100vw' }"
+    :style="{ 'max-width': `calc(100vw - ${effectiveSideBarWidth}px)` }"
   >
     <tabs v-show="showTabBar" />
     <div class="container">
@@ -23,6 +23,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useLayoutStore } from '@/store/layout'
 import { storeToRefs } from 'pinia'
 import Tabs from './tabs.vue'
@@ -45,7 +46,18 @@ defineProps<{
 
 const layoutStore = useLayoutStore()
 
-const { showSideBar, sideBarWidth } = storeToRefs(layoutStore)
+const { showSideBar, rightColumn, sideBarWidth } = storeToRefs(layoutStore)
+
+// Mirror the sidebar's `finalSideBarWidth` (see sideBar/index.vue): the store's
+// `sideBarWidth` is clamped to ≥220 and only reflects the right-column width,
+// but the actual sidebar collapses to a 45px icon strip when `rightColumn` is
+// empty. Without this, max-width subtracts the larger value and leaves a blank
+// gap to the right of the editor.
+const effectiveSideBarWidth = computed<number>(() => {
+  if (!showSideBar.value) return 0
+  if (!rightColumn.value) return 45
+  return Number(sideBarWidth.value)
+})
 </script>
 
 <style scoped>

--- a/src/renderer/src/components/editorWithTabs/index.vue
+++ b/src/renderer/src/components/editorWithTabs/index.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useLayoutStore } from '@/store/layout'
 import { storeToRefs } from 'pinia'
 import Tabs from './tabs.vue'
@@ -44,20 +43,7 @@ defineProps<{
   platform: string
 }>()
 
-const layoutStore = useLayoutStore()
-
-const { showSideBar, rightColumn, sideBarWidth } = storeToRefs(layoutStore)
-
-// Mirror the sidebar's `finalSideBarWidth` (see sideBar/index.vue): the store's
-// `sideBarWidth` is clamped to ≥220 and only reflects the right-column width,
-// but the actual sidebar collapses to a 45px icon strip when `rightColumn` is
-// empty. Without this, max-width subtracts the larger value and leaves a blank
-// gap to the right of the editor.
-const effectiveSideBarWidth = computed<number>(() => {
-  if (!showSideBar.value) return 0
-  if (!rightColumn.value) return 45
-  return Number(sideBarWidth.value)
-})
+const { effectiveSideBarWidth } = storeToRefs(useLayoutStore())
 </script>
 
 <style scoped>

--- a/src/renderer/src/components/editorWithTabs/notifications.vue
+++ b/src/renderer/src/components/editorWithTabs/notifications.vue
@@ -47,14 +47,7 @@ const editorStore = useEditorStore()
 const layoutStore = useLayoutStore()
 
 const { currentFile } = storeToRefs(editorStore)
-const { showSideBar, rightColumn, sideBarWidth } = storeToRefs(layoutStore)
-
-// Same effective width as editor-with-tabs — see comment there.
-const effectiveSideBarWidth = computed<number>(() => {
-  if (!showSideBar.value) return 0
-  if (!rightColumn.value) return 45
-  return Number(sideBarWidth.value)
-})
+const { effectiveSideBarWidth } = storeToRefs(layoutStore)
 
 const currentNotification = computed(() => {
   const notifications = currentFile.value?.notifications

--- a/src/renderer/src/components/editorWithTabs/notifications.vue
+++ b/src/renderer/src/components/editorWithTabs/notifications.vue
@@ -3,7 +3,7 @@
     v-if="currentNotification"
     class="editor-notifications"
     :class="currentNotification.style"
-    :style="{ 'max-width': showSideBar ? `calc(100vw - ${sideBarWidth}px` : '100vw' }"
+    :style="{ 'max-width': `calc(100vw - ${effectiveSideBarWidth}px)` }"
   >
     <div class="msg">
       {{ currentNotification.msg }}
@@ -47,7 +47,14 @@ const editorStore = useEditorStore()
 const layoutStore = useLayoutStore()
 
 const { currentFile } = storeToRefs(editorStore)
-const { showSideBar, sideBarWidth } = storeToRefs(layoutStore)
+const { showSideBar, rightColumn, sideBarWidth } = storeToRefs(layoutStore)
+
+// Same effective width as editor-with-tabs — see comment there.
+const effectiveSideBarWidth = computed<number>(() => {
+  if (!showSideBar.value) return 0
+  if (!rightColumn.value) return 45
+  return Number(sideBarWidth.value)
+})
 
 const currentNotification = computed(() => {
   const notifications = currentFile.value?.notifications

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import bus from '../bus'
 import { usePreferencesStore } from './preferences'
@@ -50,6 +50,16 @@ export const useLayoutStore = defineStore('layout', () => {
   const showSideBar = ref(false)
   const showTabBar = ref(false)
   const sideBarWidth = ref<number>(initialSideBarWidth)
+
+  // Actual rendered sidebar width. `sideBarWidth` is the right-column width
+  // (clamped to ≥220 by `normalizeSideBarWidth`); when `rightColumn` is empty
+  // the sidebar collapses to its 45px icon strip. Consumers that need to
+  // subtract the sidebar from viewport space must use this, not the raw ref.
+  const effectiveSideBarWidth = computed<number>(() => {
+    if (!showSideBar.value) return 0
+    if (!rightColumn.value) return 45
+    return Number(sideBarWidth.value)
+  })
 
   function SET_LAYOUT(
     layout: LayoutPartial,
@@ -178,6 +188,7 @@ export const useLayoutStore = defineStore('layout', () => {
     showSideBar,
     showTabBar,
     sideBarWidth,
+    effectiveSideBarWidth,
     SET_LAYOUT,
     CREATE_BUFFERED_STATE,
     RESTORE_BUFFERED_STATE,

--- a/test/e2e/layout-toggles.spec.ts
+++ b/test/e2e/layout-toggles.spec.ts
@@ -95,15 +95,16 @@ test.describe('Layout panel toggles', () => {
     // .click()) so Playwright handles focus/activation correctly.
     const searchIcon = page.locator('.side-bar .left-column > ul').first().locator('li').nth(1)
 
-    // Step 1: ensure rightColumn='search' (sidebar width ≥ 220)
+    // Step 1: ensure rightColumn='search' (sidebar width ≥ 220 with the
+    // search panel mounted at `.side-bar-search`).
     for (let i = 0; i < 3; i++) {
-      const width = await page.evaluate(() => {
+      const { width, hasSearch } = await page.evaluate(() => {
         const sb = document.querySelector('.side-bar') as HTMLElement | null
-        return sb ? Math.round(sb.getBoundingClientRect().width) : 0
+        return {
+          width: sb ? Math.round(sb.getBoundingClientRect().width) : 0,
+          hasSearch: !!document.querySelector('.side-bar .right-column .side-bar-search')
+        }
       })
-      const hasSearch = await page.evaluate(
-        () => !!document.querySelector('.side-bar .right-column .search')
-      )
       if (width >= 220 && hasSearch) break
       await searchIcon.click()
       await page.waitForTimeout(250)

--- a/test/e2e/layout-toggles.spec.ts
+++ b/test/e2e/layout-toggles.spec.ts
@@ -70,4 +70,71 @@ test.describe('Layout panel toggles', () => {
     await page.waitForTimeout(200)
     await clickMenuById(app, 'tocMenuItem')
   })
+
+  // Regression for the gap left between the sidebar and editor when the
+  // sidebar collapses to its 45px icon strip (rightColumn=''). The store's
+  // `sideBarWidth` is clamped to ≥220, so the editor's max-width must come
+  // from the *effective* sidebar width, not the raw store value.
+  test('Editor fills width after collapsing sidebar to icon strip', async() => {
+    // Ensure sidebar is visible.
+    const sideBar = page.locator('.side-bar')
+    if (!(await sideBar.isVisible())) {
+      await clickMenuById(app, 'sideBarMenuItem')
+      await page.waitForFunction(
+        () => {
+          const el = document.querySelector('.side-bar') as HTMLElement | null
+          return !!(el && el.offsetParent !== null)
+        },
+        null,
+        { timeout: 5000 }
+      )
+    }
+
+    // Open search panel and then collapse it back to the icon strip by
+    // clicking the search icon. We use a locator-based click (not a DOM
+    // .click()) so Playwright handles focus/activation correctly.
+    const searchIcon = page.locator('.side-bar .left-column > ul').first().locator('li').nth(1)
+
+    // Step 1: ensure rightColumn='search' (sidebar width ≥ 220)
+    for (let i = 0; i < 3; i++) {
+      const width = await page.evaluate(() => {
+        const sb = document.querySelector('.side-bar') as HTMLElement | null
+        return sb ? Math.round(sb.getBoundingClientRect().width) : 0
+      })
+      const hasSearch = await page.evaluate(
+        () => !!document.querySelector('.side-bar .right-column .search')
+      )
+      if (width >= 220 && hasSearch) break
+      await searchIcon.click()
+      await page.waitForTimeout(250)
+    }
+
+    // Step 2: click search icon again to collapse to icon strip. The sidebar
+    // shrinks to its 45px icon column (+1px border-right = 46px outer width).
+    await searchIcon.click()
+    await page.waitForFunction(
+      () => {
+        const sb = document.querySelector('.side-bar') as HTMLElement | null
+        return !!sb && sb.getBoundingClientRect().width <= 50
+      },
+      null,
+      { timeout: 5000 }
+    )
+
+    const { editorWidth, sideBarWidth, viewportWidth } = await page.evaluate(() => {
+      const editor = document.querySelector('.editor-with-tabs') as HTMLElement | null
+      const sb = document.querySelector('.side-bar') as HTMLElement | null
+      return {
+        editorWidth: editor ? editor.getBoundingClientRect().width : 0,
+        sideBarWidth: sb ? sb.getBoundingClientRect().width : 0,
+        viewportWidth: window.innerWidth
+      }
+    })
+    // Sidebar is the 45px icon strip (+1px border). The editor must consume
+    // the remaining viewport width — before the fix it was capped by the
+    // store's `sideBarWidth` (clamped to ≥220), leaving a 175+ px gap to the
+    // right of the editor.
+    expect(sideBarWidth).toBeLessThanOrEqual(50)
+    expect(Math.abs(editorWidth - (viewportWidth - sideBarWidth))).toBeLessThanOrEqual(1)
+  })
 })


### PR DESCRIPTION
## Summary

- Fixes the blank gap to the right of the editor that appears after clicking a sidebar icon (search/files/toc) a second time to collapse the right column. The editor's `max-width` was driven by the store's `sideBarWidth`, which `normalizeSideBarWidth` clamps to ≥220, so the editor stayed capped at `100vw - 220px` while the visible sidebar shrank to its 45px icon strip — leaving a ~175px gap.
- Mirror the sidebar's `finalSideBarWidth` (0 / 45 / `sideBarWidth`) in both `editorWithTabs/index.vue` and `editorWithTabs/notifications.vue` to compute the editor's effective offset.
- Also closes the unterminated `` `calc(100vw - ${sideBarWidth}px` `` template literal in both files — Chromium's CSS error recovery was silently truncating the trailing `px`.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test:unit` — all 550 tests pass
- [x] `pnpm run build:unpack`
- [x] `pnpm exec playwright test test/e2e/layout-toggles.spec.ts` — new regression test asserts `editorWidth + sideBarWidth == viewportWidth` after collapsing the sidebar; confirmed it fails against the pre-fix build and passes against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)