### PR TITLE
chore: misc simplifications

### DIFF
--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -40,9 +40,12 @@ export const getPath = (name: Parameters<typeof app.getPath>[0]): string => {
 }
 
 export const hasSameKeys = (a: Record<string, unknown>, b: Record<string, unknown>): boolean => {
-  const aKeys = Object.keys(a).sort()
-  const bKeys = Object.keys(b).sort()
-  return JSON.stringify(aKeys) === JSON.stringify(bKeys)
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) return false
+  aKeys.sort()
+  bKeys.sort()
+  return aKeys.every((k, i) => k === bKeys[i])
 }
 
 export type LogLevel = 'silly' | 'debug' | 'verbose' | 'info'

--- a/src/renderer/src/components/commandPalette/index.vue
+++ b/src/renderer/src/components/commandPalette/index.vue
@@ -286,7 +286,7 @@ const updateCommands = () => {
     availableCommands.value = cmd.subcommands ?? []
   } else {
     availableCommands.value = (cmd.subcommands ?? []).filter(
-      (c) => (c.description ?? '').toLowerCase().indexOf(queryString.toLowerCase()) !== -1
+      (c) => (c.description ?? '').toLowerCase().includes(queryString.toLowerCase())
     )
   }
   selectedCommandIndex.value = availableCommands.value.length ? 0 : -1

--- a/src/renderer/src/components/search/index.vue
+++ b/src/renderer/src/components/search/index.vue
@@ -144,7 +144,7 @@ import FindRegexIcon from '@/assets/icons/searchIcons/iconRegex.svg'
 import { useEditorStore } from '@/store/editor'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
-import { debounce } from 'underscore'
+import debounce from 'lodash/debounce'
 import { ArrowDown, ArrowUp, RefreshRight, Switch } from '@element-plus/icons-vue'
 
 const { t } = useI18n()


### PR DESCRIPTION
## Summary

Last batch of the simplify pass — three small, unrelated cleanups grouped to avoid one-line PRs.

- **`components/search/index.vue`** — switch the debounce import from `underscore` to `lodash/debounce`. `lodash` is already a renderer dependency; `underscore` was only being pulled into the renderer for this one import (it's otherwise a Muya-only dependency via `sequence-diagram-snap`).
- **`components/commandPalette/index.vue`** — replace `.toLowerCase().indexOf(q) !== -1` with `.toLowerCase().includes(q)`.
- **`main/utils/index.ts`** — `hasSameKeys` was stringifying both sorted key arrays and comparing the JSON strings. Compare lengths first, then walk the arrays — same result, no allocations.

Net change: **3 files, +8 / -5 lines**.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` — 0 errors
- [ ] Smoke-test in-file search (debounced search input)
- [ ] Smoke-test command palette filtering
- [ ] Open Preferences and change a value (exercises `hasSameKeys` in the preferences write path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
