### PR TITLE
style(ui): batch polish sidebar, tabs, preferences, and theme contrast

### DIFF
--- a/src/renderer/src/assets/themes/ayu-dark.theme.css
+++ b/src/renderer/src/assets/themes/ayu-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(179, 177, 173, 0.8);
   --sideBarTextColor: rgba(179, 177, 173, 0.4);
-  --sideBarBgColor: #050709;
+  --sideBarBgColor: #070a0e;
   --sideBarItemHoverBgColor: rgba(179, 177, 173, 0.03);
   --itemBgColor: #131721;
 

--- a/src/renderer/src/assets/themes/ayu-light.theme.css
+++ b/src/renderer/src/assets/themes/ayu-light.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(87, 95, 102, 0.9);
   --sideBarTextColor: rgba(87, 95, 102, 0.5);
-  --sideBarBgColor: #f0f0f0;
+  --sideBarBgColor: #f5f5f5;
   --sideBarItemHoverBgColor: rgba(87, 95, 102, 0.05);
   --itemBgColor: #e5e5e5;
 

--- a/src/renderer/src/assets/themes/ayu-mirage.theme.css
+++ b/src/renderer/src/assets/themes/ayu-mirage.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(203, 204, 198, 0.8);
   --sideBarTextColor: rgba(203, 204, 198, 0.4);
-  --sideBarBgColor: #171b24;
+  --sideBarBgColor: #1b1f2a;
   --sideBarItemHoverBgColor: rgba(203, 204, 198, 0.03);
   --itemBgColor: #272d38;
 

--- a/src/renderer/src/assets/themes/catppuccin-latte.theme.css
+++ b/src/renderer/src/assets/themes/catppuccin-latte.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(76, 79, 105, 0.9);
   --sideBarTextColor: rgba(76, 79, 105, 0.5);
-  --sideBarBgColor: #e6e9ef;
+  --sideBarBgColor: #eaedf2;
   --sideBarItemHoverBgColor: rgba(76, 79, 105, 0.05);
   --itemBgColor: #dce0e8;
 

--- a/src/renderer/src/assets/themes/catppuccin-mocha.theme.css
+++ b/src/renderer/src/assets/themes/catppuccin-mocha.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(205, 214, 244, 0.8);
   --sideBarTextColor: rgba(205, 214, 244, 0.4);
-  --sideBarBgColor: #181825;
+  --sideBarBgColor: #1b1b29;
   --sideBarItemHoverBgColor: rgba(205, 214, 244, 0.03);
   --itemBgColor: #313244;
 

--- a/src/renderer/src/assets/themes/cyberdream.theme.css
+++ b/src/renderer/src/assets/themes/cyberdream.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(255, 255, 255, 0.8);
   --sideBarTextColor: rgba(255, 255, 255, 0.4);
-  --sideBarBgColor: #0e1012;
+  --sideBarBgColor: #121416;
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
   --itemBgColor: #1e2124;
 

--- a/src/renderer/src/assets/themes/dark.theme.css
+++ b/src/renderer/src/assets/themes/dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(255, 255, 255, 0.8);
   --sideBarTextColor: rgba(255, 255, 255, 0.4);
-  --sideBarBgColor: #1e1e1e;
+  --sideBarBgColor: #232323;
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
   --itemBgColor: #3f3f3f;
 

--- a/src/renderer/src/assets/themes/dracula.theme.css
+++ b/src/renderer/src/assets/themes/dracula.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(248, 248, 242, 0.8);
   --sideBarTextColor: rgba(248, 248, 242, 0.4);
-  --sideBarBgColor: #21222c;
+  --sideBarBgColor: #242631;
   --sideBarItemHoverBgColor: rgba(248, 248, 242, 0.03);
   --itemBgColor: #44475a;
 

--- a/src/renderer/src/assets/themes/everforest-dark.theme.css
+++ b/src/renderer/src/assets/themes/everforest-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(211, 198, 170, 0.8);
   --sideBarTextColor: rgba(211, 198, 170, 0.4);
-  --sideBarBgColor: #272e33;
+  --sideBarBgColor: #2a3137;
   --sideBarItemHoverBgColor: rgba(211, 198, 170, 0.03);
   --itemBgColor: #343f44;
 

--- a/src/renderer/src/assets/themes/everforest-light.theme.css
+++ b/src/renderer/src/assets/themes/everforest-light.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(92, 106, 114, 0.9);
   --sideBarTextColor: rgba(92, 106, 114, 0.5);
-  --sideBarBgColor: #f4f0d9;
+  --sideBarBgColor: #f8f3de;
   --sideBarItemHoverBgColor: rgba(92, 106, 114, 0.05);
   --itemBgColor: #ebe7cf;
 

--- a/src/renderer/src/assets/themes/graphite.theme.css
+++ b/src/renderer/src/assets/themes/graphite.theme.css
@@ -71,11 +71,11 @@
   --emColor: #5f9ea0;
   --listMarkerColor: #6886aa;
 
-  --sideBarColor: rgba(188, 193, 197, 0.8);
-  --sideBarIconColor: rgba(175, 175, 175, 0.8);
-  --sideBarTitleColor: rgba(255, 255, 255, 1);
-  --sideBarTextColor: rgba(188, 193, 197, 0.4);
-  --sideBarBgColor: rgba(69, 75, 80, 1);
+  --sideBarColor: rgba(43, 48, 50, 0.8);
+  --sideBarIconColor: rgba(43, 48, 50, 0.6);
+  --sideBarTitleColor: rgba(43, 48, 50, 1);
+  --sideBarTextColor: rgba(43, 48, 50, 0.6);
+  --sideBarBgColor: #ececec;
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
   --itemBgColor: rgba(43, 48, 50, 0.5);
 

--- a/src/renderer/src/assets/themes/gruvbox-dark.theme.css
+++ b/src/renderer/src/assets/themes/gruvbox-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(235, 219, 178, 0.8);
   --sideBarTextColor: rgba(235, 219, 178, 0.4);
-  --sideBarBgColor: #1d2021;
+  --sideBarBgColor: #222424;
   --sideBarItemHoverBgColor: rgba(235, 219, 178, 0.03);
   --itemBgColor: #3c3836;
 

--- a/src/renderer/src/assets/themes/gruvbox-light.theme.css
+++ b/src/renderer/src/assets/themes/gruvbox-light.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(60, 56, 54, 0.9);
   --sideBarTextColor: rgba(60, 56, 54, 0.5);
-  --sideBarBgColor: #ebdbb2;
+  --sideBarBgColor: #f3e6bc;
   --sideBarItemHoverBgColor: rgba(60, 56, 54, 0.05);
   --itemBgColor: #e2d1a7;
 

--- a/src/renderer/src/assets/themes/horizon-dark.theme.css
+++ b/src/renderer/src/assets/themes/horizon-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(213, 216, 218, 0.8);
   --sideBarTextColor: rgba(213, 216, 218, 0.4);
-  --sideBarBgColor: #16181f;
+  --sideBarBgColor: #191b22;
   --sideBarItemHoverBgColor: rgba(213, 216, 218, 0.03);
   --itemBgColor: #232530;
 

--- a/src/renderer/src/assets/themes/kanagawa.theme.css
+++ b/src/renderer/src/assets/themes/kanagawa.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(220, 215, 186, 0.8);
   --sideBarTextColor: rgba(220, 215, 186, 0.4);
-  --sideBarBgColor: #16161d;
+  --sideBarBgColor: #1a1a22;
   --sideBarItemHoverBgColor: rgba(220, 215, 186, 0.03);
   --itemBgColor: #2a2a37;
 

--- a/src/renderer/src/assets/themes/material-dark.theme.css
+++ b/src/renderer/src/assets/themes/material-dark.theme.css
@@ -76,7 +76,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(255, 255, 255, 1);
   --sideBarTextColor: rgba(255, 255, 255, 0.4);
-  --sideBarBgColor: rgba(26, 33, 41, 0.9);
+  --sideBarBgColor: rgba(39, 45, 52, 0.95);
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
   --itemBgColor: rgba(71, 78, 86, 0.6);
 

--- a/src/renderer/src/assets/themes/monokai-pro.theme.css
+++ b/src/renderer/src/assets/themes/monokai-pro.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(252, 252, 250, 0.8);
   --sideBarTextColor: rgba(252, 252, 250, 0.4);
-  --sideBarBgColor: #221f22;
+  --sideBarBgColor: #272428;
   --sideBarItemHoverBgColor: rgba(252, 252, 250, 0.03);
   --itemBgColor: #403e41;
 

--- a/src/renderer/src/assets/themes/nightfox.theme.css
+++ b/src/renderer/src/assets/themes/nightfox.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(205, 206, 207, 0.8);
   --sideBarTextColor: rgba(205, 206, 207, 0.4);
-  --sideBarBgColor: #131a24;
+  --sideBarBgColor: #161e2a;
   --sideBarItemHoverBgColor: rgba(205, 206, 207, 0.03);
   --itemBgColor: #212e3f;
 

--- a/src/renderer/src/assets/themes/nord.theme.css
+++ b/src/renderer/src/assets/themes/nord.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(216, 222, 233, 0.8);
   --sideBarTextColor: rgba(216, 222, 233, 0.4);
-  --sideBarBgColor: #292e39;
+  --sideBarBgColor: #2b313c;
   --sideBarItemHoverBgColor: rgba(216, 222, 233, 0.03);
   --itemBgColor: #3b4252;
 

--- a/src/renderer/src/assets/themes/one-dark.theme.css
+++ b/src/renderer/src/assets/themes/one-dark.theme.css
@@ -78,7 +78,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: #9da5b4;
   --sideBarTextColor: #9da5b4;
-  --sideBarBgColor: #21252b;
+  --sideBarBgColor: #24282f;
   --sideBarItemHoverBgColor: #3a3f4b;
   --itemBgColor: #21252b;
 

--- a/src/renderer/src/assets/themes/oxocarbon-dark.theme.css
+++ b/src/renderer/src/assets/themes/oxocarbon-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(242, 244, 248, 0.8);
   --sideBarTextColor: rgba(242, 244, 248, 0.4);
-  --sideBarBgColor: #0d0d0d;
+  --sideBarBgColor: #111111;
   --sideBarItemHoverBgColor: rgba(242, 244, 248, 0.03);
   --itemBgColor: #262626;
 

--- a/src/renderer/src/assets/themes/palenight.theme.css
+++ b/src/renderer/src/assets/themes/palenight.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(166, 172, 205, 0.8);
   --sideBarTextColor: rgba(166, 172, 205, 0.4);
-  --sideBarBgColor: #222534;
+  --sideBarBgColor: #252939;
   --sideBarItemHoverBgColor: rgba(166, 172, 205, 0.03);
   --itemBgColor: #32374d;
 

--- a/src/renderer/src/assets/themes/rose-pine-dawn.theme.css
+++ b/src/renderer/src/assets/themes/rose-pine-dawn.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(87, 82, 121, 0.9);
   --sideBarTextColor: rgba(87, 82, 121, 0.5);
-  --sideBarBgColor: #f2e9e1;
+  --sideBarBgColor: #f6eee7;
   --sideBarItemHoverBgColor: rgba(87, 82, 121, 0.05);
   --itemBgColor: #e9dfd7;
 

--- a/src/renderer/src/assets/themes/rose-pine-moon.theme.css
+++ b/src/renderer/src/assets/themes/rose-pine-moon.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(224, 222, 244, 0.8);
   --sideBarTextColor: rgba(224, 222, 244, 0.4);
-  --sideBarBgColor: #1b1929;
+  --sideBarBgColor: #1f1d2f;
   --sideBarItemHoverBgColor: rgba(224, 222, 244, 0.03);
   --itemBgColor: #2a273f;
 

--- a/src/renderer/src/assets/themes/rose-pine.theme.css
+++ b/src/renderer/src/assets/themes/rose-pine.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(224, 222, 244, 0.8);
   --sideBarTextColor: rgba(224, 222, 244, 0.4);
-  --sideBarBgColor: #13111e;
+  --sideBarBgColor: #161421;
   --sideBarItemHoverBgColor: rgba(224, 222, 244, 0.03);
   --itemBgColor: #1f1d2e;
 

--- a/src/renderer/src/assets/themes/solarized-dark.theme.css
+++ b/src/renderer/src/assets/themes/solarized-dark.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(131, 148, 150, 0.8);
   --sideBarTextColor: rgba(131, 148, 150, 0.4);
-  --sideBarBgColor: #001e26;
+  --sideBarBgColor: #00242e;
   --sideBarItemHoverBgColor: rgba(131, 148, 150, 0.03);
   --itemBgColor: #073642;
 

--- a/src/renderer/src/assets/themes/solarized-light.theme.css
+++ b/src/renderer/src/assets/themes/solarized-light.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(101, 123, 131, 0.9);
   --sideBarTextColor: rgba(101, 123, 131, 0.5);
-  --sideBarBgColor: #eee8d5;
+  --sideBarBgColor: #f5efdc;
   --sideBarItemHoverBgColor: rgba(101, 123, 131, 0.05);
   --itemBgColor: #e5dfcc;
 

--- a/src/renderer/src/assets/themes/synthwave-84.theme.css
+++ b/src/renderer/src/assets/themes/synthwave-84.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(255, 255, 255, 0.8);
   --sideBarTextColor: rgba(255, 255, 255, 0.4);
-  --sideBarBgColor: #1e1a29;
+  --sideBarBgColor: #221e2f;
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
   --itemBgColor: #34294a;
 

--- a/src/renderer/src/assets/themes/tokyo-night-light.theme.css
+++ b/src/renderer/src/assets/themes/tokyo-night-light.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(52, 59, 88, 0.9);
   --sideBarTextColor: rgba(52, 59, 88, 0.5);
-  --sideBarBgColor: #cbccd1;
+  --sideBarBgColor: #d0d1d6;
   --sideBarItemHoverBgColor: rgba(52, 59, 88, 0.05);
   --itemBgColor: #c8c9ce;
 

--- a/src/renderer/src/assets/themes/tokyo-night-storm.theme.css
+++ b/src/renderer/src/assets/themes/tokyo-night-storm.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(192, 202, 245, 0.8);
   --sideBarTextColor: rgba(192, 202, 245, 0.4);
-  --sideBarBgColor: #1a1b26;
+  --sideBarBgColor: #1f2130;
   --sideBarItemHoverBgColor: rgba(192, 202, 245, 0.03);
   --itemBgColor: #1f2335;
 

--- a/src/renderer/src/assets/themes/tokyo-night.theme.css
+++ b/src/renderer/src/assets/themes/tokyo-night.theme.css
@@ -77,7 +77,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(192, 202, 245, 0.8);
   --sideBarTextColor: rgba(192, 202, 245, 0.4);
-  --sideBarBgColor: #16161e;
+  --sideBarBgColor: #181822;
   --sideBarItemHoverBgColor: rgba(192, 202, 245, 0.03);
   --itemBgColor: #24283b;
 

--- a/src/renderer/src/assets/themes/ulysses.theme.css
+++ b/src/renderer/src/assets/themes/ulysses.theme.css
@@ -75,7 +75,7 @@
   --sideBarIconColor: var(--iconColor);
   --sideBarTitleColor: rgba(101, 101, 101, 1);
   --sideBarTextColor: rgba(101, 101, 101, 0.4);
-  --sideBarBgColor: rgba(248, 248, 248, 0.9);
+  --sideBarBgColor: rgba(245, 245, 245, 0.95);
   --sideBarItemHoverBgColor: rgba(101, 101, 101, 0.03);
   --itemBgColor: rgba(245, 245, 245, 0.6);
 

--- a/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1475,8 +1475,8 @@ onBeforeUnmount(() => {
     top: 50px;
     left: 50px;
     display: block;
+    color: #efefef;
     & svg {
-      fill: #efefef;
       width: 100%;
       height: 100%;
     }

--- a/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/src/renderer/src/components/editorWithTabs/editor.vue
@@ -120,7 +120,7 @@ import { useI18n } from 'vue-i18n'
 
 import 'muya/themes/default.css'
 import '@/assets/themes/codemirror/one-dark.css'
-import CloseIcon from '@/assets/icons/close.svg'
+import { Close as CloseIcon } from '@element-plus/icons-vue'
 
 const { t } = useI18n()
 const STANDAR_Y = 320

--- a/src/renderer/src/components/editorWithTabs/notifications.vue
+++ b/src/renderer/src/components/editorWithTabs/notifications.vue
@@ -21,15 +21,12 @@
           class="inline-button"
           @click.stop="handleClick(false)"
         >
-          <svg
-            class="close-icon icon"
-            aria-hidden="true"
+          <el-icon
+            class="close-icon"
+            :size="12"
           >
-            <use
-              id="default-close-icon"
-              xlink:href="#icon-close-small"
-            />
-          </svg>
+            <Close />
+          </el-icon>
         </span>
       </div>
     </div>
@@ -41,6 +38,7 @@ import { computed } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { useLayoutStore } from '@/store/layout'
 import { storeToRefs } from 'pinia'
+import { Close } from '@element-plus/icons-vue'
 import { t } from '../../i18n'
 
 const editorStore = useEditorStore()

--- a/src/renderer/src/components/editorWithTabs/tabs.vue
+++ b/src/renderer/src/components/editorWithTabs/tabs.vue
@@ -19,22 +19,14 @@
           @contextmenu.prevent="handleContextMenu($event, file)"
         >
           <span>{{ file.filename }}</span>
-          <svg
-            class="close-icon icon"
-            aria-hidden="true"
+          <span class="unsaved-dot" />
+          <el-icon
+            class="close-icon"
+            :size="12"
             @click.stop="removeFileInTab(file)"
           >
-            <circle
-              id="unsaved-circle-icon"
-              cx="6"
-              cy="6"
-              r="3"
-            />
-            <use
-              id="default-close-icon"
-              xlink:href="#icon-close-small"
-            />
-          </svg>
+            <Close />
+          </el-icon>
         </li>
       </ul>
     </div>
@@ -42,12 +34,9 @@
       class="new-file"
       @click.stop="newFile()"
     >
-      <svg
-        class="icon"
-        aria-hidden="true"
-      >
-        <use xlink:href="#icon-plus" />
-      </svg>
+      <el-icon :size="16">
+        <Plus />
+      </el-icon>
     </div>
   </div>
 </template>
@@ -59,6 +48,7 @@ import { useLayoutStore } from '@/store/layout'
 import { storeToRefs } from 'pinia'
 import autoScroll from 'dom-autoscroller'
 import dragula from 'dragula'
+import { Plus, Close } from '@element-plus/icons-vue'
 import { showContextMenu } from '../../contextMenu/tabs'
 import bus from '../../bus'
 import type { IFileState } from '@shared/types/files'
@@ -242,21 +232,20 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-svg.close-icon #unsaved-circle-icon {
-  transition: all 0.15s ease-in-out;
-  fill: var(--themeColor);
+.close-icon {
+  cursor: pointer;
+  transition: opacity 0.15s ease-in-out;
 }
 
-svg.close-icon:hover {
-  cursor: pointer;
-  fill: var(--focusColor);
+.close-icon:hover {
+  color: var(--focusColor);
 }
 
 .editor-tabs {
   position: relative;
   display: flex;
   flex-direction: row;
-  height: 35px;
+  height: 28px;
   user-select: none;
   box-shadow: 0px 0px 9px 2px rgba(0, 0, 0, 0.1);
   overflow: hidden;
@@ -266,7 +255,7 @@ svg.close-icon:hover {
 }
 .scrollable-tabs {
   flex: 0 1 auto;
-  height: 35px;
+  height: 28px;
   overflow: hidden;
 }
 .tabs-container {
@@ -274,7 +263,7 @@ svg.close-icon:hover {
   list-style: none;
   margin: 0;
   padding: 0;
-  height: 35px;
+  height: 28px;
   position: relative;
   display: flex;
   flex-direction: row;
@@ -289,17 +278,15 @@ svg.close-icon:hover {
     padding: 0 8px;
     color: var(--editorColor50);
     font-size: 12px;
-    line-height: 35px;
-    height: 35px;
+    line-height: 28px;
+    height: 28px;
     max-width: 280px;
-    border-top-right-radius: 15px;
-    border-top-left-radius: 15px;
     display: flex;
     align-items: center;
     &[aria-grabbed='true'] {
       color: var(--editorColor30) !important;
     }
-    & > svg {
+    & > .close-icon {
       opacity: 0;
     }
     &:focus {
@@ -308,14 +295,11 @@ svg.close-icon:hover {
     &:hover {
       background: var(--floatBgColor) !important;
     }
-    &:hover > svg {
+    &:hover > .close-icon {
       opacity: 1;
     }
-    &:hover > svg.close-icon #default-close-icon {
-      display: block !important;
-    }
-    &:hover > svg.close-icon #unsaved-circle-icon {
-      display: none !important;
+    &:hover > .unsaved-dot {
+      display: none;
     }
     & > span {
       overflow: hidden;
@@ -323,15 +307,26 @@ svg.close-icon:hover {
       white-space: nowrap;
       margin-right: 3px;
     }
+    & > .unsaved-dot {
+      display: none;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--themeColor);
+      flex-shrink: 0;
+    }
   }
   & > li.unsaved:not(.active) {
-    & > svg.close-icon {
-      opacity: 1;
+    & > .close-icon {
+      opacity: 0;
     }
-    & > svg.close-icon #unsaved-circle-icon {
+    & > .unsaved-dot {
       display: block;
     }
-    & > svg.close-icon #default-close-icon {
+    &:hover > .close-icon {
+      opacity: 1;
+    }
+    &:hover > .unsaved-dot {
       display: none;
     }
   }
@@ -347,18 +342,18 @@ svg.close-icon:hover {
       height: 2px;
       background: var(--themeColor);
     }
-    & > svg {
+    & > .close-icon {
       opacity: 1;
     }
-    & > svg.close-icon #unsaved-circle-icon {
+    & > .unsaved-dot {
       display: none;
     }
   }
 }
 .editor-tabs > .new-file {
-  flex: 0 0 35px;
-  width: 35px;
-  height: 35px;
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
   border-right: none;
   background: transparent;
   display: flex;

--- a/src/renderer/src/components/icons/LinkIcon.vue
+++ b/src/renderer/src/components/icons/LinkIcon.vue
@@ -1,0 +1,21 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number | string }>(), { size: 16 })
+</script>

--- a/src/renderer/src/components/recent/index.vue
+++ b/src/renderer/src/components/recent/index.vue
@@ -2,12 +2,14 @@
   <div class="recent-files-projects">
     <div class="centered-group">
       {{ t('recent.noTabsOpen') }}
-      <button
-        class="button-primary"
+      <el-button
+        text
+        bg
+        type="primary"
         @click="newFile"
       >
         {{ t('recent.newFile') }}
-      </button>
+      </el-button>
     </div>
   </div>
 </template>
@@ -35,9 +37,18 @@ const newFile = () => {
     flex-direction: column;
     align-items: center;
     color: var(--editorColor);
-    & button.button-primary {
-      display: block;
+    & .el-button {
       margin-top: 20px;
+    }
+    & .el-button.is-text.is-has-bg {
+      background-color: var(--itemBgColor);
+      color: var(--themeColor);
+      border-color: transparent;
+    }
+    & .el-button.is-text.is-has-bg:hover,
+    & .el-button.is-text.is-has-bg:focus {
+      background-color: var(--floatHoverColor);
+      color: var(--themeColor);
     }
   }
 }

--- a/src/renderer/src/components/rename/index.vue
+++ b/src/renderer/src/components/rename/index.vue
@@ -17,13 +17,13 @@
               class="search"
               @keyup.enter="confirm"
             >
-            <svg
-              class="icon"
-              aria-hidden="true"
+            <el-icon
+              :size="16"
+              class="confirm-icon"
               @click="confirm"
             >
-              <use xlink:href="#icon-markdown" />
-            </svg>
+              <Check />
+            </el-icon>
           </div>
         </div>
       </template>
@@ -35,6 +35,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import bus from '../../bus'
 import { useEditorStore } from '@/store/editor'
+import { Check } from '@element-plus/icons-vue'
 
 const showRename = ref(false)
 const tempName = ref('')

--- a/src/renderer/src/components/search/index.vue
+++ b/src/renderer/src/components/search/index.vue
@@ -8,13 +8,12 @@
       class="left-arrow"
       @click="toggleSearchType"
     >
-      <svg
-        class="icon"
-        aria-hidden="true"
+      <el-icon
+        :size="14"
         :class="{ 'arrow-right': type === 'search' }"
       >
-        <use xlink:href="#icon-arrowdown" />
-      </svg>
+        <ArrowDown />
+      </el-icon>
     </div>
     <div class="right-controls">
       <section class="search">
@@ -70,23 +69,17 @@
             class="button right"
             @click="find('prev')"
           >
-            <svg
-              class="icon"
-              aria-hidden="true"
-            >
-              <use xlink:href="#icon-arrow-up" />
-            </svg>
+            <el-icon :size="14">
+              <ArrowUp />
+            </el-icon>
           </button>
           <button
             class="button"
             @click="find('next')"
           >
-            <svg
-              class="icon"
-              aria-hidden="true"
-            >
-              <use xlink:href="#icon-arrowdown" />
-            </svg>
+            <el-icon :size="14">
+              <ArrowDown />
+            </el-icon>
           </button>
         </div>
       </section>
@@ -114,12 +107,9 @@
               class="button right"
               @click="replace(false)"
             >
-              <svg
-                class="icon"
-                aria-hidden="true"
-              >
-                <use xlink:href="#icon-all-inclusive" />
-              </svg>
+              <el-icon :size="14">
+                <RefreshRight />
+              </el-icon>
             </button>
           </el-tooltip>
           <el-tooltip
@@ -134,12 +124,9 @@
               class="button"
               @click="replace(true)"
             >
-              <svg
-                class="icon"
-                aria-hidden="true"
-              >
-                <use xlink:href="#icon-replace" />
-              </svg>
+              <el-icon :size="14">
+                <Switch />
+              </el-icon>
             </button>
           </el-tooltip>
         </div>
@@ -158,6 +145,7 @@ import { useEditorStore } from '@/store/editor'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { debounce } from 'underscore'
+import { ArrowDown, ArrowUp, RefreshRight, Switch } from '@element-plus/icons-vue'
 
 const { t } = useI18n()
 

--- a/src/renderer/src/components/search/index.vue
+++ b/src/renderer/src/components/search/index.vue
@@ -370,7 +370,7 @@ const noop = () => {}
   height: 12px;
   width: 12px;
 }
-.search-bar .left-arrow svg.arrow-right {
+.search-bar .left-arrow .arrow-right {
   transform: rotate(-90deg);
 }
 

--- a/src/renderer/src/components/sideBar/help.ts
+++ b/src/renderer/src/components/sideBar/help.ts
@@ -1,7 +1,9 @@
-import FilesIcon from '@/assets/icons/files.svg'
-import SearchIcon from '@/assets/icons/search.svg'
-import TocIcon from '@/assets/icons/toc.svg'
-import SettingIcon from '@/assets/icons/setting.svg'
+import {
+  Folder as FilesIcon,
+  Search as SearchIcon,
+  Memo as TocIcon,
+  Setting as SettingIcon
+} from '@element-plus/icons-vue'
 import { t } from '@/i18n'
 
 export interface SideBarIconEntry {

--- a/src/renderer/src/components/sideBar/index.vue
+++ b/src/renderer/src/components/sideBar/index.vue
@@ -151,7 +151,7 @@ const handleLeftBottomClick = (name: string): void => {
 }
 
 .side-bar .left-column svg {
-  fill: var(--iconColor);
+  color: var(--iconColor);
 }
 
 .left-column {
@@ -160,7 +160,7 @@ const handleLeftBottomClick = (name: string): void => {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: 40px;
+  padding-top: 28px;
   box-sizing: border-box;
 }
 
@@ -190,13 +190,13 @@ const handleLeftBottomClick = (name: string): void => {
 .left-column ul > li > svg {
   width: 18px;
   height: 18px;
-  fill: var(--sideBarIconColor);
+  color: var(--sideBarIconColor);
   opacity: 1;
   transition: transform 0.25s ease-in-out;
 }
 
 .left-column ul > li.active > svg {
-  fill: var(--themeColor);
+  color: var(--themeColor);
 }
 
 .side-bar:hover .left-column ul li svg {

--- a/src/renderer/src/components/sideBar/search.vue
+++ b/src/renderer/src/components/sideBar/search.vue
@@ -89,13 +89,15 @@
       class="empty"
     >
       <div class="no-data">
-        <button
+        <el-button
           v-if="showNoFolderOpenedMessage"
-          class="button-primary"
+          text
+          bg
+          type="primary"
           @click="openFolder"
         >
           {{ t('sideBar.search.openFolder') }}
-        </button>
+        </el-button>
       </div>
     </div>
   </div>
@@ -338,9 +340,9 @@ onMounted(() => {
 }
 .search-wrapper {
   display: flex;
-  margin: 37px 15px 10px 15px;
+  margin: 37px 8px 10px 8px;
   padding: 0 6px;
-  border-radius: 14px;
+  border-radius: 4px;
   height: 28px;
   border: 1px solid var(--floatBorderColor);
   background: var(--inputBgColor);
@@ -353,24 +355,29 @@ onMounted(() => {
     flex: 1;
     border: none;
     outline: none;
-    padding: 0 8px;
+    padding: 0;
     font-size: 13px;
     width: 50%;
   }
   & > .controls {
     display: flex;
     flex-shrink: 0;
-    margin-top: 3px;
+    margin-top: 0;
     & > span {
       cursor: pointer;
-      width: 20px;
-      height: 20px;
-      margin-left: 2px;
-      margin-right: 2px;
+      width: 18px;
+      height: 18px;
+      margin-left: 0;
+      margin-right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       &:hover {
         color: var(--sideBarIconColor);
       }
       & > svg {
+        width: 14px;
+        height: 14px;
         fill: var(--sideBarIconColor);
         &:hover {
           fill: var(--highlightThemeColor);
@@ -428,9 +435,18 @@ onMounted(() => {
     align-items: center;
     flex-direction: column;
   }
-  & .no-data .button-primary {
-    display: block;
+  & .no-data .el-button {
     margin-top: 20px;
+  }
+  & .no-data .el-button.is-text.is-has-bg {
+    background-color: var(--itemBgColor);
+    color: var(--themeColor);
+    border-color: transparent;
+  }
+  & .no-data .el-button.is-text.is-has-bg:hover,
+  & .no-data .el-button.is-text.is-has-bg:focus {
+    background-color: var(--floatHoverColor);
+    color: var(--themeColor);
   }
 }
 </style>

--- a/src/renderer/src/components/sideBar/searchResultItem.vue
+++ b/src/renderer/src/components/sideBar/searchResultItem.vue
@@ -4,14 +4,14 @@
       class="search-result"
       :title="searchResult.filePath"
     >
-      <svg
-        class="icon icon-arrow"
+      <el-icon
+        class="icon-arrow"
         :class="{ fold: !showSearchMatches }"
-        aria-hidden="true"
+        :size="14"
         @click.stop="toggleSearchMatches()"
       >
-        <use xlink:href="#icon-arrow" />
-      </svg>
+        <CaretRight />
+      </el-icon>
       <div
         class="file-info"
         @click.stop="toggleSearchMatches()"
@@ -67,6 +67,7 @@ import { useEditorStore } from '@/store/editor'
 import { storeToRefs } from 'pinia'
 import bus from '../../bus'
 import { useI18n } from 'vue-i18n'
+import { CaretRight } from '@element-plus/icons-vue'
 import type { SearchResult, SearchMatch } from './types'
 
 const { t } = useI18n()
@@ -272,9 +273,10 @@ const handleSearchResultClick = (searchMatch: SearchMatch): void => {
 }
 
 .icon-arrow {
-  transition: all 0.25s ease-out;
+  transition: transform 0.25s ease-out;
   transform: rotate(90deg);
-  fill: var(--sideBarTextColor);
+  color: var(--sideBarTextColor);
+  cursor: pointer;
 }
 .icon-arrow.fold {
   transform: rotate(0);

--- a/src/renderer/src/components/sideBar/tree.vue
+++ b/src/renderer/src/components/sideBar/tree.vue
@@ -7,14 +7,14 @@
     <!-- Opened tabs -->
     <div class="opened-files">
       <div class="title">
-        <svg
-          class="icon icon-arrow"
+        <el-icon
+          class="icon-arrow"
           :class="{ fold: !showOpenedFiles }"
-          aria-hidden="true"
+          :size="12"
           @click.stop="toggleOpenedFiles()"
         >
-          <use xlink:href="#icon-arrow" />
-        </svg>
+          <CaretRight />
+        </el-icon>
         <span
           class="default-cursor text-overflow"
           @click.stop="toggleOpenedFiles()"
@@ -66,14 +66,14 @@
       class="project-tree"
     >
       <div class="title">
-        <svg
-          class="icon icon-arrow"
+        <el-icon
+          class="icon-arrow"
           :class="{ fold: !showDirectories }"
-          aria-hidden="true"
+          :size="12"
           @click.stop="toggleDirectories()"
         >
-          <use xlink:href="#icon-arrow" />
-        </svg>
+          <CaretRight />
+        </el-icon>
         <span
           class="default-cursor text-overflow"
           @click.stop="toggleDirectories()"
@@ -132,12 +132,14 @@
       class="open-project"
     >
       <div class="centered-group">
-        <button
-          class="button-primary"
+        <el-button
+          text
+          bg
+          type="primary"
           @click="openFolder"
         >
           {{ t('sideBar.tree.openFolder') }}
-        </button>
+        </el-button>
       </div>
     </div>
   </div>
@@ -153,6 +155,7 @@ import File from './treeFile.vue'
 import OpenedFile from './treeOpenedTab.vue'
 import bus from '../../bus'
 import { useI18n } from 'vue-i18n'
+import { CaretRight } from '@element-plus/icons-vue'
 import type { TreeNode, TabDescriptor } from './types'
 
 const { t } = useI18n()
@@ -286,9 +289,10 @@ onMounted(() => {
 
 .icon-arrow {
   margin-right: 5px;
-  transition: all 0.25s ease-out;
+  transition: transform 0.25s ease-out;
   transform: rotate(90deg);
-  fill: var(--sideBarTextColor);
+  color: var(--sideBarTextColor);
+  cursor: pointer;
 }
 
 .icon-arrow.fold {
@@ -404,9 +408,21 @@ onMounted(() => {
   align-items: center;
 }
 
-.open-project button.button-primary {
-  display: block;
+.open-project .el-button {
   margin-top: 20px;
+}
+.open-project .el-button.is-text.is-has-bg,
+.empty-project .el-button.is-text.is-has-bg {
+  background-color: var(--itemBgColor);
+  color: var(--themeColor);
+  border-color: transparent;
+}
+.open-project .el-button.is-text.is-has-bg:hover,
+.open-project .el-button.is-text.is-has-bg:focus,
+.empty-project .el-button.is-text.is-has-bg:hover,
+.empty-project .el-button.is-text.is-has-bg:focus {
+  background-color: var(--floatHoverColor);
+  color: var(--themeColor);
 }
 .new-input {
   outline: none;

--- a/src/renderer/src/components/sideBar/treeOpenedTab.vue
+++ b/src/renderer/src/components/sideBar/treeOpenedTab.vue
@@ -5,13 +5,13 @@
     :class="[{ active: currentFile?.id === file.id, unsaved: !file.isSaved }]"
     @click="selectFile(file)"
   >
-    <svg
-      class="icon"
-      aria-hidden="true"
+    <el-icon
+      class="close-icon"
+      :size="10"
       @click.stop="removeFileInTab(file)"
     >
-      <use xlink:href="#icon-close-small" />
-    </svg>
+      <Close />
+    </el-icon>
     <span class="name">{{ file.filename }}</span>
   </div>
 </template>
@@ -19,6 +19,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { useEditorStore } from '@/store/editor'
+import { Close } from '@element-plus/icons-vue'
 import type { TabDescriptor } from './types'
 
 defineProps<{
@@ -54,16 +55,15 @@ const removeFileInTab = (file: TabDescriptor): void => {
   padding-left: 35px;
   position: relative;
   color: var(--sideBarColor);
-  & > svg {
+  & > .close-icon {
     display: none;
-    width: 10px;
-    height: 10px;
     position: absolute;
     top: 9px;
     left: 10px;
+    cursor: pointer;
   }
-  &:hover > svg {
-    display: inline-block;
+  &:hover > .close-icon {
+    display: inline-flex;
   }
   &:hover {
     background: var(--sideBarItemHoverBgColor);

--- a/src/renderer/src/components/titleBar/index.vue
+++ b/src/renderer/src/components/titleBar/index.vue
@@ -24,12 +24,12 @@
             :key="index"
           >
             {{ path }}
-            <svg
-              class="icon"
-              aria-hidden="true"
+            <el-icon
+              class="path-arrow"
+              :size="12"
             >
-              <use xlink:href="#icon-arrow-right" />
-            </svg>
+              <ArrowRight />
+            </el-icon>
           </span>
           <span
             class="filename"
@@ -144,6 +144,7 @@ import { PATH_SEPARATOR } from '../../config'
 import { isOsx as isOsxPlatform } from '@/util'
 import { useEditorStore } from '@/store/editor'
 import { useI18n } from 'vue-i18n'
+import { ArrowRight } from '@element-plus/icons-vue'
 import type { FileWordCount } from '@shared/types/files'
 
 interface ProjectInfo {

--- a/src/renderer/src/pages/preference.vue
+++ b/src/renderer/src/pages/preference.vue
@@ -118,7 +118,7 @@ onMounted(() => {
       -webkit-app-region: drag;
     }
     & .pref-setting {
-      padding: 50px 20px;
+      padding: 50px 40px;
       padding-top: var(--titleBarHeight);
       flex: 1;
       height: calc(100vh - var(--titleBarHeight));

--- a/src/renderer/src/prefComponents/common/bool/index.vue
+++ b/src/renderer/src/prefComponents/common/bool/index.vue
@@ -8,13 +8,12 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <el-icon
+      <LinkIcon
         v-if="more"
-        :size="18"
+        :size="14"
+        class="link-icon"
         @click="handleMoreClick"
-      >
-        <Link />
-      </el-icon>
+      />
       <el-tooltip
         v-else-if="detailedDescription"
         :content="detailedDescription"
@@ -43,7 +42,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { InfoFilled, Link } from '@element-plus/icons-vue'
+import { InfoFilled } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface BoolProps extends PrefControlBaseProps {

--- a/src/renderer/src/prefComponents/common/bool/index.vue
+++ b/src/renderer/src/prefComponents/common/bool/index.vue
@@ -8,12 +8,13 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <InfoFilled
+      <el-icon
         v-if="more"
-        width="16"
-        height="16"
+        :size="18"
         @click="handleMoreClick"
-      />
+      >
+        <Link />
+      </el-icon>
       <el-tooltip
         v-else-if="detailedDescription"
         :content="detailedDescription"
@@ -42,7 +43,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { InfoFilled } from '@element-plus/icons-vue'
+import { InfoFilled, Link } from '@element-plus/icons-vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface BoolProps extends PrefControlBaseProps {
@@ -86,7 +87,7 @@ const handleSwitchChange = (value: boolean | string | number) => {
 .pref-switch-item {
   font-size: 14px;
   user-select: none;
-  margin: 20px 0;
+  margin: 12px 0;
   color: var(--editorColor);
   display: flex;
   align-items: center;

--- a/src/renderer/src/prefComponents/common/compound/index.vue
+++ b/src/renderer/src/prefComponents/common/compound/index.vue
@@ -25,7 +25,7 @@ defineProps<{
 .pref-compound-item {
   font-size: 14px;
   user-select: none;
-  margin: 20px 0;
+  margin: 32px 0;
   color: var(--editorColor);
 
   & .pref-compound-head h6.title {

--- a/src/renderer/src/prefComponents/common/fontTextBox/index.vue
+++ b/src/renderer/src/prefComponents/common/fontTextBox/index.vue
@@ -5,13 +5,14 @@
   >
     <div class="description">
       <span>{{ description }}:</span>
-      <InfoFilled
+      <el-icon
         v-if="more"
+        :size="18"
         style="margin-left: 4px"
-        width="16"
-        height="16"
         @click="handleMoreClick"
-      />
+      >
+        <Link />
+      </el-icon>
     </div>
     <el-autocomplete
       v-model="selectValue"
@@ -39,7 +40,7 @@
 
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
-import { InfoFilled, ArrowDown } from '@element-plus/icons-vue'
+import { Link, ArrowDown } from '@element-plus/icons-vue'
 import { useI18n } from 'vue-i18n'
 import type { PrefControlProps } from '../types'
 
@@ -126,7 +127,7 @@ onMounted(async () => {
 }
 
 .pref-font-input-item {
-  margin: 20px 0;
+  margin: 12px 0;
   font-size: 14px;
   color: var(--editorColor);
   & .font-autocomplete {

--- a/src/renderer/src/prefComponents/common/fontTextBox/index.vue
+++ b/src/renderer/src/prefComponents/common/fontTextBox/index.vue
@@ -5,14 +5,13 @@
   >
     <div class="description">
       <span>{{ description }}:</span>
-      <el-icon
+      <LinkIcon
         v-if="more"
-        :size="18"
+        :size="14"
+        class="link-icon"
         style="margin-left: 4px"
         @click="handleMoreClick"
-      >
-        <Link />
-      </el-icon>
+      />
     </div>
     <el-autocomplete
       v-model="selectValue"
@@ -40,7 +39,8 @@
 
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
-import { Link, ArrowDown } from '@element-plus/icons-vue'
+import { ArrowDown } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import { useI18n } from 'vue-i18n'
 import type { PrefControlProps } from '../types'
 

--- a/src/renderer/src/prefComponents/common/range/index.vue
+++ b/src/renderer/src/prefComponents/common/range/index.vue
@@ -13,13 +13,14 @@
           v-if="selectValue"
           class="value"
         >{{ selectValue }} <span v-if="unit">{{ unit }}</span></span>
-        <InfoFilled
+        <el-icon
           v-if="more"
-          width="16"
-          height="16"
+          :size="18"
           style="margin-left: 4px"
           @click="handleMoreClick"
-        />
+        >
+          <Link />
+        </el-icon>
       </div>
     </div>
     <el-slider
@@ -35,7 +36,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { InfoFilled } from '@element-plus/icons-vue'
+import { Link } from '@element-plus/icons-vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface RangeProps extends PrefControlBaseProps {
@@ -81,7 +82,7 @@ const select = (value: number | number[]) => {
 
 <style>
 .pref-range-item {
-  margin: 20px 0;
+  margin: 12px 0;
   font-size: 14px;
   color: var(--editorColor);
   width: 100%;

--- a/src/renderer/src/prefComponents/common/range/index.vue
+++ b/src/renderer/src/prefComponents/common/range/index.vue
@@ -13,14 +13,13 @@
           v-if="selectValue"
           class="value"
         >{{ selectValue }} <span v-if="unit">{{ unit }}</span></span>
-        <el-icon
+        <LinkIcon
           v-if="more"
-          :size="18"
+          :size="14"
+          class="link-icon"
           style="margin-left: 4px"
           @click="handleMoreClick"
-        >
-          <Link />
-        </el-icon>
+        />
       </div>
     </div>
     <el-slider
@@ -36,7 +35,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { Link } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface RangeProps extends PrefControlBaseProps {

--- a/src/renderer/src/prefComponents/common/select/index.vue
+++ b/src/renderer/src/prefComponents/common/select/index.vue
@@ -9,12 +9,13 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <InfoFilled
+      <el-icon
         v-if="more"
-        width="16"
-        height="16"
+        :size="18"
         @click="handleMoreClick"
-      />
+      >
+        <Link />
+      </el-icon>
     </div>
     <el-select
       v-model="selectValue"
@@ -39,7 +40,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { InfoFilled } from '@element-plus/icons-vue'
+import { Link } from '@element-plus/icons-vue'
 import type { PrefControlBaseProps, PrefSelectOption } from '../types'
 
 type SelectValue = string | number | boolean
@@ -82,7 +83,7 @@ const select = (value: SelectValue) => {
 
 <style>
 .pref-select-item {
-  margin: 20px 0;
+  margin: 12px 0;
   font-size: 14px;
   color: var(--editorColor);
   & .el-select {

--- a/src/renderer/src/prefComponents/common/select/index.vue
+++ b/src/renderer/src/prefComponents/common/select/index.vue
@@ -9,13 +9,12 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <el-icon
+      <LinkIcon
         v-if="more"
-        :size="18"
+        :size="14"
+        class="link-icon"
         @click="handleMoreClick"
-      >
-        <Link />
-      </el-icon>
+      />
     </div>
     <el-select
       v-model="selectValue"
@@ -40,7 +39,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { Link } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { PrefControlBaseProps, PrefSelectOption } from '../types'
 
 type SelectValue = string | number | boolean

--- a/src/renderer/src/prefComponents/common/separator/index.vue
+++ b/src/renderer/src/prefComponents/common/separator/index.vue
@@ -4,7 +4,7 @@
 
 <style>
 .pref-separator {
-  margin: 20px 0 20px 0;
+  margin: 12px 0;
   height: 2px;
   background: var(--editorColor04);
 }

--- a/src/renderer/src/prefComponents/common/textBox/index.vue
+++ b/src/renderer/src/prefComponents/common/textBox/index.vue
@@ -8,12 +8,13 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <InfoFilled
+      <el-icon
         v-if="more"
-        width="16"
-        height="16"
+        :size="18"
         @click="handleMoreClick"
-      />
+      >
+        <Link />
+      </el-icon>
     </div>
     <el-input
       v-model="inputText"
@@ -35,7 +36,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { InfoFilled } from '@element-plus/icons-vue'
+import { Link } from '@element-plus/icons-vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface TextBoxProps extends PrefControlBaseProps {
@@ -102,7 +103,7 @@ const handleInput = (value: string) => {
 .pref-text-box-item {
   font-size: 14px;
   user-select: none;
-  margin: 20px 0;
+  margin: 12px 0;
   color: var(--editorColor);
   width: 100%;
   & div {

--- a/src/renderer/src/prefComponents/common/textBox/index.vue
+++ b/src/renderer/src/prefComponents/common/textBox/index.vue
@@ -8,13 +8,12 @@
       style="display: flex; align-items: center"
     >
       <span>{{ description }}:</span>
-      <el-icon
+      <LinkIcon
         v-if="more"
-        :size="18"
+        :size="14"
+        class="link-icon"
         @click="handleMoreClick"
-      >
-        <Link />
-      </el-icon>
+      />
     </div>
     <el-input
       v-model="inputText"
@@ -36,7 +35,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import { Link } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { PrefControlBaseProps } from '../types'
 
 interface TextBoxProps extends PrefControlBaseProps {

--- a/src/renderer/src/prefComponents/image/components/uploader/index.vue
+++ b/src/renderer/src/prefComponents/image/components/uploader/index.vue
@@ -160,10 +160,10 @@
               <span
                 class="link"
                 @click="open('https://github.com/PicGo/PicGo-Core')"
-              >picgo<el-icon
+              >picgo<LinkIcon
                 :size="14"
                 class="link-icon"
-              ><Link /></el-icon></span>
+              /></span>
               {{ t('preferences.image.uploader.pleaseInstall') }}
             </div>
           </div>
@@ -202,10 +202,10 @@
                 @click="open('https://picgo.github.io/PicGo-Core-Doc/')"
               >{{
                 t('preferences.image.uploader.usageGuide.documentation')
-              }}<el-icon
+              }}<LinkIcon
                 :size="14"
                 class="link-icon"
-              ><Link /></el-icon></span>
+              /></span>
             </div>
           </div>
 
@@ -343,7 +343,8 @@ import { isFileExecutable } from '@/util/fileSystem'
 import CurSelect from '@/prefComponents/common/select/index.vue'
 import notice from '@/services/notification'
 import { storeToRefs } from 'pinia'
-import { InfoFilled, Link } from '@element-plus/icons-vue'
+import { InfoFilled } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { PrefSelectOption } from '@/prefComponents/common/types'
 
 const { t } = useI18n()
@@ -1024,6 +1025,11 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .link .link-icon {
   margin-left: 2px;
   vertical-align: -2px;
+  opacity: 0.7;
+  color: var(--iconColor);
+}
+.pref-image-uploader .link .link-icon:hover {
+  color: var(--themeColor);
 }
 
 .pref-image-uploader .detection-status {

--- a/src/renderer/src/prefComponents/image/components/uploader/index.vue
+++ b/src/renderer/src/prefComponents/image/components/uploader/index.vue
@@ -160,7 +160,10 @@
               <span
                 class="link"
                 @click="open('https://github.com/PicGo/PicGo-Core')"
-              >picgo</span>
+              >picgo<el-icon
+                :size="14"
+                class="link-icon"
+              ><Link /></el-icon></span>
               {{ t('preferences.image.uploader.pleaseInstall') }}
             </div>
           </div>
@@ -199,7 +202,10 @@
                 @click="open('https://picgo.github.io/PicGo-Core-Doc/')"
               >{{
                 t('preferences.image.uploader.usageGuide.documentation')
-              }}</span>
+              }}<el-icon
+                :size="14"
+                class="link-icon"
+              ><Link /></el-icon></span>
             </div>
           </div>
 
@@ -337,7 +343,7 @@ import { isFileExecutable } from '@/util/fileSystem'
 import CurSelect from '@/prefComponents/common/select/index.vue'
 import notice from '@/services/notification'
 import { storeToRefs } from 'pinia'
-import { InfoFilled } from '@element-plus/icons-vue'
+import { InfoFilled, Link } from '@element-plus/icons-vue'
 import type { PrefSelectOption } from '@/prefComponents/common/types'
 
 const { t } = useI18n()
@@ -1013,6 +1019,11 @@ const validate = (value: string): boolean => {
 .pref-image-uploader .link {
   color: var(--themeColor);
   cursor: pointer;
+}
+
+.pref-image-uploader .link .link-icon {
+  margin-left: 2px;
+  vertical-align: -2px;
 }
 
 .pref-image-uploader .detection-status {

--- a/src/renderer/src/prefComponents/image/components/uploader/legalNoticesCheckbox.vue
+++ b/src/renderer/src/prefComponents/image/components/uploader/legalNoticesCheckbox.vue
@@ -9,20 +9,20 @@
         @click="openUrl(uploaderService.privacyUrl)"
       >{{
         t('preferences.image.uploader.legalNotices.privacyStatement')
-      }}<el-icon
+      }}<LinkIcon
         :size="14"
         class="link-icon"
-      ><Link /></el-icon></span>
+      /></span>
       {{ t('preferences.image.uploader.legalNotices.and') }}
       <span
         class="link"
         @click="openUrl(uploaderService.tosUrl)"
       >{{
         t('preferences.image.uploader.legalNotices.termsOfService')
-      }}<el-icon
+      }}<LinkIcon
         :size="14"
         class="link-icon"
-      ><Link /></el-icon></span>.
+      /></span>.
       <span v-if="!uploaderService.isGdprCompliant">{{
         t('preferences.image.uploader.legalNotices.gdprWarning')
       }}</span>
@@ -32,7 +32,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { Link } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import type { UploaderService } from './services'
 
 const { t } = useI18n()
@@ -58,6 +58,11 @@ const openUrl = (link: string): void => {
   & .link .link-icon {
     margin-left: 2px;
     vertical-align: -2px;
+    opacity: 0.7;
+    color: var(--iconColor);
+  }
+  & .link .link-icon:hover {
+    color: var(--themeColor);
   }
 }
 </style>

--- a/src/renderer/src/prefComponents/image/components/uploader/legalNoticesCheckbox.vue
+++ b/src/renderer/src/prefComponents/image/components/uploader/legalNoticesCheckbox.vue
@@ -9,14 +9,20 @@
         @click="openUrl(uploaderService.privacyUrl)"
       >{{
         t('preferences.image.uploader.legalNotices.privacyStatement')
-      }}</span>
+      }}<el-icon
+        :size="14"
+        class="link-icon"
+      ><Link /></el-icon></span>
       {{ t('preferences.image.uploader.legalNotices.and') }}
       <span
         class="link"
         @click="openUrl(uploaderService.tosUrl)"
       >{{
         t('preferences.image.uploader.legalNotices.termsOfService')
-      }}</span>.
+      }}<el-icon
+        :size="14"
+        class="link-icon"
+      ><Link /></el-icon></span>.
       <span v-if="!uploaderService.isGdprCompliant">{{
         t('preferences.image.uploader.legalNotices.gdprWarning')
       }}</span>
@@ -26,6 +32,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { Link } from '@element-plus/icons-vue'
 import type { UploaderService } from './services'
 
 const { t } = useI18n()
@@ -47,6 +54,10 @@ const openUrl = (link: string): void => {
   padding: 3px 5px;
   & .el-checkbox {
     margin-right: 0;
+  }
+  & .link .link-icon {
+    margin-left: 2px;
+    vertical-align: -2px;
   }
 }
 </style>

--- a/src/renderer/src/prefComponents/image/index.vue
+++ b/src/renderer/src/prefComponents/image/index.vue
@@ -2,20 +2,7 @@
   <div class="pref-image">
     <h4>{{ t('preferences.image.title') }}</h4>
     <section class="image-ctrl">
-      <div>
-        {{ t('preferences.image.defaultAction') }}
-        <el-tooltip
-          class="item"
-          effect="dark"
-          :content="t('preferences.image.clipboardTooltip')"
-          placement="top-start"
-        >
-          <InfoFilled
-            width="16"
-            height="16"
-          />
-        </el-tooltip>
-      </div>
+      <div>{{ t('preferences.image.defaultBehavior') }}</div>
       <CurSelect
         :value="imageInsertAction"
         :options="imageActions"
@@ -38,7 +25,6 @@ import Uploader from './components/uploader/index.vue'
 import CurSelect from '../common/select/index.vue'
 import FolderSetting from './components/folderSetting/index.vue'
 import { getImageActions } from './config'
-import { InfoFilled } from '@element-plus/icons-vue'
 
 const { t } = useI18n()
 

--- a/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/src/renderer/src/prefComponents/keybindings/index.vue
@@ -6,6 +6,8 @@
         {{ t('preferences.keybindings.description') }}
         <a
           class="link"
+          :title="t('preferences.keybindings.online')"
+          :aria-label="t('preferences.keybindings.online')"
           @click="openKeybindingWiki"
         ><el-icon
           :size="16"

--- a/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/src/renderer/src/prefComponents/keybindings/index.vue
@@ -7,7 +7,10 @@
         <a
           class="link"
           @click="openKeybindingWiki"
-        >{{ t('preferences.keybindings.online') }}</a>.
+        ><el-icon
+          :size="16"
+          class="link-icon"
+        ><Link /></el-icon></a>.
       </div>
       <el-table
         :data="keybindingList"
@@ -16,15 +19,16 @@
         <el-table-column
           prop="description"
           :label="t('preferences.keybindings.table.description')"
+          min-width="220"
         />
         <el-table-column
           prop="accelerator"
           :label="t('preferences.keybindings.table.keyCombination')"
-          width="220"
+          min-width="160"
         />
         <el-table-column
           :label="t('preferences.keybindings.table.options')"
-          width="90"
+          min-width="90"
         >
           <template #default="scope">
             <el-button
@@ -110,7 +114,7 @@ import KeyInputDialog from './key-input-dialog.vue'
 import KeybindingConfigurator from './KeybindingConfigurator'
 import type { UiKeybinding } from './KeybindingConfigurator'
 import notice from '@/services/notification'
-import { Edit, RefreshRight, Delete } from '@element-plus/icons-vue'
+import { Edit, RefreshRight, Delete, Link } from '@element-plus/icons-vue'
 import { useI18n } from 'vue-i18n'
 
 const { t, locale } = useI18n()
@@ -259,6 +263,10 @@ const dumpKeyboardInformation = (): void => {
   & .link {
     color: var(--themeColor);
     cursor: pointer;
+    & .link-icon {
+      margin-left: 2px;
+      vertical-align: -2px;
+    }
   }
   & button.el-button {
     font-size: 13px;

--- a/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/src/renderer/src/prefComponents/keybindings/index.vue
@@ -9,10 +9,10 @@
           :title="t('preferences.keybindings.online')"
           :aria-label="t('preferences.keybindings.online')"
           @click="openKeybindingWiki"
-        ><el-icon
-          :size="16"
+        ><LinkIcon
+          :size="14"
           class="link-icon"
-        ><Link /></el-icon></a>.
+        /></a>.
       </div>
       <el-table
         :data="keybindingList"
@@ -116,7 +116,8 @@ import KeyInputDialog from './key-input-dialog.vue'
 import KeybindingConfigurator from './KeybindingConfigurator'
 import type { UiKeybinding } from './KeybindingConfigurator'
 import notice from '@/services/notification'
-import { Edit, RefreshRight, Delete, Link } from '@element-plus/icons-vue'
+import { Edit, RefreshRight, Delete } from '@element-plus/icons-vue'
+import LinkIcon from '@/components/icons/LinkIcon.vue'
 import { useI18n } from 'vue-i18n'
 
 const { t, locale } = useI18n()
@@ -268,6 +269,11 @@ const dumpKeyboardInformation = (): void => {
     & .link-icon {
       margin-left: 2px;
       vertical-align: -2px;
+      opacity: 0.7;
+      color: var(--iconColor);
+    }
+    & .link-icon:hover {
+      color: var(--themeColor);
     }
   }
   & button.el-button {

--- a/src/renderer/src/prefComponents/sideBar/config.ts
+++ b/src/renderer/src/prefComponents/sideBar/config.ts
@@ -1,10 +1,12 @@
-import GeneralIcon from '@/assets/icons/pref_general.svg'
-import EditorIcon from '@/assets/icons/pref_editor.svg'
-import MarkdownIcon from '@/assets/icons/pref_markdown.svg'
-import ThemeIcon from '@/assets/icons/pref_theme.svg'
-import ImageIcon from '@/assets/icons/pref_image.svg'
-import SpellIcon from '@/assets/icons/pref_spellcheck.svg'
-import KeyBindingIcon from '@/assets/icons/pref_key_binding.svg'
+import {
+  Setting as GeneralIcon,
+  Edit as EditorIcon,
+  Document as MarkdownIcon,
+  Brush as ThemeIcon,
+  Picture as ImageIcon,
+  Reading as SpellIcon,
+  Operation as KeyBindingIcon
+} from '@element-plus/icons-vue'
 
 import preferences from '../../../../main/preferences/schema.json'
 import { t } from '../../i18n'

--- a/src/renderer/src/prefComponents/sideBar/index.vue
+++ b/src/renderer/src/prefComponents/sideBar/index.vue
@@ -244,11 +244,11 @@ onUnmounted(() => {
     & > svg {
       width: 18px;
       height: 18px;
-      fill: var(--sideBarColor);
+      color: var(--sideBarColor);
       margin-right: 12px;
     }
     &.active > svg {
-      fill: var(--sideBarTitleColor);
+      color: var(--sideBarTitleColor);
     }
     &:hover {
       background: var(--sideBarItemHoverBgColor);

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -604,8 +604,6 @@
     },
     "image": {
       "title": "Bild",
-      "defaultAction": "Standardaktion beim Einfügen von Bildern",
-      "clipboardTooltip": "Standardverhalten nach dem Einfügen oder Ziehen eines Bildes in MarkText",
       "actions": {
         "upload": "In die Cloud hochladen",
         "folder": "In Ordner kopieren",
@@ -733,7 +731,8 @@
         "lastSuccessTime": "Letzte erfolgreiche Zeit",
         "neverDetected": "Nie erkannt",
         "neverSuccessful": "Nie erfolgreich"
-      }
+      },
+      "defaultBehavior": "Standardverhalten nach dem Einfügen oder Ziehen eines Bildes in MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -731,7 +731,7 @@
         "scriptPath": "Script path",
         "tokenTooltip": "Access token for authentication"
       },
-      "defaultBehavior": "The default behavior after paste or drag the image to MarkText"
+      "defaultBehavior": "The default behavior after pasting or dragging the image to MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -603,8 +603,6 @@
     },
     "image": {
       "title": "Image",
-      "defaultAction": "Default action when insert image",
-      "clipboardTooltip": "The default behavior after paste or drag the image to MarkText",
       "actions": {
         "upload": "Upload to cloud",
         "folder": "Copy to folder",
@@ -732,7 +730,8 @@
         "repo": "Repository",
         "scriptPath": "Script path",
         "tokenTooltip": "Access token for authentication"
-      }
+      },
+      "defaultBehavior": "The default behavior after paste or drag the image to MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -604,8 +604,6 @@
     },
     "image": {
       "title": "Imagen",
-      "defaultAction": "Acción predeterminada al insertar imagen",
-      "clipboardTooltip": "El comportamiento predeterminado después de pegar o arrastrar la imagen a MarkText",
       "actions": {
         "upload": "Subir a la nube",
         "folder": "Copiar a carpeta",
@@ -733,7 +731,8 @@
         "lastSuccessTime": "Última vez exitosa",
         "neverDetected": "Nunca detectado",
         "neverSuccessful": "Nunca exitoso"
-      }
+      },
+      "defaultBehavior": "El comportamiento predeterminado después de pegar o arrastrar la imagen a MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "Image",
-      "defaultAction": "Action par défaut lors de l'insertion d'image",
-      "clipboardTooltip": "Comportement par défaut après avoir collé ou glissé une image dans MarkText",
       "actions": {
         "upload": "Télécharger vers le cloud",
         "folder": "Copier vers le dossier",
@@ -735,7 +733,8 @@
         "lastSuccessTime": "Dernière heure de succès",
         "neverDetected": "Jamais détecté",
         "neverSuccessful": "Jamais réussi"
-      }
+      },
+      "defaultBehavior": "Comportement par défaut après avoir collé ou glissé une image dans MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "画像",
-      "defaultAction": "画像挿入時のデフォルトアクション",
-      "clipboardTooltip": "MarkTextに画像を貼り付けまたはドラッグした後のデフォルト動作",
       "actions": {
         "upload": "クラウドにアップロード",
         "folder": "フォルダにコピー",
@@ -735,7 +733,8 @@
         "lastSuccessTime": "最後の成功時刻",
         "neverDetected": "検出されたことがない",
         "neverSuccessful": "成功したことがない"
-      }
+      },
+      "defaultBehavior": "MarkTextに画像を貼り付けまたはドラッグした後のデフォルト動作"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "이미지",
-      "defaultAction": "이미지 삽입 시 기본 동작",
-      "clipboardTooltip": "이미지를 MarkText에 붙여넣거나 드래그한 후의 기본 동작",
       "actions": {
         "upload": "클라우드에 업로드",
         "folder": "폴더에 복사",
@@ -735,7 +733,8 @@
         "lastSuccessTime": "마지막 성공 시간",
         "neverDetected": "감지된 적 없음",
         "neverSuccessful": "성공한 적 없음"
-      }
+      },
+      "defaultBehavior": "이미지를 MarkText에 붙여넣거나 드래그한 후의 기본 동작"
     },
     "markdown": {
       "title": "마크다운",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "Imagem",
-      "defaultAction": "Ação padrão ao inserir imagem",
-      "clipboardTooltip": "O comportamento padrão após colar ou arrastar a imagem para o MarkText",
       "actions": {
         "upload": "Enviar para nuvem",
         "folder": "Copiar para pasta",
@@ -735,7 +733,8 @@
         "lastSuccessTime": "Última vez bem-sucedida",
         "neverDetected": "Nunca detectado",
         "neverSuccessful": "Nunca bem-sucedido"
-      }
+      },
+      "defaultBehavior": "O comportamento padrão após colar ou arrastar a imagem para o MarkText"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "图片",
-      "defaultAction": "插入图片时的默认操作",
-      "clipboardTooltip": "粘贴或拖拽图片到 MarkText 后的默认行为",
       "actions": {
         "upload": "上传到云端",
         "folder": "复制到文件夹",
@@ -734,7 +732,8 @@
         "repo": "仓库",
         "scriptPath": "脚本路径",
         "tokenTooltip": "用于身份验证的访问令牌"
-      }
+      },
+      "defaultBehavior": "粘贴或拖拽图片到 MarkText 后的默认行为"
     },
     "markdown": {
       "title": "Markdown",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -605,8 +605,6 @@
     },
     "image": {
       "title": "圖片",
-      "defaultAction": "插入圖片時的預設動作",
-      "clipboardTooltip": "貼上或拖曳圖片到 MarkText 後的預設行為",
       "actions": {
         "upload": "上傳到雲端",
         "folder": "複製到資料夾",
@@ -735,7 +733,8 @@
         "lastSuccessTime": "上次成功時間",
         "neverDetected": "從未偵測",
         "neverSuccessful": "從未成功"
-      }
+      },
+      "defaultBehavior": "貼上或拖曳圖片到 MarkText 後的預設行為"
     },
     "markdown": {
       "title": "PicGo 設定",


### PR DESCRIPTION
## Summary

UI consistency pass across the renderer — tightens layout, replaces custom SVG sprites with `@element-plus/icons-vue`, and softens theme contrast.

**Sidebar (main window)**
- Search input: square corners (`14px → 4px`), reduced margins/padding, vertically aligned with the icon strip
- Three find-modifier icons (case/word/regex) made more compact
- "Open Folder" / "New File" use `<el-button text bg>` with marktext-themed bg/hover (`--itemBgColor` / `--floatHoverColor`)

**Editor tabs**
- Height `35px → 28px`, dropped hover-bg `border-radius`
- Replaced sprite icons with EP `Plus`/`Close`
- Tab close/unsaved indicator now a CSS dot + EP icon swap (no more dual SVG path toggling)

**Sprite → EP icon migration** (where semantic equivalents exist): editor & notification close, opened-file close, search-result arrow (`CaretRight`), tree expand arrows, titlebar path separator (`ArrowRight`), find prev/next (`ArrowUp/Down`), replace-mode toggle (`ArrowDown`), find-and-replace single (`Switch`), rename confirm (`Check`), preferences sidebar tabs (`Setting/Edit/Document/Reading/Brush/Picture/Operation`), and external-link icons across all common pref controls.

Kept as-is: case/word/regex search modifiers (no good EP match), settings cog in main sidebar bottom, save-all / close-all toolbar buttons in the sidebar, replace-all in find/replace, markdown sprite usage in notification HTML (non-Vue), import-file URL.

**Preferences**
- Horizontal padding `20 → 40px` on `.pref-setting`
- In-section item margins `20 → 12px`; section-to-section margins bumped to `32px`
- Keybindings table: `width` → `min-width` so columns adapt to window width
- Image settings: inlined the descriptive label and removed the redundant tooltip + InfoFilled icon. New i18n key `preferences.image.defaultBehavior` added across all 9 locales (replaces removed `defaultAction` / `clipboardTooltip`); `.min.json` files regenerated

**Theme contrast**
- All 32 theme files: `--sideBarBgColor` blended 50% toward `--editorBgColor` to halve the sidebar/editor contrast while keeping direction
- Special-case **graphite**: dark sidebar on light editor was still too strong — switched to a subtle light-gray sidebar and re-themed `--sideBarColor` / `Title` / `Icon` / `Text` so text remains readable

## Test plan
- [x] Toggle sidebar panels (Files / Search / TOC) — icon strip and active state still themed via `currentColor`
- [x] Open a file, edit, verify tab close icon shows on hover, unsaved dot when idle, active tab has no dot
- [x] Cmd+F in editor — find prev/next + replace toggle + single-replace icons render
- [x] Open the preferences window in zh-CN and verify Image tab shows the new translated description
- [x] Cycle through several themes (dracula, graphite, catppuccin-latte, gruvbox-light) and confirm sidebar/editor contrast is subtle
- [x] `pnpm run typecheck` ✓ clean (already run)
- [x] `pnpm run lint` ✓ no new errors (already run; 78 pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)