### PR TITLE
docs(release): expand RELEASE.md into a step-by-step playbook

### DIFF
--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -1,5 +1,147 @@
-# Steps to release MarkText
+# Releasing MarkText
 
-- Create a release candidate
-  - Simply create a tag at the latest commit `git tag v0.18.3`
-  - Push the tag and a build will automatically triggered `git push --tags`
+The release pipeline is driven entirely by tag pushes. Pushing a valid `v*` tag triggers the `Release MarkText` workflow (`.github/workflows/release.yml`), which runs **validate → build (4-platform matrix) → publish** and creates a GitHub Release with installers and a `SHA256SUMS.txt`.
+
+This guide covers both release candidates and stable releases — the path is the same; only the version string differs.
+
+## Prerequisites
+
+- Push access to `marktext/marktext` (you need to push branches and tags directly to `origin`)
+- `gh` CLI authenticated (`gh auth status` to confirm)
+- Clean checkout of the latest `develop`
+
+## 1. Cut a release branch (first RC only)
+
+Branch from the `develop` tip. The same branch is reused for all subsequent RCs *and* the stable tag of that minor version.
+
+```bash
+git checkout develop
+git pull --ff-only
+git checkout -b release/vX.Y.0     # e.g. release/v0.19.0
+```
+
+For any follow-up RC (`rc.2`, `rc.3`, …) or the eventual stable release, just `git checkout release/vX.Y.0` and skip to step 2.
+
+## 2. Bump `package.json`
+
+Edit the `version` field. This is the **only** file that needs editing — `app.getVersion()` and `electron-builder` both read it.
+
+| Stage | Version string |
+|---|---|
+| Release candidate | `0.19.0-rc.1`, `0.19.0-rc.2`, … |
+| Stable | `0.19.0` |
+
+## 3. Commit and push the branch
+
+```bash
+git add package.json
+git commit -m "chore(release): vX.Y.Z[-rc.N]"
+git push -u origin release/vX.Y.0
+```
+
+## 4. Tag and push
+
+```bash
+git tag -a vX.Y.Z-rc.N -m "vX.Y.Z-rc.N"
+git push origin vX.Y.Z-rc.N
+```
+
+Tag rules enforced by the `validate` job:
+
+- Must match `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`
+- A `-` in the tag (e.g. `v0.19.0-rc.1`) makes the GitHub Release **automatically a pre-release**. Tags without `-` (e.g. `v0.19.0`) publish as a normal release.
+
+## 5. Open a tracking PR (RC only)
+
+Open a **draft** PR from `release/vX.Y.0` → `develop` for visibility. Do **not** merge it until the stable tag of the same minor version is pushed — merging an RC commit would freeze `develop` at the RC version.
+
+```bash
+gh pr create --draft --base develop --head release/vX.Y.0 \
+  --title "chore(release): vX.Y.0 release branch (DO NOT MERGE until stable)" \
+  --body "Tracking branch for vX.Y.0. Merge after the stable tag is published."
+```
+
+## 6. Monitor the workflow
+
+```bash
+gh run list --workflow=release.yml --limit 3
+gh run watch <run-id> --exit-status
+```
+
+Approximate timings: `validate` ~30 s · `build` matrix ~15–30 min (4 platforms run in parallel) · `publish` ~1 min.
+
+## 7. Verify the published release
+
+```bash
+gh release view vX.Y.Z-rc.N
+```
+
+Confirm:
+
+- `Pre-release` label on the release page (RC only) — should be auto-set from the `-` in the tag
+- **12 assets**: 5 Linux (`AppImage`, `deb`, `rpm`, `snap`, `tar.gz`) + 4 macOS (`arm64.dmg`, `arm64.zip`, `x64.dmg`, `x64.zip`) + 2 Windows (`setup.exe`, `zip`) + `SHA256SUMS.txt`
+- Auto-generated release notes list the PRs merged since the previous tag
+- The boilerplate body (pre-release warning if applicable, macOS `xattr -cr` instructions, SHA-256 verification snippet) is present
+
+## 8. Post-stable cleanup (after stable `vX.Y.0` ships)
+
+Once the stable release is shipped and binaries pass smoke testing:
+
+1. Mark the tracking PR (from step 5) as ready for review and merge it into `develop`
+2. Open a follow-up PR bumping `develop` `package.json` to the next dev version (e.g. `0.20.0-dev`)
+
+---
+
+## Troubleshooting
+
+### `validate` rejects the tag
+
+The tag doesn't match the semver regex. Common causes: typo (`v.0.19.0`), missing `v` prefix, invalid prerelease characters. Delete and retag:
+
+```bash
+git push origin :refs/tags/<bad-tag>   # remote delete
+git tag -d <bad-tag>                   # local delete
+git tag -a <good-tag> -m "<good-tag>"
+git push origin <good-tag>
+```
+
+### A single platform's `build` job fails
+
+The artifacts from the three healthy platforms are kept on the run for 7 days. Fix the underlying issue on the release branch, then either:
+
+- Re-run only the failed job (artifacts of healthy platforms are reused):
+  ```bash
+  gh run rerun <run-id> --failed
+  ```
+- If the fix needs a new commit on the release branch, bump to the next RC (`-rc.N+1`) and tag again. The previous failed run can be left alone — the new tag triggers a fresh run.
+
+### `publish` reports `Bad credentials`
+
+Seen in practice during `v0.19.0-rc.1`: the default `GITHUB_TOKEN` occasionally fails to issue for the publish step even though `permissions: contents: write` is declared correctly. It is transient.
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+Only the ~1-minute publish step re-runs; build artifacts are reused. If it fails twice in a row, inspect repo **Settings → Actions → General → Workflow permissions** — it must allow read/write or honor per-job `permissions:` blocks.
+
+### Manual fallback (workflow stuck, artifacts in hand)
+
+If automation is hopelessly stuck but the build artifacts from a partially-failed run are still available:
+
+```bash
+gh run download <run-id> --dir dist
+cd dist
+LC_ALL=C find . -maxdepth 1 -type f ! -name 'SHA256SUMS.txt' -printf '%f\n' \
+  | sort | xargs -I{} sha256sum "{}" > SHA256SUMS.txt
+gh release create vX.Y.Z-rc.N \
+  --prerelease --generate-notes \
+  --title vX.Y.Z-rc.N \
+  ./*
+```
+
+Drop `--prerelease` for stable releases.
+
+---
+
+For hotfixes off a previously-released tag, see [RELEASE_HOTFIX.md](RELEASE_HOTFIX.md). Once a hotfix branch is ready, the steps above (from §2 onward) apply.

--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -1,18 +1,16 @@
 # Releasing MarkText
 
-The release pipeline is driven entirely by tag pushes. Pushing a valid `v*` tag triggers the `Release MarkText` workflow (`.github/workflows/release.yml`), which runs **validate → build (4-platform matrix) → publish** and creates a GitHub Release with installers and a `SHA256SUMS.txt`.
+The release pipeline is triggered by pushing a `v*` tag. The `Release MarkText` workflow (`.github/workflows/release.yml`) then runs **validate → build (4-platform matrix) → publish** and creates a GitHub Release with installers and `SHA256SUMS.txt`.
 
-This guide covers both release candidates and stable releases — the path is the same; only the version string differs.
+The flow below covers both release candidates and stable releases — same steps, only the version string differs.
 
 ## Prerequisites
 
-- Push access to `marktext/marktext` (you need to push branches and tags directly to `origin`)
-- `gh` CLI authenticated (`gh auth status` to confirm)
-- Clean checkout of the latest `develop`
+- Push access to `marktext/marktext`
+- `gh` CLI authenticated (`gh auth status`)
+- A clean checkout of the latest `develop`
 
 ## 1. Cut a release branch (first RC only)
-
-Branch from the `develop` tip. The same branch is reused for all subsequent RCs *and* the stable tag of that minor version.
 
 ```bash
 git checkout develop
@@ -20,11 +18,11 @@ git pull --ff-only
 git checkout -b release/vX.Y.0     # e.g. release/v0.19.0
 ```
 
-For any follow-up RC (`rc.2`, `rc.3`, …) or the eventual stable release, just `git checkout release/vX.Y.0` and skip to step 2.
+Reuse the same branch for every RC of that minor version (`rc.1`, `rc.2`, …) **and** the eventual stable tag. For follow-ups, just `git checkout release/vX.Y.0` and skip to step 2.
 
 ## 2. Bump `package.json`
 
-Edit the `version` field. This is the **only** file that needs editing — `app.getVersion()` and `electron-builder` both read it.
+Edit the `version` field — it is the only file you need to change.
 
 | Stage | Version string |
 |---|---|
@@ -46,14 +44,11 @@ git tag -a vX.Y.Z-rc.N -m "vX.Y.Z-rc.N"
 git push origin vX.Y.Z-rc.N
 ```
 
-Tag rules enforced by the `validate` job:
-
-- Must match `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`
-- A `-` in the tag (e.g. `v0.19.0-rc.1`) makes the GitHub Release **automatically a pre-release**. Tags without `-` (e.g. `v0.19.0`) publish as a normal release.
+A `-` in the tag (e.g. `v0.19.0-rc.1`) tells the workflow to mark the GitHub Release as **pre-release** automatically. Plain `vX.Y.Z` tags publish as stable releases.
 
 ## 5. Open a tracking PR (RC only)
 
-Open a **draft** PR from `release/vX.Y.0` → `develop` for visibility. Do **not** merge it until the stable tag of the same minor version is pushed — merging an RC commit would freeze `develop` at the RC version.
+Open a **draft** PR from `release/vX.Y.0` → `develop` for visibility. Do **not** merge it until the matching stable tag is pushed — merging an RC commit would freeze `develop` at the RC version.
 
 ```bash
 gh pr create --draft --base develop --head release/vX.Y.0 \
@@ -68,7 +63,7 @@ gh run list --workflow=release.yml --limit 3
 gh run watch <run-id> --exit-status
 ```
 
-Approximate timings: `validate` ~30 s · `build` matrix ~15–30 min (4 platforms run in parallel) · `publish` ~1 min.
+Approximate timing: validate ~30 s · build matrix ~15–30 min (4 platforms in parallel) · publish ~1 min.
 
 ## 7. Verify the published release
 
@@ -78,70 +73,15 @@ gh release view vX.Y.Z-rc.N
 
 Confirm:
 
-- `Pre-release` label on the release page (RC only) — should be auto-set from the `-` in the tag
+- `Pre-release` badge on the release page (RC only)
 - **12 assets**: 5 Linux (`AppImage`, `deb`, `rpm`, `snap`, `tar.gz`) + 4 macOS (`arm64.dmg`, `arm64.zip`, `x64.dmg`, `x64.zip`) + 2 Windows (`setup.exe`, `zip`) + `SHA256SUMS.txt`
 - Auto-generated release notes list the PRs merged since the previous tag
-- The boilerplate body (pre-release warning if applicable, macOS `xattr -cr` instructions, SHA-256 verification snippet) is present
 
 ## 8. Post-stable cleanup (after stable `vX.Y.0` ships)
 
-Once the stable release is shipped and binaries pass smoke testing:
-
-1. Mark the tracking PR (from step 5) as ready for review and merge it into `develop`
-2. Open a follow-up PR bumping `develop` `package.json` to the next dev version (e.g. `0.20.0-dev`)
+1. Mark the tracking PR from step 5 ready for review and merge into `develop`
+2. Open a follow-up PR bumping `develop`'s `package.json` to the next dev version (e.g. `0.20.0-dev`)
 
 ---
 
-## Troubleshooting
-
-### `validate` rejects the tag
-
-The tag doesn't match the semver regex. Common causes: typo (`v.0.19.0`), missing `v` prefix, invalid prerelease characters. Delete and retag:
-
-```bash
-git push origin :refs/tags/<bad-tag>   # remote delete
-git tag -d <bad-tag>                   # local delete
-git tag -a <good-tag> -m "<good-tag>"
-git push origin <good-tag>
-```
-
-### A single platform's `build` job fails
-
-The artifacts from the three healthy platforms are kept on the run for 7 days. Fix the underlying issue on the release branch, then either:
-
-- Re-run only the failed job (artifacts of healthy platforms are reused):
-  ```bash
-  gh run rerun <run-id> --failed
-  ```
-- If the fix needs a new commit on the release branch, bump to the next RC (`-rc.N+1`) and tag again. The previous failed run can be left alone — the new tag triggers a fresh run.
-
-### `publish` reports `Bad credentials`
-
-Seen in practice during `v0.19.0-rc.1`: the default `GITHUB_TOKEN` occasionally fails to issue for the publish step even though `permissions: contents: write` is declared correctly. It is transient.
-
-```bash
-gh run rerun <run-id> --failed
-```
-
-Only the ~1-minute publish step re-runs; build artifacts are reused. If it fails twice in a row, inspect repo **Settings → Actions → General → Workflow permissions** — it must allow read/write or honor per-job `permissions:` blocks.
-
-### Manual fallback (workflow stuck, artifacts in hand)
-
-If automation is hopelessly stuck but the build artifacts from a partially-failed run are still available:
-
-```bash
-gh run download <run-id> --dir dist
-cd dist
-LC_ALL=C find . -maxdepth 1 -type f ! -name 'SHA256SUMS.txt' -printf '%f\n' \
-  | sort | xargs -I{} sha256sum "{}" > SHA256SUMS.txt
-gh release create vX.Y.Z-rc.N \
-  --prerelease --generate-notes \
-  --title vX.Y.Z-rc.N \
-  ./*
-```
-
-Drop `--prerelease` for stable releases.
-
----
-
-For hotfixes off a previously-released tag, see [RELEASE_HOTFIX.md](RELEASE_HOTFIX.md). Once a hotfix branch is ready, the steps above (from §2 onward) apply.
+For hotfixes off a previously-released tag, see [RELEASE_HOTFIX.md](RELEASE_HOTFIX.md). Once the hotfix branch is ready, steps 2–7 above apply.


### PR DESCRIPTION
## Summary

`docs/dev/RELEASE.md` was two lines (\"create a tag, push it\") and hadn't been updated since the release workflow was reshaped in #4266 into a 3-stage pipeline (validate → build matrix → publish). Anyone trying to cut a release had to reverse-engineer the workflow YAML.

This PR turns RELEASE.md into a clean playbook a teammate can follow end-to-end without other docs.

## What's in it

- Step-by-step happy path: cut `release/vX.Y.0` → bump `package.json` → commit/push → tag/push → tracking PR → monitor → verify → post-stable cleanup
- Tag semantics: a `-` in the tag flips the GitHub Release to pre-release automatically
- Tracking-PR convention for RCs: draft PR to `develop` marked \"DO NOT MERGE until stable\" — explains why merging an RC into develop is harmful
- Verification checklist: 12 expected assets, pre-release flag, generated notes
- Post-stable cleanup: merge the tracking PR, then bump `develop` to the next dev cycle in a separate PR

## What's intentionally NOT in it

No troubleshooting section. RELEASE.md is for team members planning a release, not for debugging a stuck pipeline. Rare failure modes (transient `Bad credentials`, single-platform build failures, manual fallback from existing artifacts) would just clutter the doc; anyone hitting them can read the workflow file directly.

## Test plan

- [x] Followed this guide while cutting v0.19.0-rc.1 (https://github.com/marktext/marktext/releases/tag/v0.19.0-rc.1) — every step in §1–§7 matches reality.
- [ ] Reviewer sanity-check: clone fresh, follow §1–§4 against a throwaway `v0.0.0-test.N` tag, confirm the workflow runs without doc lookups outside this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)