### PR TITLE
feat: port clean write mode from develop to myMode

### DIFF
--- a/docs/superpowers/plans/2026-05-03-cleanwrite-syntax-visibility-fixes.md
+++ b/docs/superpowers/plans/2026-05-03-cleanwrite-syntax-visibility-fixes.md
@@ -1,0 +1,101 @@
+# Clean Write Syntax Visibility Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix heading `#` detection (require space) and show inline format markers at line boundaries in clean write mode.
+
+**Architecture:** Two isolated edits in muya parser layer. No new files, no new dependencies.
+
+**Tech Stack:** JavaScript, muya markdown parser
+
+---
+
+### Task 1: Fix heading regex — `#` must be followed by space
+
+**Files:**
+- Modify: `src/muya/lib/parser/rules.js:7`
+
+- [ ] **Step 1: Apply regex change**
+
+The current regex `(\s{1,}|$)` allows bare `#` at EOL. Remove `$` alternative:
+
+```js
+// Before
+header: /(^ {0,3}#{1,6}(\s{1,}|$))/,
+
+// After
+header: /(^ {0,3}#{1,6}\s{1,})/,
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: Build passes
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/muya/lib/parser/rules.js
+git commit -m "fix: require space after # for heading detection
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Show inline format markers at line boundaries in clean write mode
+
+**Files:**
+- Modify: `src/muya/lib/parser/render/index.js:212-213`
+
+- [ ] **Step 1: Add token type filter for clean write mode**
+
+Replace the unconditional `AG_HIDE` in clean write branch with boundary-aware logic:
+
+```js
+// Before (lines 212-214)
+if (this.muya.options.cleanWrite) {
+  return CLASS_OR_ID.AG_HIDE
+}
+
+// After
+if (this.muya.options.cleanWrite) {
+  if (/^(strong|em|del|inline_code|inline_math|highlight|sup_sub|code_fense)$/.test(token.type)) {
+    // Show markers at line boundaries so user can see format edges
+    const blockTextLen = (block.text || '').length
+    const atStart = token.range && token.range.start === 0
+    const atEnd = token.range && token.range.end === blockTextLen
+    if (atStart || atEnd) {
+      return CLASS_OR_ID.AG_GRAY
+    }
+  }
+  return CLASS_OR_ID.AG_HIDE
+}
+```
+
+Note: If `block.text` is not the correct way to get total text length during implementation, compute it from `block.children` tokens by summing their range extents.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `npm run build`
+Expected: Build passes
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/muya/lib/parser/render/index.js
+git commit -m "feat: show inline format markers at line boundaries in clean write mode
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Manual verification in `npm run dev`
+
+- [ ] Type `#` alone → `#` visible as plain text (not hidden)
+- [ ] Type `#text` (no space) → `#text` visible as plain text
+- [ ] Type `# title` → heading created, `# ` hidden
+- [ ] Full-line `**text**` → `**` markers dimmed at ends
+- [ ] Mid-line `a **bold** word` → `**` markers hidden
+- [ ] Non-clean-write mode: `#` behavior unchanged (heading still works with space)

--- a/docs/superpowers/specs/2026-05-03-cleanwrite-syntax-visibility-fixes.md
+++ b/docs/superpowers/specs/2026-05-03-cleanwrite-syntax-visibility-fixes.md
@@ -1,0 +1,48 @@
+# Clean Write Mode: Syntax Visibility Fixes
+
+**Goal:** Fix broken heading detection (`#` without space) and show inline format markers at line boundaries in clean write mode.
+
+**Scope:** Two targeted fixes in muya parser layer. No new files. All modes get corrected heading behavior; inline marker boundary visibility is clean-write-only.
+
+---
+
+## Fix 1: Heading `#` requires space
+
+**Problem:** `/^ {0,3}#{1,6}(\s{1,}|$)/` matches bare `#` at EOL via `$`, treating it as valid heading. In clean write mode the `#` is hidden, but the user considers `#` alone (or `#text` without space) broken syntax.
+
+**Change:** `src/muya/lib/parser/rules.js:7`
+
+```
+header: /(^ {0,3}#{1,6}(\s{1,}|$))/  →  /(^ {0,3}#{1,6}\s{1,})/
+```
+
+Remove `$` alternative. `#` followed by 1+ spaces required. `#text` (no space) naturally fails match — rendered as plain text.
+
+**Affects:** All modes. Behavior is more correct: empty heading marker has no content.
+
+---
+
+## Fix 2: Inline format markers visible at line boundaries
+
+**Problem:** `getClassName` unconditionally returns `AG_HIDE` in clean write mode. Inline format markers (`**`, `*`, `` ` ``, `~~`, `==`, `$`) wrapping entire content are invisible — user can't see format boundaries.
+
+**Change:** `src/muya/lib/parser/render/index.js:212` — in `getClassName` cleanWrite branch
+
+When clean write is active, inline format tokens whose range touches the line start or end get `AG_GRAY` (dimmed visible) instead of `AG_HIDE` (hidden). Mid-line markers stay hidden.
+
+Token types to match: `strong`, `em`, `del`, `inline_code`, `inline_math`, `highlight`, `sup_sub`
+
+Boundary test:
+- `atLineStart`: token.range.start === 0
+- `atLineEnd`: token.range.end === text content length
+
+**Affects:** Clean write mode only.
+
+---
+
+## Verification
+
+1. `npm run build` passes
+2. In clean write mode: type `#` → `#` visible (plain text); type `# ` → heading created, `# ` hidden
+3. In clean write mode: `**text**` spanning full line shows `**` markers dimmed at ends; `a **bold** word` hides `**` in middle
+4. Non-clean-write modes unaffected

--- a/src/main/menu/actions/view.ts
+++ b/src/main/menu/actions/view.ts
@@ -47,6 +47,10 @@ export const toggleFocusMode = (win: Win): void => {
   toggleTypeMode(win, 'focus')
 }
 
+export const toggleCleanWrite = (win: Win): void => {
+  toggleTypeMode(win, 'cleanWrite')
+}
+
 export const toggleSourceCodeMode = (win: Win): void => {
   toggleTypeMode(win, 'sourceCode')
 }
@@ -107,6 +111,8 @@ export const viewLayoutChanged = (
   applicationMenu: any,
   changes: Record<string, unknown>
 ): void => {
+  if (!applicationMenu) return
+
   const disableMenuByName = (id: string, value: boolean): void => {
     const menuItem: MenuItem = applicationMenu.getMenuItemById(id)
     menuItem.enabled = value
@@ -135,6 +141,9 @@ export const viewLayoutChanged = (
         break
       case 'focus':
         changeMenuByName(focusModeMenuItemId, value)
+        break
+      case 'cleanWrite':
+        changeMenuByName('cleanWriteMenuItem', value)
         break
     }
   }

--- a/src/main/menu/index.ts
+++ b/src/main/menu/index.ts
@@ -299,6 +299,7 @@ class AppMenu {
       updateMenuItem(oldMenu, newMenu, 'sourceCodeModeMenuItem')
       updateMenuItem(oldMenu, newMenu, 'typewriterModeMenuItem')
       updateMenuItem(oldMenu, newMenu, 'focusModeMenuItem')
+      updateMenuItem(oldMenu, newMenu, 'cleanWriteMenuItem')
       updateMenuItem(oldMenu, newMenu, 'sideBarMenuItem')
       updateMenuItem(oldMenu, newMenu, 'tabBarMenuItem')
 

--- a/src/main/menu/templates/view.ts
+++ b/src/main/menu/templates/view.ts
@@ -46,6 +46,15 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       }
     },
     {
+      id: 'cleanWriteMenuItem',
+      label: 'Clean Write Mode',
+      type: 'checkbox',
+      checked: true,
+      click(_item, focusedWindow) {
+        actions.toggleCleanWrite(focusedWindow as BrowserWindow | undefined)
+      }
+    },
+    {
       type: 'separator'
     },
     {

--- a/src/muya/lib/config/index.js
+++ b/src/muya/lib/config/index.js
@@ -444,7 +444,12 @@ export const MUYA_DEFAULT_OPTION = Object.freeze({
   isGitlabCompatibilityEnabled: false,
 
   // Whether HTML rendering is disabled or not.
-  disableHtml: true
+  disableHtml: true,
+
+  // Clean write mode: always hide valid markdown syntax markers. Only show
+  // raw syntax when it's broken/incomplete. The tokenizer naturally handles
+  // broken syntax as plain text.
+  cleanWrite: false
 })
 
 // export const DIAGRAM_TEMPLATE = Object.freeze({

--- a/src/muya/lib/contentState/enterCtrl.js
+++ b/src/muya/lib/contentState/enterCtrl.js
@@ -620,7 +620,7 @@ const enterCtrl = (ContentState) => {
 
     cursorBlock = getParagraphBlock(cursorBlock)
     const key =
-      cursorBlock.type === 'p' || cursorBlock.type === 'pre'
+      (cursorBlock.type === 'p' || cursorBlock.type === 'pre') && cursorBlock.children.length
         ? cursorBlock.children[0].key
         : cursorBlock.key
     let offset = 0

--- a/src/muya/lib/parser/render/index.js
+++ b/src/muya/lib/parser/render/index.js
@@ -72,10 +72,42 @@ class StateRender {
   }
 
   getClassName(outerClass, block, token, cursor) {
+    if (this.muya.options.cleanWrite) {
+      if (/^(strong|em|del|inline_code|inline_math|highlight|sup_sub)$/.test(token.type)) {
+        const textLen = (block.text || '').length
+        const atStart = token.range && token.range.start === 0
+        const atEnd = token.range && token.range.end === textLen
+        if (atStart && atEnd) {
+          // Emphasis spanning the entire block is normal inside table cells
+          // and blockquotes — these containers are the natural text boundary.
+          // Only show gray markers when the cursor is actively editing the block.
+          if (this._isInTableOrBlockquote(block)) {
+            if (cursor && cursor.start && cursor.start.key === block.key) {
+              return CLASS_OR_ID.AG_GRAY
+            }
+            return CLASS_OR_ID.AG_HIDE
+          }
+          return CLASS_OR_ID.AG_GRAY
+        }
+      }
+      return CLASS_OR_ID.AG_HIDE
+    }
     return (
       outerClass ||
       (this.checkConflicted(block, token, cursor) ? CLASS_OR_ID.AG_GRAY : CLASS_OR_ID.AG_HIDE)
     )
+  }
+
+  _isInTableOrBlockquote(block) {
+    if (block.functionType === 'cellContent') return true
+    const contentState = this.muya.contentState
+    let current = block
+    while (current.parent) {
+      current = contentState.getParent(current)
+      if (!current) break
+      if (current.type === 'blockquote') return true
+    }
+    return false
   }
 
   getHighlightClassName(active) {

--- a/src/muya/lib/parser/render/renderInlines/header.js
+++ b/src/muya/lib/parser/render/renderInlines/header.js
@@ -3,12 +3,21 @@ import { CLASS_OR_ID } from '../../../config'
 export default function header(h, cursor, block, token, outerClass) {
   const { content } = token
   const { start, end } = token.range
-  const className = this.getClassName(outerClass, block, {
+  let className = this.getClassName(outerClass, block, {
     range: {
       start,
       end: end - content.length
     }
   }, cursor)
+  // In clean write mode, show heading markers when there is no actual title text.
+  // The token's content is only the space/EOL from the regex capture group;
+  // actual title text lives in separate tokens. Check block.text instead.
+  if (this.muya.options.cleanWrite) {
+    const titleText = (block.text || '').replace(/^ {0,3}#{1,6}\s*/, '')
+    if (!titleText.trim()) {
+      className = CLASS_OR_ID.AG_GRAY
+    }
+  }
   const markerVnode = this.highlight(h, block, start, end - content.length, token)
   const contentVnode = this.highlight(h, block, end - content.length, end, token)
   const spaceSelector = className === CLASS_OR_ID.AG_HIDE

--- a/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/src/renderer/src/components/editorWithTabs/editor.vue
@@ -187,7 +187,8 @@ const {
   // Edit modes
   typewriter,
   focus,
-  sourceCode
+  sourceCode,
+  cleanWrite
 } = storeToRefs(preferencesStore)
 
 // Editor store refs
@@ -309,6 +310,12 @@ watch(typewriter, (value) => {
 watch(focus, (value) => {
   if (editor.value) {
     editor.value.setFocusMode(value)
+  }
+})
+
+watch(cleanWrite, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ cleanWrite: value }, true)
   }
 })
 
@@ -1197,6 +1204,7 @@ onMounted(() => {
     hideLinkPopup: hideLinkPopup.value,
     autoCheck: autoCheck.value,
     sequenceTheme: sequenceTheme.value,
+    cleanWrite: cleanWrite.value,
     spellcheckEnabled: spellcheckerEnabled.value,
     imageAction,
     imagePathPicker,

--- a/src/renderer/src/store/preferences.ts
+++ b/src/renderer/src/store/preferences.ts
@@ -233,6 +233,7 @@ export const usePreferencesStore = defineStore('preferences', {
     typewriter: false, // typewriter mode
     focus: false, // focus mode
     sourceCode: false, // source code mode
+    cleanWrite: true, // clean write mode — hide valid markdown syntax markers
 
     // user configration
     imageFolderPath: '',
@@ -290,6 +291,17 @@ export const usePreferencesStore = defineStore('preferences', {
 
       window.electron.ipcRenderer.on('mt::user-preference', (_e, preferences) => {
         this.SET_USER_PREFERENCE(preferences as Partial<PreferencesState>)
+
+        // Sync initial view mode states so menu checkboxes match defaults.
+        // Must happen here (not in LISTEN_FOR_VIEW) because the main process
+        // window menu and window.marktext.env are only ready after the async
+        // preference response.
+        this.DISPATCH_EDITOR_VIEW_STATE({
+          sourceCode: this.sourceCode,
+          typewriter: this.typewriter,
+          focus: this.focus,
+          cleanWrite: this.cleanWrite
+        })
       })
     },
 


### PR DESCRIPTION
Cherry-pick all 12 clean write mode commits from develop, adapted for upstream TypeScript migration and path layout changes:

- Add cleanWrite option to muya config (default: false) and preferences store (default: true, enabled on first launch)
- Implement getClassName logic: hide valid syntax markers, show gray only for broken/incomplete syntax or at block boundaries in table/blockquote
- Add empty heading detection in header renderer (block.text-based)
- Add View > Clean Write Mode menu item with IPC toggle chain
- Null-safe enterCtrl children access
- Preserve cleanWriteMenuItem checked state across menu rebuilds
- Null-guard viewLayoutChanged for settings windows without menus
- Sync initial view mode states after preference response

Muya changes: config, parser/render (getClassName + _isInTableOrBlockquote), renderInlines/header, contentState/enterCtrl
Main process: menu/actions/view.ts, menu/templates/view.ts, menu/index.ts Renderer: editor.vue (storeToRefs + watch + options), store/preferences.ts

<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #

## Summary

<!-- A concise description of what this PR does and why -->

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New tests added (or explain why not needed)
- [ ] Manually tested on: <!-- macOS / Windows / Linux -->

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
