### PR TITLE
feat(website): serve www.marktext.me (301 → apex)

### DIFF
--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -15,6 +15,19 @@ const config: NextConfig = {
   },
   experimental: {
     optimizePackageImports: ['katex']
+  },
+  // marktext.me is canonical; redirect www -> apex permanently so SEO doesn't
+  // index duplicate hostnames. Both are bound as Worker Custom Domains in
+  // wrangler.toml, so the Worker handles www requests before issuing the 301.
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'www.marktext.me' }],
+        destination: 'https://marktext.me/:path*',
+        permanent: true
+      }
+    ]
   }
 }
 

--- a/packages/website/wrangler.toml
+++ b/packages/website/wrangler.toml
@@ -7,13 +7,18 @@ compatibility_flags = ["nodejs_compat"]
 directory = ".open-next/assets"
 binding = "ASSETS"
 
-# Bind marktext.me as a Worker Custom Domain. The zone lives on the same
-# account as CLOUDFLARE_API_TOKEN (verified 2026-05-29), so wrangler will
-# create the route + DNS record automatically on first deploy. If the apex
-# currently has a conflicting A/AAAA/CNAME record, delete it first or the
-# deploy will refuse to bind the domain.
+# Bind both apex and www as Worker Custom Domains. The zone lives on the same
+# Cloudflare account as CLOUDFLARE_API_TOKEN (verified 2026-05-29), so wrangler
+# creates the route + DNS record for each automatically. If either hostname has
+# an existing A/AAAA/CNAME record, delete it first or the deploy will refuse to
+# bind. The Worker (via next.config.ts redirects) sends www -> apex with 301 so
+# only the canonical hostname is indexed.
 [[routes]]
 pattern = "marktext.me"
+custom_domain = true
+
+[[routes]]
+pattern = "www.marktext.me"
 custom_domain = true
 
 [observability]


### PR DESCRIPTION
Adds `www.marktext.me` as a second Worker Custom Domain. Worker 301-permanents `www.marktext.me/*` → `marktext.me/*` via Next.js `redirects()`, so SEO indexes only the canonical hostname.

## Prerequisites (already done)
- [x] Apex DNS records cleared (done previously)
- [x] www.marktext.me DNS records cleared (user confirmed)

## After merge
`Deploy (production)` will bind both apex and www as Custom Domains on the `marktext-website` Worker. Cloudflare auto-creates the routing records.