### PR TITLE
fix(muya): guard stale cursor/block lookups against null

### DIFF
--- a/src/muya/lib/contentState/clickCtrl.js
+++ b/src/muya/lib/contentState/clickCtrl.js
@@ -165,6 +165,7 @@ const clickCtrl = (ContentState) => {
     let needRender = false
     // is show format float box?
     if (
+      block &&
       start.key === end.key &&
       start.offset !== end.offset &&
       HAS_TEXT_BLOCK_REG.test(block.type) &&

--- a/src/muya/lib/contentState/imageCtrl.js
+++ b/src/muya/lib/contentState/imageCtrl.js
@@ -194,9 +194,18 @@ const imageCtrl = (ContentState) => {
 
   ContentState.prototype.deleteImage = function({ key, token }) {
     const block = this.getBlock(key)
+    const { eventCenter } = this.muya
+    // The image block may have been removed by a prior render (e.g. a figure
+    // replacement). Clear selection so backspace doesn't keep firing on the
+    // stale reference — see issue #3950.
+    if (!block) {
+      this.selectedImage = null
+      eventCenter.dispatch('muya-transformer', { reference: null })
+      eventCenter.dispatch('muya-image-toolbar', { reference: null })
+      return
+    }
     const oldText = block.text
     const { start, end } = token.range
-    const { eventCenter } = this.muya
     block.text = oldText.substring(0, start) + oldText.substring(end)
 
     this.cursor = {

--- a/src/muya/lib/contentState/paragraphCtrl.js
+++ b/src/muya/lib/contentState/paragraphCtrl.js
@@ -29,6 +29,12 @@ const paragraphCtrl = (ContentState) => {
     const cursorCoords = selection.getCursorCoords()
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)
+    // Cursor may reference a block that a prior render removed. Bail out with
+    // an empty affiliation rather than crash downstream on null.type — same
+    // stale-cursor family as #3674 / #3950; protects getTOC-style callers too.
+    if (!startBlock || !endBlock) {
+      return { start, end, affiliation: [], cursorCoords }
+    }
     const startParents = this.getParents(startBlock)
     const endParents = this.getParents(endBlock)
     const affiliation = startParents

--- a/src/muya/lib/contentState/updateCtrl.js
+++ b/src/muya/lib/contentState/updateCtrl.js
@@ -26,6 +26,10 @@ const updateCtrl = (ContentState) => {
     const { start: cStart, end: cEnd, anchor, focus } = cursor
     const startBlock = this.getBlock(cStart ? cStart.key : anchor.key)
     const endBlock = this.getBlock(cEnd ? cEnd.key : focus.key)
+    // Cursor may still reference a block that a prior render removed. There is
+    // nothing left to re-tokenize, so skip the check instead of crashing on
+    // null.text — see issues #3674, #3842, #4032, #4072, #4122, #4143, #4162.
+    if (!startBlock || !endBlock) return false
     const startOffset = cStart ? cStart.offset : anchor.offset
     const endOffset = cEnd ? cEnd.offset : focus.offset
     const NO_NEED_TOKEN_REG = /text|hard_line_break|soft_line_break/


### PR DESCRIPTION
## Summary

The Muya editor's click / keyboard / backspace handlers re-dereference cursor state that can outlive the render which removed the block it points to (code-block reload, image figure swap, async rerenders, etc.). `getBlock()` then returns `null` and the renderer crashes with `Cannot read properties of null (reading 'text')`.

This PR adds null guards at four call sites — three on the actual code paths reported in the issue tracker, plus one same-family hardening in `selectionChange` to protect `getTOC`-style callers.

- `checkNeedRender` (updateCtrl.js): bail out when start/end block is missing
- `clickHandler` (clickCtrl.js): guard the format-picker branch on the same lookup
- `deleteImage` (imageCtrl.js): drop the stale selection + close image toolbar instead of reading `.text` on null
- `selectionChange` (paragraphCtrl.js): return an empty `affiliation` when blocks are missing

## Issues closed

`checkNeedRender` family:

- Closes #3674
- Closes #3842
- Closes #4122
- Closes #4143

`deleteImage` family:

- Closes #3950

`getTOC` / `selectionChange` family (official code-path hardening):

- Closes #3999

## Related (already closed as duplicates)

- #4032
- #4072
- #4162

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec eslint` on the four touched files — clean
- [x] `pnpm run test:unit` — 523 tests pass (2 pre-existing suite-load failures unrelated to this change)
- [ ] Manual: place cursor in a code block, swap files, click back — no renderer crash
- [ ] Manual: select an inline image, press Backspace twice — second press no-ops instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)