### PR TITLE
fix(uploader): remove 5 MB hard limit on image uploads

### DIFF
--- a/src/main/ipc/uploader.ts
+++ b/src/main/ipc/uploader.ts
@@ -140,7 +140,6 @@ const uploadFromPath = async(
 interface BufferImagePayload {
   data: Uint8Array | number[]
   name: string
-  byteLength: number
 }
 
 const uploadFromBuffer = async(

--- a/src/main/ipc/uploader.ts
+++ b/src/main/ipc/uploader.ts
@@ -127,20 +127,11 @@ const writeBinaryToTmp = async(
   return tmpPath
 }
 
-const MAX_SIZE = 5 * 1024 * 1024
-
 const uploadFromPath = async(
   imagePath: string,
   options: { currentUploader: string; cliScript: string }
 ): Promise<string> => {
   const { currentUploader, cliScript } = options
-  const { size } = await fs.stat(imagePath)
-  if (size > MAX_SIZE) {
-    throw new Error(
-      'Cannot upload more than 5M image, the image will be copied to the image folder'
-    )
-  }
-
   if (currentUploader === 'picgo') return uploadByPicgo(imagePath)
   if (currentUploader === 'cliScript') return uploadByCli(cliScript, imagePath)
   throw new Error(`Unsupported uploader: ${currentUploader}`)
@@ -153,18 +144,13 @@ interface BufferImagePayload {
 }
 
 const uploadFromBuffer = async(
-  { data, name, byteLength }: BufferImagePayload,
+  { data, name }: BufferImagePayload,
   options: {
     currentUploader: string
     cliScript: string
   }
 ): Promise<string> => {
   const { currentUploader, cliScript } = options
-  if (byteLength > MAX_SIZE) {
-    throw new Error(
-      'Cannot upload more than 5M image, the image will be copied to the image folder'
-    )
-  }
   const suffix = path.extname(name || '') || ''
   const localPath = await writeBinaryToTmp(data, suffix)
   const cleanup = () =>

--- a/src/renderer/src/util/fileSystem.ts
+++ b/src/renderer/src/util/fileSystem.ts
@@ -131,8 +131,7 @@ export const uploadImage = async(
     pathname,
     image: {
       data: new Uint8Array(arrayBuffer),
-      name: file.name,
-      byteLength: arrayBuffer.byteLength
+      name: file.name
     },
     isPath: false,
     preferences: ipcPrefs


### PR DESCRIPTION
## Summary

- Removes the hardcoded 5 MB size check from the main-process uploader (`src/main/ipc/uploader.ts`) that was rejecting images before even handing them off to PicGo or a custom CLI uploader.
- The restriction existed in both the file-path upload path and the buffer (paste/drag) upload path.
- No user-facing configuration is needed — each uploader's own backend limits apply directly.

## Motivation

Fixes #3561. Users who configure PicGo against backends that accept larger files (e.g. self-hosted Chevereto, custom S3 buckets) were silently blocked by MarkText's own cap. The terminal PicGo CLI succeeded with the same files, confirming the limit was entirely on MarkText's side.

## Changes

- Deleted `const MAX_SIZE = 5 * 1024 * 1024`
- Removed `fs.stat` size guard in `uploadFromPath`
- Removed `byteLength` size guard in `uploadFromBuffer`

## Test plan

- [ ] Upload an image smaller than 5 MB via PicGo — should continue to work
- [ ] Upload an image larger than 5 MB via PicGo — should now succeed (previously failed before reaching PicGo)
- [ ] Upload an image larger than 5 MB via a custom CLI script — should now succeed
- [ ] Paste an image larger than 5 MB — should now attempt upload instead of falling back to local copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)