### PR TITLE
style(preferences): polish dialog UI and unify design

### DIFF
--- a/src/renderer/src/pages/preference.vue
+++ b/src/renderer/src/pages/preference.vue
@@ -59,7 +59,7 @@ onMounted(() => {
 
 <style>
 .pref-container {
-  --prefSideBarWidth: 280px;
+  --prefSideBarWidth: 220px;
 
   width: 100vw;
   height: 100vh;
@@ -71,13 +71,36 @@ onMounted(() => {
   display: flex;
   background: var(--editorBgColor);
 
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    color: var(--editorColor);
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
   & h4 {
     margin: 0;
-    font-weight: normal;
+    font-size: 18px;
   }
 
   & h5 {
-    font-weight: normal;
+    font-size: 15px;
+  }
+
+  & h6 {
+    font-size: 15px;
+  }
+
+  & .notes {
+    display: block;
+    margin: 8px 0 0;
+    font-style: italic;
+    font-size: 12px;
+    color: var(--editorColor80);
   }
 
   & .pref-content {

--- a/src/renderer/src/pages/preference.vue
+++ b/src/renderer/src/pages/preference.vue
@@ -130,7 +130,8 @@ onMounted(() => {
     & h2,
     & h3,
     & h4,
-    & h5 {
+    & h5,
+    & h6 {
       user-select: none;
     }
   }

--- a/src/renderer/src/prefComponents/common/bool/index.vue
+++ b/src/renderer/src/prefComponents/common/bool/index.vue
@@ -104,10 +104,6 @@ const handleSwitchChange = (value: boolean | string | number) => {
     }
   }
 
-  & .notes {
-    font-style: italic;
-    font-size: 12px;
-  }
 }
 
 span.el-switch__core::after {

--- a/src/renderer/src/prefComponents/common/bool/index.vue
+++ b/src/renderer/src/prefComponents/common/bool/index.vue
@@ -102,8 +102,11 @@ const handleSwitchChange = (value: boolean | string | number) => {
     & svg:hover {
       color: var(--themeColor);
     }
+    & > .notes {
+      display: inline;
+      margin: 0 0 0 8px;
+    }
   }
-
 }
 
 span.el-switch__core::after {

--- a/src/renderer/src/prefComponents/common/compound/index.vue
+++ b/src/renderer/src/prefComponents/common/compound/index.vue
@@ -29,16 +29,12 @@ defineProps<{
   color: var(--editorColor);
 
   & .pref-compound-head h6.title {
-    font-weight: 400;
-    font-size: 1.1em;
     padding-bottom: 6px;
   }
 
   & .pref-compound-body {
-    padding: 8px 16px 8px 16px;
-    margin-top: -12px;
-    background: rgba(0, 0, 0, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.03);
+    padding: 0;
+    margin-top: -4px;
   }
 
   & .description {
@@ -51,12 +47,6 @@ defineProps<{
     & i:hover {
       color: var(--themeColor);
     }
-  }
-
-  & .notes {
-    margin-left: 10px;
-    font-style: italic;
-    font-size: 12px;
   }
 }
 </style>

--- a/src/renderer/src/prefComponents/common/select/index.vue
+++ b/src/renderer/src/prefComponents/common/select/index.vue
@@ -85,11 +85,6 @@ const select = (value: SelectValue) => {
   margin: 20px 0;
   font-size: 14px;
   color: var(--editorColor);
-  & .notes {
-    margin-top: 10px;
-    font-style: italic;
-    font-size: 12px;
-  }
   & .el-select {
     width: 100%;
   }

--- a/src/renderer/src/prefComponents/common/textBox/index.vue
+++ b/src/renderer/src/prefComponents/common/textBox/index.vue
@@ -119,11 +119,6 @@ const handleInput = (value: string) => {
       color: var(--editorColor30);
     }
   }
-  & .notes {
-    margin-top: 10px;
-    font-style: italic;
-    font-size: 12px;
-  }
   & .input {
     width: 100%;
   }

--- a/src/renderer/src/prefComponents/editor/index.vue
+++ b/src/renderer/src/prefComponents/editor/index.vue
@@ -74,6 +74,11 @@
           :bool="trimUnnecessaryCodeBlockEmptyLines"
           :on-change="(value) => onSelectChange('trimUnnecessaryCodeBlockEmptyLines', value)"
         />
+        <bool
+          :description="t('preferences.editor.misc.wrapCodeBlocks')"
+          :bool="wrapCodeBlocks"
+          :on-change="(value) => onSelectChange('wrapCodeBlocks', value)"
+        />
       </template>
     </compound>
 
@@ -173,11 +178,6 @@
           :description="t('preferences.editor.misc.autoCheck')"
           :bool="autoCheck"
           :on-change="(value) => onSelectChange('autoCheck', value)"
-        />
-        <bool
-          :description="t('preferences.editor.misc.wrapCodeBlocks')"
-          :bool="wrapCodeBlocks"
-          :on-change="(value) => onSelectChange('wrapCodeBlocks', value)"
         />
       </template>
     </compound>

--- a/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
+++ b/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="image-folder">
-    <h5>{{ t('preferences.image.folderSetting.title') }}</h5>
+    <h6 class="title">{{ t('preferences.image.folderSetting.title') }}</h6>
     <text-box
       :description="t('preferences.image.folderSetting.globalFolder')"
       :input="imageFolderPath"

--- a/src/renderer/src/prefComponents/image/components/uploader/index.vue
+++ b/src/renderer/src/prefComponents/image/components/uploader/index.vue
@@ -1033,7 +1033,7 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .detection-status h6 {
   margin: 0;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   color: var(--editorColor);
 }
 
@@ -1245,15 +1245,15 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .install-commands {
   margin-top: 12px;
   padding: 12px;
-  background-color: #f8f9fa;
+  background-color: var(--floatBgColor);
   border-radius: 6px;
-  border-left: 4px solid #ffc107;
+  border-left: 4px solid var(--warningColor, #ffc107);
 }
 
 .pref-image-uploader .install-title {
-  font-weight: 600;
+  font-weight: 500;
   margin-bottom: 8px;
-  color: #333;
+  color: var(--editorColor);
   font-size: 13px;
 }
 
@@ -1271,17 +1271,17 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .install-option strong {
   min-width: 50px;
   font-size: 12px;
-  color: #666;
+  color: var(--editorColor70);
 }
 
 .pref-image-uploader .install-command {
-  background-color: #e9ecef;
+  background-color: var(--editorColor10);
   padding: 2px 6px;
   border-radius: 3px;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 11px;
-  color: #495057;
-  border: 1px solid #dee2e6;
+  color: var(--editorColor);
+  border: 1px solid var(--editorColor20);
   user-select: all;
 }
 
@@ -1293,15 +1293,15 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .usage-guide {
   margin-top: 15px;
   padding: 15px;
-  background-color: #f8f9fa;
+  background-color: var(--floatBgColor);
   border-radius: 6px;
-  border-left: 4px solid #17a2b8;
+  border-left: 4px solid var(--themeColor);
 }
 
 .pref-image-uploader .usage-title {
-  font-weight: 600;
+  font-weight: 500;
   margin-bottom: 12px;
-  color: #333;
+  color: var(--editorColor);
   font-size: 14px;
 }
 
@@ -1315,7 +1315,7 @@ const validate = (value: string): boolean => {
 }
 
 .pref-image-uploader .usage-step strong {
-  color: #495057;
+  color: var(--editorColor);
   font-size: 13px;
   display: block;
   margin-bottom: 4px;
@@ -1323,19 +1323,19 @@ const validate = (value: string): boolean => {
 
 .pref-image-uploader .usage-description {
   font-size: 12px;
-  color: #6c757d;
+  color: var(--editorColor70);
   margin-bottom: 6px;
   line-height: 1.4;
 }
 
 .pref-image-uploader .usage-command {
-  background-color: #e9ecef;
+  background-color: var(--editorColor10);
   padding: 4px 8px;
   border-radius: 3px;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 11px;
-  color: #495057;
-  border: 1px solid #dee2e6;
+  color: var(--editorColor);
+  border: 1px solid var(--editorColor20);
   user-select: all;
   display: inline-block;
 }

--- a/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/src/renderer/src/prefComponents/keybindings/index.vue
@@ -336,4 +336,19 @@ const dumpKeyboardInformation = (): void => {
   padding: 2px 0;
   margin: 0;
 }
+.pref-keybindings .el-table,
+.pref-keybindings .el-table .el-table__inner-wrapper,
+.pref-keybindings .el-table .el-table__body-wrapper,
+.pref-keybindings .el-table .el-scrollbar,
+.pref-keybindings .el-table .el-scrollbar__wrap,
+.pref-keybindings .el-table .el-scrollbar__view {
+  height: auto !important;
+  max-height: none !important;
+}
+.pref-keybindings .el-table .el-scrollbar__wrap {
+  overflow: visible !important;
+}
+.pref-keybindings .el-table .el-scrollbar__bar {
+  display: none !important;
+}
 </style>

--- a/src/renderer/src/prefComponents/sideBar/index.vue
+++ b/src/renderer/src/prefComponents/sideBar/index.vue
@@ -165,10 +165,11 @@ onUnmounted(() => {
   background: var(--sideBarBgColor);
   width: var(--prefSideBarWidth);
   height: 100vh;
-  padding-top: 30px;
+  padding-top: 24px;
   box-sizing: border-box;
   & h3 {
     margin: 0;
+    font-size: 20px;
     font-weight: normal;
     text-align: center;
     color: var(--sideBarColor);
@@ -176,8 +177,8 @@ onUnmounted(() => {
 }
 .search-wrapper {
   -webkit-app-region: no-drag;
-  padding: 0 20px;
-  margin: 30px 0;
+  padding: 0 16px;
+  margin: 18px 0;
 }
 .el-autocomplete {
   width: 100%;
@@ -189,8 +190,9 @@ onUnmounted(() => {
   & .el-input__inner {
     border: none;
     background: transparent;
-    height: 35px;
-    line-height: 35px;
+    height: 28px;
+    line-height: 28px;
+    font-size: 13px;
   }
 }
 .pref-autocomplete {
@@ -228,10 +230,10 @@ onUnmounted(() => {
   overflow-y: auto;
   & .item {
     width: 100%;
-    height: 50px;
-    font-size: 18px;
+    height: 38px;
+    font-size: 16px;
     color: var(--sideBarColor);
-    padding-left: 20px;
+    padding-left: 16px;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;
@@ -240,10 +242,13 @@ onUnmounted(() => {
     position: relative;
     user-select: none;
     & > svg {
-      width: 28px;
-      height: 28px;
-      fill: var(--iconColor);
-      margin-right: 15px;
+      width: 18px;
+      height: 18px;
+      fill: var(--sideBarColor);
+      margin-right: 12px;
+    }
+    &.active > svg {
+      fill: var(--sideBarTitleColor);
     }
     &:hover {
       background: var(--sideBarItemHoverBgColor);

--- a/src/renderer/src/prefComponents/spellchecker/index.vue
+++ b/src/renderer/src/prefComponents/spellchecker/index.vue
@@ -192,13 +192,8 @@ const handleDeleteClick = (selectedItem: CustomDictionaryWord): void => {
   & div.description {
     margin-top: 10px;
     margin-bottom: 2px;
-    color: var(--iconColor);
+    color: var(--editorColor);
     font-size: 14px;
-  }
-  & h6.title {
-    font-weight: 400;
-    font-size: 1.1em;
-    margin-bottom: 0;
   }
 }
 .el-table,

--- a/src/renderer/src/prefComponents/theme/index.vue
+++ b/src/renderer/src/prefComponents/theme/index.vue
@@ -50,17 +50,12 @@
       </template>
     </compound>
 
-    <div>
-      <div style="font-size: smaller; color: var(--editorColor)">
+    <div class="custom-css">
+      <div class="description">
         {{ t('preferences.theme.customCss') }}
       </div>
       <textarea
-        style="
-          width: 100%;
-          background: transparent;
-          color: var(--editorColor);
-          border: 1px solid var(--editorColor10);
-        "
+        class="custom-css-input"
         rows="10"
         :value="customCss"
         @change="
@@ -148,15 +143,16 @@ const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
 <style>
 .offcial-themes {
   margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
   & .theme {
     cursor: pointer;
-    width: 248px;
-    height: 100px;
-    margin: 0px 20px 10px 20px;
-    padding-left: 30px;
-    padding-top: 20px;
+    width: 100%;
+    height: 110px;
+    margin: 0;
+    padding: 16px 18px 16px 32px;
     overflow: hidden;
-    display: inline-block;
     background: var(--editorBgColor);
     color: var(--editorColor);
     box-sizing: border-box;
@@ -436,7 +432,40 @@ const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
     }
   }
   & p {
+    margin: 6px 0 0;
     font-size: 12px;
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.custom-css {
+  margin: 20px 0;
+  font-size: 14px;
+  color: var(--editorColor);
+  & .description {
+    margin-bottom: 10px;
+  }
+  & .custom-css-input {
+    width: 100%;
+    background: transparent;
+    color: var(--editorColor);
+    border: 1px solid var(--editorColor10);
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-family: 'DejaVu Sans Mono', 'Source Code Pro', 'Droid Sans Mono', Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    box-sizing: border-box;
+    resize: vertical;
+  }
+  & .custom-css-input:focus {
+    outline: none;
+    border-color: var(--themeColor);
   }
 }
 

--- a/src/renderer/src/prefComponents/theme/index.vue
+++ b/src/renderer/src/prefComponents/theme/index.vue
@@ -144,7 +144,7 @@ const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
 .offcial-themes {
   margin-top: 12px;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
   & .theme {
     cursor: pointer;


### PR DESCRIPTION
## Summary

Tighten the preferences dialog visuals so it reads like one coherent surface across all tabs, and fix several long-standing layout/scroll issues that surface on certain themes or window widths. No behavioral changes — purely visual.

### Sidebar
- Shrink to **220px**, icon size 28px → **18px** (matches the main editor sidebar)
- Type scale: title **20px** / menu **16px** / body section **15px**
- Icons use `--sideBarColor` instead of `--iconColor` (no longer washed out)

### Body headings
- Per-theme `--h*Color` (cyberdream / tokyo-night / one-dark, etc.) was painting page titles ("通用") and section heads ("自动保存") in the theme accent color
- All `h1`–`h6` in the dialog now resolve to `--editorColor` with a unified `font-weight: 500`

### Compound section
- Remove the rgba gray background; left-align controls to the section title
- Consolidate `.notes` style (italic 12px `--editorColor80`) at the container so per-control duplicates can go away

### Tab-specific fixes
- **Editor**: move "wrap code blocks" from *Misc* into the *Code Block* group
- **Theme**: switch from inline-block fixed-width cards to a 3-column grid that adapts to window width; bump card height; clamp the lorem paragraph to 2 lines; restore the 32px left padding so the h3 pseudo-indicator stays visible
- **Theme**: Custom CSS textarea — extract inline styles into a class with monospace font and themed focus border
- **Image uploader**: replace hardcoded `#333` / `#666` / `#f8f9fa` style values in the install + usage panels with theme variables; the panels are now readable on dark themes
- **Keybindings**: hide the `el-scrollbar` internals and unconstrain the body wrapper so only the outer `.pref-setting` scrolls
- **Image / folderSetting**: switch the inner `<h5>` to `<h6 class="title">` for visual parity with other section heads

## Test plan
- [x] Open Preferences on a colorful theme (e.g. **cyberdream**, **tokyo-night**, **one-dark**) and confirm section titles are no longer accent-colored
- [x] Resize the window narrow → wide and confirm Theme cards stay in a 3-column grid without truncating the heading
- [x] Switch to a dark theme and open *Image → Upload* — install + usage panels read correctly (no light-mode hardcoded colors)
- [x] Open Keybindings tab — only the outer dialog scrolls; no nested scrollbar inside the table
- [x] Walk every tab and confirm typography is consistent (title 18px / section 15px / control 14px / note 12px)