### PR TITLE
fix(website): www→apex redirect (middleware) + smarter preview-URL parsing

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -74,56 +74,79 @@ jobs:
 
       # ---- Preview deploy: pull_request ----
       #
-      # `wrangler versions upload` only updates an EXISTING worker. If this is
-      # the very first time the worker is being deployed, the API returns
-      # "Could not route to /accounts/.../workers/services/marktext-website".
-      # In that case we treat the preview step as soft-failed: the build is
-      # still proven green, and the worker will be bootstrapped automatically
-      # on the next push to `develop` (which uses `wrangler deploy`).
+      # Uploads a Worker version tagged + aliased with the PR number. With
+      # Preview URLs enabled on the Worker (Cloudflare dashboard → Workers &
+      # Pages → marktext-website → Settings → Preview URLs), wrangler emits a
+      # URL like https://pr-NNNN-marktext-website.<subdomain>.workers.dev that
+      # stays stable for the life of the PR. If the URL is not present in the
+      # output, the Preview URLs feature is off and we report that via a
+      # notice on the PR rather than failing the build.
       - name: Deploy preview
         id: preview
         if: github.event_name == 'pull_request'
         working-directory: packages/website
         run: |
           set +e
+          ALIAS="pr-${{ github.event.pull_request.number }}"
           pnpm exec wrangler versions upload \
             --message "PR #${{ github.event.pull_request.number }} @ ${{ github.event.pull_request.head.sha }}" \
-            --tag "pr-${{ github.event.pull_request.number }}" \
+            --tag "$ALIAS" \
+            --preview-alias "$ALIAS" \
             > upload.log 2>&1
-          status=$?
+          upload_status=$?
           cat upload.log
-          if [ $status -ne 0 ]; then
-            if grep -q "Could not route to" upload.log; then
-              echo "bootstrapped=false" >> "$GITHUB_OUTPUT"
-              echo "::warning::Worker 'marktext-website' is not bootstrapped yet. Merge this PR to develop to create it; subsequent PRs will get real preview URLs."
-              exit 0
-            fi
-            exit $status
+
+          if [ $upload_status -ne 0 ] && grep -q "Could not route to" upload.log; then
+            echo "result=not-bootstrapped" >> "$GITHUB_OUTPUT"
+            echo "::warning::Worker 'marktext-website' is not bootstrapped yet. Merge this PR to develop to create it; subsequent PRs will get real preview URLs."
+            exit 0
           fi
-          PREVIEW_URL=$(grep -Eo 'https://[a-z0-9-]+\.[a-z0-9-]+\.workers\.dev' upload.log | head -n1 || true)
-          if [ -z "$PREVIEW_URL" ]; then
-            echo "Could not parse preview URL from wrangler output" >&2
+          if [ $upload_status -ne 0 ]; then
+            exit $upload_status
+          fi
+
+          PREVIEW_URL=$(grep -Eo 'https://[a-z0-9-]+\.workers\.dev[^[:space:]]*' upload.log | head -n1 || true)
+          VERSION_ID=$(grep -Eo 'Worker Version ID:[[:space:]]*[a-f0-9-]+' upload.log | awk '{print $NF}' || true)
+
+          if [ -n "$PREVIEW_URL" ]; then
+            echo "result=ok"          >> "$GITHUB_OUTPUT"
+            echo "url=$PREVIEW_URL"   >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION_ID" >> "$GITHUB_OUTPUT"
+          elif [ -n "$VERSION_ID" ]; then
+            echo "result=preview-disabled" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION_ID"     >> "$GITHUB_OUTPUT"
+            echo "::warning::Worker version $VERSION_ID uploaded but no preview URL was emitted. Enable Preview URLs on the marktext-website Worker in the Cloudflare dashboard to get clickable PR previews."
+          else
+            echo "Could not parse a preview URL or version ID from wrangler output" >&2
             exit 1
           fi
-          echo "url=$PREVIEW_URL"           >> "$GITHUB_OUTPUT"
-          echo "bootstrapped=true"          >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request' && steps.preview.outputs.url != ''
+        if: github.event_name == 'pull_request' && steps.preview.outputs.result == 'ok'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: website-preview
           message: |
             **Website preview ready:** ${{ steps.preview.outputs.url }}
 
-            Built from `${{ github.event.pull_request.head.sha }}` · Worker: `marktext-website` · Tag: `pr-${{ github.event.pull_request.number }}`
+            Built from `${{ github.event.pull_request.head.sha }}` · Worker: `marktext-website` · Version: `${{ steps.preview.outputs.version }}` · Alias: `pr-${{ github.event.pull_request.number }}`
+
+      - name: Comment preview-disabled notice on PR
+        if: github.event_name == 'pull_request' && steps.preview.outputs.result == 'preview-disabled'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: website-preview
+          message: |
+            **Website preview not generated** — Preview URLs are disabled on the `marktext-website` Worker.
+
+            The version `${{ steps.preview.outputs.version }}` was uploaded successfully. To enable clickable PR previews, in the Cloudflare dashboard go to **Workers & Pages → marktext-website → Settings → Preview URLs** and turn the feature on. Subsequent PR runs will then post a real preview URL here.
 
       - name: Comment bootstrap notice on PR
-        if: github.event_name == 'pull_request' && steps.preview.outputs.bootstrapped == 'false'
+        if: github.event_name == 'pull_request' && steps.preview.outputs.result == 'not-bootstrapped'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: website-preview
           message: |
             **Website preview not generated** — the `marktext-website` Worker does not exist on Cloudflare yet.
 
-            The build itself succeeded. Merge this PR to `develop` to create the Worker (binds `marktext.me`); subsequent PRs will get a real preview URL automatically.
+            The build itself succeeded. Merge this PR to `develop` to create the Worker; subsequent PRs will get a real preview URL automatically.

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -15,20 +15,12 @@ const config: NextConfig = {
   },
   experimental: {
     optimizePackageImports: ['katex']
-  },
-  // marktext.me is canonical; redirect www -> apex permanently so SEO doesn't
-  // index duplicate hostnames. Both are bound as Worker Custom Domains in
-  // wrangler.toml, so the Worker handles www requests before issuing the 301.
-  async redirects() {
-    return [
-      {
-        source: '/:path*',
-        has: [{ type: 'host', value: 'www.marktext.me' }],
-        destination: 'https://marktext.me/:path*',
-        permanent: true
-      }
-    ]
   }
+  // www -> apex redirect lives in middleware.ts. We tried Next's redirects()
+  // here first, but OpenNext Cloudflare currently does not substitute
+  // `:path*` tokens in destination URLs, so requests landed on the literal
+  // /:path* path and 404'd. Middleware uses NextResponse.redirect and avoids
+  // the templating layer entirely.
 }
 
 initOpenNextCloudflareForDev()

--- a/packages/website/src/middleware.ts
+++ b/packages/website/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+// 301 www.marktext.me/* -> marktext.me/* so SEO indexes a single canonical
+// host. We do this in middleware rather than next.config.ts redirects()
+// because OpenNext Cloudflare does not currently substitute Next's `:path*`
+// destination tokens, which sends users to the literal /:path* URL (404).
+export function middleware(req: NextRequest) {
+  if (req.headers.get('host')?.toLowerCase() !== 'www.marktext.me') return
+  const url = req.nextUrl.clone()
+  url.host = 'marktext.me'
+  url.protocol = 'https:'
+  url.port = ''
+  return NextResponse.redirect(url, 301)
+}
+
+export const config = {
+  // Skip Next.js static + image internals so the middleware doesn't redirect
+  // chunk requests (they come from the apex anyway, but be explicit).
+  matcher: ['/((?!_next/static|_next/image|favicon\\.ico).*)']
+}


### PR DESCRIPTION
## What

Two production deploy bugs:

1. **`www.marktext.me` 308-ing to literal `https://marktext.me/:path*` → 404 white screen.** OpenNext Cloudflare does not currently substitute Next's `:path*` destination tokens. Move www→apex redirect into `src/middleware.ts` which uses `NextResponse.redirect` directly and avoids the templating layer. Drop the now-unused `redirects()` block.

2. **PR-preview workflow failed to parse a URL from `wrangler versions upload`.** Wrangler 4.x only emits a `*.workers.dev` URL when "Preview URLs" is enabled on the Worker; otherwise it just prints the Worker Version ID. Workflow now distinguishes three outcomes:
   - `ok` — URL parsed, comment with URL
   - `preview-disabled` — version uploaded but Preview URLs feature is off, guide maintainer to enable it
   - `not-bootstrapped` — Worker does not exist yet (existing notice)

## Local verification
- `pnpm --filter marktext-website run build` ✅ (middleware: 33 kB)
- `pnpm --filter marktext-website run lint` / `type-check` ✅
- Reproduced the original `:path*` → 404 on production before this fix

## After merge
- `www.marktext.me` will 301 to `marktext.me` with the correct path preserved
- Future PR runs will get a proper preview URL once you enable Preview URLs on the `marktext-website` Worker in Cloudflare dashboard → Workers & Pages → Settings → Preview URLs
