### PR TITLE
fix(sidebar): create-file button works in non-English locales

### DIFF
--- a/src/renderer/src/components/sideBar/tree.vue
+++ b/src/renderer/src/components/sideBar/tree.vue
@@ -119,7 +119,7 @@
           <div class="centered-group">
             <button
               class="button-primary"
-              @click="createFile"
+              @click.stop="createFile"
             >
               {{ t('sideBar.tree.createFile') }}
             </button>
@@ -229,10 +229,11 @@ const handleInputEnter = (): void => {
 onMounted(() => {
   bus.on('SIDEBAR::show-new-input', handleInputFocus)
 
-  // hide rename or create input if needed
+  // Hide rename / create inputs on outside clicks. Buttons that open these
+  // inputs must use @click.stop so their click never reaches this listener.
   document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement | null
-    if (target && target.tagName !== 'INPUT' && target.textContent !== 'Create File') {
+    if (target && target.tagName !== 'INPUT') {
       projectStore.CHANGE_ACTIVE_ITEM({})
       projectStore.createCache = {}
       projectStore.renameCache = null


### PR DESCRIPTION
## Summary

- In the sidebar's empty-folder state, clicking **Create File** did nothing in non-English locales (e.g. zh-CN). No console error was logged, which made the regression invisible.
- A `document` click listener in `tree.vue` cleared the just-set `createCache` unless `event.target.textContent === 'Create File'` (a hard-coded English string). In Chinese the button reads `创建文件`, so the exemption never matched and the new-file `<input>` was unmounted on the same tick it was meant to appear.
- Dev builds appeared to work only because dev and packaged Electron use different `userData` paths, so the persisted Chinese locale exists only in the installed app — dev fell back to the `'en'` default and the broken string check accidentally matched.

## Fix

- Add `@click.stop` to the empty-state "Create File" button so the click never bubbles to the global listener.
- Drop the locale-dependent `target.textContent !== 'Create File'` term from the listener.

## Test plan

- [ ] In dev mode with English locale, open an empty folder → click **Create File** → input appears → enter name + Enter → file created.
- [ ] Repeat in zh-CN (and any other non-English locale): the input now appears in `pnpm run build:mac` packaged builds.
- [ ] With the new-file input open, clicking elsewhere in the tree still closes it (existing behavior preserved).
- [ ] Sidebar context-menu "New file" / "New folder" still works (uses the same `SIDEBAR::new` bus event, no click involved).
- [ ] Rename input on a tree item still closes on outside click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)