### PR TITLE
ci(website): enable Preview URLs on marktext-website Worker

### DIFF
--- a/packages/website/wrangler.toml
+++ b/packages/website/wrangler.toml
@@ -3,6 +3,11 @@ main = ".open-next/worker.js"
 compatibility_date = "2025-05-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Enables versioned preview URLs like
+# https://pr-NNN-marktext-website.<subdomain>.workers.dev which the CI workflow
+# parses out of `wrangler versions upload` output and posts back to PRs.
+preview_urls = true
+
 [assets]
 directory = ".open-next/assets"
 binding = "ASSETS"
@@ -11,8 +16,7 @@ binding = "ASSETS"
 # Cloudflare account as CLOUDFLARE_API_TOKEN (verified 2026-05-29), so wrangler
 # creates the route + DNS record for each automatically. If either hostname has
 # an existing A/AAAA/CNAME record, delete it first or the deploy will refuse to
-# bind. The Worker (via next.config.ts redirects) sends www -> apex with 301 so
-# only the canonical hostname is indexed.
+# bind. www → apex 301 redirect lives in src/middleware.ts.
 [[routes]]
 pattern = "marktext.me"
 custom_domain = true


### PR DESCRIPTION
Sets `preview_urls = true` in `wrangler.toml`. After this merges and the next `wrangler deploy` runs on develop, the Worker will emit per-version preview URLs like `https://pr-NNN-marktext-website.<subdomain>.workers.dev` from `wrangler versions upload`. The CI workflow already parses these URLs and posts them to PRs — last piece of plumbing for the "preview ready" comment to fire instead of the "preview-disabled" notice.

Bonus: this PR itself should be the first one to receive a real preview URL — after `Deploy preview` runs, watch the PR comment update from the disabled-notice to a working URL.

Tiny doc fix: the wrangler.toml comment about the www→apex redirect was still pointing at `next.config.ts` but it now lives in `src/middleware.ts` (since #4309). Updated.
