### PR TITLE
docs(release): update Step 7 asset list to 24

### DIFF
--- a/docs/dev/RELEASE.md
+++ b/docs/dev/RELEASE.md
@@ -74,7 +74,14 @@ gh release view vX.Y.Z-rc.N
 Confirm:
 
 - `Pre-release` badge on the release page (RC only)
-- **12 assets**: 5 Linux (`AppImage`, `deb`, `rpm`, `snap`, `tar.gz`) + 4 macOS (`arm64.dmg`, `arm64.zip`, `x64.dmg`, `x64.zip`) + 2 Windows (`setup.exe`, `zip`) + `SHA256SUMS.txt`
+- **24 assets**:
+  - **Linux** (5): `AppImage`, `deb`, `rpm`, `snap`, `tar.gz`
+  - **macOS arm64** (4): `dmg`, `dmg.blockmap`, `zip`, `zip.blockmap`
+  - **macOS x64** (4): `dmg`, `dmg.blockmap`, `zip`, `zip.blockmap`
+  - **Windows x64** (3): `setup.exe`, `setup.exe.blockmap`, `zip`
+  - **Windows arm64** (3): `setup.exe`, `setup.exe.blockmap`, `zip`
+  - **Auto-updater metadata** (4): `latest.yml`, `latest-mac.yml`, `latest-linux.yml`, `builder-debug.yml`
+  - **Checksums** (1): `SHA256SUMS.txt`
 - Auto-generated release notes list the PRs merged since the previous tag
 
 ## 8. Post-stable cleanup (after stable `vX.Y.0` ships)


### PR DESCRIPTION
## Summary

Step 7 in `docs/dev/RELEASE.md` still said **12 assets**. Two later PRs expanded the matrix:

- **#4272** — auto-updater metadata (`latest.yml`, `latest-mac.yml`, `latest-linux.yml`, `builder-debug.yml`, plus `.blockmap` files)
- **#4279** — Windows ARM64 (`setup.exe`, `setup.exe.blockmap`, `zip`)

v0.19.0 stable shipped **24 assets**. Update Step 7 to reflect the current matrix so future verification doesn't get a false alarm.

## Test plan

- [x] Docs-only change; no code or CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)