### PR TITLE
fix(window): clamp restored window size to the work area

### DIFF
--- a/packages/desktop/src/main/windows/utils.ts
+++ b/packages/desktop/src/main/windows/utils.ts
@@ -41,34 +41,58 @@ export interface WindowStateLike {
   height: number
 }
 
+/**
+ * Resolve the position and size to use when (re)opening a window.
+ *
+ * The restored size is clamped to the work area of the display the window will
+ * appear on (the display that contains the saved position, or the primary
+ * display on first start or when the saved position is off-screen) so a window
+ * whose saved size exceeds that screen never opens larger than the screen and
+ * covers the taskbar. When the saved coordinates are missing or fall outside
+ * every display, the window is centered on that display.
+ *
+ * @param windowState The persisted window bounds (from electron-window-state).
+ * @returns The position and size to apply to the BrowserWindow.
+ */
 export const ensureWindowPosition = (
   windowState: WindowStateLike
 ): { x: number; y: number; width: number; height: number } => {
-  // "workArea" doesn't work on Linux
-  const { bounds, workArea } = screen.getPrimaryDisplay()
-  const screenArea = isLinux ? bounds : workArea
+  const displays = screen.getAllDisplays()
 
   let { x, y, width, height } = windowState
-  let center = false
-  if (x === undefined || y === undefined) {
-    center = true
 
-    // First app start; check whether window size is larger than screen size
-    if (screenArea.width < width) width = screenArea.width
-    if (screenArea.height < height) height = screenArea.height
-  } else {
-    center = !screen
-      .getAllDisplays()
-      .map(
+  // Determine the display the window will be restored on: the one whose bounds
+  // contain the saved top-left corner. Fall back to the primary display on
+  // first start (no saved position) or when the saved position lies outside
+  // every display (those are re-centered below).
+  const savedX = x
+  const savedY = y
+  const savedDisplay =
+    savedX === undefined || savedY === undefined
+      ? undefined
+      : displays.find(
         (display) =>
-          x! >= display.bounds.x &&
-          x! <= display.bounds.x + display.bounds.width &&
-          y! >= display.bounds.y &&
-          y! <= display.bounds.y + display.bounds.height
+          savedX >= display.bounds.x &&
+            savedX <= display.bounds.x + display.bounds.width &&
+            savedY >= display.bounds.y &&
+            savedY <= display.bounds.y + display.bounds.height
       )
-      .some((display) => display)
-  }
-  if (center) {
+  const targetDisplay = savedDisplay ?? screen.getPrimaryDisplay()
+
+  // "workArea" doesn't work on Linux
+  const screenArea = isLinux ? targetDisplay.bounds : targetDisplay.workArea
+
+  // Clamp the restored size to the target display's work area. The saved size
+  // can exceed that screen (for example the window was last used on a larger
+  // display, or the display scale factor changed), which would otherwise open
+  // the window larger than the screen and cover the taskbar. This check
+  // previously ran only on first start (when x/y are undefined); run it on
+  // every launch. See #2928.
+  if (screenArea.width < width) width = screenArea.width
+  if (screenArea.height < height) height = screenArea.height
+
+  // Center when there is no saved position, or it lies outside every display.
+  if (savedDisplay === undefined) {
     x = Math.ceil(screenArea.x + (screenArea.width - width) / 2)
     y = Math.ceil(screenArea.y + (screenArea.height - height) / 2)
   }

--- a/packages/desktop/src/main/windows/utils.ts
+++ b/packages/desktop/src/main/windows/utils.ts
@@ -44,12 +44,12 @@ export interface WindowStateLike {
 /**
  * Resolve the position and size to use when (re)opening a window.
  *
- * The restored size is clamped to the work area of the display the window will
- * appear on (the display that contains the saved position, or the primary
- * display on first start or when the saved position is off-screen) so a window
- * whose saved size exceeds that screen never opens larger than the screen and
- * covers the taskbar. When the saved coordinates are missing or fall outside
- * every display, the window is centered on that display.
+ * The window is restored onto the display that contains its saved position (or
+ * the primary display on first start, or when the saved position is off every
+ * display). Its size is clamped to that display's work area so a window whose
+ * saved size exceeds the screen never opens larger than the screen and covers
+ * the taskbar. A saved position is kept but nudged so the window stays fully
+ * within the work area; with no saved position the window is centered.
  *
  * @param windowState The persisted window bounds (from electron-window-state).
  * @returns The position and size to apply to the BrowserWindow.
@@ -72,10 +72,12 @@ export const ensureWindowPosition = (
       ? undefined
       : displays.find(
         (display) =>
+          // Half-open bounds: a point on a shared edge (e.g. savedX ===
+          // display.bounds.x + width) belongs to the neighbouring display.
           savedX >= display.bounds.x &&
-            savedX <= display.bounds.x + display.bounds.width &&
+            savedX < display.bounds.x + display.bounds.width &&
             savedY >= display.bounds.y &&
-            savedY <= display.bounds.y + display.bounds.height
+            savedY < display.bounds.y + display.bounds.height
       )
   const targetDisplay = savedDisplay ?? screen.getPrimaryDisplay()
 
@@ -91,10 +93,16 @@ export const ensureWindowPosition = (
   if (screenArea.width < width) width = screenArea.width
   if (screenArea.height < height) height = screenArea.height
 
-  // Center when there is no saved position, or it lies outside every display.
-  if (savedDisplay === undefined) {
+  if (savedX === undefined || savedY === undefined || savedDisplay === undefined) {
+    // First start, or the saved position is off every display: center the
+    // (clamped) window on the target display.
     x = Math.ceil(screenArea.x + (screenArea.width - width) / 2)
     y = Math.ceil(screenArea.y + (screenArea.height - height) / 2)
+  } else {
+    // Returning to a known display: keep the saved position, but nudge it so
+    // the (clamped) window stays fully within the display's work area.
+    x = Math.min(Math.max(savedX, screenArea.x), screenArea.x + screenArea.width - width)
+    y = Math.min(Math.max(savedY, screenArea.y), screenArea.y + screenArea.height - height)
   }
   return {
     x: x as number,

--- a/packages/desktop/test/unit/specs/ensure-window-position.spec.ts
+++ b/packages/desktop/test/unit/specs/ensure-window-position.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface FakeDisplay {
+  bounds: Rect
+  workArea: Rect
+}
+
+// `ensureWindowPosition` reads Electron's `screen` module. Drive it with a
+// configurable set of fake displays. `bounds` and `workArea` are kept equal so
+// the result is independent of the isLinux branch (which picks bounds vs
+// workArea), except where a test sets a work area apart on purpose.
+const state = vi.hoisted(() => {
+  const primary: FakeDisplay = {
+    bounds: { x: 0, y: 0, width: 1138, height: 640 },
+    workArea: { x: 0, y: 0, width: 1138, height: 640 }
+  }
+  return { displays: [primary] as FakeDisplay[], primary }
+})
+
+vi.mock('electron', () => ({
+  screen: {
+    getPrimaryDisplay: () => state.primary,
+    getAllDisplays: () => state.displays
+  }
+}))
+
+import { ensureWindowPosition } from 'main_renderer/windows/utils'
+
+const makePrimary = (): FakeDisplay => ({
+  bounds: { x: 0, y: 0, width: 1138, height: 640 },
+  workArea: { x: 0, y: 0, width: 1138, height: 640 }
+})
+
+// A larger secondary monitor positioned to the right of the primary. bounds
+// and workArea are kept equal so the expected result is the same on Linux
+// (which clamps against bounds) and macOS/Windows (which use workArea).
+const makeSecondary = (): FakeDisplay => ({
+  bounds: { x: 1138, y: 0, width: 2560, height: 1400 },
+  workArea: { x: 1138, y: 0, width: 2560, height: 1400 }
+})
+
+beforeEach(() => {
+  const primary = makePrimary()
+  state.primary = primary
+  state.displays = [primary]
+})
+
+describe('ensureWindowPosition', () => {
+  it('clamps a restored size larger than the screen for a returning user', () => {
+    // Saved coordinates are present, yet the saved size exceeds the screen
+    // (e.g. the display scale factor increased). Without clamping the window
+    // opens larger than the screen and covers the taskbar. Regression for #2928.
+    const result = ensureWindowPosition({ x: 0, y: 0, width: 1200, height: 800 })
+    expect(result.width).to.equal(1138)
+    expect(result.height).to.equal(640)
+    expect(result.x).to.equal(0)
+    expect(result.y).to.equal(0)
+  })
+
+  it('clamps an oversized size on first start (no saved coordinates)', () => {
+    const result = ensureWindowPosition({ width: 1200, height: 800 })
+    expect(result.width).to.equal(1138)
+    expect(result.height).to.equal(640)
+    // Centered on the primary display; with the size clamped to the screen the
+    // centered origin is the top-left corner.
+    expect(result.x).to.equal(0)
+    expect(result.y).to.equal(0)
+  })
+
+  it('leaves a size that already fits the screen untouched', () => {
+    const result = ensureWindowPosition({ x: 100, y: 80, width: 900, height: 500 })
+    expect(result.width).to.equal(900)
+    expect(result.height).to.equal(500)
+    expect(result.x).to.equal(100)
+    expect(result.y).to.equal(80)
+  })
+
+  it('centers a window whose saved position is off every display', () => {
+    const result = ensureWindowPosition({ x: 9000, y: 9000, width: 800, height: 600 })
+    expect(result.width).to.equal(800)
+    expect(result.height).to.equal(600)
+    expect(result.x).to.equal(Math.ceil((1138 - 800) / 2))
+    expect(result.y).to.equal(Math.ceil((640 - 600) / 2))
+  })
+
+  it('does not shrink a window restored on a larger secondary display', () => {
+    // Regression guard: the size must be clamped against the display that holds
+    // the saved position, not the (smaller) primary display.
+    state.primary = makePrimary()
+    state.displays = [state.primary, makeSecondary()]
+
+    const result = ensureWindowPosition({ x: 1200, y: 100, width: 1600, height: 1000 })
+    expect(result.width).to.equal(1600)
+    expect(result.height).to.equal(1000)
+    expect(result.x).to.equal(1200)
+    expect(result.y).to.equal(100)
+  })
+
+  it('clamps to the secondary display work area when the saved size exceeds it', () => {
+    state.primary = makePrimary()
+    state.displays = [state.primary, makeSecondary()]
+
+    const result = ensureWindowPosition({ x: 1200, y: 100, width: 3000, height: 1600 })
+    expect(result.width).to.equal(2560)
+    expect(result.height).to.equal(1400)
+    // Position is preserved (not re-centered).
+    expect(result.x).to.equal(1200)
+    expect(result.y).to.equal(100)
+  })
+})

--- a/packages/desktop/test/unit/specs/ensure-window-position.spec.ts
+++ b/packages/desktop/test/unit/specs/ensure-window-position.spec.ts
@@ -103,15 +103,38 @@ describe('ensureWindowPosition', () => {
     expect(result.y).to.equal(100)
   })
 
-  it('clamps to the secondary display work area when the saved size exceeds it', () => {
+  it('clamps size and position to the secondary display when the saved size exceeds it', () => {
     state.primary = makePrimary()
     state.displays = [state.primary, makeSecondary()]
 
     const result = ensureWindowPosition({ x: 1200, y: 100, width: 3000, height: 1600 })
     expect(result.width).to.equal(2560)
     expect(result.height).to.equal(1400)
-    // Position is preserved (not re-centered).
-    expect(result.x).to.equal(1200)
-    expect(result.y).to.equal(100)
+    // Full-size on the secondary, so the position is nudged to its top-left.
+    expect(result.x).to.equal(1138)
+    expect(result.y).to.equal(0)
+  })
+
+  it('nudges a window back on-screen when the saved position would overflow', () => {
+    // 400x300 saved near the bottom-right of the 1138x640 primary: the size
+    // fits but the position would push it past the edges, so it is nudged in.
+    const result = ensureWindowPosition({ x: 1000, y: 560, width: 400, height: 300 })
+    expect(result.width).to.equal(400)
+    expect(result.height).to.equal(300)
+    expect(result.x).to.equal(1138 - 400)
+    expect(result.y).to.equal(640 - 300)
+  })
+
+  it('selects the display by half-open bounds at a shared edge', () => {
+    // The saved x sits exactly on the shared edge between the primary (right
+    // edge 1138) and the secondary (left edge 1138). With half-open bounds the
+    // point belongs to the secondary, so the size is clamped against it (2560),
+    // not the smaller primary (1138).
+    state.primary = makePrimary()
+    state.displays = [state.primary, makeSecondary()]
+
+    const result = ensureWindowPosition({ x: 1138, y: 0, width: 2000, height: 500 })
+    expect(result.width).to.equal(2000)
+    expect(result.x).to.equal(1138)
   })
 })


### PR DESCRIPTION
Refs #2928, #1947

## Summary

On high or fractional-DPI displays the editor window can open *larger than the screen*, spilling past the screen edges and covering the taskbar until it is manually maximized.

`ensureWindowPosition` already intends to clamp the restored window size to the screen (its comment reads "check whether window size is larger than screen size"), but that clamp only runs on the first-start path, when the saved `x`/`y` are `undefined`. For a returning user (saved coordinates present) the saved size is used unclamped. When the work area measured in DIP is smaller than the saved size, for example the default 1200x800 on a 4K panel at 337.5% scaling (work area ~1138x608), or after the window was last used on a larger display, the window opens bigger than the screen.

This makes the function restore the window safely on every launch:

- It picks the display that contains the saved position, using half-open bounds (`[x, x + width)`, `[y, y + height)`) so a point on a shared monitor edge is attributed to the correct neighbouring display. It falls back to the primary display on first start, or when the saved position is off every display.
- It clamps the restored size to that display's work area.
- It keeps the saved position but nudges it so the window stays fully within the work area; with no saved position the window is centered.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New unit tests added: `packages/desktop/test/unit/specs/ensure-window-position.spec.ts` covering the returning-user clamp, the first-start clamp, an already-fitting window left untouched, an off-screen saved position being centered, multi-monitor clamping against the correct display, half-open boundary selection at a shared edge, and an edge-overflow position nudge.
- [x] Manually tested on: Linux (Ubuntu). `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (558 passing), `pnpm build`, and `pnpm test:e2e` (73 passing) all green locally.

## Notes for reviewers [optional]

- Size and position are clamped against the work area of the display that contains the saved top-left corner, so multi-monitor setups with a larger secondary display keep their restored size, and a window is never restored partially off-screen or under the taskbar.
- Display selection uses half-open bounds to avoid attributing a point on a shared monitor edge to the wrong display.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
