### PR TITLE
perf(filesystem): cut stat syscalls and per-call regex compilation

### DIFF
--- a/src/common/filesystem/index.ts
+++ b/src/common/filesystem/index.ts
@@ -1,7 +1,7 @@
 import { access } from 'fs/promises'
 import { lstatSync, readlinkSync } from 'fs'
 import { resolve, dirname } from 'path'
-import { ensureDirSync as fsExtraEnsureDirSync, pathExistsSync } from 'fs-extra'
+import { ensureDirSync as fsExtraEnsureDirSync } from 'fs-extra'
 
 /**
  * Test whether or not the given path exists.
@@ -33,7 +33,7 @@ export const ensureDirSync = (dirPath: string): void => {
  */
 export const isDirectory = (dirPath: string): boolean => {
   try {
-    return pathExistsSync(dirPath) && lstatSync(dirPath).isDirectory()
+    return lstatSync(dirPath).isDirectory()
   } catch {
     return false
   }
@@ -45,10 +45,6 @@ export const isDirectory = (dirPath: string): boolean => {
  */
 export const isDirectory2 = (dirPath: string): boolean => {
   try {
-    if (!pathExistsSync(dirPath)) {
-      return false
-    }
-
     const fi = lstatSync(dirPath)
     if (fi.isDirectory()) {
       return true
@@ -67,7 +63,7 @@ export const isDirectory2 = (dirPath: string): boolean => {
  */
 export const isFile = (filepath: string): boolean => {
   try {
-    return pathExistsSync(filepath) && lstatSync(filepath).isFile()
+    return lstatSync(filepath).isFile()
   } catch {
     return false
   }
@@ -79,10 +75,6 @@ export const isFile = (filepath: string): boolean => {
  */
 export const isFile2 = (filepath: string): boolean => {
   try {
-    if (!pathExistsSync(filepath)) {
-      return false
-    }
-
     const fi = lstatSync(filepath)
     if (fi.isFile()) {
       return true
@@ -101,7 +93,7 @@ export const isFile2 = (filepath: string): boolean => {
  */
 export const isSymbolicLink = (filepath: string): boolean => {
   try {
-    return pathExistsSync(filepath) && lstatSync(filepath).isSymbolicLink()
+    return lstatSync(filepath).isSymbolicLink()
   } catch {
     return false
   }

--- a/src/common/filesystem/paths.ts
+++ b/src/common/filesystem/paths.ts
@@ -44,14 +44,8 @@ export const hasMarkdownExtension = (filename: string): boolean => {
  * Returns true if the path is an image file.
  */
 export const isImageFile = (filepath: string): boolean => {
-  const extname = path.extname(filepath)
-  return (
-    isFile(filepath) &&
-    IMAGE_EXTENSIONS.some((ext) => {
-      const EXT_REG = new RegExp(ext, 'i')
-      return EXT_REG.test(extname)
-    })
-  )
+  const ext = path.extname(filepath).slice(1).toLowerCase()
+  return !!ext && IMAGE_EXTENSIONS.includes(ext) && isFile(filepath)
 }
 
 /**

--- a/src/main/utils/imagePathAutoComplement.ts
+++ b/src/main/utils/imagePathAutoComplement.ts
@@ -17,12 +17,13 @@ interface DirOrImageEntry {
 const IMAGE_PATH: Map<string, DirOrImageEntry[]> = new Map()
 export const watchers: Map<string, fs.FSWatcher> = new Map()
 
+const IMAGE_REG = new RegExp('(' + IMAGE_EXTENSIONS.join('|') + ')$', 'i')
+
 const filesHandler = (
   files: string[],
   directory: string,
   key?: string
 ): DirOrImageEntry[] | undefined => {
-  const IMAGE_REG = new RegExp('(' + IMAGE_EXTENSIONS.join('|') + ')$', 'i')
   const onlyDirAndImage: DirOrImageEntry[] = files
     .map((file): DirOrImageEntry => {
       const fullPath = path.join(directory, file)


### PR DESCRIPTION
## Summary

Part of a larger simplify pass. Three small perf wins in the filesystem helpers that get hammered on every folder listing / image-path autocomplete keystroke:

- **`common/filesystem/index.ts`** — drop the `pathExistsSync` pre-check in `isDirectory`, `isDirectory2`, `isFile`, `isFile2`, `isSymbolicLink`. Each call previously did **two syscalls** (stat + lstat) where one suffices, and the pre-check made the predicates racy (TOCTOU). The `try { lstatSync(...) } catch { return false }` form returns the same result with half the work.
- **`common/filesystem/paths.ts`** — `isImageFile` rebuilt one `RegExp` per IMAGE_EXTENSION on every call (6 regex allocations / call). Replace with `IMAGE_EXTENSIONS.includes(ext.toLowerCase())` — pure string compare on a fixed array. Also skips the `isFile` syscall when the extension obviously doesn't match.
- **`main/utils/imagePathAutoComplement.ts`** — hoist `IMAGE_REG` out of the inner `filesHandler` so it isn't recompiled on every directory rebuild.

Net change: **3 files, -21 / +8 lines**.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` — 0 errors
- [ ] Smoke-test sidebar file tree: open a folder with many images and markdown files, confirm icons + filtering match the develop branch
- [ ] Smoke-test image path autocomplete: type an image path in the editor, confirm directory + image suggestions still appear correctly
- [ ] Smoke-test symbolic-link handling: open a folder containing a symlinked .md file, confirm it opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
