### PR TITLE
test(e2e): regression guards for previously-reported "Unexpected error" crashes

### DIFF
--- a/test/e2e/crash-range-offset.spec.ts
+++ b/test/e2e/crash-range-offset.spec.ts
@@ -31,7 +31,7 @@ test.describe('Crash: setStart Range offset', () => {
   let page: Page
 
   test.beforeEach(async() => {
-    const launched = await launchWithMarkdown('# Repro\n\nSeed.\n')
+    const launched = await launchWithMarkdown('# Repro\n\nSeed.\n', { suppressErrorDialog: true })
     app = launched.app
     page = launched.page
     await placeCaretInEditor(page)
@@ -50,8 +50,9 @@ test.describe('Crash: setStart Range offset', () => {
 
     // The user then clicks on / highlights the text. We simulate by selecting
     // all and then collapsing to caret to provoke setCursorRange across the
-    // mixed inline DOM the paragraph now contains.
-    await page.keyboard.press('Control+A')
+    // mixed inline DOM the paragraph now contains. ControlOrMeta+A maps to
+    // Cmd+A on macOS and Ctrl+A elsewhere (Select All on both).
+    await page.keyboard.press('ControlOrMeta+A')
     await page.waitForTimeout(50)
     await page.keyboard.press('ArrowRight')
     await page.waitForTimeout(50)
@@ -183,7 +184,7 @@ test.describe('Crash: setStart Range offset', () => {
     await placeCaretInEditor(page)
     await clearRendererErrors(app)
 
-    await page.keyboard.press('Control+A')
+    await page.keyboard.press('ControlOrMeta+A')
     await page.waitForTimeout(50)
     await page.keyboard.press('Delete')
     await page.waitForTimeout(100)
@@ -202,7 +203,7 @@ test.describe('Crash: paste-induced setCursorRange', () => {
   let page: Page
 
   test.beforeEach(async() => {
-    const launched = await launchWithMarkdown('# Doc\n\nEdit here.\n')
+    const launched = await launchWithMarkdown('# Doc\n\nEdit here.\n', { suppressErrorDialog: true })
     app = launched.app
     page = launched.page
     await placeCaretInEditor(page)
@@ -276,7 +277,7 @@ test.describe('Crash: paste-induced setCursorRange', () => {
 // helper would always pass.
 test.describe('Crash counter sanity', () => {
   test('Forced throw in renderer is captured by getRendererErrors', async() => {
-    const { app, page } = await launchWithMarkdown('# Sanity\n')
+    const { app, page } = await launchWithMarkdown('# Sanity\n', { suppressErrorDialog: true })
     try {
       await page.evaluate(() => {
         setTimeout(() => {

--- a/test/e2e/crash-range-offset.spec.ts
+++ b/test/e2e/crash-range-offset.spec.ts
@@ -283,10 +283,13 @@ test.describe('Crash counter sanity', () => {
           throw new Error('intentional-sanity-error')
         }, 0)
       })
-      await page.waitForTimeout(300)
-      const { getRendererErrors } = await import('./helpers')
-      const errs = await getRendererErrors(app)
-      expect(errs.some((e) => e.message?.includes('intentional-sanity-error'))).toBe(true)
+      const { waitForRendererError } = await import('./helpers')
+      const captured = await waitForRendererError(
+        app,
+        (e) => !!e.message?.includes('intentional-sanity-error'),
+        5000
+      )
+      expect(captured, 'expected the renderer-thrown error to reach the IPC sink').not.toBeNull()
     } finally {
       await app.close()
     }

--- a/test/e2e/crash-range-offset.spec.ts
+++ b/test/e2e/crash-range-offset.spec.ts
@@ -1,0 +1,294 @@
+// Regression guard for "Failed to execute 'setStart' on 'Range': There is no
+// child at offset N" crashes (issues #4159, #4111, #4101, #4091, #4052,
+// #4035, #4006, #4005, #4004, #3996, #3954, #3936, #3929, #3886, #3829,
+// #3793, #3790, #3771, #3737, #3727, #3636, #3542, #3378, #2627, #2526).
+//
+// These tests exercise the user-described recipes from the original bug
+// reports — most notably:
+//   #2526 — type the literal escaped HTML "\<pre\>some text\</pre\>", then
+//           click on or highlight that text.
+//   #3737 — delete a code block with the keyboard Backspace at the start of
+//           its first line, instead of clicking the "delete" button.
+//
+// As of develop (post-electron-vite refactor), none of these recipes
+// reproduce the crash anymore — the existing clamp at
+// src/muya/lib/selection/index.js:528 plus other cumulative fixes appear to
+// have closed the bug surface. The tests assert zero
+// `mt::handle-renderer-error` IPC events (captured via the helper installed
+// by launchElectron); if they start failing, the offset clamp has regressed.
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  expectNoRendererErrors,
+  clearRendererErrors,
+  launchWithMarkdown,
+  placeCaretInEditor,
+  typeIntoEditor
+} from './helpers'
+
+test.describe('Crash: setStart Range offset', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('# Repro\n\nSeed.\n')
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  // Recipe from #2526.
+  test('Issue #2526: typing escaped <pre>...</pre> then re-selecting does not crash', async() => {
+    // Type literal `\<pre\>some text\</pre\>` as the user described.
+    await typeIntoEditor(page, '\\<pre\\>some text\\</pre\\>')
+    await page.waitForTimeout(200)
+
+    // The user then clicks on / highlights the text. We simulate by selecting
+    // all and then collapsing to caret to provoke setCursorRange across the
+    // mixed inline DOM the paragraph now contains.
+    await page.keyboard.press('Control+A')
+    await page.waitForTimeout(50)
+    await page.keyboard.press('ArrowRight')
+    await page.waitForTimeout(50)
+    await page.keyboard.press('Home')
+    await page.waitForTimeout(50)
+    await page.keyboard.press('End')
+    await page.waitForTimeout(150)
+
+    await expectNoRendererErrors(app)
+  })
+
+  // Recipe from #3737 — backspace at the start of a code block.
+  test('Issue #3737: backspace at start of a code block does not crash', async() => {
+    // Build a code block via the markdown source-mode round-trip.
+    // (Code blocks are rendered as CodeMirror instances inside Muya; the
+    // crash from #3737 happens when the user backspaces from the first
+    // character of the code into the block container.)
+    const { setSourceMarkdown } = await import('./helpers')
+    await setSourceMarkdown(page, app, '# Doc\n\n```js\nconst x = 1\n```\n\nafter\n')
+    await page.waitForTimeout(400)
+    await clearRendererErrors(app)
+
+    // Click into the code block.
+    await page.evaluate(() => {
+      const block = document.querySelector('.editor-component .CodeMirror, .editor-component pre.ag-active')
+      if (block) (block as HTMLElement).click()
+    })
+    await page.waitForTimeout(150)
+
+    // Send several backspaces (this is what triggers the crash for users who
+    // delete the code block from the keyboard instead of via the inline
+    // toolbar's delete button).
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press('Backspace')
+      await page.waitForTimeout(40)
+    }
+
+    await expectNoRendererErrors(app)
+  })
+
+  // General "mixed-inline" stressor — selection across a paragraph that holds
+  // bold/italic/inline-code/math, the most common substrate for setCursorRange
+  // miscalculations.
+  test('Repeated cursor moves through bold+code+math do not crash', async() => {
+    const md = '# Header\n\nThis has **bold**, *italic*, `code`, and $a+b$ math, ~~strike~~ end.\n'
+    const { setSourceMarkdown } = await import('./helpers')
+    await setSourceMarkdown(page, app, md)
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+
+    // Move caret across the rich inline content many times — each call
+    // re-runs setCursorRange against a paragraph whose childNodes.length is
+    // small while textContent.length is much larger (the exact mismatch the
+    // clamp bug exploits).
+    for (let i = 0; i < 30; i++) {
+      await page.keyboard.press('Home')
+      await page.keyboard.press('End')
+      await page.keyboard.press('ArrowLeft')
+      await page.keyboard.press('ArrowLeft')
+      await page.keyboard.press('ArrowLeft')
+    }
+    // Now type to trigger inputHandler -> partialRender -> setCursor at an
+    // offset that no longer corresponds to a leaf in the new DOM.
+    await page.keyboard.type(' xyz', { delay: 10 })
+    await page.waitForTimeout(200)
+
+    await expectNoRendererErrors(app)
+  })
+
+  // Recipe drawn from closed issues #2874, #3782, #3754: the offset 4294967292
+  // crashes all originated in `enterHandler`. Try Enter at end of paragraph
+  // with mixed inline content, then inside a list with formatting.
+  test('Enter at end of mixed-inline paragraph does not crash', async() => {
+    const md = '# H\n\nAlpha **bold** *italic* `code` $a+b$ end\n'
+    const { setSourceMarkdown } = await import('./helpers')
+    await setSourceMarkdown(page, app, md)
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+
+    await page.keyboard.press('End')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('new line', { delay: 5 })
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(200)
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('Enter inside list item with inline formatting does not crash', async() => {
+    const md = '- item with **bold** and `code`\n- second\n- third\n'
+    const { setSourceMarkdown } = await import('./helpers')
+    await setSourceMarkdown(page, app, md)
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+
+    // Click into the first list item and press Enter several times
+    await page.evaluate(() => {
+      const first = document.querySelector('.editor-component ul li span.ag-paragraph') as HTMLElement | null
+      if (!first) return
+      const range = document.createRange()
+      range.selectNodeContents(first)
+      range.collapse(false)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    })
+    await page.waitForTimeout(100)
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('x', { delay: 5 })
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(200)
+
+    await expectNoRendererErrors(app)
+  })
+
+  // Stress: select-all delete inside a paragraph with inline math, which has
+  // historically thrown the largest "offset N" values (#4035, #2627 — offset
+  // 4294967292 = -4 >>> 0).
+  test('Select-all delete in math-rich paragraph does not crash', async() => {
+    const md = '# H\n\nstart $\\int_0^1 x$ middle $\\frac{a}{b}$ end\n'
+    const { setSourceMarkdown } = await import('./helpers')
+    await setSourceMarkdown(page, app, md)
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+
+    await page.keyboard.press('Control+A')
+    await page.waitForTimeout(50)
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(100)
+    await page.keyboard.type('replacement', { delay: 10 })
+    await page.waitForTimeout(200)
+
+    await expectNoRendererErrors(app)
+  })
+})
+
+// Paste-induced crash recipes: many "setStart" crashes in user reports
+// mention pasting (HTML from a browser, formatted text from Word). The paste
+// path goes through html2State → markdownToState → render → setCursor.
+test.describe('Crash: paste-induced setCursorRange', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\nEdit here.\n')
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  test('Paste rich HTML into mid-paragraph does not crash', async() => {
+    // Place caret in the middle of "Edit here." then dispatch a paste event
+    // with rich HTML (bold + lists + table + math fragment) — the worst case
+    // for the DOM-walking selection logic.
+    const html =
+      '<p>Pasted <b>bold</b> and <i>italic</i> with <code>code</code>.</p>' +
+      '<ul><li>one</li><li>two <strong>two-strong</strong></li></ul>' +
+      '<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>' +
+      '<p>And inline math: <span class="math">a+b</span></p>'
+    await page.evaluate((h) => {
+      const target = document.querySelector('.editor-component span.ag-paragraph') as HTMLElement | null
+      if (!target) return
+      const range = document.createRange()
+      range.selectNodeContents(target)
+      range.collapse(false)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+      const dt = new DataTransfer()
+      dt.setData('text/html', h)
+      dt.setData('text/plain', 'Pasted bold and italic')
+      target.dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
+      )
+    }, html)
+    await page.waitForTimeout(400)
+    await expectNoRendererErrors(app)
+  })
+
+  test('Paste then immediate cursor-shuffle does not crash', async() => {
+    const html = '<p>x<b>y</b>z <em>e</em><code>c</code></p>'.repeat(20)
+    await page.evaluate((h) => {
+      const target = document.querySelector('.editor-component span.ag-paragraph') as HTMLElement | null
+      if (!target) return
+      const range = document.createRange()
+      range.selectNodeContents(target)
+      range.collapse(false)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+      const dt = new DataTransfer()
+      dt.setData('text/html', h)
+      dt.setData('text/plain', 'x'.repeat(200))
+      target.dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
+      )
+    }, html)
+    await page.waitForTimeout(300)
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('ArrowLeft')
+    }
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press('ArrowRight')
+    }
+    await expectNoRendererErrors(app)
+  })
+})
+
+// Sanity test: ensure the crash counter works (a renderer-side `throw` should
+// be captured by our helper). Guards against silent test failure where the
+// helper would always pass.
+test.describe('Crash counter sanity', () => {
+  test('Forced throw in renderer is captured by getRendererErrors', async() => {
+    const { app, page } = await launchWithMarkdown('# Sanity\n')
+    try {
+      await page.evaluate(() => {
+        setTimeout(() => {
+          throw new Error('intentional-sanity-error')
+        }, 0)
+      })
+      await page.waitForTimeout(300)
+      const { getRendererErrors } = await import('./helpers')
+      const errs = await getRendererErrors(app)
+      expect(errs.some((e) => e.message?.includes('intentional-sanity-error'))).toBe(true)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/test/e2e/crash-selection-change.spec.ts
+++ b/test/e2e/crash-selection-change.spec.ts
@@ -1,0 +1,105 @@
+// Regression guard for "selectionChange: expected cursor but cursor is null"
+// (issues #4160, #3942 — thrown at src/muya/lib/contentState/paragraphCtrl.js:27).
+//
+// The throw is reachable when both the DOM selection has been cleared and
+// `this.cursor` is null. We attempt the closest user-action recipe (lose DOM
+// selection, then invoke a format menu item that calls selectionChange). On
+// current develop these recipes pass — the model-cursor fallback at
+// paragraphCtrl.js:18-22 catches the transient DOM-selection-loss case.
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  expectNoRendererErrors,
+  clearRendererErrors,
+  clickMenuById,
+  launchWithMarkdown,
+  placeCaretInEditor
+} from './helpers'
+
+test.describe('Crash: selectionChange null cursor', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\nSome text with **bold**.\n')
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  test('Blur editor, clear DOM selection, then invoke format shortcut', async() => {
+    // Lose the DOM selection — emulates the user clicking outside the editor
+    // or another script (clipboard manager, screen reader) clearing it.
+    await page.evaluate(() => {
+      window.getSelection()?.removeAllRanges()
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+    await page.waitForTimeout(100)
+
+    // Trigger a format menu item that internally calls selectionChange.
+    // Format menu ids come from src/main/menu/templates/format.ts.
+    try {
+      await clickMenuById(app, 'strongMenuItem')
+    } catch {
+      // ignored — the menu may not be ready in some test environments
+    }
+    await page.waitForTimeout(200)
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('Repeated focus/blur with menu invocation does not throw', async() => {
+    for (let i = 0; i < 5; i++) {
+      await page.evaluate(() => {
+        window.getSelection()?.removeAllRanges()
+        ;(document.activeElement as HTMLElement | null)?.blur()
+      })
+      await page.waitForTimeout(50)
+      await placeCaretInEditor(page)
+      await page.waitForTimeout(50)
+    }
+    await expectNoRendererErrors(app)
+  })
+})
+
+// Sanity: confirm the throw exists in code by directly invoking the
+// contentState API. If this fails, the throw site has changed and the test
+// suite above no longer covers the right surface.
+test.describe('selectionChange API behaviour', () => {
+  test('Calling selectionChange with null cursor today throws', async() => {
+    const { app, page } = await launchWithMarkdown('# Doc\n')
+    try {
+      await page.waitForTimeout(300)
+      // Reach into the renderer global to invoke selectionChange directly.
+      // This is a white-box probe (not a user-action repro) used only to keep
+      // the higher-level user-path tests honest — if Muya later removes the
+      // throw, this assertion changes and we update the spec.
+      const threw = await page.evaluate(() => {
+        // Muya is not exposed on window; we walk the editor component to find
+        // the muya instance via a known property if available, otherwise
+        // return null and let the spec be informational.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const anyWin = window as any
+        const muya = anyWin.__MUYA__ || anyWin.muya
+        if (!muya || !muya.contentState) return 'no-muya'
+        try {
+          muya.contentState.cursor = null
+          muya.contentState.selectionChange(null)
+          return 'did-not-throw'
+        } catch {
+          return 'threw'
+        }
+      })
+      // Either we don't have access to muya (acceptable — informational), or
+      // calling with null cursor still throws (which is the bug).
+      expect(['no-muya', 'threw', 'did-not-throw']).toContain(threw)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/test/e2e/crash-selection-change.spec.ts
+++ b/test/e2e/crash-selection-change.spec.ts
@@ -13,7 +13,8 @@ import {
   clearRendererErrors,
   clickMenuById,
   launchWithMarkdown,
-  placeCaretInEditor
+  placeCaretInEditor,
+  waitForMenuReady
 } from './helpers'
 
 test.describe('Crash: selectionChange null cursor', () => {
@@ -24,6 +25,7 @@ test.describe('Crash: selectionChange null cursor', () => {
     const launched = await launchWithMarkdown('# Doc\n\nSome text with **bold**.\n')
     app = launched.app
     page = launched.page
+    await waitForMenuReady(app)
     await placeCaretInEditor(page)
     await clearRendererErrors(app)
   })
@@ -32,28 +34,32 @@ test.describe('Crash: selectionChange null cursor', () => {
     if (app) await app.close()
   })
 
-  test('Blur editor, clear DOM selection, then invoke format shortcut', async() => {
-    // Lose the DOM selection — emulates the user clicking outside the editor
-    // or another script (clipboard manager, screen reader) clearing it.
+  test('Blur the editor, clear DOM selection, then invoke a format menu item', async() => {
+    // Actually blur (not just clear selection) — the bug report path is the
+    // user clicking outside the editor before invoking a shortcut.
     await page.evaluate(() => {
+      const ae = document.activeElement as HTMLElement | null
+      if (ae && typeof ae.blur === 'function') ae.blur()
       window.getSelection()?.removeAllRanges()
       document.dispatchEvent(new Event('selectionchange'))
     })
     await page.waitForTimeout(100)
 
-    // Trigger a format menu item that internally calls selectionChange.
-    // Format menu ids come from src/main/menu/templates/format.ts.
-    try {
-      await clickMenuById(app, 'strongMenuItem')
-    } catch {
-      // ignored — the menu may not be ready in some test environments
-    }
-    await page.waitForTimeout(200)
+    // Trigger the format menu item that internally calls selectionChange.
+    // Surface failures from clickMenuById rather than swallowing them —
+    // if the menu id is wrong, the assertion below would be vacuous.
+    await clickMenuById(app, 'strongMenuItem')
+    await page.waitForTimeout(150)
 
     await expectNoRendererErrors(app)
   })
 
-  test('Repeated focus/blur with menu invocation does not throw', async() => {
+  test('Repeated DOM selection clear + refocus does not throw', async() => {
+    // Pure selection thrash — this verifies that the listeners hung off
+    // `document.selectionchange` and the focus/blur lifecycle do not throw
+    // when DOM selection is cycled out from underneath them. Menu invocation
+    // is intentionally NOT part of this test (it's covered by the previous
+    // case) so the spec name accurately describes the surface exercised.
     for (let i = 0; i < 5; i++) {
       await page.evaluate(() => {
         window.getSelection()?.removeAllRanges()
@@ -67,22 +73,17 @@ test.describe('Crash: selectionChange null cursor', () => {
   })
 })
 
-// Sanity: confirm the throw exists in code by directly invoking the
-// contentState API. If this fails, the throw site has changed and the test
-// suite above no longer covers the right surface.
+// White-box probe: directly invoke the contentState API to confirm the throw
+// is still present in the source. The renderer does not expose `muya` on
+// `window`, so we walk the editor component to find the instance via a known
+// property if available. If the probe cannot reach muya in this environment
+// it is skipped rather than passing vacuously.
 test.describe('selectionChange API behaviour', () => {
-  test('Calling selectionChange with null cursor today throws', async() => {
+  test('Calling selectionChange with null cursor throws (white-box)', async() => {
     const { app, page } = await launchWithMarkdown('# Doc\n')
     try {
       await page.waitForTimeout(300)
-      // Reach into the renderer global to invoke selectionChange directly.
-      // This is a white-box probe (not a user-action repro) used only to keep
-      // the higher-level user-path tests honest — if Muya later removes the
-      // throw, this assertion changes and we update the spec.
-      const threw = await page.evaluate(() => {
-        // Muya is not exposed on window; we walk the editor component to find
-        // the muya instance via a known property if available, otherwise
-        // return null and let the spec be informational.
+      const outcome = await page.evaluate(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const anyWin = window as any
         const muya = anyWin.__MUYA__ || anyWin.muya
@@ -95,9 +96,16 @@ test.describe('selectionChange API behaviour', () => {
           return 'threw'
         }
       })
-      // Either we don't have access to muya (acceptable — informational), or
-      // calling with null cursor still throws (which is the bug).
-      expect(['no-muya', 'threw', 'did-not-throw']).toContain(threw)
+      // Muya is not currently exposed on `window` — this probe is
+      // informational and is skipped when it cannot reach the instance.
+      // If a future change starts exposing muya, this guard switches from
+      // skip to a hard assertion that null-cursor selectionChange still
+      // throws (which is the current documented behaviour).
+      if (outcome === 'no-muya') {
+        test.skip(true, 'muya instance is not exposed on window in this build')
+      } else {
+        expect(outcome).toBe('threw')
+      }
     } finally {
       await app.close()
     }

--- a/test/e2e/crash-selection-change.spec.ts
+++ b/test/e2e/crash-selection-change.spec.ts
@@ -6,7 +6,7 @@
 // selection, then invoke a format menu item that calls selectionChange). On
 // current develop these recipes pass — the model-cursor fallback at
 // paragraphCtrl.js:18-22 catches the transient DOM-selection-loss case.
-import { expect, test } from '@playwright/test'
+import { test } from '@playwright/test'
 import type { ElectronApplication, Page } from 'playwright'
 import {
   expectNoRendererErrors,
@@ -22,7 +22,9 @@ test.describe('Crash: selectionChange null cursor', () => {
   let page: Page
 
   test.beforeEach(async() => {
-    const launched = await launchWithMarkdown('# Doc\n\nSome text with **bold**.\n')
+    const launched = await launchWithMarkdown('# Doc\n\nSome text with **bold**.\n', {
+      suppressErrorDialog: true
+    })
     app = launched.app
     page = launched.page
     await waitForMenuReady(app)
@@ -70,44 +72,5 @@ test.describe('Crash: selectionChange null cursor', () => {
       await page.waitForTimeout(50)
     }
     await expectNoRendererErrors(app)
-  })
-})
-
-// White-box probe: directly invoke the contentState API to confirm the throw
-// is still present in the source. The renderer does not expose `muya` on
-// `window`, so we walk the editor component to find the instance via a known
-// property if available. If the probe cannot reach muya in this environment
-// it is skipped rather than passing vacuously.
-test.describe('selectionChange API behaviour', () => {
-  test('Calling selectionChange with null cursor throws (white-box)', async() => {
-    const { app, page } = await launchWithMarkdown('# Doc\n')
-    try {
-      await page.waitForTimeout(300)
-      const outcome = await page.evaluate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const anyWin = window as any
-        const muya = anyWin.__MUYA__ || anyWin.muya
-        if (!muya || !muya.contentState) return 'no-muya'
-        try {
-          muya.contentState.cursor = null
-          muya.contentState.selectionChange(null)
-          return 'did-not-throw'
-        } catch {
-          return 'threw'
-        }
-      })
-      // Muya is not currently exposed on `window` — this probe is
-      // informational and is skipped when it cannot reach the instance.
-      // If a future change starts exposing muya, this guard switches from
-      // skip to a hard assertion that null-cursor selectionChange still
-      // throws (which is the current documented behaviour).
-      if (outcome === 'no-muya') {
-        test.skip(true, 'muya instance is not exposed on window in this build')
-      } else {
-        expect(outcome).toBe('threw')
-      }
-    } finally {
-      await app.close()
-    }
   })
 })

--- a/test/e2e/crash-update-paragraph.spec.ts
+++ b/test/e2e/crash-update-paragraph.spec.ts
@@ -13,7 +13,7 @@
 // `isAllowedTransformation` filtering keep updateParagraph from being called
 // with a stale cursor. If these tests start failing, the upstream guards
 // have regressed and paragraphCtrl.updateParagraph needs its own check.
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import type { ElectronApplication, Page } from 'playwright'
 import {
   clickMenuById,
@@ -21,7 +21,8 @@ import {
   expectNoRendererErrors,
   launchWithMarkdown,
   placeCaretInEditor,
-  typeIntoEditor
+  typeIntoEditor,
+  waitForMenuReady
 } from './helpers'
 
 test.describe('Crash: updateParagraph null block', () => {
@@ -32,6 +33,7 @@ test.describe('Crash: updateParagraph null block', () => {
     const launched = await launchWithMarkdown('# Doc\n\nFirst para.\n\nSecond para.\n')
     app = launched.app
     page = launched.page
+    await waitForMenuReady(app)
     await placeCaretInEditor(page)
     await clearRendererErrors(app)
   })
@@ -44,22 +46,22 @@ test.describe('Crash: updateParagraph null block', () => {
     // Fresh, single empty paragraph so the block-removal race in the report
     // (cursor on a paragraph that no longer exists) has the strongest chance.
     await typeIntoEditor(page, '@')
-    await page.waitForTimeout(300)
-    // Look for the quick-insert overlay and click the Header 1 item if present.
-    const overlay = await page.$('.ag-quick-insert')
-    if (overlay) {
-      const header1 = await page.$('.ag-quick-insert [data-label="header 1"], .ag-quick-insert .item:has-text("Header 1")')
-      if (header1) await header1.click()
-    } else {
-      // No overlay surfaced — fall back to using the menu item that produces
-      // the same updateParagraph code path.
-      try {
-        await clickMenuById(app, 'heading1MenuItem')
-      } catch {
-        // ignored
-      }
-    }
-    await page.waitForTimeout(300)
+    // The quick-insert overlay surfaces asynchronously after the @ is
+    // committed — wait for it rather than guessing.
+    const overlay = page.locator('.ag-quick-insert')
+    await overlay.waitFor({ state: 'attached', timeout: 5000 })
+
+    // Quick-insert items expose data-label matching the config in
+    // src/muya/lib/ui/quickInsert/config.js — "heading 1" (lowercase, with
+    // a space). Don't fall back to a localized text selector; fail loudly
+    // if the stable selector breaks.
+    const heading1 = overlay.locator('[data-label="heading 1"]')
+    await heading1.waitFor({ state: 'attached', timeout: 5000 })
+    await heading1.click()
+
+    // Allow the paragraph to be rewritten as a heading.
+    await page.waitForSelector('.editor-component h1', { state: 'attached', timeout: 5000 })
+
     await expectNoRendererErrors(app)
   })
 
@@ -76,8 +78,7 @@ test.describe('Crash: updateParagraph null block', () => {
       sel?.addRange(range)
     })
     await page.waitForTimeout(100)
-    // Delete the selected paragraph contents (Backspace × line length is
-    // simpler than orchestrating a Delete that removes the block).
+    // Delete the selected paragraph contents.
     for (let i = 0; i < 15; i++) {
       await page.keyboard.press('Backspace')
       await page.waitForTimeout(10)
@@ -85,27 +86,30 @@ test.describe('Crash: updateParagraph null block', () => {
     await page.keyboard.press('Backspace')
     await page.waitForTimeout(50)
 
-    // Now invoke the menu item that calls updateParagraph; if the model
-    // cursor still references the removed block, this is the crash.
-    try {
-      await clickMenuById(app, 'heading1MenuItem')
-    } catch {
-      // ignored
-    }
-    await page.waitForTimeout(300)
+    // Now invoke the menu item that calls updateParagraph. If clickMenuById
+    // throws (menu not built or id renamed), surface it — the test cannot
+    // honestly assert no-crash if the crash surface was never exercised.
+    await clickMenuById(app, 'heading1MenuItem')
+
+    // The mutation runs through partialRender → renderer commits. Wait for
+    // either an h1 to appear or a captured error.
+    await page.waitForTimeout(200)
 
     await expectNoRendererErrors(app)
   })
 
   test('Rapid alternation between Paragraph/Heading menu items', async() => {
     for (let i = 0; i < 6; i++) {
-      try {
-        await clickMenuById(app, i % 2 === 0 ? 'heading1MenuItem' : 'paragraphMenuItem')
-      } catch {
-        // ignored
-      }
+      // Surface failures — if the menu item id is wrong / menu not ready,
+      // the test must fail rather than silently no-op.
+      await clickMenuById(app, i % 2 === 0 ? 'heading1MenuItem' : 'paragraphMenuItem')
       await page.waitForTimeout(50)
     }
+    // Verify some structural transition actually happened — if neither
+    // heading nor paragraph styling toggles, the test was a no-op.
+    const hasHeading = await page.locator('.editor-component h1').count()
+    const hasParagraph = await page.locator('.editor-component p').count()
+    expect(hasHeading + hasParagraph).toBeGreaterThan(0)
     await expectNoRendererErrors(app)
   })
 })

--- a/test/e2e/crash-update-paragraph.spec.ts
+++ b/test/e2e/crash-update-paragraph.spec.ts
@@ -1,0 +1,111 @@
+// Regression guard for
+// "TypeError: Cannot destructure property 'text' of 'block' as it is null."
+// thrown at src/muya/lib/contentState/paragraphCtrl.js:486 (issues #2099,
+// #3571, #3663, #3667, #3879).
+//
+// User-action paths from the bug reports:
+//  - Type `@` in a fresh file to open quick-insert, pick "Header 1" (now
+//    pre-guarded at quickInsert/index.js:160).
+//  - Delete a paragraph then immediately trigger the Paragraph→Heading menu
+//    while the model cursor still points at the now-removed block.
+//
+// On current develop, none of these recipes crash — the upstream guard plus
+// `isAllowedTransformation` filtering keep updateParagraph from being called
+// with a stale cursor. If these tests start failing, the upstream guards
+// have regressed and paragraphCtrl.updateParagraph needs its own check.
+import { test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  clickMenuById,
+  clearRendererErrors,
+  expectNoRendererErrors,
+  launchWithMarkdown,
+  placeCaretInEditor,
+  typeIntoEditor
+} from './helpers'
+
+test.describe('Crash: updateParagraph null block', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\nFirst para.\n\nSecond para.\n')
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  test('Issue #2099: type @ in fresh file then select Header 1', async() => {
+    // Fresh, single empty paragraph so the block-removal race in the report
+    // (cursor on a paragraph that no longer exists) has the strongest chance.
+    await typeIntoEditor(page, '@')
+    await page.waitForTimeout(300)
+    // Look for the quick-insert overlay and click the Header 1 item if present.
+    const overlay = await page.$('.ag-quick-insert')
+    if (overlay) {
+      const header1 = await page.$('.ag-quick-insert [data-label="header 1"], .ag-quick-insert .item:has-text("Header 1")')
+      if (header1) await header1.click()
+    } else {
+      // No overlay surfaced — fall back to using the menu item that produces
+      // the same updateParagraph code path.
+      try {
+        await clickMenuById(app, 'heading1MenuItem')
+      } catch {
+        // ignored
+      }
+    }
+    await page.waitForTimeout(300)
+    await expectNoRendererErrors(app)
+  })
+
+  test('Delete a paragraph then invoke Heading 1 menu immediately', async() => {
+    // Position at end of "Second para." and select the line backwards.
+    await page.evaluate(() => {
+      const spans = document.querySelectorAll('.editor-component span.ag-paragraph')
+      const target = spans[spans.length - 1] as HTMLElement | null
+      if (!target) return
+      const range = document.createRange()
+      range.selectNodeContents(target)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    })
+    await page.waitForTimeout(100)
+    // Delete the selected paragraph contents (Backspace × line length is
+    // simpler than orchestrating a Delete that removes the block).
+    for (let i = 0; i < 15; i++) {
+      await page.keyboard.press('Backspace')
+      await page.waitForTimeout(10)
+    }
+    await page.keyboard.press('Backspace')
+    await page.waitForTimeout(50)
+
+    // Now invoke the menu item that calls updateParagraph; if the model
+    // cursor still references the removed block, this is the crash.
+    try {
+      await clickMenuById(app, 'heading1MenuItem')
+    } catch {
+      // ignored
+    }
+    await page.waitForTimeout(300)
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('Rapid alternation between Paragraph/Heading menu items', async() => {
+    for (let i = 0; i < 6; i++) {
+      try {
+        await clickMenuById(app, i % 2 === 0 ? 'heading1MenuItem' : 'paragraphMenuItem')
+      } catch {
+        // ignored
+      }
+      await page.waitForTimeout(50)
+    }
+    await expectNoRendererErrors(app)
+  })
+})

--- a/test/e2e/crash-update-paragraph.spec.ts
+++ b/test/e2e/crash-update-paragraph.spec.ts
@@ -25,91 +25,104 @@ import {
   waitForMenuReady
 } from './helpers'
 
+// Each test owns its own launch so the seed markdown can match the recipe
+// being exercised (the #2099 report describes "fresh file", whereas the
+// menu-driven tests need a paragraph to mutate). Keeping launch inside the
+// test also makes failures easier to attribute to the right recipe.
+const launchAndReady = async(
+  seed: string
+): Promise<{ app: ElectronApplication; page: Page }> => {
+  const launched = await launchWithMarkdown(seed, { suppressErrorDialog: true })
+  await waitForMenuReady(launched.app)
+  await placeCaretInEditor(launched.page)
+  await clearRendererErrors(launched.app)
+  return { app: launched.app, page: launched.page }
+}
+
 test.describe('Crash: updateParagraph null block', () => {
-  let app: ElectronApplication
-  let page: Page
-
-  test.beforeEach(async() => {
-    const launched = await launchWithMarkdown('# Doc\n\nFirst para.\n\nSecond para.\n')
-    app = launched.app
-    page = launched.page
-    await waitForMenuReady(app)
-    await placeCaretInEditor(page)
-    await clearRendererErrors(app)
-  })
-
-  test.afterEach(async() => {
-    if (app) await app.close()
-  })
-
   test('Issue #2099: type @ in fresh file then select Header 1', async() => {
-    // Fresh, single empty paragraph so the block-removal race in the report
-    // (cursor on a paragraph that no longer exists) has the strongest chance.
-    await typeIntoEditor(page, '@')
-    // The quick-insert overlay surfaces asynchronously after the @ is
-    // committed — wait for it rather than guessing.
-    const overlay = page.locator('.ag-quick-insert')
-    await overlay.waitFor({ state: 'attached', timeout: 5000 })
+    // Fresh file = empty markdown. The #2099 report specifically says "opened
+    // a new file" — seeding with anything else changes the recipe.
+    const { app, page } = await launchAndReady('')
+    try {
+      await typeIntoEditor(page, '@')
+      // The quick-insert overlay surfaces asynchronously after the @ is
+      // committed — wait for it rather than guessing.
+      const overlay = page.locator('.ag-quick-insert')
+      await overlay.waitFor({ state: 'attached', timeout: 5000 })
 
-    // Quick-insert items expose data-label matching the config in
-    // src/muya/lib/ui/quickInsert/config.js — "heading 1" (lowercase, with
-    // a space). Don't fall back to a localized text selector; fail loudly
-    // if the stable selector breaks.
-    const heading1 = overlay.locator('[data-label="heading 1"]')
-    await heading1.waitFor({ state: 'attached', timeout: 5000 })
-    await heading1.click()
+      // Quick-insert items expose data-label matching the config in
+      // src/muya/lib/ui/quickInsert/config.js — "heading 1" (lowercase, with
+      // a space). Don't fall back to a localized text selector; fail loudly
+      // if the stable selector breaks.
+      const heading1 = overlay.locator('[data-label="heading 1"]')
+      await heading1.waitFor({ state: 'attached', timeout: 5000 })
+      await heading1.click()
 
-    // Allow the paragraph to be rewritten as a heading.
-    await page.waitForSelector('.editor-component h1', { state: 'attached', timeout: 5000 })
+      // Allow the paragraph to be rewritten as a heading.
+      await page.waitForSelector('.editor-component h1', { state: 'attached', timeout: 5000 })
 
-    await expectNoRendererErrors(app)
+      await expectNoRendererErrors(app)
+    } finally {
+      await app.close()
+    }
   })
 
   test('Delete a paragraph then invoke Heading 1 menu immediately', async() => {
-    // Position at end of "Second para." and select the line backwards.
-    await page.evaluate(() => {
-      const spans = document.querySelectorAll('.editor-component span.ag-paragraph')
-      const target = spans[spans.length - 1] as HTMLElement | null
-      if (!target) return
-      const range = document.createRange()
-      range.selectNodeContents(target)
-      const sel = window.getSelection()
-      sel?.removeAllRanges()
-      sel?.addRange(range)
-    })
-    await page.waitForTimeout(100)
-    // Delete the selected paragraph contents.
-    for (let i = 0; i < 15; i++) {
+    const { app, page } = await launchAndReady('# Doc\n\nFirst para.\n\nSecond para.\n')
+    try {
+      // Position at end of "Second para." and select the line backwards.
+      await page.evaluate(() => {
+        const spans = document.querySelectorAll('.editor-component span.ag-paragraph')
+        const target = spans[spans.length - 1] as HTMLElement | null
+        if (!target) return
+        const range = document.createRange()
+        range.selectNodeContents(target)
+        const sel = window.getSelection()
+        sel?.removeAllRanges()
+        sel?.addRange(range)
+      })
+      await page.waitForTimeout(100)
+      // Delete the selected paragraph contents.
+      for (let i = 0; i < 15; i++) {
+        await page.keyboard.press('Backspace')
+        await page.waitForTimeout(10)
+      }
       await page.keyboard.press('Backspace')
-      await page.waitForTimeout(10)
+      await page.waitForTimeout(50)
+
+      // Now invoke the menu item that calls updateParagraph. If clickMenuById
+      // throws (menu not built or id renamed), surface it — the test cannot
+      // honestly assert no-crash if the crash surface was never exercised.
+      await clickMenuById(app, 'heading1MenuItem')
+
+      // The mutation runs through partialRender → renderer commits. Wait for
+      // either an h1 to appear or a captured error.
+      await page.waitForTimeout(200)
+
+      await expectNoRendererErrors(app)
+    } finally {
+      await app.close()
     }
-    await page.keyboard.press('Backspace')
-    await page.waitForTimeout(50)
-
-    // Now invoke the menu item that calls updateParagraph. If clickMenuById
-    // throws (menu not built or id renamed), surface it — the test cannot
-    // honestly assert no-crash if the crash surface was never exercised.
-    await clickMenuById(app, 'heading1MenuItem')
-
-    // The mutation runs through partialRender → renderer commits. Wait for
-    // either an h1 to appear or a captured error.
-    await page.waitForTimeout(200)
-
-    await expectNoRendererErrors(app)
   })
 
   test('Rapid alternation between Paragraph/Heading menu items', async() => {
-    for (let i = 0; i < 6; i++) {
-      // Surface failures — if the menu item id is wrong / menu not ready,
-      // the test must fail rather than silently no-op.
-      await clickMenuById(app, i % 2 === 0 ? 'heading1MenuItem' : 'paragraphMenuItem')
-      await page.waitForTimeout(50)
+    const { app, page } = await launchAndReady('# Doc\n\nFirst para.\n\nSecond para.\n')
+    try {
+      for (let i = 0; i < 6; i++) {
+        // Surface failures — if the menu item id is wrong / menu not ready,
+        // the test must fail rather than silently no-op.
+        await clickMenuById(app, i % 2 === 0 ? 'heading1MenuItem' : 'paragraphMenuItem')
+        await page.waitForTimeout(50)
+      }
+      // Verify some structural transition actually happened — if neither
+      // heading nor paragraph styling toggles, the test was a no-op.
+      const hasHeading = await page.locator('.editor-component h1').count()
+      const hasParagraph = await page.locator('.editor-component p').count()
+      expect(hasHeading + hasParagraph).toBeGreaterThan(0)
+      await expectNoRendererErrors(app)
+    } finally {
+      await app.close()
     }
-    // Verify some structural transition actually happened — if neither
-    // heading nor paragraph styling toggles, the test was a no-op.
-    const hasHeading = await page.locator('.editor-component h1').count()
-    const hasParagraph = await page.locator('.editor-component p').count()
-    expect(hasHeading + hasParagraph).toBeGreaterThan(0)
-    await expectNoRendererErrors(app)
   })
 })

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -52,24 +52,37 @@ export interface LaunchResult {
   page: Page
 }
 
-export const launchElectron = async(userArgs?: string[]): Promise<LaunchResult> => {
+export interface LaunchOptions {
+  // When true, sets MARKTEXT_ERROR_INTERACTION=1 in the launch env so
+  // src/main/exceptionHandler.ts suppresses the modal "Unexpected error"
+  // dialog. Only crash-guard specs that explicitly call expectNoRendererErrors
+  // should opt in — otherwise existing specs would silently ignore renderer
+  // exceptions that previously surfaced as a dialog (a hidden regression risk).
+  suppressErrorDialog?: boolean
+}
+
+export const launchElectron = async(
+  userArgs?: string[],
+  options: LaunchOptions = {}
+): Promise<LaunchResult> => {
   userArgs = userArgs || []
   const executablePath = getElectronPath()
   // Pass project root as entry so Electron reads package.json and getAppPath() returns project root.
   // Passing out/main/index.js directly bypasses package.json and breaks __static path resolution.
   const userDataDir = trackTempDir(getTempPath())
   const args = [projectRoot, '--user-data-dir', userDataDir].concat(userArgs)
+  const env: Record<string, string> = {}
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v
+  env.PERF_TESTING = 'true'
+  if (options.suppressErrorDialog) env.MARKTEXT_ERROR_INTERACTION = '1'
   const app = await _electron.launch({
     executablePath,
     args,
     cwd: projectRoot,
-    // MARKTEXT_ERROR_INTERACTION suppresses the modal "Unexpected error" dialog
-    // (see src/main/exceptionHandler.ts) — we instead capture errors via the
-    // mt::handle-renderer-error IPC below so specs can assert on them.
-    env: { ...process.env, PERF_TESTING: 'true', MARKTEXT_ERROR_INTERACTION: '1' },
+    env,
     timeout: 30000
   })
-  await installRendererErrorCounter(app)
+  if (options.suppressErrorDialog) await installRendererErrorCounter(app)
   const page = await app.firstWindow()
   await page.waitForLoadState('domcontentloaded')
   await new Promise((resolve) => setTimeout(resolve, 500))
@@ -325,8 +338,11 @@ const writeTempMarkdown = (content: string): string => {
   return filePath
 }
 
-export const launchWithDoc = async(relativeFixture: string): Promise<LaunchResult> => {
-  const { app, page } = await launchElectron([relativeFixture])
+export const launchWithDoc = async(
+  relativeFixture: string,
+  options: LaunchOptions = {}
+): Promise<LaunchResult> => {
+  const { app, page } = await launchElectron([relativeFixture], options)
   await waitForEditor(page)
   await waitForMenuReady(app)
   return { app, page }
@@ -336,9 +352,12 @@ export interface LaunchWithMarkdownResult extends LaunchResult {
   filePath: string
 }
 
-export const launchWithMarkdown = async(markdown = ''): Promise<LaunchWithMarkdownResult> => {
+export const launchWithMarkdown = async(
+  markdown = '',
+  options: LaunchOptions = {}
+): Promise<LaunchWithMarkdownResult> => {
   const filePath = writeTempMarkdown(markdown)
-  const { app, page } = await launchElectron([filePath])
+  const { app, page } = await launchElectron([filePath], options)
   await waitForEditor(page)
   await waitForMenuReady(app)
   return { app, page, filePath }

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test'
 import { _electron, type ElectronApplication, type Page } from 'playwright'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
@@ -62,13 +63,68 @@ export const launchElectron = async(userArgs?: string[]): Promise<LaunchResult> 
     executablePath,
     args,
     cwd: projectRoot,
-    env: { ...process.env, PERF_TESTING: 'true' },
+    // MARKTEXT_ERROR_INTERACTION suppresses the modal "Unexpected error" dialog
+    // (see src/main/exceptionHandler.ts) — we instead capture errors via the
+    // mt::handle-renderer-error IPC below so specs can assert on them.
+    env: { ...process.env, PERF_TESTING: 'true', MARKTEXT_ERROR_INTERACTION: '1' },
     timeout: 30000
   })
+  await installRendererErrorCounter(app)
   const page = await app.firstWindow()
   await page.waitForLoadState('domcontentloaded')
   await new Promise((resolve) => setTimeout(resolve, 500))
   return { app, page }
+}
+
+// Capture renderer-process errors that would otherwise pop the "Unexpected
+// error" dialog. We attach a parallel listener to the same IPC channel
+// (`mt::handle-renderer-error`) that exceptionHandler.ts listens on, and
+// accumulate the count in a shared global so specs can read it back via
+// `getRendererErrors`. Multiple listeners are allowed on ipcMain.
+const installRendererErrorCounter = async(app: ElectronApplication): Promise<void> => {
+  await app.evaluate(({ ipcMain }) => {
+    const g = global as unknown as {
+      __mt_renderer_errors__?: Array<{ message?: string; name?: string; stack?: string }>
+    }
+    if (!g.__mt_renderer_errors__) {
+      const sink: Array<{ message?: string; name?: string; stack?: string }> = []
+      g.__mt_renderer_errors__ = sink
+      ipcMain.on('mt::handle-renderer-error', (_e, error) => {
+        sink.push(error)
+      })
+    }
+  })
+}
+
+export const getRendererErrors = async(
+  app: ElectronApplication
+): Promise<Array<{ message?: string; name?: string; stack?: string }>> => {
+  return await app.evaluate(() => {
+    const g = global as unknown as {
+      __mt_renderer_errors__?: Array<{ message?: string; name?: string; stack?: string }>
+    }
+    return (g.__mt_renderer_errors__ || []).slice()
+  })
+}
+
+export const clearRendererErrors = async(app: ElectronApplication): Promise<void> => {
+  await app.evaluate(() => {
+    const g = global as unknown as {
+      __mt_renderer_errors__?: Array<unknown>
+    }
+    if (g.__mt_renderer_errors__) g.__mt_renderer_errors__.length = 0
+  })
+}
+
+// Assert that no renderer-process error has been captured since the last clear.
+// On failure, prints the captured stacks so the spec output is actionable.
+export const expectNoRendererErrors = async(app: ElectronApplication): Promise<void> => {
+  const errors = await getRendererErrors(app)
+  if (errors.length > 0) {
+    const summary = errors.map((e) => `- ${e.name ?? 'Error'}: ${e.message}\n${e.stack ?? ''}`).join('\n\n')
+    throw new Error(`Expected no renderer errors, captured ${errors.length}:\n\n${summary}`)
+  }
+  expect(errors.length).toBe(0)
 }
 
 export const waitForMenuReady = async(

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -127,6 +127,25 @@ export const expectNoRendererErrors = async(app: ElectronApplication): Promise<v
   expect(errors.length).toBe(0)
 }
 
+// Poll until a renderer error matching `predicate` is captured (or timeout).
+// Prefer this over a fixed `waitForTimeout` when waiting for an error to
+// surface — IPC delivery time varies on slower CI runners.
+export const waitForRendererError = async(
+  app: ElectronApplication,
+  predicate: (e: { message?: string; name?: string; stack?: string }) => boolean,
+  timeoutMs = 5000,
+  pollMs = 50
+): Promise<{ message?: string; name?: string; stack?: string } | null> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const errors = await getRendererErrors(app)
+    const match = errors.find(predicate)
+    if (match) return match
+    await new Promise((resolve) => setTimeout(resolve, pollMs))
+  }
+  return null
+}
+
 export const waitForMenuReady = async(
   app: ElectronApplication,
   timeout = 10000


### PR DESCRIPTION
## Summary

Triaged the **88 OPEN issues** with the title prefix `Unexpected error` (`gh issue list --search "Unexpected error in:title" --state open`), grouped them by error signature, located each crash site in current code, and attempted to reproduce every reproducible category with **Playwright user-action recipes only** (no programmatic state hacks).

**Empirical finding**: on current `develop` (0.18.9), none of the historical user recipes still crashes. Cumulative changes from the electron-vite refactor (#4001) and subsequent fixes already closed the main crash surfaces:

| Original crash | Where the guard now lives |
|---|---|
| `getMuyaIndexCursor` null anchorBlock destructure (#4117/#4090/#4079/#4078) | `src/muya/lib/utils/importMarkdown.js:464-467` — `if (!anchorBlock || !focusBlock) return null` |
| `quickInsert.selectItem` null block destructure (#2099/#3571/#3663/#3667/#3879) | `src/muya/lib/ui/quickInsert/index.js:160-164` |
| `CLOSE_TABS` undefined-tab pathname destructure (#3100/#3551) | `src/renderer/src/store/editor.ts:1044` — `?? { pathname: '' }` |
| `bringToFront` null window deref (#2065/#3321/#4137) | `src/main/windows/base.ts:85` early return |
| setCursorRange element-offset clamp (#4159 et al.) | `src/muya/lib/selection/index.js:524-530` |
| `selectionChange` null cursor (#4160/#3942) | `src/muya/lib/contentState/paragraphCtrl.js:18-22` model-cursor fallback |

Rather than add speculative defensive fixes that cannot be validated by a failing test, this PR encodes the historical crash recipes as **regression-guard e2e specs**. If any of these crash paths reopens, CI fails before another user files the same issue.

## What's in the PR

**3 new e2e specs** under `test/e2e/`, totalling 14 tests:

- `crash-range-offset.spec.ts` (9 tests) — recipes from the 25 `setStart` issues (escaped HTML typing from #2526, code-block backspace from #3737, Enter mid-formatted-paragraph, paste of rich HTML, select-all-delete in math-rich paragraphs).
- `crash-update-paragraph.spec.ts` (3 tests) — type `@` then pick Header 1 (#2099 recipe), delete paragraph then heading-menu, rapid heading↔paragraph menu alternation.
- `crash-selection-change.spec.ts` (2 tests) — clear DOM selection + blur then invoke format menu, repeated DOM selection clear + refocus.

**Helper infra** in `test/e2e/helpers.ts`:
- Adds a `LaunchOptions { suppressErrorDialog?: boolean }` parameter on `launchElectron` / `launchWithDoc` / `launchWithMarkdown`. When opted in, sets `MARKTEXT_ERROR_INTERACTION=1` so the main-process exception handler does not pop the modal "Unexpected error" dialog under Playwright (would deadlock the worker). Only the crash-guard specs opt in — existing specs keep getting the dialog if a renderer error leaks (no silent-regression risk).
- Installs a second `mt::handle-renderer-error` IPC listener on `ipcMain` that accumulates errors into a shared global, plus `getRendererErrors` / `clearRendererErrors` / `expectNoRendererErrors` helpers.
- A "crash counter sanity" test that forces a renderer-side `throw` and asserts it is captured — guards against the new assertion passing vacuously.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — no new errors/warnings introduced by these files
- [x] `pnpm run test:unit` — 550 tests pass
- [x] `pnpm exec playwright test test/e2e/crash-*.spec.ts` — 14 / 14 pass
- [x] `pnpm exec playwright test test/e2e/editor-input.spec.ts test/e2e/launch.spec.ts test/e2e/tabs.spec.ts` — existing specs unaffected by the new env var / IPC listener

## Out of scope

Issues that are **not user-reproducible** at all stay open for now:
- main-process timing races: `Cannot find window menu for id N` #3313/#2262/#2295, `getPrimaryDisplay: callback can only be called for once` #2203/#2519
- environment issues: `net::ERR_*` auto-updater #3184/#2531/#3237, `EMFILE` #2906, `EISDIR` #3779
- old-version bugs already gone after migration: `registerKeyHandlers` #3365, `resolvePath` #3797
- vue-i18n `SyntaxError: 9` during HTML/PDF export (#4046) — worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
