### PR TITLE
fix(release): restore updater metadata artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,8 @@ jobs:
             dist/*.exe
             dist/*.zip
             dist/*.dmg
+            dist/*.blockmap
+            dist/*.yml
             dist/*.AppImage
             dist/*.snap
             dist/*.deb


### PR DESCRIPTION
## Summary
This restores electron-updater release metadata to the GitHub Release publish flow.

The regression was introduced by e668532f, which switched release publishing to a build-artifact fan-in workflow but only uploaded installer/archive files from the build jobs. That dropped `latest*.yml` and `.blockmap` files from the final GitHub Release, so packaged apps could not resolve update channel metadata during Check for Updates.

## Changes
- upload `dist/*.yml` from build artifacts
- upload `dist/*.blockmap` from build artifacts

## Verification
- validated `.github/workflows/release.yml` after the edit with no file errors
- confirmed the fix is limited to the release workflow

## Notes
- existing unrelated local change in `.vscode/settings.json` was intentionally left out of this PR