### PR TITLE
chore: bump develop to 0.20.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marktext",
-  "version": "0.19.0",
+  "version": "0.20.0-dev",
   "description": "MarkText",
   "main": "./out/main/index.js",
   "author": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` `version` from `0.19.0` to `0.20.0-dev` on `develop`.

Follow-up to the v0.19.0 stable release ([release page](https://github.com/marktext/marktext/releases/tag/v0.19.0), tracking PR #4269 merged at 2026-05-28). Opens the next development cycle.

## Test plan

- [x] Single-file change to `package.json` `version` field
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)