### PR TITLE
docs(end-user): align user docs with 0.19 prefs and platform matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ MarkText is an open-source Markdown editor powered by the support of its communi
 
 ## Download and Installation
 
-![platform](https://img.shields.io/static/v1.svg?label=Platform&message=Linux-64%20|%20macOS-64%20|%20Win-64&style=for-the-badge)
+![platform](https://img.shields.io/static/v1.svg?label=Platform&message=Linux%20x64%20|%20macOS%20x64%2Farm64%20|%20Windows%20x64%2Farm64&style=for-the-badge)
 
 | ![](https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/mac-pass-sm.png)                                                                                         | ![](https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/windows-pass-sm.png)                                                                                         | ![](https://raw.githubusercontent.com/wiki/ryanoasis/nerd-fonts/screenshots/v1.0.x/linux-pass-sm.png)                                                                                                       |
 |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
@@ -134,7 +134,9 @@ Want to see new features of the latest version? Please refer to [CHANGELOG](docs
 
 #### macOS
 
-You can either download the latest `marktext-%version%.dmg` from the [release page](https://github.com/marktext/marktext/releases/latest) or install MarkText using [**homebrew cask**](https://github.com/caskroom/homebrew-cask). To use Homebrew-Cask you just need to have [Homebrew](https://brew.sh/) installed.
+Requires macOS 11 (Big Sur) or later. Universal builds aren't published — pick the matching `arm64` or `x64` installer.
+
+You can either download the latest `marktext-mac-(arm64|x64)-%version%.dmg` from the [release page](https://github.com/marktext/marktext/releases/latest) or install MarkText using [**homebrew cask**](https://github.com/caskroom/homebrew-cask). To use Homebrew-Cask you just need to have [Homebrew](https://brew.sh/) installed.
 
 ```bash
 brew install --cask mark-text
@@ -142,7 +144,9 @@ brew install --cask mark-text
 
 #### Windows
 
-Simply download and install MarkText via setup wizard (`marktext-setup-%version%.exe`) and choose whether to install per-user or machine wide. Alternatively, install MarkText using a package manager such as [Chocolatey](https://chocolatey.org/) or [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
+Requires Windows 10 or 11. Both x64 and arm64 installers are published — pick the architecture that matches your machine.
+
+Simply download and install MarkText via the setup wizard (`marktext-win-(x64|arm64)-%version%-setup.exe`) and choose whether to install per-user or machine wide. Alternatively, install MarkText using a package manager such as [Chocolatey](https://chocolatey.org/) or [Winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/).
 
 To use Chocolatey, you need to have [Chocolatey](https://chocolatey.org/install) installed:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the end-user documentation of MarkText.
 - [Command line interface](end-user/CLI.md)
 - [Environment variables](end-user/ENVIRONMENT.md)
 - [Export a document](end-user/EXPORT.md)
+- [Image handling](end-user/IMAGES.md)
 - [Image uploader configuration](end-user/IMAGE_UPLOADER_CONFIGRATION.md)
 - [Installation instructions](../README.md#download-and-installation)
 - [Key bindings](end-user/KEYBINDINGS.md)

--- a/docs/end-user/BASICS.md
+++ b/docs/end-user/BASICS.md
@@ -12,7 +12,7 @@ MarkText is a realtime preview editor for markdown with various markdown extensi
 
 The sidebar consists of three panels and you can toggle the sidebar by pressing <kbd>CmdOrCtrl</kbd>+<kbd>J</kbd>:
 
-- Filesystem explorer (tree view) of the opened root directory
+- Filesystem explorer (tree view) of the opened root directory. The tree also exposes a collapsible *Opened Files* subsection — toggle it via the `openedFilesInSidebar` preference.
 - Find in files
 - Table of contents of the selected tab
 

--- a/docs/end-user/CLI.md
+++ b/docs/end-user/CLI.md
@@ -10,6 +10,7 @@ Usage: marktext [commands] [path ...]
     -n, --new-window              Open a new window on second-instance
         --user-data-dir           Change the user data directory
         --disable-gpu             Disable GPU hardware acceleration
+        --disable-spellcheck      Disable the spell checker for this session
     -v, --verbose                 Be verbose
         --version                 Print version information
     -h, --help                    Print this help message

--- a/docs/end-user/ENVIRONMENT.md
+++ b/docs/end-user/ENVIRONMENT.md
@@ -9,8 +9,7 @@
 
 ## Development
 
-| Name                                 | Description                                                  |
-| ------------------------------------ | ------------------------------------------------------------ |
-| `MARKTEXT_EXIT_ON_ERROR`             | Exit on the first error or exception that occurs.            |
-| `MARKTEXT_DEV_HIDE_BROWSER_ANALYZER` | Don't show the dependency analyzer.                          |
-| `MARKTEXT_IS_STABLE`                 | **Please don't use this!** Used to identify stable releases. |
+| Name                     | Description                                                  |
+| ------------------------ | ------------------------------------------------------------ |
+| `MARKTEXT_EXIT_ON_ERROR` | Exit on the first error or exception that occurs.            |
+| `MARKTEXT_IS_STABLE`     | **Please don't use this!** Used to identify stable releases. |

--- a/docs/end-user/FAQ.md
+++ b/docs/end-user/FAQ.md
@@ -5,8 +5,8 @@
 MarkText is a desktop application and available for:
 
 - Linux x64 (tested on Debian and Red Hat based distros)
-- macOS 10.10 x64 or later
-- Windows 7-10 x86 and x64
+- macOS 11 (Big Sur) or later, x64 and arm64 (Apple Silicon)
+- Windows 10 or 11, x64 and arm64
 
 ### Is MarkText open-source and free?
 
@@ -22,7 +22,7 @@ Documentation is currently under development.
 
 - [End-user documentation](https://github.com/marktext/marktext/blob/develop/docs/README.md)
 
-- [Developer documentation](https://github.com/marktext/marktext/blob/develop/../dev/README.md)
+- [Developer documentation](https://github.com/marktext/marktext/blob/develop/docs/dev/README.md)
 
 ### Can I run a portable version of MarkText?
 

--- a/docs/end-user/IMAGE_UPLOADER_CONFIGRATION.md
+++ b/docs/end-user/IMAGE_UPLOADER_CONFIGRATION.md
@@ -1,25 +1,7 @@
-#### Image Uploader Configration
+#### Image Uploader Configuration
 
 ##### PicGo
 
-PicGo is a CLI tool to upload images to various cloud providers. Please see [here](https://picgo.github.io/PicGo-Doc/en/guide/) of more information.
+PicGo is a CLI tool that uploads images to various cloud providers. See the [PicGo documentation](https://picgo.github.io/PicGo-Doc/en/guide/) for installation, configuration, and supported backends.
 
-##### GitHub
-
-> NOTE: This uploader is deprecated and will be replaced by PicGo in version 0.18.
-
-1. Step 1, Create a GitHub [repo](https://github.com/new).
-
-![5ce17b03726c384991](https://i.loli.net/2019/05/19/5ce17b03726c384991.png)
-
-2. Step 2, Create a GitHub token in [Settings/Developer settings.](https://github.com/settings/tokens)
-
-![5ce17bd849d5589341](https://i.loli.net/2019/05/19/5ce17bd849d5589341.png)
-
-3. Config in MarkText Preferences window. click `CmdOrCtrl + ,` to open MarkText Preferences window.
-
-![5ce17cb97b0f111638](https://i.loli.net/2019/05/19/5ce17cb97b0f111638.png)
-
-4. Input you `token`, `owner name` and `repo name` whick you just created. Click `Save` and `Set As default Uploader`.
-
-5. Paste an image into MarkText and open you created repo to see the uploaded image.
+Once PicGo is installed and configured, point MarkText at the PicGo executable in *Preferences → Image* and choose `upload` as the *image insert action* (or use it on demand from the image overlay). PicGo is the only built-in uploader; the legacy GitHub uploader was removed in 0.19.

--- a/docs/end-user/PREFERENCES.md
+++ b/docs/end-user/PREFERENCES.md
@@ -1,89 +1,132 @@
 ## MarkText Preferences
 
-Preferences can be controlled and modified in the settings window or via the `preferences.json` file in the [application data directory](APPLICATION_DATA_DIRECTORY.md).
+Preferences can be controlled and modified in the settings window or via the `preferences.json` file in the [application data directory](APPLICATION_DATA_DIRECTORY.md). The authoritative list of keys, defaults, and accepted values lives in `src/main/preferences/schema.json` — the tables below mirror that schema.
 
 #### General
 
-| Key                    | Type    | Default Value | Description                                                                                                                                                |
-| ---------------------- | ------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| autoSave               | Boolean | false         | Automatically save the content being edited. option value: true, false                                                                                     |
-| autoSaveDelay          | Number  | 5000          | The delay in milliseconds after a changed file is saved automatically? 1000 ~10000                                                                         |
-| titleBarStyle          | String  | custom        | The title bar style on Linux and Window: `custom` or `native`                                                                                              |
-| openFilesInNewWindow   | Boolean | false         | true, false                                                                                                                                                |
-| openFolderInNewWindow  | Boolean | false         | true, false                                                                                                                                                |
-| zoom                   | Number  | 1.0           | The zoom level. Between 0.5 and 2.0 inclusive.                                                                                              |
-| hideScrollbar          | Boolean | false         | Whether to hide scrollbars. Optional value: true, false                                                                                                    |
-| wordWrapInToc          | Boolean | false         | Whether to enable word wrap in TOC. Optional value: true, false                                                                                            |
-| fileSortBy             | String  | created       | Sort files in opened folder by `created` time, modified time and title.                                                                                    |
-| startUpAction          | String  | lastState     | The action after MarkText startup, open the last edited content, open the specified folder or blank page, optional value: `lastState`, `folder`, `blank` |
-| defaultDirectoryToOpen | String  | `""`          | The path that should be opened if `startUpAction=folder`.                                                                                                  |
-| language               | String  | en            | The language MarkText use.                                                                                                                                |
+| Key                    | Type    | Default       | Description                                                                                                                |
+| ---------------------- | ------- | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| autoSave               | Boolean | `false`       | Automatically save the content being edited.                                                                               |
+| autoSaveDelay          | Number  | `5000`        | The delay in milliseconds after a change before a file is saved automatically. Minimum `1000`.                             |
+| titleBarStyle          | String  | `custom`      | The title bar style on Linux and Windows: `custom` or `native`.                                                            |
+| openFilesInNewWindow   | Boolean | `false`       | Open files in a new window.                                                                                                |
+| openFolderInNewWindow  | Boolean | `false`       | Open folder via menu in a new window.                                                                                      |
+| zoom                   | Number  | `1.0`         | The zoom level. Between `0.5` and `2.0` inclusive.                                                                         |
+| hideScrollbar          | Boolean | `false`       | Whether to hide scrollbars.                                                                                                |
+| wordWrapInToc          | Boolean | `false`       | Whether to enable word wrap in the table of contents.                                                                      |
+| fileSortBy             | String  | `modified`    | Sort files in the opened folder. Optional values: `created`, `modified`, `title`.                                          |
+| fileSortOrder          | String  | `asc`         | Sort order for files in opened folders: `asc` (ascending) or `desc` (descending).                                          |
+| startUpAction          | String  | `restoreAll`  | The action when MarkText launches. Optional values: `folder`, `openLastFolder`, `blank`, `restoreAll`.                     |
+| defaultDirectoryToOpen | String  | `""`          | The path that should be opened when `startUpAction=folder`.                                                                |
+| language               | String  | `en`          | The display language MarkText uses.                                                                                        |
+| restoreLayoutState     | Boolean | `true`        | Restore the previous editor state (open tabs, layout) on startup.                                                          |
+| openedFilesInSidebar   | Boolean | `true`        | Whether to show the *Opened Files* subsection inside the sidebar file tree.                                                |
 
 #### Editor
 
-| Key                                | Type    | Defaut             | Description                                                                                                                                                                   |
-| ---------------------------------- | ------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| fontSize                           | Number  | 16                 | Font size in pixels. 12 ~ 32                                                                                                                                                   |
-| editorFontFamily                   | String  | Open Sans          | Font Family                                                                                                                                                                    |
-| lineHeight                         | Number  | 1.6                | Line Height                                                                                                                                                                    |
-| autoPairBracket                    | Boolean | true               | Automatically brackets when editing                                                                                                                                            |
-| autoPairMarkdownSyntax             | Boolean | true               | Autocomplete markdown syntax                                                                                                                                                   |
-| autoPairQuote                      | Boolean | true               | Automatic completion of quotes                                                                                                                                                 |
-| endOfLine                          | String  | default            | The newline character used at the end of each line. The default value is default, which selects your operating system's default newline character. `lf` `crlf` `default`         |
-| textDirection                      | String  | ltr                | The writing text direction, optional value: `ltr` or `rtl`                                                                                                                     |
-| codeFontSize                       | Number  | 14                 | Font size on code block, the range is 12 ~ 28                                                                                                                                  |
-| codeFontFamily                     | String  | `DejaVu Sans Mono` | Code font family                                                                                                                                                               |
-| trimUnnecessaryCodeBlockEmptyLines | Boolean | true               | Whether to trim the beginning and end empty line in Code block                                                                                                                 |
-| hideQuickInsertHint                | Boolean | false              | Hide hint for quickly creating paragraphs                                                                                                                                      |
-| imageDropAction                    | String  | folder             | The default behavior after paste or drag the image to MarkText, upload it to the image cloud (if configured), move to the specified folder, insert the path          |
-| defaultEncoding                    | String  | `utf8`             | The default file encoding                                                                                                                                                      |
-| autoGuessEncoding                  | Boolean | true               | Try to automatically guess the file encoding when opening files                                                                                                                |
-| trimTrailingNewline                | Enum    | `2`                | Ensure a single trailing newline or whether trailing newlines should be removed: `0`: trim all trailing newlines, `1`: ensure single newline, `2`: auto detect, `3`: disabled. |
-| hideLinkPopup                      | Boolean | false              | It will not show the link popup when hover over the link if set `hideLinkPopup` to true                                                                                        |
-| autoCheck                          | Boolean | false              | Whether to automatically check related task. Optional value: true, false                                                                                             |
+| Key                                | Type    | Default            | Description                                                                                                                                                                          |
+| ---------------------------------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| editorFontFamily                   | String  | `Open Sans`        | Editor font family.                                                                                                                                                                  |
+| fontSize                           | Number  | `16`               | Font size in pixels. Range `12`–`32`.                                                                                                                                                |
+| lineHeight                         | Number  | `1.6`              | Line height. Range `1.2`–`2.0`.                                                                                                                                                      |
+| wrapCodeBlocks                     | Boolean | `true`             | Wrap text inside code blocks.                                                                                                                                                        |
+| editorLineWidth                    | String  | `""`               | Maximum editor area width. Empty or a value with a `ch`, `px` or `%` suffix.                                                                                                         |
+| codeFontSize                       | Number  | `14`               | Font size inside code blocks. Range `12`–`28`.                                                                                                                                       |
+| codeFontFamily                     | String  | `DejaVu Sans Mono` | Code-block font family.                                                                                                                                                              |
+| codeBlockLineNumbers               | Boolean | `true`             | Show line numbers inside code blocks.                                                                                                                                                |
+| trimUnnecessaryCodeBlockEmptyLines | Boolean | `true`             | Trim the beginning and ending empty lines in code blocks.                                                                                                                            |
+| autoPairBracket                    | Boolean | `true`             | Auto-close brackets when editing.                                                                                                                                                    |
+| autoPairMarkdownSyntax             | Boolean | `true`             | Autocomplete markdown syntax.                                                                                                                                                        |
+| autoPairQuote                      | Boolean | `true`             | Auto-close quotes.                                                                                                                                                                   |
+| endOfLine                          | String  | `default`          | Newline character at the end of each line: `default` (OS default), `lf`, or `crlf`.                                                                                                  |
+| defaultEncoding                    | String  | `utf8`             | The default file encoding. See `src/main/preferences/schema.json` for the full enum (35 encodings).                                                                                  |
+| autoGuessEncoding                  | Boolean | `true`             | Try to automatically guess the file encoding when opening files.                                                                                                                     |
+| trimTrailingNewline                | Number  | `2`                | Trailing-newline handling: `0` trim all, `1` ensure single newline, `2` auto-detect, `3` disabled.                                                                                   |
+| textDirection                      | String  | `ltr`              | Writing direction: `ltr` or `rtl`.                                                                                                                                                   |
+| hideQuickInsertHint                | Boolean | `false`            | Hide the hint for the quick-insert overlay.                                                                                                                                          |
+| hideLinkPopup                      | Boolean | `false`            | Hide the link popup when the cursor hovers over a link.                                                                                                                              |
+| autoCheck                          | Boolean | `false`            | Whether to automatically check related task items when one is toggled.                                                                                                               |
+| autoNormalizeLineEndings           | Boolean | `false`            | Automatically normalize line endings when opening files. When disabled, files are opened as-is.                                                                                      |
 
 #### Markdown
 
-| Key                 | Type    | Default | Description                                                                                                                          |
-| ------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| preferLooseListItem | Boolean | true    | The preferred list type.                                                                                                             |
-| bulletListMarker    | String  | `-`     | The preferred marker used in bullet list, optional value: `-`, `*` `+`                                                               |
-| orderListDelimiter  | String  | `.`     | The preferred delimiter used in order list, optional value: `.` `)`                                                                  |
-| preferHeadingStyle  | String  | `atx`   | The preferred heading style in MarkText, optional value `atx` `setext`, [more info](https://spec.commonmark.org/0.31.2/#atx-headings) |
-| tabSize             | Number  | 4       | The number of spaces a tab is equal to                                                                                               |
-| listIndentation     | String  | 1       | The list indentation of sub list items or paragraphs, optional value `dfm`, `tab` or number 1~4                                      |
-| frontmatterType     | String  | `-`     | The frontmatter type: `-` (YAML), `+` (TOML), `;` (JSON) or `{` (JSON)                                                               |
-| superSubScript      | Boolean | `false` | Enable pandoc's markdown extension superscript and subscript.                                                                        |
-| footnote            | Boolean | `false` | Enable pandoc's footnote markdown extension                                                                                          |
-| sequenceTheme       | String  | `hand`  | Change the theme of [js-sequence-diagrams](https://bramp.github.io/js-sequence-diagrams/)                                                                                         |
+| Key                          | Type    | Default | Description                                                                                                                          |
+| ---------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| preferLooseListItem          | Boolean | `true`  | The preferred list type.                                                                                                             |
+| bulletListMarker             | String  | `-`     | Marker for bullet lists. Optional values: `-`, `*`, `+`.                                                                             |
+| orderListDelimiter           | String  | `.`     | Delimiter for ordered lists. Optional values: `.`, `)`.                                                                              |
+| preferHeadingStyle           | String  | `atx`   | Heading style. Optional values: `atx`, `setext` ([details](https://spec.commonmark.org/0.31.2/#atx-headings)).                       |
+| tabSize                      | Number  | `4`     | Number of spaces a tab equals.                                                                                                       |
+| listIndentation              | Mixed   | `1`     | List indentation. Optional values: `dfm`, `tab`, or a number `1`–`4`.                                                                |
+| frontmatterType              | String  | `-`     | Frontmatter delimiter: `-` (YAML), `+` (TOML), `;` (JSON), or `{` (JSON).                                                            |
+| superSubScript               | Boolean | `false` | Enable pandoc's superscript/subscript markdown extension.                                                                            |
+| footnote                     | Boolean | `false` | Enable pandoc's footnote markdown extension.                                                                                         |
+| isHtmlEnabled                | Boolean | `true`  | Enable inline HTML rendering.                                                                                                        |
+| isGitlabCompatibilityEnabled | Boolean | `false` | Enable GitLab compatibility mode.                                                                                                    |
+| sequenceTheme                | String  | `hand`  | Theme for [js-sequence-diagrams](https://bramp.github.io/js-sequence-diagrams/): `hand` or `simple`.                                 |
 
 #### Theme
 
-| Key   | Type   | Default | Description                                                           |
-| ----- | ------ | ------- | --------------------------------------------------------------------- |
-| theme | String | light   | `dark`, `graphite`, `material-dark`, `one-dark`, `light` or `ulysses` |
+| Key               | Type    | Default | Description                                                                                                                  |
+| ----------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| theme             | String  | `light` | The current theme id. See [Themes](THEMES.md) for the full list.                                                             |
+| followSystemTheme | Boolean | `false` | Follow the system light/dark mode and switch automatically.                                                                  |
+| lightModeTheme    | String  | `light` | Theme id used when the system is in light mode (only when `followSystemTheme` is `true`).                                    |
+| darkModeTheme     | String  | `dark`  | Theme id used when the system is in dark mode (only when `followSystemTheme` is `true`).                                     |
+
+#### Spelling
+
+| Key                    | Type    | Default | Description                                                                  |
+| ---------------------- | ------- | ------- | ---------------------------------------------------------------------------- |
+| spellcheckerEnabled    | Boolean | `false` | Whether spell checking is enabled.                                           |
+| spellcheckerNoUnderline | Boolean | `false` | Don't underline spelling mistakes.                                          |
+| spellcheckerLanguage   | String  | `en-US` | The spell-checker language (BCP-47, e.g. `en-US`, `de-DE`, `zh-CN`).         |
+
+#### Image
+
+| Key                          | Type    | Default  | Description                                                                                                  |
+| ---------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| imageInsertAction            | String  | `path`   | Default action after inserting a local image: `upload`, `folder`, or `path`.                                 |
+| imagePreferRelativeDirectory | Boolean | `false`  | Prefer the relative image directory when copying images.                                                     |
+| imageRelativeDirectoryBase   | String  | `file`   | Where relative images are anchored: `file` (next to the document) or `folder` (project root).                |
+| imageRelativeDirectoryName   | String  | `assets` | Folder name (or relative path) used for local image copies. Supports the `${filename}` variable.             |
 
 #### Editable via file
 
-These entires don't have a settings option and need to be changed manually.
+These entries are marked `--internal` in the schema. They have no UI control and must be edited directly in `preferences.json`.
 
 ##### View
 
-| Key                           | Type    | Default | Description                                        |
-| ----------------------------- | ------- | ------- | -------------------------------------------------- |
-| sideBarVisibility<sup>*</sup> | Boolean | false   | Controls the visibility of the sidebar.            |
-| tabBarVisibility<sup>*</sup>  | Boolean | false   | Controls the visibility of the tabs.               |
-| sourceCodeModeEnabled*        | Boolean | false   | Controls the visibility of the source-code editor. |
+| Key                   | Type    | Default | Description                                                              |
+| --------------------- | ------- | ------- | ------------------------------------------------------------------------ |
+| sideBarVisibility     | Boolean | `false` | Initial visibility of the sidebar. Overridden by the menu / shortcut.    |
+| tabBarVisibility      | Boolean | `false` | Initial visibility of the tab bar. Overridden by the menu / shortcut.    |
+| sourceCodeModeEnabled | Boolean | `false` | Initial source-code mode state. Overridden by the menu / shortcut.       |
 
-\*: These options are default/fallback values that are used if not session is loaded and are overwritten by the menu entries.
+##### General (internal)
 
-##### File system
+| Key              | Type   | Default | Description                                                          |
+| ---------------- | ------ | ------- | -------------------------------------------------------------------- |
+| lastOpenedFolder | String | `""`    | The last folder opened in MarkText (used for session restore).       |
 
-| Key                  | Type             | Default | Description                                                                                                                                                      |
-| -------------------- | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| searchExclusions     | Array of Strings | `[]`    | The filename exclusions for the file searcher. Default: `'*.markdown', '*.mdown', '*.mkdn', '*.md', '*.mkd', '*.mdwn', '*.mdtxt', '*.mdtext', '*.mdx', '*.text', '*.txt'` |
-| searchMaxFileSize    | String           | `""`    | The maximum file size to search in (e.g. 50K or 10MB). Default: unlimited                                                                                        |
-| searchIncludeHidden  | Boolean          | false   | Search hidden files and directories                                                                                                                              |
-| searchNoIgnore       | Boolean          | false   | Don't respect ignore files such as `.gitignore`.                                                                                                                 |
-| searchFollowSymlinks | Boolean          | true    | Whether to follow symbolic links.                                                                                                                                |
-| watcherUsePolling    | Boolean          | false   | Whether to use polling to receive file changes. Polling may leads to high CPU utilization.                                                                       |
+##### Custom CSS
+
+| Key       | Type   | Default | Description                                            |
+| --------- | ------ | ------- | ------------------------------------------------------ |
+| customCss | String | `""`    | Extra CSS appended after the active theme stylesheet.  |
+
+##### File system / Searcher
+
+| Key                  | Type             | Default | Description                                                                                                                                                              |
+| -------------------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| searchExclusions     | Array of Strings | `[]`    | Filename glob exclusions for the in-folder search.                                                                                                                       |
+| searchMaxFileSize    | String           | `""`    | Maximum file size to search in (e.g. `50K`, `10M`, `2G`). Empty means unlimited.                                                                                         |
+| searchIncludeHidden  | Boolean          | `false` | Search hidden files and directories.                                                                                                                                     |
+| searchNoIgnore       | Boolean          | `false` | Don't respect ignore files such as `.gitignore`.                                                                                                                         |
+| searchFollowSymlinks | Boolean          | `true`  | Whether to follow symbolic links.                                                                                                                                        |
+
+##### Watcher
+
+| Key               | Type    | Default | Description                                                                                                            |
+| ----------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| watcherUsePolling | Boolean | `false` | Use polling to receive file changes. Necessary for network shares; may cause high CPU utilization on large workspaces. |

--- a/docs/end-user/THEMES.md
+++ b/docs/end-user/THEMES.md
@@ -2,6 +2,8 @@
 
 MarkText includes 33 built-in themes organized into Light and Dark categories. Each theme provides a complete color scheme for the editor interface and syntax highlighting.
 
+The names below match the labels shown in the **Theme** menu. The underlying id stored in `preferences.json` under the `theme` field can differ — e.g. *Cadmium Light* → `light`, *Cadmium Dark* → `dark`, *Graphite Light* → `graphite`, *Ulysses Light* → `ulysses`. The full label↔id mapping lives in `src/main/menu/templates/theme.ts`.
+
 ## Light Themes
 
 | Theme | Description |
@@ -69,7 +71,7 @@ You can switch themes in several ways:
 
 | Dark | Material Dark |
 |------|---------------|
-| ![Dark](../themeImages/dark.png) | ![Material Dark](../themeImages/materal-dark.png) |
+| ![Dark](../themeImages/dark.png) | ![Material Dark](../themeImages/material-dark.png) |
 
 | One Dark | Dracula |
 |----------|---------|


### PR DESCRIPTION
## Summary

Companion to #4299. Brings the end-user docs and the top-level README back in line with what 0.19 actually ships.

- **PREFERENCES.md** — full rewrite against `src/main/preferences/schema.json`. Adds the keys that landed since the table was last touched (`fileSortOrder`, `openedFilesInSidebar`, `wrapCodeBlocks`, `editorLineWidth`, `codeBlockLineNumbers`, `autoNormalizeLineEndings`, `isHtmlEnabled`, `isGitlabCompatibilityEnabled`, `followSystemTheme` / `lightModeTheme` / `darkModeTheme`, `restoreLayoutState`, `customCss`, the `spellchecker*` trio, `imageInsertAction` and the `image*` relative-directory trio). Fixes stale defaults / enums (`startUpAction` default is `restoreAll`, `fileSortBy` default is `modified`, `imageDropAction` is now `imageInsertAction`).
- **IMAGE_UPLOADER_CONFIGRATION.md** — strip the GitHub-uploader section. It was removed in #4276; PicGo is the only built-in uploader now.
- **CLI.md** — document the `--disable-spellcheck` flag.
- **FAQ.md** — refresh the supported-platforms list (macOS 11+ x64/arm64, Windows 10/11 x64/arm64 after the Windows arm64 build in #4279) and fix a broken developer-docs link.
- **THEMES.md** — explain that the menu labels map to different ids in `preferences.json` (e.g. *Cadmium Light* → `light`) and fix the `materal-dark.png` typo in the screenshot table.
- **ENVIRONMENT.md** — drop the no-longer-used `MARKTEXT_DEV_HIDE_BROWSER_ANALYZER` row.
- **BASICS.md** — note the new collapsible *Opened Files* subsection in the sidebar (toggle via `openedFilesInSidebar`, #4278).
- **docs/README.md** — add a link to `IMAGES.md`.
- **README.md** — refresh the platform badge and the macOS / Windows install sections so they describe the actual installer file names and reflect the Windows arm64 build.

## Test plan

- [ ] Skim the rendered Markdown on GitHub for layout regressions
- [ ] Schema↔doc parity (should print empty sets):
      \`\`\`bash
      python3 -c \"import json,re;s=set(json.load(open('src/main/preferences/schema.json')).keys());d=set(re.findall(r'\\\\| (\\\\w+) +\\\\|', open('docs/end-user/PREFERENCES.md').read()))-{'Default','Key'};print(sorted(s-d), sorted(d-s))\"
      \`\`\`
- [ ] \`rg 'imageDropAction|MARKTEXT_DEV_HIDE_BROWSER_ANALYZER|materal-dark' docs/ README.md\` returns nothing
- [ ] \`ls docs/themeImages/material-dark.png\` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)