### PR TITLE
feat(sidebar): implement file & folder sort with natural ordering

### DIFF
--- a/src/main/filesystem/watcher.ts
+++ b/src/main/filesystem/watcher.ts
@@ -51,6 +51,7 @@ const add = async(
 ): Promise<void> => {
   const stats = await fsPromises.stat(pathname)
   const birthTime = stats.birthtime
+  const mtimeMs = stats.mtimeMs
   const isMarkdown = hasMarkdownExtension(pathname)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const file: any = {
@@ -59,6 +60,7 @@ const add = async(
     isFile: true,
     isDirectory: false,
     birthTime,
+    mtimeMs,
     isMarkdown
   }
   if (isMarkdown) {

--- a/src/main/filesystem/watcher.ts
+++ b/src/main/filesystem/watcher.ts
@@ -109,19 +109,28 @@ const change = async(
   trimTrailingNewline: number,
   autoNormalizeLineEndings: boolean
 ): Promise<void> => {
-  if (type === 'dir') return
+  if (type === 'dir') {
+    // Only send mtimeMs so the sidebar can re-sort; skip loading file content.
+    try {
+      const stats = await fsPromises.stat(pathname)
+      win.webContents.send('mt::update-object-tree', {
+        type: 'change',
+        change: { pathname, mtimeMs: stats.mtimeMs }
+      })
+    } catch {
+      // File may have been deleted between the event and the stat; ignore.
+    }
+    return
+  }
 
   const isMarkdown = hasMarkdownExtension(pathname)
   if (isMarkdown) {
     try {
-      const data = await loadMarkdownFile(
-        pathname,
-        endOfLine,
-        autoGuessEncoding,
-        trimTrailingNewline,
-        autoNormalizeLineEndings
-      )
-      const file = { pathname, data }
+      const [data, stats] = await Promise.all([
+        loadMarkdownFile(pathname, endOfLine, autoGuessEncoding, trimTrailingNewline, autoNormalizeLineEndings),
+        fsPromises.stat(pathname)
+      ])
+      const file = { pathname, data, mtimeMs: stats.mtimeMs }
       win.webContents.send('mt::update-file', {
         type: 'change',
         change: file

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -47,6 +47,12 @@
     "enum": ["modified", "created", "title"],
     "default": "modified"
   },
+  "fileSortOrder": {
+    "description": "General--Sort order for files in opened folder: ascending or descending.",
+    "type": "string",
+    "enum": ["asc", "desc"],
+    "default": "asc"
+  },
   "lastOpenedFolder": {
     "description": "General--The last folder that was opened in MarkText.--internal",
     "type": "string"

--- a/src/main/preferences/schema.json
+++ b/src/main/preferences/schema.json
@@ -48,7 +48,7 @@
     "default": "modified"
   },
   "fileSortOrder": {
-    "description": "General--Sort order for files in opened folder: ascending or descending.",
+    "description": "General--Sort order for files in opened folders: ascending or descending.",
     "type": "string",
     "enum": ["asc", "desc"],
     "default": "asc"

--- a/src/renderer/src/prefComponents/general/config.ts
+++ b/src/renderer/src/prefComponents/general/config.ts
@@ -82,16 +82,18 @@ export const getFileSortByOptions = (): PrefSelectOption<string>[] => [
   }
 ]
 
-export const getFileSortOrderOptions = (): PrefSelectOption<string>[] => [
-  {
-    label: t('preferences.general.sidebar.fileSortOrder.ascending'),
-    value: 'asc'
-  },
-  {
-    label: t('preferences.general.sidebar.fileSortOrder.descending'),
-    value: 'desc'
+export const getFileSortOrderOptions = (sortBy: string = 'title'): PrefSelectOption<string>[] => {
+  if (sortBy === 'title') {
+    return [
+      { label: t('preferences.general.sidebar.fileSortOrder.aToZ'), value: 'asc' },
+      { label: t('preferences.general.sidebar.fileSortOrder.zToA'), value: 'desc' }
+    ]
   }
-]
+  return [
+    { label: t('preferences.general.sidebar.fileSortOrder.oldestFirst'), value: 'asc' },
+    { label: t('preferences.general.sidebar.fileSortOrder.newestFirst'), value: 'desc' }
+  ]
+}
 
 export const getLanguageOptions = (): PrefSelectOption<string>[] => [
   {

--- a/src/renderer/src/prefComponents/general/config.ts
+++ b/src/renderer/src/prefComponents/general/config.ts
@@ -77,8 +77,19 @@ export const getFileSortByOptions = (): PrefSelectOption<string>[] => [
     value: 'modified'
   },
   {
-    label: t('preferences.general.sidebar.fileSortBy.title'),
+    label: t('preferences.general.sidebar.fileSortBy.filename'),
     value: 'title'
+  }
+]
+
+export const getFileSortOrderOptions = (): PrefSelectOption<string>[] => [
+  {
+    label: t('preferences.general.sidebar.fileSortOrder.ascending'),
+    value: 'asc'
+  },
+  {
+    label: t('preferences.general.sidebar.fileSortOrder.descending'),
+    value: 'desc'
   }
 ]
 

--- a/src/renderer/src/prefComponents/general/index.vue
+++ b/src/renderer/src/prefComponents/general/index.vue
@@ -85,13 +85,17 @@
           more="https://github.com/isaacs/minimatch"
         />
 
-        <!-- TODO: The description is very bad and the entry isn't used by the editor. -->
         <cur-select
           :description="t('preferences.general.sidebar.fileSortBy.title')"
           :value="fileSortBy"
           :options="getFileSortByOptions()"
           :on-change="(value) => onSelectChange('fileSortBy', value)"
-          :disable="true"
+        />
+        <cur-select
+          :description="t('preferences.general.sidebar.fileSortOrder.title')"
+          :value="fileSortOrder"
+          :options="getFileSortOrderOptions()"
+          :on-change="(value) => onSelectChange('fileSortOrder', value)"
         />
       </template>
     </compound>
@@ -190,6 +194,7 @@ import {
   getTitleBarStyleOptions,
   zoomOptions,
   getFileSortByOptions,
+  getFileSortOrderOptions,
   getLanguageOptions
 } from './config'
 
@@ -208,6 +213,7 @@ const {
   hideScrollbar,
   wordWrapInToc,
   fileSortBy,
+  fileSortOrder,
   language
 } = storeToRefs(preferenceStore)
 

--- a/src/renderer/src/prefComponents/general/index.vue
+++ b/src/renderer/src/prefComponents/general/index.vue
@@ -94,7 +94,7 @@
         <cur-select
           :description="t('preferences.general.sidebar.fileSortOrder.title')"
           :value="fileSortOrder"
-          :options="getFileSortOrderOptions()"
+          :options="getFileSortOrderOptions(String(fileSortBy))"
           :on-change="(value) => onSelectChange('fileSortOrder', value)"
         />
       </template>

--- a/src/renderer/src/store/preferences.ts
+++ b/src/renderer/src/store/preferences.ts
@@ -17,6 +17,7 @@ export type SequenceTheme = 'hand' | 'simple'
 export type ImageInsertAction = 'folder' | 'path' | 'upload'
 export type ImageRelativeDirectoryBase = 'file' | 'root'
 export type FileSortBy = 'created' | 'modified' | 'title'
+export type FileSortOrder = 'asc' | 'desc'
 
 export interface GithubImageBedConfig {
   owner: string
@@ -39,6 +40,7 @@ export interface PreferencesState {
   hideScrollbar: boolean
   wordWrapInToc: boolean
   fileSortBy: FileSortBy | string
+  fileSortOrder: FileSortOrder | string
   startUpAction: StartUpAction | string
   restoreLayoutState: boolean
   defaultDirectoryToOpen: string
@@ -156,6 +158,7 @@ export const usePreferencesStore = defineStore('preferences', {
     hideScrollbar: false,
     wordWrapInToc: false,
     fileSortBy: 'created',
+    fileSortOrder: 'asc',
     startUpAction: 'restoreAll',
     restoreLayoutState: true,
     defaultDirectoryToOpen: '',

--- a/src/renderer/src/store/project.ts
+++ b/src/renderer/src/store/project.ts
@@ -1,6 +1,7 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { addFile, unlinkFile, addDirectory, unlinkDirectory } from './treeCtrl'
+import { addFile, unlinkFile, addDirectory, unlinkDirectory, resortTree } from './treeCtrl'
+import { usePreferencesStore } from './preferences'
 import bus from '../bus'
 import { create, paste, rename } from '../util/fileSystem'
 import { PATH_SEPARATOR } from '../config'
@@ -82,6 +83,17 @@ export const useProjectStore = defineStore('project', () => {
   const projectTree = ref<ProjectTree | null>(null)
   const pendingTreeEvents = ref<PendingEvent[]>([])
 
+  const preferencesStore = usePreferencesStore()
+
+  watch(
+    [() => preferencesStore.fileSortBy, () => preferencesStore.fileSortOrder],
+    ([sortBy, sortOrder]) => {
+      if (projectTree.value) {
+        resortTree(projectTree.value, String(sortBy), String(sortOrder))
+      }
+    }
+  )
+
   function OPEN_PROJECT(
     pathname: string,
     { scheduleBufferUpdate = true }: OpenProjectOptions = {}
@@ -151,7 +163,7 @@ export const useProjectStore = defineStore('project', () => {
     switch (type) {
       case 'add': {
         const { pathname, data, isMarkdown } = change
-        addFile(projectTree.value, change)
+        addFile(projectTree.value, change, String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
         if (isMarkdown && newFileNameCache.value && pathname === newFileNameCache.value) {
           const fileState = getFileStateFromData(data)
           editorStore.UPDATE_CURRENT_FILE(fileState)

--- a/src/renderer/src/store/project.ts
+++ b/src/renderer/src/store/project.ts
@@ -156,7 +156,6 @@ export const useProjectStore = defineStore('project', () => {
       }
       _processTreeEvent(type, change)
     })
-
   }
 
   function _processTreeEvent(type: string, change: TreeChange): void {

--- a/src/renderer/src/store/project.ts
+++ b/src/renderer/src/store/project.ts
@@ -1,6 +1,6 @@
 import { ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { addFile, unlinkFile, addDirectory, unlinkDirectory, resortTree } from './treeCtrl'
+import { addFile, unlinkFile, addDirectory, unlinkDirectory, resortTree, updateFileMtime } from './treeCtrl'
 import { usePreferencesStore } from './preferences'
 import bus from '../bus'
 import { create, paste, rename } from '../util/fileSystem'
@@ -156,6 +156,7 @@ export const useProjectStore = defineStore('project', () => {
       }
       _processTreeEvent(type, change)
     })
+
   }
 
   function _processTreeEvent(type: string, change: TreeChange): void {
@@ -182,6 +183,9 @@ export const useProjectStore = defineStore('project', () => {
         unlinkDirectory(projectTree.value, change)
         break
       case 'change':
+        if (change?.mtimeMs !== undefined) {
+          updateFileMtime(projectTree.value, change, String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
+        }
         break
       default:
         if (window.electron?.process?.env?.NODE_ENV === 'development') {

--- a/src/renderer/src/store/treeCtrl.ts
+++ b/src/renderer/src/store/treeCtrl.ts
@@ -160,6 +160,47 @@ export const addDirectory = (tree: TreeFolder, dir: { pathname: string }): void 
 }
 
 /**
+ * Update a file's mtimeMs and re-insert it at the correct sorted position.
+ * Called when a file-change event arrives so modified-time sort stays live.
+ */
+export const updateFileMtime = (
+  tree: TreeFolder,
+  file: { pathname: string; mtimeMs: number },
+  sortBy: string,
+  sortOrder: string
+): void => {
+  const dirname = window.path.dirname(file.pathname)
+  const subDirectories = getSubdirectoriesFromRoot(tree.pathname, dirname)
+
+  let currentFolder: TreeFolder = tree
+  let currentSubFolders: TreeFolder[] = tree.folders
+  for (const directoryName of subDirectories) {
+    const childFolder = currentSubFolders.find((f) => f.name === directoryName)
+    if (!childFolder) return
+    currentFolder = childFolder
+    currentSubFolders = childFolder.folders
+  }
+
+  const index = currentFolder.files.findIndex((f) => f.pathname === file.pathname)
+  if (index === -1) return
+
+  const entry = currentFolder.files[index]
+  entry.mtimeMs = file.mtimeMs
+
+  // Re-insert only if sorting by modified time — avoids unnecessary churn otherwise.
+  if (sortBy === 'modified') {
+    currentFolder.files.splice(index, 1)
+    const comparator = makeFileComparator(sortBy, sortOrder)
+    const idx = currentFolder.files.findIndex((f) => comparator(f, entry) > 0)
+    if (idx !== -1) {
+      currentFolder.files.splice(idx, 0, entry)
+    } else {
+      currentFolder.files.push(entry)
+    }
+  }
+}
+
+/**
  * Re-sort an already-populated tree in place when the sort preference changes.
  */
 export const resortTree = (tree: TreeFolder, sortBy: string, sortOrder: string): void => {

--- a/src/renderer/src/store/treeCtrl.ts
+++ b/src/renderer/src/store/treeCtrl.ts
@@ -29,19 +29,25 @@ interface TreeFile {
   isMarkdown: boolean
 }
 
+const safeTime = (v: number | undefined): number => (v !== undefined && isFinite(v) ? v : 0)
+
 const makeFileComparator = (sortBy: string, sortOrder: string) =>
   (a: TreeFile, b: TreeFile): number => {
     let result: number
     if (sortBy === 'created') {
-      const aTime = a.birthTime instanceof Date ? a.birthTime.getTime() : Number(a.birthTime ?? 0)
-      const bTime = b.birthTime instanceof Date ? b.birthTime.getTime() : Number(b.birthTime ?? 0)
+      const aTime = a.birthTime instanceof Date ? a.birthTime.getTime() : safeTime(Number(a.birthTime))
+      const bTime = b.birthTime instanceof Date ? b.birthTime.getTime() : safeTime(Number(b.birthTime))
       result = aTime - bTime
     } else if (sortBy === 'modified') {
-      result = (a.mtimeMs ?? 0) - (b.mtimeMs ?? 0)
+      result = safeTime(a.mtimeMs) - safeTime(b.mtimeMs)
     } else {
       result = naturalCompare(a.name, b.name)
     }
-    return sortOrder === 'desc' ? -result : result
+    const ordered = sortOrder === 'desc' ? -result : result
+    if (ordered !== 0) return ordered
+    // Stable tie-breaker: natural name, then full pathname
+    const byName = naturalCompare(a.name, b.name)
+    return byName !== 0 ? byName : a.pathname.localeCompare(b.pathname)
   }
 
 /**
@@ -81,7 +87,12 @@ export const addFile = (tree: TreeFolder, file: any, sortBy: string = 'title', s
         folders: [],
         files: []
       }
-      currentSubFolders.push(childFolder)
+      const idx = currentSubFolders.findIndex((f) => naturalCompare(f.name, directoryName) > 0)
+      if (idx !== -1) {
+        currentSubFolders.splice(idx, 0, childFolder)
+      } else {
+        currentSubFolders.push(childFolder)
+      }
     }
 
     currentPath = `${currentPath}${PATH_SEPARATOR}${directoryName}`

--- a/src/renderer/src/store/treeCtrl.ts
+++ b/src/renderer/src/store/treeCtrl.ts
@@ -3,6 +3,9 @@ import { PATH_SEPARATOR } from '../config'
 
 // Helper module (NOT a Pinia store): file-tree mutation helpers.
 
+const naturalCompare = (a: string, b: string): number =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+
 interface TreeFolder {
   id?: string
   pathname: string
@@ -20,10 +23,26 @@ interface TreeFile {
   pathname: string
   name: string
   birthTime?: number | Date
+  mtimeMs?: number
   isDirectory: false
   isFile: true
   isMarkdown: boolean
 }
+
+const makeFileComparator = (sortBy: string, sortOrder: string) =>
+  (a: TreeFile, b: TreeFile): number => {
+    let result: number
+    if (sortBy === 'created') {
+      const aTime = a.birthTime instanceof Date ? a.birthTime.getTime() : Number(a.birthTime ?? 0)
+      const bTime = b.birthTime instanceof Date ? b.birthTime.getTime() : Number(b.birthTime ?? 0)
+      result = aTime - bTime
+    } else if (sortBy === 'modified') {
+      result = (a.mtimeMs ?? 0) - (b.mtimeMs ?? 0)
+    } else {
+      result = naturalCompare(a.name, b.name)
+    }
+    return sortOrder === 'desc' ? -result : result
+  }
 
 /**
  * Return all sub-directories relative to the root directory.
@@ -40,7 +59,7 @@ const getSubdirectoriesFromRoot = (rootPath: string, pathname: string): string[]
  * Add a new file to the tree list.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const addFile = (tree: TreeFolder, file: any): void => {
+export const addFile = (tree: TreeFolder, file: any, sortBy: string = 'title', sortOrder: string = 'asc'): void => {
   const { pathname, name } = file
   const dirname = window.path.dirname(pathname)
   const subDirectories = getSubdirectoriesFromRoot(tree.pathname, dirname)
@@ -76,6 +95,7 @@ export const addFile = (tree: TreeFolder, file: any): void => {
     const fileCopy: TreeFile = {
       id: getUniqueId(),
       birthTime: file.birthTime,
+      mtimeMs: file.mtimeMs,
       isDirectory: file.isDirectory,
       isFile: file.isFile,
       isMarkdown: file.isMarkdown,
@@ -83,7 +103,8 @@ export const addFile = (tree: TreeFolder, file: any): void => {
       pathname: file.pathname
     }
 
-    const idx = currentFolder.files.findIndex((f) => f.name.localeCompare(name) > 0)
+    const comparator = makeFileComparator(sortBy, sortOrder)
+    const idx = currentFolder.files.findIndex((f) => comparator(f, fileCopy) > 0)
     if (idx !== -1) {
       currentFolder.files.splice(idx, 0, fileCopy)
     } else {
@@ -114,7 +135,7 @@ export const addDirectory = (tree: TreeFolder, dir: { pathname: string }): void 
         folders: [],
         files: []
       }
-      const idx = currentSubFolders.findIndex((f) => f.name.localeCompare(directoryName) > 0)
+      const idx = currentSubFolders.findIndex((f) => naturalCompare(f.name, directoryName) > 0)
       if (idx !== -1) {
         currentSubFolders.splice(idx, 0, childFolder)
       } else {
@@ -124,6 +145,17 @@ export const addDirectory = (tree: TreeFolder, dir: { pathname: string }): void 
 
     currentPath = `${currentPath}${PATH_SEPARATOR}${directoryName}`
     currentSubFolders = childFolder.folders
+  }
+}
+
+/**
+ * Re-sort an already-populated tree in place when the sort preference changes.
+ */
+export const resortTree = (tree: TreeFolder, sortBy: string, sortOrder: string): void => {
+  tree.files.sort(makeFileComparator(sortBy, sortOrder))
+  tree.folders.sort((a, b) => naturalCompare(a.name, b.name))
+  for (const folder of tree.folders) {
+    resortTree(folder, sortBy, sortOrder)
   }
 }
 

--- a/src/shared/types/preferences.ts
+++ b/src/shared/types/preferences.ts
@@ -15,6 +15,7 @@ export interface IUserPreferences {
   hideScrollbar?: boolean
   sidebarColumn?: number
   fileSortBy?: string
+  fileSortOrder?: string
   startUpAction?: string
   defaultDirectoryToOpen?: string
   language?: string

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -528,12 +528,12 @@
           "title": "Dateien sortieren nach",
           "creationTime": "Erstellungszeit",
           "modificationTime": "Änderungszeit",
-          "filename": "File Name"
+          "filename": "Dateiname"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "Sortierreihenfolge",
+          "ascending": "Aufsteigend",
+          "descending": "Absteigend"
         }
       },
       "misc": {

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -532,8 +532,10 @@
         },
         "fileSortOrder": {
           "title": "Sortierreihenfolge",
-          "ascending": "Aufsteigend",
-          "descending": "Absteigend"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "Älteste zuerst",
+          "newestFirst": "Neueste zuerst"
         }
       },
       "misc": {

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -527,7 +527,13 @@
         "fileSortBy": {
           "title": "Dateien sortieren nach",
           "creationTime": "Erstellungszeit",
-          "modificationTime": "Änderungszeit"
+          "modificationTime": "Änderungszeit",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -526,7 +526,13 @@
         "fileSortBy": {
           "title": "File Sort By",
           "creationTime": "Creation Time",
-          "modificationTime": "Modification Time"
+          "modificationTime": "Modification Time",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -531,8 +531,10 @@
         },
         "fileSortOrder": {
           "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "Oldest First",
+          "newestFirst": "Newest First"
         }
       },
       "misc": {

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -528,12 +528,12 @@
           "title": "Ordenar Archivos Por",
           "creationTime": "Tiempo de Creación",
           "modificationTime": "Tiempo de Modificación",
-          "filename": "File Name"
+          "filename": "Nombre de archivo"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "Orden de clasificación",
+          "ascending": "Ascendente",
+          "descending": "Descendente"
         }
       },
       "misc": {

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -527,7 +527,13 @@
         "fileSortBy": {
           "title": "Ordenar Archivos Por",
           "creationTime": "Tiempo de Creación",
-          "modificationTime": "Tiempo de Modificación"
+          "modificationTime": "Tiempo de Modificación",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -532,8 +532,10 @@
         },
         "fileSortOrder": {
           "title": "Orden de clasificación",
-          "ascending": "Ascendente",
-          "descending": "Descendente"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "Más antiguo primero",
+          "newestFirst": "Más reciente primero"
         }
       },
       "misc": {

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -529,12 +529,12 @@
           "title": "Trier les fichiers par",
           "creationTime": "Heure de création",
           "modificationTime": "Heure de modification",
-          "filename": "File Name"
+          "filename": "Nom de fichier"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "Ordre de tri",
+          "ascending": "Croissant",
+          "descending": "Décroissant"
         }
       },
       "misc": {

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "Trier les fichiers par",
           "creationTime": "Heure de création",
-          "modificationTime": "Heure de modification"
+          "modificationTime": "Heure de modification",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "Ordre de tri",
-          "ascending": "Croissant",
-          "descending": "Décroissant"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "Plus ancien en premier",
+          "newestFirst": "Plus récent en premier"
         }
       },
       "misc": {

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "並び順",
-          "ascending": "昇順",
-          "descending": "降順"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "古い順",
+          "newestFirst": "新しい順"
         }
       },
       "misc": {

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -529,12 +529,12 @@
           "title": "ファイルの並び順",
           "creationTime": "作成時刻",
           "modificationTime": "変更時刻",
-          "filename": "File Name"
+          "filename": "ファイル名"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "並び順",
+          "ascending": "昇順",
+          "descending": "降順"
         }
       },
       "misc": {

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "ファイルの並び順",
           "creationTime": "作成時刻",
-          "modificationTime": "変更時刻"
+          "modificationTime": "変更時刻",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "파일 정렬 기준",
           "creationTime": "생성 시간",
-          "modificationTime": "수정 시간"
+          "modificationTime": "수정 시간",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -529,12 +529,12 @@
           "title": "파일 정렬 기준",
           "creationTime": "생성 시간",
           "modificationTime": "수정 시간",
-          "filename": "File Name"
+          "filename": "파일 이름"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "정렬 순서",
+          "ascending": "오름차순",
+          "descending": "내림차순"
         }
       },
       "misc": {

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "정렬 순서",
-          "ascending": "오름차순",
-          "descending": "내림차순"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "오래된 순",
+          "newestFirst": "최신 순"
         }
       },
       "misc": {

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -529,12 +529,12 @@
           "title": "Ordenar Arquivos Por",
           "creationTime": "Hora de Criação",
           "modificationTime": "Hora de Modificação",
-          "filename": "File Name"
+          "filename": "Nome do arquivo"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "Ordem de classificação",
+          "ascending": "Ascendente",
+          "descending": "Descendente"
         }
       },
       "misc": {

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "Ordem de classificação",
-          "ascending": "Ascendente",
-          "descending": "Descendente"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "Mais antigo primeiro",
+          "newestFirst": "Mais recente primeiro"
         }
       },
       "misc": {

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "Ordenar Arquivos Por",
           "creationTime": "Hora de Criação",
-          "modificationTime": "Hora de Modificação"
+          "modificationTime": "Hora de Modificação",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -529,12 +529,12 @@
           "title": "文件排序方式",
           "creationTime": "创建时间",
           "modificationTime": "修改时间",
-          "filename": "File Name"
+          "filename": "文件名"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "排序顺序",
+          "ascending": "升序",
+          "descending": "降序"
         }
       },
       "misc": {

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "文件排序方式",
           "creationTime": "创建时间",
-          "modificationTime": "修改时间"
+          "modificationTime": "修改时间",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "排序顺序",
-          "ascending": "升序",
-          "descending": "降序"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "从旧到新",
+          "newestFirst": "从新到旧"
         }
       },
       "misc": {

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -529,12 +529,12 @@
           "title": "檔案排序方式",
           "creationTime": "建立時間",
           "modificationTime": "修改時間",
-          "filename": "File Name"
+          "filename": "檔案名稱"
         },
         "fileSortOrder": {
-          "title": "Sort Order",
-          "ascending": "Ascending",
-          "descending": "Descending"
+          "title": "排序順序",
+          "ascending": "升序",
+          "descending": "降序"
         }
       },
       "misc": {

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -528,7 +528,13 @@
         "fileSortBy": {
           "title": "檔案排序方式",
           "creationTime": "建立時間",
-          "modificationTime": "修改時間"
+          "modificationTime": "修改時間",
+          "filename": "File Name"
+        },
+        "fileSortOrder": {
+          "title": "Sort Order",
+          "ascending": "Ascending",
+          "descending": "Descending"
         }
       },
       "misc": {

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -533,8 +533,10 @@
         },
         "fileSortOrder": {
           "title": "排序順序",
-          "ascending": "升序",
-          "descending": "降序"
+          "aToZ": "A → Z",
+          "zToA": "Z → A",
+          "oldestFirst": "從舊到新",
+          "newestFirst": "從新到舊"
         }
       },
       "misc": {

--- a/static/preference.json
+++ b/static/preference.json
@@ -8,6 +8,7 @@
   "hideScrollbar": false,
   "wordWrapInToc": false,
   "fileSortBy": "created",
+  "fileSortOrder": "asc",
   "startUpAction": "restoreAll",
   "restoreLayoutState": true,
   "defaultDirectoryToOpen": "",


### PR DESCRIPTION
## Summary

- **Fixes folder ordering on Windows** (#2078) — subfolders now sort by natural order on all platforms instead of raw filesystem order
- **Wires the `fileSortBy` preference** to actual sidebar sorting (was always ignored; dropdown was hard-disabled since it was added)
- **Adds `fileSortOrder` (asc/desc) preference** with a new toggle in Preferences → General → Sidebar
- **Natural/numeric sort** throughout: `Chapter 2` before `Chapter 10`, not `Chapter 10` before `Chapter 2` (#1248)

## Changes

| File | What changed |
|---|---|
| `src/main/filesystem/watcher.ts` | Expose `mtimeMs` in file IPC payload for modified-time sorting |
| `src/renderer/src/store/treeCtrl.ts` | `naturalCompare`, `makeFileComparator` (routes by sortBy/sortOrder), `resortTree()` export; `addFile()` accepts sort params |
| `src/renderer/src/store/project.ts` | Passes sort preferences to `addFile()`; watches both prefs for live re-sort |
| `src/renderer/src/store/preferences.ts` | Adds `FileSortOrder` type + `fileSortOrder: 'asc'` state |
| `src/renderer/src/prefComponents/general/config.ts` | Fixes `fileSortBy` 'title' label key collision; adds `getFileSortOrderOptions()` |
| `src/renderer/src/prefComponents/general/index.vue` | Enables sort dropdown (removes `:disable="true"`); adds Sort Order selector |
| `src/main/preferences/schema.json` + `static/preference.json` | Adds `fileSortOrder` field with default `"asc"` |
| `static/locales/*.json` (9 files) | Adds `fileSortBy.filename` and `fileSortOrder.*` i18n keys |

## Test plan

- [x] Open a folder containing numerically-named files (e.g. `1.md`, `2.md`, `10.md`, `20.md`) → order should be `1, 2, 10, 20` not `1, 10, 2, 20`
- [x] Switch sort to **Modification Time** + **Descending** → most recently modified file appears first
- [x] Switch sort to **File Name** + **Ascending** → alphabetical A→Z
- [ ] Add a new file while folder is open → file appears in correct sorted position without re-opening
- [ ] Open same folder in two windows → identical ordering in both
- [ ] On Windows: subfolders now sorted alphabetically (regression check for #2078)
- [ ] Preferences → General → Sidebar shows both **File Sort By** and **Sort Order** dropdowns, both enabled

Closes #2078, #1248, #1605, #3675, #4168

🤖 Generated with [Claude Code](https://claude.com/claude-code)