### PR TITLE
fix(build): restore dedicated .md file icon on Windows

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,31 +58,37 @@ fileAssociations:
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
   - ext: markdown
     name: Markdown
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
   - ext: mmd
     name: Markdown
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
   - ext: mdown
     name: Markdown
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
   - ext: mdtxt
     name: Markdown
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
   - ext: mdtext
     name: Markdown
     description: Markdown document
     mimeType: text/markdown
     role: Editor
+    icon: icons/md.ico
 win:
   executableName: marktext
   artifactName: 'marktext-win-${arch}-${version}.${ext}'


### PR DESCRIPTION
## Summary

Restore the dedicated **Markdown document icon** for `.md` (and other Markdown) files on Windows. After installing `v0.19.0-rc.3`, Markdown files in Explorer show the MarkText application logo instead of the document-style icon used by `v0.17.x` and earlier.

| Before (current `develop` / `v0.19.0-rc.x`) | After (this PR) |
| --- | --- |
| `.md` → app logo (fallback to `marktext.exe,0`) | `.md` → dedicated `md.ico` document icon |

## Root cause

PR #4001 (*Re-Factor MarkText with electron-vite*) rewrote `electron-builder.yml`. In the new file each extension is its own `fileAssociations` entry, but the original

```yaml
icon: "../resources/icons/md.icns"
```

field (present in `v0.17.1`) was not carried over to any of the new entries. With no per-association icon, electron-builder’s NSIS target falls back to the main application icon when registering `DefaultIcon` in the registry, which is exactly what users see now:

```
HKCR\Markdown\DefaultIcon = "...\marktext.exe",0
```

The icon assets themselves are still shipped — `extraResources` already copies `build/icons/*.ico` to `resources/icons/`, so `resources/icons/md.ico` is present in the installed app. They were simply no longer referenced from the file associations.

## Fix

Re-add `icon: icons/md.ico` (resolved against `buildResources`, i.e. `build/icons/md.ico`) to every Markdown extension in `fileAssociations`. This restores the pre-refactor behavior without touching anything else.

```yaml
fileAssociations:
  - ext: md
    name: Markdown
    description: Markdown document
    mimeType: text/markdown
    role: Editor
    icon: icons/md.ico         # ← restored
  - ext: markdown
    ...
    icon: icons/md.ico
  # …same for mmd / mdown / mdtxt / mdtext
```

Linux and macOS file associations are unaffected (Linux doesn’t use this field; macOS file types are declared elsewhere with `icons/md.icns` already wired up via `mac.extendInfo` / dmg flow as before).

## Verification

Local registry check on a `v0.19.0-rc.3` install confirms the regression and the fix path:

```text
# Before
HKCR\.md           = Markdown
HKCR\Markdown\DefaultIcon = "...\marktext.exe",0       # falls back to app logo

# After (with this patch, or as a manual user override)
HKCR\Markdown\DefaultIcon = "...\resources\icons\md.ico",0
```

Re-running the icon cache (`ie4uinit.exe -ClearIconCache && ie4uinit.exe -show`) immediately switches Explorer to the document icon.

I have not produced a fresh installer locally for this change (no Windows signing setup), but the patch is a one-line-per-entry config restoration of behavior that already shipped in `v0.17.x`, against assets that are still present and copied into the installer.

## Notes

- I searched issues and open PRs (`md.ico`, `fileAssociations`, `file icon`, etc.) and didn’t find an existing report or fix for this specific regression.
- Happy to also restore the `.icns` reference for any platform that needs it if reviewers want it bundled in the same PR.
