### PR TITLE
feat(theme): import custom editor themes from a folder

### DIFF
--- a/packages/desktop/src/main/app/nativeTheme.ts
+++ b/packages/desktop/src/main/app/nativeTheme.ts
@@ -1,9 +1,16 @@
 import { isDarkThemeId } from '../../common/theme'
+import { isDarkCustomTheme } from '../themes'
 
 export type NativeThemeSource = 'system' | 'dark' | 'light'
 
 export const isDarkApplicationTheme = (theme: unknown): boolean => {
-  return isDarkThemeId(theme)
+  if (isDarkThemeId(theme)) return true
+  // Custom themes (`custom:<id>`) declare light/dark via their @type header, so
+  // the dark check for them is resolved from the themes folder.
+  if (typeof theme === 'string' && theme.startsWith('custom:')) {
+    return isDarkCustomTheme(theme)
+  }
+  return false
 }
 
 export const getNativeThemeSource = ({

--- a/packages/desktop/src/main/ipc/index.ts
+++ b/packages/desktop/src/main/ipc/index.ts
@@ -8,6 +8,7 @@ import { registerShellHandlers } from './shell'
 import { registerWindowHandlers } from './window'
 import { registerCmdHandlers } from './cmd'
 import { registerI18nHandlers } from './i18n'
+import { registerThemeHandlers } from './themes'
 
 export const registerSandboxIpcHandlers = (): void => {
   registerBootInfo()
@@ -20,4 +21,5 @@ export const registerSandboxIpcHandlers = (): void => {
   registerWindowHandlers()
   registerCmdHandlers()
   registerI18nHandlers()
+  registerThemeHandlers()
 }

--- a/packages/desktop/src/main/ipc/themes.ts
+++ b/packages/desktop/src/main/ipc/themes.ts
@@ -1,0 +1,9 @@
+import { ipcMain } from 'electron'
+import { listCustomThemes, importCustomTheme, openThemesFolder } from '../themes'
+
+/** Register IPC handlers for user-imported ("custom") themes. */
+export const registerThemeHandlers = (): void => {
+  ipcMain.handle('mt::themes::list-custom', () => listCustomThemes())
+  ipcMain.handle('mt::themes::import-custom', () => importCustomTheme())
+  ipcMain.handle('mt::themes::open-folder', () => openThemesFolder())
+}

--- a/packages/desktop/src/main/menu/templates/theme.ts
+++ b/packages/desktop/src/main/menu/templates/theme.ts
@@ -1,6 +1,7 @@
 import { type MenuItemConstructorOptions } from 'electron'
 import * as actions from '../actions/theme'
 import { t } from '../../i18n'
+import { listCustomThemes } from '../../themes'
 import type Preference from '../../preferences'
 
 export default function(userPreference: Preference): MenuItemConstructorOptions {
@@ -371,6 +372,29 @@ export default function(userPreference: Preference): MenuItemConstructorOptions 
       }
     }
   )
+
+  // Append user-imported custom themes (read from <userData>/themes).
+  const customThemes = listCustomThemes()
+  if (customThemes.length > 0) {
+    submenu.push(
+      { type: 'separator' },
+      {
+        label: t('preferences.theme.customThemes'),
+        enabled: false
+      },
+      ...customThemes.map((customTheme) => ({
+        label: customTheme.name,
+        type: 'radio' as const,
+        id: customTheme.id,
+        enabled: isThemeSelectionEnabled,
+        checked: theme === customTheme.id,
+        click() {
+          actions.selectTheme(customTheme.id)
+        }
+      }))
+    )
+  }
+
   return {
     label: t('menu.theme.theme'),
     id: 'themeMenu',

--- a/packages/desktop/src/main/themes/index.ts
+++ b/packages/desktop/src/main/themes/index.ts
@@ -1,0 +1,166 @@
+import path from 'path'
+import fs from 'fs'
+import { app, dialog, shell } from 'electron'
+import log from 'electron-log'
+import type { CustomThemeDescriptor, ImportCustomThemeResult } from '../../shared/types/theme'
+import {
+  THEME_FILE_SUFFIX,
+  MAX_THEME_FILE_BYTES,
+  fileIdFromFilename,
+  parseThemeMetadata
+} from './metadata'
+import { sanitizeThemeCss } from './sanitize'
+
+/**
+ * Absolute path of the user editor-themes directory (`<userData>/themes/editor`).
+ *
+ * This sits alongside `<userData>/themes/export` (the existing custom export /
+ * print themes), keeping editor themes and export themes cleanly separated.
+ */
+export const getThemesDir = (): string => path.join(app.getPath('userData'), 'themes', 'editor')
+
+/** Create the user themes directory if it does not exist. Returns its path. */
+export const ensureThemesDir = (): string => {
+  const dir = getThemesDir()
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+  } catch (err) {
+    log.error('Failed to create themes directory:', err)
+  }
+  return dir
+}
+
+/**
+ * Read and describe a single `<id>.theme.css` file. Returns `null` (and logs)
+ * for anything that is not a valid, regular, in-size theme file. Symlinks and
+ * directories are ignored.
+ */
+const readDescriptor = (dir: string, filename: string): CustomThemeDescriptor | null => {
+  const fileId = fileIdFromFilename(filename)
+  if (!fileId) return null
+  const fullPath = path.join(dir, filename)
+  try {
+    const stat = fs.lstatSync(fullPath)
+    if (!stat.isFile()) return null
+    if (stat.size > MAX_THEME_FILE_BYTES) {
+      log.warn(`Skipping custom theme "${filename}": larger than ${MAX_THEME_FILE_BYTES} bytes`)
+      return null
+    }
+    const raw = fs.readFileSync(fullPath, 'utf8')
+    const meta = parseThemeMetadata(fileId, raw)
+    return {
+      id: `custom:${fileId}`,
+      fileId,
+      name: meta.name,
+      type: meta.type,
+      css: sanitizeThemeCss(raw)
+    }
+  } catch (err) {
+    log.error(`Failed to read custom theme "${filename}":`, err)
+    return null
+  }
+}
+
+/**
+ * Read and describe every valid custom theme in `<userData>/themes`, sorted by
+ * display name. The returned CSS is already sanitized.
+ */
+export const listCustomThemes = (): CustomThemeDescriptor[] => {
+  const dir = ensureThemesDir()
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dir)
+  } catch (err) {
+    log.error('Failed to read themes directory:', err)
+    return []
+  }
+  const themes: CustomThemeDescriptor[] = []
+  for (const entry of entries) {
+    const descriptor = readDescriptor(dir, entry)
+    if (descriptor) themes.push(descriptor)
+  }
+  themes.sort((a, b) => a.name.localeCompare(b.name))
+  return themes
+}
+
+/**
+ * Whether a custom theme id (`custom:<fileId>`) refers to a dark theme, per its
+ * `@type` header. Lets the main process keep `nativeTheme.themeSource` correct
+ * when a custom dark theme is selected.
+ */
+export const isDarkCustomTheme = (id: string): boolean => {
+  try {
+    return listCustomThemes().some((theme) => theme.id === id && theme.type === 'dark')
+  } catch {
+    return false
+  }
+}
+
+/** Open the user themes directory in the OS file manager. */
+export const openThemesFolder = async(): Promise<string> => {
+  const dir = ensureThemesDir()
+  return shell.openPath(dir)
+}
+
+/**
+ * Prompt the user to pick a `*.theme.css` file and copy it into the themes
+ * directory. The destination name is derived solely from the source basename
+ * (never a caller- or header-controlled path), so traversal is not possible.
+ */
+export const importCustomTheme = async(): Promise<ImportCustomThemeResult> => {
+  const dir = ensureThemesDir()
+  let selection: Electron.OpenDialogReturnValue
+  try {
+    selection = await dialog.showOpenDialog({
+      title: 'Import Theme',
+      properties: ['openFile'],
+      filters: [{ name: 'MarkText theme', extensions: ['css'] }]
+    })
+  } catch (err) {
+    log.error('Theme import dialog failed:', err)
+    return { status: 'error', message: String(err instanceof Error ? err.message : err) }
+  }
+  if (selection.canceled || selection.filePaths.length === 0) {
+    return { status: 'cancelled' }
+  }
+
+  const source = selection.filePaths[0]
+  const fileId = fileIdFromFilename(source)
+  if (!fileId) {
+    return {
+      status: 'invalid',
+      message: 'Theme files must be named "<id>.theme.css" (a lowercase id of letters, numbers, - or _).'
+    }
+  }
+
+  const destFilename = `${fileId}${THEME_FILE_SUFFIX}`
+  const dest = path.join(dir, destFilename)
+  if (fs.existsSync(dest)) {
+    return { status: 'exists', message: `A theme named "${fileId}" already exists.` }
+  }
+
+  try {
+    const stat = fs.lstatSync(source)
+    if (!stat.isFile() || stat.size > MAX_THEME_FILE_BYTES) {
+      return {
+        status: 'invalid',
+        message: 'The selected file is not a regular file, or is larger than 512KB.'
+      }
+    }
+    // COPYFILE_EXCL fails if the destination exists, closing the race between
+    // the existsSync check above and the copy.
+    fs.copyFileSync(source, dest, fs.constants.COPYFILE_EXCL)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') {
+      return { status: 'exists', message: `A theme named "${fileId}" already exists.` }
+    }
+    log.error('Failed to import theme:', err)
+    return { status: 'error', message: String(err instanceof Error ? err.message : err) }
+  }
+
+  const descriptor = readDescriptor(dir, destFilename)
+  if (!descriptor) {
+    return { status: 'error', message: 'The imported theme could not be read back.' }
+  }
+  return { status: 'imported', theme: descriptor }
+}

--- a/packages/desktop/src/main/themes/index.ts
+++ b/packages/desktop/src/main/themes/index.ts
@@ -62,8 +62,8 @@ const readDescriptor = (dir: string, filename: string): CustomThemeDescriptor | 
 }
 
 /**
- * Read and describe every valid custom theme in `<userData>/themes`, sorted by
- * display name. The returned CSS is already sanitized.
+ * Read and describe every valid custom theme in `<userData>/themes/editor`,
+ * sorted by display name. The returned CSS is already sanitized.
  */
 export const listCustomThemes = (): CustomThemeDescriptor[] => {
   const dir = ensureThemesDir()
@@ -160,6 +160,14 @@ export const importCustomTheme = async(): Promise<ImportCustomThemeResult> => {
 
   const descriptor = readDescriptor(dir, destFilename)
   if (!descriptor) {
+    // Roll back the copy: a file we cannot read back would otherwise be left
+    // behind to fail every future scan and to block re-importing the same id
+    // (the `exists` check above would keep matching it).
+    try {
+      fs.unlinkSync(dest)
+    } catch (err) {
+      log.error(`Failed to remove unreadable imported theme "${destFilename}":`, err)
+    }
     return { status: 'error', message: 'The imported theme could not be read back.' }
   }
   return { status: 'imported', theme: descriptor }

--- a/packages/desktop/src/main/themes/metadata.ts
+++ b/packages/desktop/src/main/themes/metadata.ts
@@ -1,0 +1,79 @@
+import path from 'path'
+import type { CustomThemeType } from '../../shared/types/theme'
+
+/** A custom theme file must be named `<id>.theme.css`. */
+export const THEME_FILE_SUFFIX = '.theme.css'
+
+/**
+ * Valid custom theme file id: lowercase, starts with a letter or digit, then
+ * letters/digits/hyphen/underscore, up to 64 chars. Keeps ids filesystem-safe
+ * and free of path separators or traversal sequences.
+ */
+export const THEME_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+/** Maximum size (in bytes) of a custom theme file we will read. */
+export const MAX_THEME_FILE_BYTES = 512 * 1024
+
+export interface ThemeMetadata {
+  fileId: string
+  name: string
+  type: CustomThemeType
+}
+
+/**
+ * Derive the canonical file id from a `<id>.theme.css` path or filename.
+ *
+ * @returns The file id, or `null` when the name is not a valid `*.theme.css`
+ *   with an allowed id.
+ */
+export const fileIdFromFilename = (filename: string): string | null => {
+  const base = path.basename(filename)
+  if (!base.toLowerCase().endsWith(THEME_FILE_SUFFIX)) return null
+  const fileId = base.slice(0, base.length - THEME_FILE_SUFFIX.length)
+  return THEME_ID_PATTERN.test(fileId) ? fileId : null
+}
+
+/** Title-case a hyphen/underscore id, e.g. `solarized-light` -> `Solarized Light`. */
+const titleCase = (id: string): string =>
+  id
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+/**
+ * Parse the optional leading metadata header from a theme's CSS and combine it
+ * with the (authoritative) file id.
+ *
+ * The header is a leading block comment within the first 2KB, for example:
+ *
+ *     /*!
+ *      * @name My Theme
+ *      * @type dark
+ *      *\/
+ *
+ * The filename always wins for the id; a mismatched `@id` header is ignored.
+ * `@type` defaults to `light` when missing or invalid (colour auto-detection is
+ * intentionally avoided as unreliable).
+ *
+ * @param fileId The canonical id derived from the filename.
+ * @param css The raw CSS contents.
+ */
+export const parseThemeMetadata = (fileId: string, css: string): ThemeMetadata => {
+  const head = css.slice(0, 2048)
+  const comment = head.match(/\/\*[!*]?([\s\S]*?)\*\//)
+  let name = ''
+  let type: CustomThemeType = 'light'
+  if (comment) {
+    const body = comment[1]
+    const nameMatch = body.match(/@name\s+(.+)/)
+    if (nameMatch) name = nameMatch[1].trim()
+    const typeMatch = body.match(/@type\s+(light|dark)\b/i)
+    if (typeMatch) type = typeMatch[1].toLowerCase() as CustomThemeType
+  }
+  return {
+    fileId,
+    name: name || titleCase(fileId),
+    type
+  }
+}

--- a/packages/desktop/src/main/themes/sanitize.ts
+++ b/packages/desktop/src/main/themes/sanitize.ts
@@ -1,0 +1,69 @@
+/**
+ * Sanitize user-provided theme CSS before it is injected into a renderer that
+ * runs with `webSecurity: false`.
+ *
+ * CSS cannot execute JavaScript, but it can trigger network requests (for
+ * example `background: url(https://attacker.example/x)`), which can beacon or
+ * exfiltrate. We therefore remove every construct that can load an external or
+ * local resource, leaving a colours-only theme:
+ *
+ *   - `@import` and `@namespace` rules
+ *   - `@font-face` blocks
+ *   - any value using `url()`, `image-set()` / `-webkit-image-set()`, or
+ *     `image()` (covers remote, `file:` and `data:` URLs)
+ *
+ * CSS lets identifiers be written with backslash escapes (`\75 rl(...)` is
+ * `url(...)`), so escapes are decoded first - otherwise a literal-text denylist
+ * is trivially bypassed. This is best-effort hardening, not a sandbox; it is the
+ * reason custom themes are colours-only.
+ */
+
+/**
+ * Decode CSS escape sequences to their literal characters so the denylist below
+ * cannot be evaded by spelling `url`/`@import`/etc. with escapes. Hex escapes
+ * are `\` + 1-6 hex digits + one optional trailing whitespace; any other `\x`
+ * is the literal `x` (and `\` before a newline is a line continuation).
+ */
+const decodeCssEscapes = (css: string): string =>
+  css.replace(/\\([0-9a-fA-F]{1,6})[ \t\r\n\f]?|\\([\s\S])/g, (_match, hex?: string, ch?: string) => {
+    if (hex !== undefined) {
+      const code = parseInt(hex, 16)
+      if (code === 0 || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff)) return '\ufffd'
+      try {
+        return String.fromCodePoint(code)
+      } catch {
+        return '\ufffd'
+      }
+    }
+    // `\<newline>` is a line continuation (removed); otherwise the literal char.
+    return ch === '\n' || ch === '\r' || ch === '\f' ? '' : (ch ?? '')
+  })
+
+/** Strip CSS block comments. */
+const stripComments = (css: string): string => css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+/**
+ * Remove all resource-loading CSS from a theme stylesheet.
+ *
+ * @param rawCss The raw (untrusted) CSS contents.
+ * @returns CSS safe to inject via `textContent` into a `<style>` element.
+ */
+export const sanitizeThemeCss = (rawCss: string): string => {
+  // Decode escapes first so matching sees canonical identifiers, then drop
+  // comments (which could otherwise hide constructs from the matchers).
+  let css = stripComments(decodeCssEscapes(rawCss))
+  // Resource-loading functions. Matching up to the first ')' (rather than
+  // excluding ';') reliably captures data: URLs, whose value contains ';'
+  // (e.g. data:image/png;base64,...); base64 and percent-encoded URLs never
+  // contain a literal ')'. `image-set` must precede `image` in the alternation.
+  css = css.replace(/(?:-webkit-)?(?:url|image-set|image)\s*\([^)]*\)/gi, '')
+  // Resource-loading at-rules.
+  css = css.replace(/@import\b[^;]*;/gi, '')
+  css = css.replace(/@namespace\b[^;]*;/gi, '')
+  css = css.replace(/@font-face\s*\{[^}]*\}/gi, '')
+  // Defensive: legacy IE/old-Gecko resource vectors. Inert in Chromium, but
+  // removed anyway so the output is safe regardless of engine.
+  css = css.replace(/(?:behavior|-moz-binding)\s*:[^;}]*/gi, '')
+  css = css.replace(/expression\s*\([^)]*\)/gi, '')
+  return css.trim()
+}

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -226,6 +226,12 @@ const fontsAPI = {
   list: () => invoke('mt::fonts::list')
 }
 
+const themesAPI = {
+  listCustom: () => invoke('mt::themes::list-custom'),
+  importCustom: () => invoke('mt::themes::import-custom'),
+  openFolder: () => invoke('mt::themes::open-folder')
+}
+
 const electronAPI = {
   ipcRenderer: ipcWrapper,
   shell: shellAPI,
@@ -294,6 +300,7 @@ try {
   contextBridge.exposeInMainWorld('ripgrep', ripgrepAPI)
   contextBridge.exposeInMainWorld('uploader', uploaderAPI)
   contextBridge.exposeInMainWorld('fonts', fontsAPI)
+  contextBridge.exposeInMainWorld('themes', themesAPI)
 } catch (error) {
   console.error(error)
 }

--- a/packages/desktop/src/renderer/src/pages/app.vue
+++ b/packages/desktop/src/renderer/src/pages/app.vue
@@ -42,6 +42,7 @@ import { computed, watch, nextTick, onMounted, ref } from 'vue'
 import { useMainStore } from '@/store'
 import { storeToRefs } from 'pinia'
 import { addStyles, addThemeStyle, addCustomStyle, type AddStylesOptions } from '@/util/theme'
+import { loadCustomThemes } from '@/util/customThemes'
 import Recent from '@/components/recent/index.vue'
 import EditorWithTabs from '@/components/editorWithTabs/index.vue'
 import TitleBar from '@/components/titleBar/index.vue'
@@ -197,6 +198,10 @@ onMounted(async () => {
   notificationStore.listenForNotification()
 
   setupDragDropHandler()
+
+  // Load user-imported themes before applying styles so a custom theme id
+  // resolves to its CSS on first paint.
+  await loadCustomThemes()
 
   nextTick(() => {
     // `initialState` from bootstrap carries nullable URL params (string|null);

--- a/packages/desktop/src/renderer/src/pages/preference.vue
+++ b/packages/desktop/src/renderer/src/pages/preference.vue
@@ -22,6 +22,7 @@ import { storeToRefs } from 'pinia'
 import TitleBar from '@/prefComponents/common/titlebar.vue'
 import SideBar from '@/prefComponents/sideBar/index.vue'
 import { addThemeStyle } from '@/util/theme'
+import { loadCustomThemes } from '@/util/customThemes'
 import { DEFAULT_STYLE } from '@/config'
 import { isOsx } from '@/util'
 
@@ -47,7 +48,8 @@ watch(theme, (newValue, oldValue) => {
 })
 
 // Lifecycle
-onMounted(() => {
+onMounted(async () => {
+  await loadCustomThemes()
   nextTick(() => {
     const state = window.marktext?.initialState ?? DEFAULT_STYLE
     addThemeStyle(state.theme ?? DEFAULT_STYLE.theme)

--- a/packages/desktop/src/renderer/src/prefComponents/theme/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/theme/index.vue
@@ -19,6 +19,32 @@
         <div v-html="themeItem.html" />
       </div>
     </section>
+
+    <template v-if="customThemes.length">
+      <h4 class="custom-themes-title">
+        {{ t('preferences.theme.customThemes') }}
+      </h4>
+      <section class="offcial-themes">
+        <div
+          v-for="item of customThemes"
+          :key="item.id"
+          class="theme custom"
+          :class="[
+            item.type,
+            {
+              active: item.id === theme,
+              disabled: followSystemTheme
+            }
+          ]"
+          @click="!followSystemTheme && onSelectChange('theme', item.id)"
+        >
+          <div class="theme-name">
+            {{ item.name }}
+          </div>
+        </div>
+      </section>
+    </template>
+
     <separator />
 
     <Bool
@@ -64,21 +90,24 @@
         "
       />
     </div>
-    <separator v-show="false" />
-    <section
-      v-show="false"
-      class="import-themes ag-underdevelop"
-    >
+    <separator />
+    <section class="import-themes">
       <div>
         <span>{{ t('preferences.theme.openThemesFolder') }}</span>
-        <el-button size="small">
+        <el-button
+          size="small"
+          @click="onOpenThemesFolder"
+        >
           {{ t('preferences.theme.openFolder') }}
         </el-button>
       </div>
 
       <div>
         <span>{{ t('preferences.theme.importCustomThemes') }}</span>
-        <el-button size="small">
+        <el-button
+          size="small"
+          @click="onImportTheme"
+        >
           {{ t('preferences.theme.importTheme') }}
         </el-button>
       </div>
@@ -87,13 +116,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { ElMessage } from 'element-plus'
 import { usePreferencesStore } from '@/store/preferences'
 import type { PreferencesState } from '@/store/preferences'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import themeMd from './theme.md?raw'
 import { themes as configThemes } from './config'
+import { loadCustomThemes } from '@/util/customThemes'
+import type { CustomThemeDescriptor } from '@shared/types/theme'
 import markdownToHtml from '@/util/markdownToHtml'
 import Bool from '../common/bool/index.vue'
 import CurSelect from '../common/select/index.vue'
@@ -107,6 +139,7 @@ interface ThemePreview {
 }
 
 const themes = ref<ThemePreview[]>([])
+const customThemes = ref<CustomThemeDescriptor[]>([])
 
 const { t } = useI18n()
 const preferenceStore = usePreferencesStore()
@@ -114,16 +147,23 @@ const preferenceStore = usePreferencesStore()
 const { followSystemTheme, lightModeTheme, darkModeTheme, theme, customCss } =
   storeToRefs(preferenceStore)
 
-// Generate dropdown options from configThemes
-const themeOptions: PrefSelectOption<string>[] = configThemes.map((theme) => ({
-  label: theme.name
+const titleCaseThemeName = (name: string): string =>
+  name
     .split('-')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' '),
-  value: theme.name
-}))
+    .join(' ')
+
+// Dropdown options: built-in themes plus any imported custom themes.
+const themeOptions = computed<PrefSelectOption<string>[]>(() => [
+  ...configThemes.map((themeItem) => ({
+    label: titleCaseThemeName(themeItem.name),
+    value: themeItem.name
+  })),
+  ...customThemes.value.map((item) => ({ label: item.name, value: item.id }))
+])
 
 onMounted(async () => {
+  customThemes.value = await loadCustomThemes()
   const newThemes: ThemePreview[] = []
   for (const theme of configThemes) {
     const html = await markdownToHtml(themeMd.replace(/{theme}/, theme.name))
@@ -137,6 +177,21 @@ onMounted(async () => {
 
 const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
   preferenceStore.SET_SINGLE_PREFERENCE({ type, value })
+}
+
+const onOpenThemesFolder = (): void => {
+  window.themes.openFolder()
+}
+
+const onImportTheme = async (): Promise<void> => {
+  const result = await window.themes.importCustom()
+  if (result.status === 'imported' && result.theme) {
+    customThemes.value = await loadCustomThemes()
+    // Select and apply the newly imported theme.
+    onSelectChange('theme', result.theme.id)
+  } else if (result.status !== 'cancelled') {
+    ElMessage.error(result.message ?? t('preferences.theme.importFailed'))
+  }
 }
 </script>
 
@@ -441,6 +496,25 @@ const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
     overflow: hidden;
     text-overflow: ellipsis;
   }
+}
+
+.custom-themes-title {
+  margin: 18px 0 0;
+  font-size: 14px;
+}
+
+.offcial-themes .theme.custom {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.offcial-themes .theme.custom .theme-name {
+  font-size: 15px;
+  font-weight: 500;
+  text-align: center;
+  word-break: break-word;
 }
 
 .custom-css {

--- a/packages/desktop/src/renderer/src/util/customThemes.ts
+++ b/packages/desktop/src/renderer/src/util/customThemes.ts
@@ -1,0 +1,37 @@
+import type { CustomThemeDescriptor } from '@shared/types/theme'
+
+/**
+ * In-memory registry of user-imported ("custom") themes for the renderer.
+ *
+ * Built-in themes are compiled into the bundle and handled by the switch in
+ * `addThemeStyle`. Custom themes are read and sanitized by the main process and
+ * fetched here over IPC, then applied via `addThemeStyle`'s default branch.
+ */
+const registry = new Map<string, CustomThemeDescriptor>()
+
+/** Replace the registry contents with the given descriptors. */
+export const setCustomThemes = (themes: CustomThemeDescriptor[]): void => {
+  registry.clear()
+  for (const theme of themes) registry.set(theme.id, theme)
+}
+
+/** Look up a custom theme by its runtime id (e.g. `custom:my-theme`). */
+export const getCustomTheme = (id: string): CustomThemeDescriptor | undefined => registry.get(id)
+
+/** Every custom theme currently in the registry, sorted by display name. */
+export const getCustomThemes = (): CustomThemeDescriptor[] =>
+  [...registry.values()].sort((a, b) => a.name.localeCompare(b.name))
+
+/**
+ * Fetch the custom themes from the main process and populate the registry.
+ * Returns the loaded descriptors (empty on failure).
+ */
+export const loadCustomThemes = async(): Promise<CustomThemeDescriptor[]> => {
+  try {
+    const themes = await window.themes.listCustom()
+    setCustomThemes(themes)
+    return themes
+  } catch {
+    return []
+  }
+}

--- a/packages/desktop/src/renderer/src/util/customThemes.ts
+++ b/packages/desktop/src/renderer/src/util/customThemes.ts
@@ -32,6 +32,11 @@ export const loadCustomThemes = async(): Promise<CustomThemeDescriptor[]> => {
     setCustomThemes(themes)
     return themes
   } catch {
+    // Clear any previously loaded themes so the registry never disagrees with a
+    // failed refresh: callers treat the empty result as "no custom themes", and
+    // `getCustomTheme`/`getCustomThemes` must reflect that rather than serving
+    // stale descriptors from an earlier successful load.
+    setCustomThemes([])
     return []
   }
 }

--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -42,6 +42,7 @@ import {
   rosePineDawn
 } from './themeColor'
 import { isLinux } from './index'
+import { getCustomTheme } from './customThemes'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ORIGINAL_THEME = '#409EFF'
@@ -57,7 +58,10 @@ const getEmojiPickerPatch = (): string => {
 }
 
 export const addThemeStyle = (theme: string): void => {
-  const isCmRailscasts = railscastsThemes.includes(theme)
+  const customTheme = getCustomTheme(theme)
+  // A custom dark theme reuses the railscasts CodeMirror source-view theme,
+  // since custom themes only ship app/editor CSS variables (no CodeMirror theme).
+  const isCmRailscasts = railscastsThemes.includes(theme) || customTheme?.type === 'dark'
   const isCmOneDark = oneDarkThemes.includes(theme)
   const isDarkTheme = isCmOneDark || isCmRailscasts
   let themeStyleEle = document.querySelector(`#${THEME_STYLE_ID}`) as HTMLStyleElement | null
@@ -170,6 +174,10 @@ export const addThemeStyle = (theme: string): void => {
       themeStyleEle.innerHTML = patchTheme(rosePineDawn())
       break
     default:
+      // Custom themes imported from <userData>/themes. Their CSS is sanitized
+      // in the main process (no @import/@font-face/url()/remote resources) and
+      // assigned via textContent so it can never be treated as markup.
+      themeStyleEle.textContent = customTheme ? patchTheme(customTheme.css) : ''
       break
   }
 

--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -174,7 +174,7 @@ export const addThemeStyle = (theme: string): void => {
       themeStyleEle.innerHTML = patchTheme(rosePineDawn())
       break
     default:
-      // Custom themes imported from <userData>/themes. Their CSS is sanitized
+      // Custom themes imported from <userData>/themes/editor. Their CSS is sanitized
       // in the main process (no @import/@font-face/url()/remote resources) and
       // assigned via textContent so it can never be treated as markup.
       themeStyleEle.textContent = customTheme ? patchTheme(customTheme.css) : ''

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -32,6 +32,7 @@ import type {
 } from './files'
 import type { BufferedState as BufferedStateType } from './bufferedState'
 import type { MenuTemplate, MenuPopupPosition } from './menu'
+import type { CustomThemeDescriptor, ImportCustomThemeResult } from './theme'
 
 // =================================================================
 // Invoke channels (renderer → main, returns Promise<T>)
@@ -77,6 +78,9 @@ export interface IpcInvokeChannels {
   'mt::spellchecker-remove-word': { args: [word: string]; ret: boolean }
   'mt::spellchecker-set-enabled': { args: [enabled: boolean]; ret: void }
   'mt::spellchecker-switch-language': { args: [language: string]; ret: void }
+  'mt::themes::import-custom': { args: []; ret: ImportCustomThemeResult }
+  'mt::themes::list-custom': { args: []; ret: CustomThemeDescriptor[] }
+  'mt::themes::open-folder': { args: []; ret: string }
   'mt::uploader::upload': { args: [req: unknown]; ret: unknown }
   'mt::win::is-fullscreen': { args: []; ret: boolean }
   'mt::win::is-maximized': { args: []; ret: boolean }

--- a/packages/desktop/src/shared/types/theme.ts
+++ b/packages/desktop/src/shared/types/theme.ts
@@ -2,9 +2,9 @@
  * Shapes for user-imported ("custom") themes.
  *
  * Built-in themes are compiled into the renderer bundle. Custom themes live as
- * `<fileId>.theme.css` files in `<userData>/themes`; the main process reads,
- * parses, and sanitizes them (see `src/main/themes`) and the renderer applies
- * them at runtime (see `src/renderer/src/util/customThemes.ts`).
+ * `<fileId>.theme.css` files in `<userData>/themes/editor`; the main process
+ * reads, parses, and sanitizes them (see `src/main/themes`) and the renderer
+ * applies them at runtime (see `src/renderer/src/util/customThemes.ts`).
  */
 
 export type CustomThemeType = 'light' | 'dark'

--- a/packages/desktop/src/shared/types/theme.ts
+++ b/packages/desktop/src/shared/types/theme.ts
@@ -1,0 +1,30 @@
+/**
+ * Shapes for user-imported ("custom") themes.
+ *
+ * Built-in themes are compiled into the renderer bundle. Custom themes live as
+ * `<fileId>.theme.css` files in `<userData>/themes`; the main process reads,
+ * parses, and sanitizes them (see `src/main/themes`) and the renderer applies
+ * them at runtime (see `src/renderer/src/util/customThemes.ts`).
+ */
+
+export type CustomThemeType = 'light' | 'dark'
+
+export interface CustomThemeDescriptor {
+  /** Runtime theme id, namespaced to never collide with a built-in: `custom:<fileId>`. */
+  id: string
+  /** Canonical file id, i.e. the `<fileId>` in `<fileId>.theme.css`. */
+  fileId: string
+  /** Human-readable display name (from the `@name` header, else the title-cased id). */
+  name: string
+  /** Light or dark; drives the `body.dark` class. Defaults to `light` when unspecified. */
+  type: CustomThemeType
+  /** Sanitized CSS, safe to inject (no `@import`, `@font-face`, `url()` or remote resources). */
+  css: string
+}
+
+/** Outcome of an interactive "import custom theme" action. */
+export interface ImportCustomThemeResult {
+  status: 'imported' | 'cancelled' | 'exists' | 'invalid' | 'error'
+  theme?: CustomThemeDescriptor
+  message?: string
+}

--- a/packages/desktop/src/types/global.d.ts
+++ b/packages/desktop/src/types/global.d.ts
@@ -12,6 +12,7 @@ import type {
 } from '@shared/types/ipc'
 import type { MenuTemplate, MenuPopupPosition } from '@shared/types/menu'
 import type { SerializedStat } from '@shared/types/files'
+import type { CustomThemeDescriptor, ImportCustomThemeResult } from '@shared/types/theme'
 
 declare global {
   // ---- Build-time defines (electron-vite `define`) ----
@@ -165,6 +166,12 @@ declare global {
     list(): Promise<string[]>
   }
 
+  interface ThemesAPI {
+    listCustom(): Promise<CustomThemeDescriptor[]>
+    importCustom(): Promise<ImportCustomThemeResult>
+    openFolder(): Promise<string>
+  }
+
   interface ProcessShim {
     platform: NodeJS.Platform
     arch?: string
@@ -184,6 +191,7 @@ declare global {
     ripgrep: RipgrepAPI
     uploader: UploaderAPI
     fonts: FontsAPI
+    themes: ThemesAPI
     process: ProcessShim
     rgPath: string
     // Set by the legacy editor store at runtime; consumed by muya internals.

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -831,7 +831,9 @@
       "importCustomThemes": "Benutzerdefinierte Designs importieren",
       "importTheme": "Design importieren",
       "openFolder": "Ordner öffnen",
-      "openThemesFolder": "Design-Ordner öffnen"
+      "openThemesFolder": "Design-Ordner öffnen",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "Tastenkürzel",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -830,7 +830,9 @@
       "importCustomThemes": "Import custom themes",
       "importTheme": "Import Theme",
       "openFolder": "Open Folder",
-      "openThemesFolder": "Open themes folder"
+      "openThemesFolder": "Open themes folder",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "Keybindings",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -831,7 +831,9 @@
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Carpeta",
-      "openThemesFolder": "Abrir carpeta de temas"
+      "openThemesFolder": "Abrir carpeta de temas",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "Atajos de Teclado",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -833,7 +833,9 @@
       "importCustomThemes": "Importer des thèmes personnalisés",
       "importTheme": "Importer un thème",
       "openFolder": "Ouvrir le dossier",
-      "openThemesFolder": "Ouvrir le dossier des thèmes"
+      "openThemesFolder": "Ouvrir le dossier des thèmes",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "Raccourcis clavier",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -833,7 +833,9 @@
       "importCustomThemes": "カスタムテーマをインポート",
       "importTheme": "テーマをインポート",
       "openFolder": "フォルダを開く",
-      "openThemesFolder": "テーマフォルダを開く"
+      "openThemesFolder": "テーマフォルダを開く",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "キーバインド",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -833,7 +833,9 @@
       "importCustomThemes": "사용자 정의 테마 가져오기",
       "importTheme": "테마 가져오기",
       "openFolder": "폴더 열기",
-      "openThemesFolder": "테마 폴더 열기"
+      "openThemesFolder": "테마 폴더 열기",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "키 바인딩",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -833,7 +833,9 @@
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Pasta",
-      "openThemesFolder": "Abrir pasta de temas"
+      "openThemesFolder": "Abrir pasta de temas",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "Atalhos de Teclado",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -832,7 +832,9 @@
       "importCustomThemes": "导入自定义主题",
       "importTheme": "导入主题",
       "openFolder": "打开文件夹",
-      "openThemesFolder": "打开主题文件夹"
+      "openThemesFolder": "打开主题文件夹",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "快捷键",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -833,7 +833,9 @@
       "importCustomThemes": "匯入自訂主題",
       "importTheme": "匯入主題",
       "openFolder": "開啟資料夾",
-      "openThemesFolder": "開啟主題資料夾"
+      "openThemesFolder": "開啟主題資料夾",
+      "customThemes": "Custom Themes",
+      "importFailed": "Could not import the theme."
     },
     "keybindings": {
       "title": "按鍵綁定",

--- a/packages/desktop/test/e2e/custom-themes.spec.ts
+++ b/packages/desktop/test/e2e/custom-themes.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { launchWithMarkdown, clickMenuById } from './helpers'
+
+const darkTheme = `/*!
+ * @name E2E Dark
+ * @type dark
+ */
+:root {
+  --themeColor: #ff0000;
+  --editorBgColor: #101418;
+  --editorColor: #e6e6e6;
+}
+`
+
+const lightTheme = `/*!
+ * @name E2E Light
+ * @type light
+ */
+:root {
+  --themeColor: #0033cc;
+}
+`
+
+test.describe('Custom (imported) editor themes', () => {
+  let app: ElectronApplication
+  let page: Page
+  let userDataDir: string
+
+  test.beforeAll(async() => {
+    // Pre-seed two custom themes in <userData>/themes/editor before launch so
+    // they are discovered by the renderer (on load) and the native menu (built
+    // on startup).
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'marktext-e2e-customtheme-'))
+    const editorThemes = path.join(userDataDir, 'themes', 'editor')
+    fs.mkdirSync(editorThemes, { recursive: true })
+    fs.writeFileSync(path.join(editorThemes, 'e2e-dark.theme.css'), darkTheme, 'utf-8')
+    fs.writeFileSync(path.join(editorThemes, 'e2e-light.theme.css'), lightTheme, 'utf-8')
+
+    const launched = await launchWithMarkdown('# Custom theme test\n', { userDataDir })
+    app = launched.app
+    page = launched.page
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+    if (userDataDir) fs.rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  test('exposes themes from <userData>/themes/editor over IPC', async() => {
+    const ids = await page.evaluate(async() => {
+      const themes = await window.themes.listCustom()
+      return themes.map((theme) => theme.id)
+    })
+    expect(ids).toContain('custom:e2e-dark')
+    expect(ids).toContain('custom:e2e-light')
+  })
+
+  test('applies a custom dark theme (body.dark) from the Theme menu', async() => {
+    await clickMenuById(app, 'custom:e2e-dark')
+    await expect(page.locator('body')).toHaveClass(/(^|\s)dark(\s|$)/)
+  })
+
+  test('injects the custom theme CSS into the document', async() => {
+    await clickMenuById(app, 'custom:e2e-dark')
+    const injected = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('style')).some((styleEl) =>
+        (styleEl.textContent ?? '').includes('--themeColor: #ff0000')
+      )
+    )
+    expect(injected).toBe(true)
+  })
+
+  test('applies a custom light theme and removes body.dark', async() => {
+    await clickMenuById(app, 'custom:e2e-light')
+    await page.waitForFunction(() => !document.body.classList.contains('dark'), null, {
+      timeout: 5000
+    })
+    expect(await page.evaluate(() => document.body.classList.contains('dark'))).toBe(false)
+  })
+})

--- a/packages/desktop/test/e2e/helpers.ts
+++ b/packages/desktop/test/e2e/helpers.ts
@@ -59,6 +59,10 @@ export interface LaunchOptions {
   // should opt in — otherwise existing specs would silently ignore renderer
   // exceptions that previously surfaced as a dialog (a hidden regression risk).
   suppressErrorDialog?: boolean
+  // Use this user-data directory instead of a fresh temp one. Lets a spec
+  // pre-seed files under it (e.g. custom themes in themes/editor) before launch.
+  // The caller owns cleanup of a directory it provides.
+  userDataDir?: string
 }
 
 export const launchElectron = async(
@@ -69,7 +73,7 @@ export const launchElectron = async(
   const executablePath = getElectronPath()
   // Pass project root as entry so Electron reads package.json and getAppPath() returns project root.
   // Passing out/main/index.js directly bypasses package.json and breaks __static path resolution.
-  const userDataDir = trackTempDir(getTempPath())
+  const userDataDir = options.userDataDir ?? trackTempDir(getTempPath())
   const args = [projectRoot, '--user-data-dir', userDataDir].concat(userArgs)
   const env: Record<string, string> = {}
   for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v

--- a/packages/desktop/test/unit/specs/custom-themes.spec.ts
+++ b/packages/desktop/test/unit/specs/custom-themes.spec.ts
@@ -69,4 +69,15 @@ describe('loadCustomThemes', () => {
     const result = await loadCustomThemes()
     expect(result).to.deep.equal([])
   })
+
+  it('clears previously loaded themes when a later refresh fails', async() => {
+    stubListCustom(() => Promise.resolve([make('one', 'One')]))
+    await loadCustomThemes()
+    expect(getCustomTheme('custom:one')).to.not.equal(undefined)
+
+    stubListCustom(() => Promise.reject(new Error('boom')))
+    await loadCustomThemes()
+    expect(getCustomTheme('custom:one')).to.equal(undefined)
+    expect(getCustomThemes()).to.deep.equal([])
+  })
 })

--- a/packages/desktop/test/unit/specs/custom-themes.spec.ts
+++ b/packages/desktop/test/unit/specs/custom-themes.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  setCustomThemes,
+  getCustomTheme,
+  getCustomThemes,
+  loadCustomThemes
+} from '@/util/customThemes'
+import type { CustomThemeDescriptor } from '@shared/types/theme'
+
+const make = (
+  id: string,
+  name: string,
+  type: 'light' | 'dark' = 'light'
+): CustomThemeDescriptor => ({
+  id: `custom:${id}`,
+  fileId: id,
+  name,
+  type,
+  css: ':root {}'
+})
+
+const stubListCustom = (impl: () => Promise<CustomThemeDescriptor[]>): void => {
+  window.themes = {
+    listCustom: impl,
+    importCustom: vi.fn(),
+    openFolder: vi.fn()
+  } as unknown as typeof window.themes
+}
+
+beforeEach(() => {
+  setCustomThemes([])
+})
+
+describe('custom theme registry', () => {
+  it('stores and retrieves a theme by its runtime id', () => {
+    const theme = make('cool', 'Cool')
+    setCustomThemes([theme])
+    expect(getCustomTheme('custom:cool')).to.deep.equal(theme)
+  })
+
+  it('returns undefined for an unknown id', () => {
+    expect(getCustomTheme('custom:missing')).to.equal(undefined)
+  })
+
+  it('replaces previous contents on each set', () => {
+    setCustomThemes([make('a', 'A')])
+    setCustomThemes([make('b', 'B')])
+    expect(getCustomTheme('custom:a')).to.equal(undefined)
+    expect(getCustomTheme('custom:b')).to.not.equal(undefined)
+  })
+
+  it('lists themes sorted by display name', () => {
+    setCustomThemes([make('z', 'Zen'), make('a', 'Apple'), make('m', 'Mango')])
+    expect(getCustomThemes().map((theme) => theme.name)).to.deep.equal(['Apple', 'Mango', 'Zen'])
+  })
+})
+
+describe('loadCustomThemes', () => {
+  it('populates the registry from window.themes.listCustom', async() => {
+    const themes = [make('one', 'One'), make('two', 'Two', 'dark')]
+    stubListCustom(() => Promise.resolve(themes))
+    const result = await loadCustomThemes()
+    expect(result).to.have.length(2)
+    expect(getCustomTheme('custom:two')?.type).to.equal('dark')
+  })
+
+  it('returns an empty array and does not throw when the IPC call fails', async() => {
+    stubListCustom(() => Promise.reject(new Error('boom')))
+    const result = await loadCustomThemes()
+    expect(result).to.deep.equal([])
+  })
+})

--- a/packages/desktop/test/unit/specs/theme-metadata.spec.ts
+++ b/packages/desktop/test/unit/specs/theme-metadata.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { fileIdFromFilename, parseThemeMetadata } from 'main_renderer/themes/metadata'
+
+describe('fileIdFromFilename', () => {
+  it('extracts the id from a valid <id>.theme.css name', () => {
+    expect(fileIdFromFilename('solarized-light.theme.css')).to.equal('solarized-light')
+    expect(fileIdFromFilename('my_theme.theme.css')).to.equal('my_theme')
+  })
+
+  it('extracts from a full path using the basename', () => {
+    expect(fileIdFromFilename('/home/user/.config/marktext/themes/cool.theme.css')).to.equal('cool')
+  })
+
+  it('accepts a case-insensitive .theme.css suffix', () => {
+    expect(fileIdFromFilename('cool.THEME.CSS')).to.equal('cool')
+  })
+
+  it('rejects files that are not *.theme.css', () => {
+    expect(fileIdFromFilename('cool.css')).to.equal(null)
+    expect(fileIdFromFilename('cool.theme.scss')).to.equal(null)
+    expect(fileIdFromFilename('theme.css')).to.equal(null)
+  })
+
+  it('rejects ids that are not lowercase/safe', () => {
+    expect(fileIdFromFilename('MyTheme.theme.css')).to.equal(null)
+    expect(fileIdFromFilename('-leading.theme.css')).to.equal(null)
+    expect(fileIdFromFilename('has space.theme.css')).to.equal(null)
+  })
+
+  it('neutralizes path traversal by using only the basename', () => {
+    expect(fileIdFromFilename('../../etc/evil.theme.css')).to.equal('evil')
+    expect(fileIdFromFilename('/abs/path/cool.theme.css')).to.equal('cool')
+  })
+
+  it('rejects ids longer than 64 characters', () => {
+    expect(fileIdFromFilename(`${'a'.repeat(65)}.theme.css`)).to.equal(null)
+    expect(fileIdFromFilename(`${'a'.repeat(64)}.theme.css`)).to.equal('a'.repeat(64))
+  })
+})
+
+describe('parseThemeMetadata', () => {
+  it('reads @name and @type from a leading header comment', () => {
+    const css = '/*!\n * @name My Cool Theme\n * @type dark\n */\n:root { --themeColor: #fff; }'
+    const meta = parseThemeMetadata('my-cool', css)
+    expect(meta.fileId).to.equal('my-cool')
+    expect(meta.name).to.equal('My Cool Theme')
+    expect(meta.type).to.equal('dark')
+  })
+
+  it('defaults the type to light when missing or invalid', () => {
+    expect(parseThemeMetadata('x', ':root {}').type).to.equal('light')
+    expect(parseThemeMetadata('x', '/* @type purple */ :root {}').type).to.equal('light')
+  })
+
+  it('falls back to a title-cased id when @name is absent', () => {
+    expect(parseThemeMetadata('solarized-light', ':root {}').name).to.equal('Solarized Light')
+    expect(parseThemeMetadata('my_cool_theme', ':root {}').name).to.equal('My Cool Theme')
+  })
+
+  it('accepts a case-insensitive @type value', () => {
+    expect(parseThemeMetadata('x', '/* @type DARK */ :root {}').type).to.equal('dark')
+  })
+
+  it('ignores a header that appears after the first 2KB', () => {
+    const css = `${' '.repeat(2100)}/* @name Too Late\n * @type dark */`
+    const meta = parseThemeMetadata('late', css)
+    expect(meta.name).to.equal('Late')
+    expect(meta.type).to.equal('light')
+  })
+})

--- a/packages/desktop/test/unit/specs/theme-sanitize.spec.ts
+++ b/packages/desktop/test/unit/specs/theme-sanitize.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeThemeCss } from 'main_renderer/themes/sanitize'
+
+describe('sanitizeThemeCss', () => {
+  it('keeps plain :root variable declarations and selectors', () => {
+    const css = ':root {\n  --themeColor: #8da101;\n  --editorColor: #2d353b;\n}\n.token.keyword { color: #b16286; }'
+    const out = sanitizeThemeCss(css)
+    expect(out).to.contain('--themeColor: #8da101')
+    expect(out).to.contain('.token.keyword')
+  })
+
+  it('removes @import rules', () => {
+    expect(sanitizeThemeCss('@import url(https://evil.example/x.css);\n:root { --a: 1; }')).to.not.contain('@import')
+    expect(sanitizeThemeCss("@import 'theme.css';\n:root {}")).to.not.contain('@import')
+  })
+
+  it('removes @font-face blocks', () => {
+    const css = '@font-face { font-family: x; src: url(https://evil.example/f.woff2); }\n:root { --a: 1; }'
+    const out = sanitizeThemeCss(css)
+    expect(out).to.not.contain('@font-face')
+    expect(out.toLowerCase()).to.not.contain('url(')
+  })
+
+  it('strips declarations using url() for remote, file and data URLs', () => {
+    const remote = sanitizeThemeCss(':root { background: url(https://evil.example/x.png); --a: 1; }')
+    expect(remote.toLowerCase()).to.not.contain('url(')
+    const file = sanitizeThemeCss(':root { background: url(file:///etc/passwd); }')
+    expect(file.toLowerCase()).to.not.contain('url(')
+    const data = sanitizeThemeCss(':root { background: url(data:image/png;base64,AAAA); }')
+    expect(data.toLowerCase()).to.not.contain('url(')
+  })
+
+  it('strips image-set() and -webkit-image-set()', () => {
+    const out = sanitizeThemeCss(':root { background-image: -webkit-image-set(url(https://e/x.png) 1x); }')
+    expect(out.toLowerCase()).to.not.contain('image-set')
+    expect(out.toLowerCase()).to.not.contain('url(')
+  })
+
+  it('does not let a url() hidden in a comment survive', () => {
+    const out = sanitizeThemeCss('/* background: url(https://evil.example/x) */\n:root { --a: 1; }')
+    expect(out.toLowerCase()).to.not.contain('url(')
+    expect(out).to.not.contain('evil.example')
+  })
+
+  it('preserves a safe declaration next to a stripped one', () => {
+    const out = sanitizeThemeCss(':root { --themeColor: #fff; }\n.x { background: url(https://e/x); color: red; }')
+    expect(out).to.contain('--themeColor: #fff')
+    expect(out.toLowerCase()).to.not.contain('url(')
+  })
+
+  // Regression: CSS identifiers may be written with backslash escapes, so a
+  // literal-text denylist must decode them first or it is trivially bypassed.
+  it('decodes CSS escapes so @import cannot be smuggled past the filter', () => {
+    const out = sanitizeThemeCss('@\\69 mport "https://evil.example/x.css";\n:root { --a: 1; }')
+    expect(out.toLowerCase()).to.not.contain('@import')
+    expect(out).to.not.contain('evil.example')
+  })
+
+  it('decodes CSS escapes so url() cannot be smuggled past the filter', () => {
+    const out = sanitizeThemeCss(':root { background: \\75 rl("https://evil.example/x"); }')
+    expect(out.toLowerCase()).to.not.contain('url(')
+    expect(out).to.not.contain('evil.example')
+  })
+
+  it('decodes escapes inside @font-face and image-set', () => {
+    const ff = sanitizeThemeCss('@\\66 ont-face { src: \\75 rl("https://evil.example/f.woff2"); }')
+    expect(ff.toLowerCase()).to.not.contain('@font-face')
+    expect(ff).to.not.contain('evil.example')
+    const imageSet = sanitizeThemeCss(
+      ':root { background-image: image\\2d set("https://evil.example/a.png" 1x); }'
+    )
+    expect(imageSet.toLowerCase()).to.not.contain('image-set')
+    expect(imageSet).to.not.contain('evil.example')
+  })
+
+  it('removes @namespace and legacy expression()/behavior vectors', () => {
+    expect(
+      sanitizeThemeCss('@namespace url(http://evil.example/ns);\n:root {}').toLowerCase()
+    ).to.not.contain('evil.example')
+    expect(sanitizeThemeCss(':root { width: expression(alert(1)); }')).to.not.contain('expression(')
+    expect(sanitizeThemeCss('.x { behavior: url(evil.htc); }').toLowerCase()).to.not.contain('url(')
+  })
+})

--- a/packages/website/content/docs/end-user/THEMES.md
+++ b/packages/website/content/docs/end-user/THEMES.md
@@ -83,7 +83,54 @@ You can switch themes in several ways:
 
 ## Custom Themes
 
-Custom theme support is planned for a future release. In the meantime, you can use the "Custom CSS" option in Preferences → Theme to override theme styles.
+You can add your own editor themes without rebuilding MarkText. A custom theme is a single CSS file you drop into a folder; MarkText discovers it and lists it under **Custom Themes** in the **Theme** menu and in **Preferences → Theme**.
+
+### Where to put themes
+
+Create a `.theme.css` file in the `themes/editor` folder inside MarkText's user-data directory:
+
+- **Windows:** `%APPDATA%\marktext\themes\editor\`
+- **macOS:** `~/Library/Application Support/marktext/themes/editor/`
+- **Linux:** `~/.config/marktext/themes/editor/`
+
+The quickest way to get there is **Preferences → Theme → Open themes folder**. You can also use **Import Theme** to pick a `.css` file and have it copied in for you.
+
+> This is separate from `themes/export`, which holds custom **export** (PDF / HTML) themes.
+
+### File name
+
+The file must be named `<id>.theme.css`, where `<id>` is lowercase letters, numbers, `-` or `_` (for example `my-theme.theme.css`). The id is also used to remember your selection.
+
+### File format
+
+A theme is plain CSS that overrides MarkText's CSS variables on `:root`, with an optional metadata header:
+
+```css
+/*!
+ * @name My Theme
+ * @type dark
+ */
+:root {
+  --themeColor: #8da101;
+  --editorColor: #2d353b;
+  --editorBgColor: #f3f4f2;
+  --sideBarBgColor: #e3e4df;
+  /* ...override as many variables as you like... */
+}
+```
+
+- `@name` - the label shown in the menu (defaults to a title-cased file id).
+- `@type` - `light` or `dark` (defaults to `light`). `dark` enables MarkText's dark-mode UI affordances.
+
+For the full list of variables you can set, copy one of the built-in themes as a starting point - see [`src/renderer/src/assets/themes`](https://github.com/marktext/marktext/tree/develop/packages/desktop/src/renderer/src/assets/themes) (for example `everforest-light.theme.css`).
+
+### Applying a theme
+
+Drop the file in the folder and reopen the window (or the **Preferences → Theme** pane), or use **Import Theme**, which applies it immediately. Your theme then appears under **Custom Themes** in the **Theme** menu and in Preferences.
+
+### Security note
+
+Custom theme CSS is sanitized before it is applied: `@import`, `@font-face`, and any `url()` / `image-set()` value (including remote, `file:` and `data:` URLs) are removed. Custom themes are therefore **colors-only** - they cannot load external images or fonts. For deeper one-off tweaks, the **Custom CSS** box in Preferences → Theme still applies raw (unsanitized) CSS to the current theme.
 
 ## Theme Credits
 


### PR DESCRIPTION
Closes #174

## Summary

Adds support for user-provided **editor themes**, a long-standing request (#174). A custom theme is a single `<id>.theme.css` file placed in `<userData>/themes/editor/` (a sibling of the existing `<userData>/themes/export/` used for export themes). It is auto-discovered and listed under **Custom Themes** in the **Theme** menu and in **Preferences -> Theme**, and applies to the app like a built-in theme. This also enables the previously-disabled "Open themes folder" / "Import Theme" UI.

How it works:

- The **main process** reads `<userData>/themes/editor/*.theme.css`, parses an optional `@name` / `@type` header, sanitizes the CSS, and exposes the themes over a typed IPC contract (`mt::themes::list-custom` / `import-custom` / `open-folder`).
- The **renderer** keeps a small registry, applies a custom theme through `addThemeStyle`'s default branch (injected via `textContent`), and merges custom themes into the preview grid, the mode dropdowns, and the native menu. A custom `@type dark` theme also drives the dark `body` class and `nativeTheme.themeSource`.
- **Import Theme** copies a chosen `.css` into the folder and applies it immediately; **Open themes folder** reveals the folder for manual drops.

### Security

The editor renderer runs with `webSecurity: false`, so untrusted theme CSS is sanitized in the main process before it is applied: `@import`, `@namespace`, `@font-face`, and any `url()` / `image-set()` / `image()` value (remote, `file:` and `data:`) are removed. CSS escapes are decoded first so the denylist cannot be bypassed with, for example, `\75 rl(...)`. Custom themes are therefore colors-only (no external images or fonts). This is best-effort hardening, not a sandbox; the existing "Custom CSS" box remains the raw, unsanitized escape hatch.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Documentation update

## Test plan

- [x] Unit tests: theme metadata parser, the CSS sanitizer (including escape-bypass regression cases), and the renderer registry.
- [x] E2E (`packages/desktop/test/e2e/custom-themes.spec.ts`): seeds themes in `<userData>/themes/editor`, then asserts IPC discovery, that selecting a custom dark theme from the Theme menu applies `body.dark`, that the sanitized CSS is injected, and that a custom light theme removes `body.dark`.
- [x] Manually validated on Linux (Ubuntu): `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (579 passing), `pnpm build`, and `pnpm test:e2e` (77 passing) all green.

## Notes for reviewers [optional]

- The folder is `<userData>/themes/editor/`, deliberately separate from `<userData>/themes/export/` (export/PDF themes).
- Imported themes apply immediately and appear in Preferences right away; they appear in the **native Theme menu** when a window is next opened or the menu is rebuilt. A live file-watcher was intentionally left out to keep this PR focused.
- The theme file format and a complete example are documented in `THEMES.md` (the "planned for a future release" placeholder is replaced).
- The new `customThemes` / `importFailed` i18n keys were added to every locale with English values for translators to localize later.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
