### PR TITLE
fix(i18n): auto-detect system language before the 'ready' event

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # MarkText Contributing Guide
 
+> 🌐 Translations: [Deutsch](../docs/i18n/CONTRIBUTING-de.md)
+
 We are really excited that you are interested in contributing to MarkText :tada:. Before submitting your contribution, please make sure to take a moment and read through the following guidelines.
 
 - [Code of Conduct](../packages/website/content/docs/dev/CODE_OF_CONDUCT.md)
@@ -52,7 +54,7 @@ A good way to start is to find an [issue](https://github.com/marktext/marktext/i
 Other ways to help:
 
 - Documentation
-- Translation (currently unavailable)
+- Translation — MarkText ships localized UI (see `packages/desktop/static/locales/`); new languages and fixes are welcome
 - Design icons and logos
 - Improve the UI
 - Write tests for MarkText

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@
   <a href="docs/i18n/README-fr.md#readme">
     <span>:fr:</span>
   </a>
+  <a href="docs/i18n/README-de.md#readme">
+    <span>:de:</span>
+  </a>
   <a href="docs/i18n/README-tr.md#readme">
     <span>:tr:</span>
   </a>
@@ -83,6 +86,9 @@
   </a>
   <a href="docs/i18n/README-kr.md#readme">
     <span>:kr:</span>
+  </a>
+  <a href="docs/i18n/README-ar.md#readme">
+    <span>:saudi_arabia:</span>
   </a>
 </div>
 

--- a/docs/i18n/CONTRIBUTING-de.md
+++ b/docs/i18n/CONTRIBUTING-de.md
@@ -1,0 +1,94 @@
+> 🌐 Dies ist die deutsche Übersetzung von [CONTRIBUTING.md](../../.github/CONTRIBUTING.md).
+
+# MarkText Contributing Guide
+
+Wir freuen uns sehr, dass du dich für einen Beitrag zu MarkText interessierst :tada:. Bevor du deinen Beitrag einreichst, nimm dir bitte einen Moment Zeit und lies die folgenden Richtlinien durch.
+
+- [Code of Conduct](../../packages/website/content/docs/dev/CODE_OF_CONDUCT.md)
+- [Philosophie](#philosophie)
+- [Richtlinien zum Melden von Issues](#richtlinien-zum-melden-von-issues)
+- [Richtlinien für Pull Requests](#richtlinien-für-pull-requests)
+  - [Wo sollte ich anfangen?](#wo-sollte-ich-anfangen)
+- [Schnellstart](#schnellstart)
+  - [Build-Anleitung](#build-anleitung)
+  - [Style Guide](#style-guide)
+- [Entwicklerdokumentation](#entwicklerdokumentation)
+
+## Philosophie
+
+🔑 Unsere Philosophie ist es, die Dinge sauber, einfach und minimal zu halten.
+MarkText verändert sich ständig, und wir möchten, dass diese Verbesserungen mit unserer Philosophie im Einklang stehen. Schau dir zum Beispiel die Seitenleiste und die Tabs an; diese beiden Panels bieten großartige Funktionalität *und* lenken den Benutzer nicht ab. Wir werden weiterhin mehr Features (wie Plugins) hinzufügen, die über die „Einstellungen“ aktiviert werden können, um MarkText zu verbessern. So kann jeder MarkText an seine Bedürfnisse anpassen und erhält trotzdem eine minimale Standardoberfläche.
+
+## Richtlinien zum Melden von Issues
+
+Bitte suche nach ähnlichen Issues, bevor du ein neues Issue eröffnest, und halte dich immer an das [Issue-Template](../../.github/ISSUE_TEMPLATE/). Bitte sieh dir die folgenden Pull-Request-Richtlinien an, bevor du deinen eigenen PR erstellst.
+
+## Richtlinien für Pull Requests
+
+**In *allen* Pull Requests:** Gib eine detaillierte Beschreibung des Problems an, ebenso wie eine Demonstration mit Bildschirmaufnahmen und/oder Screenshots.
+
+Bitte stelle sicher, dass Folgendes erledigt ist, bevor du einen PR einreichst:
+
+- Reiche PRs direkt am `develop`-Branch ein.
+- Verweise im PR-Kommentar auf das zugehörige Issue.
+- Nutze [JSDoc](https://github.com/jsdoc/jsdoc) für eine bessere Code-Dokumentation.
+- Stelle sicher, dass alle Tests bestehen.
+- Bitte lass deinen PR durch den Linter laufen (`pnpm run lint`).
+- Alle PRs müssen die **CI** bestehen, bevor sie gemergt werden. Falls sie fehlschlägt, versuche bitte, die Probleme zu beheben, und frag gern jederzeit nach Hilfe.
+
+Wenn du ein neues Feature hinzufügst:
+
+- Eröffne zuerst ein Vorschlags-Issue.
+- Begründe, warum du dieses Feature hinzufügen möchtest.
+- Reiche deinen PR ein.
+
+Wenn du einen Bug behebst:
+
+- Wenn du ein bestimmtes Issue löst, füge bitte `fix: #<issue number> <short message>` in deinen PR-Titel ein (z. B. `fix: #3899 update entities encoding/decoding`).
+- Gib eine detaillierte Beschreibung des Bugs in deinem PR an und/oder verlinke das Issue.
+
+### Wo sollte ich anfangen?
+
+Ein guter Einstieg ist es, ein [Issue](https://github.com/marktext/marktext/issues) zu finden, das mit `bug`, `help wanted` oder `feature request` gekennzeichnet ist. Die mit `good first issue` markierten Issues eignen sich gut für Neueinsteiger. Bitte diskutiere die Lösung größerer Issues zuerst, und nachdem die endgültige Lösung von den MarkText-Mitgliedern genehmigt wurde, kannst du den PR einreichen bzw. daran arbeiten. Für kleine Änderungen kannst du direkt einen PR eröffnen.
+
+Weitere Möglichkeiten zu helfen:
+
+- Dokumentation
+- Übersetzungen
+- Icons und Logos gestalten
+- Die UI verbessern
+- Tests für MarkText schreiben
+- Teile deine Gedanken! Wir möchten von Features hören, die deiner Meinung nach fehlen, von Bugs, die du findest, und davon, warum du MarkText :heart:.
+
+## Schnellstart
+
+1. Forke das Repository.
+2. Klone deinen Fork: `git clone git@github.com:<username>/marktext.git`
+3. Erstelle einen Feature-Branch: `git checkout -b feature`
+4. Nimm deine Änderungen vor und pushe deinen Branch.
+5. Erstelle einen PR gegen `develop` und beschreibe deine Änderungen.
+
+**Rebase deines PR:**
+
+Wenn es Konflikte gibt oder du deinen lokalen Branch aktualisieren möchtest, gehe bitte wie folgt vor:
+
+1. `git fetch upstream`
+2. `git rebase upstream/develop`
+3. Bitte [behebe](https://help.github.com/articles/resolving-merge-conflicts-after-a-git-rebase/) alle Konflikte und force-pushe deinen Feature-Branch: `git push -f`
+
+### Build-Anleitung
+
+🔗 [Build-Anleitung](https://marktext.me/docs/dev/build)
+
+### Style Guide
+
+Du kannst ESLint (`pnpm run lint`) ausführen, um dir dabei zu helfen, den Style Guide einzuhalten.
+
+- ES6 und „Best Practices“
+- 2 Leerzeichen Einrückung
+- keine Semikolons
+- Dokumentation: [JSDoc](https://github.com/jsdoc/jsdoc)
+
+## Entwicklerdokumentation
+
+Bitte [klicke hier](https://marktext.me/docs/dev/overview) für weitere Details.

--- a/packages/desktop/src/common/i18n.ts
+++ b/packages/desktop/src/common/i18n.ts
@@ -97,6 +97,36 @@ function isLanguageSupported(language: string): boolean {
   return (SUPPORTED_LANGUAGES as readonly string[]).includes(language)
 }
 
+/**
+ * Normalizes a raw OS locale string (e.g. 'de_DE.UTF-8', 'de-DE', 'en') and
+ * matches it against the supported languages — first by exact BCP 47 tag, then
+ * by primary subtag (so 'de-DE' → 'de' and 'zh' → 'zh-CN'). Returns null for
+ * empty / `C` / `POSIX` locales or when nothing matches.
+ *
+ * This is deliberately defensive: callers may pass a locale obtained before the
+ * Electron `ready` event, when `app.getLocale()` can return ''. An empty string
+ * must never accidentally match a language — the previous `startsWith(primary)`
+ * approach matched the first supported language ('en') for an empty primary.
+ */
+function matchSystemLocale(rawLocale: string | undefined | null): string | null {
+  if (!rawLocale) return null
+
+  // 'de_DE.UTF-8' / 'de_DE@euro' -> 'de-DE'
+  const normalized = rawLocale.split('.')[0]!.split('@')[0]!.replace(/_/g, '-').trim()
+  if (!normalized || normalized === 'C' || normalized === 'POSIX') return null
+
+  // Exact tag match first (e.g. 'zh-CN').
+  if (isLanguageSupported(normalized)) return normalized
+
+  // Fall back to the primary subtag (e.g. 'de-DE' -> 'de', 'zh-Hant' -> 'zh').
+  const primary = normalized.split('-')[0]!.toLowerCase()
+  if (!primary) return null
+
+  return (
+    SUPPORTED_LANGUAGES.find((lang) => lang === primary || lang.startsWith(`${primary}-`)) ?? null
+  )
+}
+
 function clearCache(): void {
   translationsCache = {}
 }
@@ -109,6 +139,7 @@ export {
   getTranslation,
   getSupportedLanguages,
   isLanguageSupported,
+  matchSystemLocale,
   clearCache,
   getAllTranslations,
   loadTranslations

--- a/packages/desktop/src/main/preferences/index.ts
+++ b/packages/desktop/src/main/preferences/index.ts
@@ -5,7 +5,7 @@ import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import log from 'electron-log'
 import { isWindows } from '../config'
 import { hasSameKeys } from '../utils'
-import { getSupportedLanguages, isLanguageSupported } from 'common/i18n'
+import { matchSystemLocale } from 'common/i18n'
 import { TypedEmitter } from '@shared/types/typedEmitter'
 import type { IUserPreferences } from '@shared/types/preferences'
 import schema from './schema.json'
@@ -202,29 +202,37 @@ class Preference extends TypedEmitter<PreferenceEvents> {
    */
   _getSystemLanguage(): string | null {
     try {
-      // Get the system language
-      const systemLocale = app.getLocale()
-      log.info(`System locale detected: ${systemLocale}`)
+      // Gather locale candidates from several sources and return the first that
+      // maps to a supported language. `app.getLocale()` is only reliable after
+      // the 'ready' event, but Preference is constructed at module load (see
+      // main/index.ts) — before 'ready'. On Linux that makes `app.getLocale()`
+      // return '' on first launch, so detection silently fell back to English
+      // even on e.g. a German system. The POSIX locale env vars and
+      // `app.getPreferredSystemLanguages()` are available immediately, so we
+      // consult them as fallbacks.
+      const candidates: Array<string | undefined> = [
+        app.getLocale(),
+        ...(typeof app.getPreferredSystemLanguages === 'function'
+          ? app.getPreferredSystemLanguages()
+          : []),
+        process.env.LC_ALL,
+        process.env.LC_MESSAGES,
+        process.env.LANG
+      ]
 
-      // Get the list of supported languages
-      const supportedLanguages = getSupportedLanguages()
-
-      // Directly match the full language code (e.g. zh-CN)
-      if (isLanguageSupported(systemLocale)) {
-        log.info(`Using system language: ${systemLocale}`)
-        return systemLocale
+      for (const candidate of candidates) {
+        const matched = matchSystemLocale(candidate)
+        if (matched) {
+          log.info(`Detected system language '${matched}' from locale '${candidate}'`)
+          return matched
+        }
       }
 
-      // Attempt to match the primary part of the language (e.g. zh)
-      const primaryLanguage = systemLocale.split('-')[0]!
-      const matchedLanguage = supportedLanguages.find((lang) => lang.startsWith(primaryLanguage))
-
-      if (matchedLanguage) {
-        log.info(`Using matched language: ${matchedLanguage} for system locale: ${systemLocale}`)
-        return matchedLanguage
-      }
-
-      log.info(`System language ${systemLocale} not supported, will use default language`)
+      log.info(
+        `No supported system language detected (candidates: ${candidates
+          .filter(Boolean)
+          .join(', ')}); using default language`
+      )
       return null
     } catch (error) {
       log.error('Error detecting system language:', error)

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -410,6 +410,7 @@
       "items": {
         "autoSave": "Automatically save the content being edited",
         "autoSaveDelay": "The time in ms after a change that the file is saved",
+        "autoNormalizeLineEndings": "Automatically normalize line endings to LF when opening files",
         "titleBarStyle": "The title bar style (Windows and Linux system only)",
         "openFilesInNewWindow": "Open files in a new window",
         "openFolderInNewWindow": "Open folder via menu in a new window",

--- a/packages/desktop/test/unit/specs/system-locale.spec.ts
+++ b/packages/desktop/test/unit/specs/system-locale.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { matchSystemLocale } from '../../../src/common/i18n'
+
+describe('matchSystemLocale', () => {
+  it('matches an exact supported BCP 47 tag', () => {
+    expect(matchSystemLocale('zh-CN')).toBe('zh-CN')
+    expect(matchSystemLocale('en')).toBe('en')
+    expect(matchSystemLocale('de')).toBe('de')
+  })
+
+  it('falls back to the primary subtag', () => {
+    expect(matchSystemLocale('de-DE')).toBe('de')
+    expect(matchSystemLocale('fr-CA')).toBe('fr')
+    expect(matchSystemLocale('pt-BR')).toBe('pt')
+  })
+
+  it('normalizes POSIX locale strings from env vars', () => {
+    expect(matchSystemLocale('de_DE.UTF-8')).toBe('de')
+    expect(matchSystemLocale('ja_JP.UTF-8')).toBe('ja')
+    expect(matchSystemLocale('de_DE@euro')).toBe('de')
+  })
+
+  it('prefers a region variant for ambiguous primary subtags', () => {
+    // 'zh' alone is not a supported tag; the primary-subtag fallback must pick a
+    // concrete supported variant rather than returning null.
+    expect(matchSystemLocale('zh')).toBe('zh-CN')
+    expect(matchSystemLocale('zh-Hant')).toBe('zh-CN')
+  })
+
+  it('never matches an empty or absent locale to a language', () => {
+    // Regression: before the fix, an empty primary subtag made
+    // `supportedLanguages.find(lang => lang.startsWith(''))` return the first
+    // language ('en'), so a German system silently showed English. An empty
+    // locale (what `app.getLocale()` returns before the Electron 'ready' event
+    // on Linux) must yield null so the next candidate source is consulted.
+    expect(matchSystemLocale('')).toBeNull()
+    expect(matchSystemLocale(undefined)).toBeNull()
+    expect(matchSystemLocale(null)).toBeNull()
+    expect(matchSystemLocale('C')).toBeNull()
+    expect(matchSystemLocale('POSIX')).toBeNull()
+  })
+
+  it('returns null for an unsupported but well-formed locale', () => {
+    expect(matchSystemLocale('ru-RU')).toBeNull()
+    expect(matchSystemLocale('it')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

On a system whose locale is non-English (reproduced on CachyOS with German as the system language), MarkText starts in **English** on first launch even though a complete translation exists and is registered — the user has to switch the language manually in preferences. This makes it look as if there is no translation at all.

### Root cause

`Preference` is constructed at module load in `main/index.ts`, **before** Electron's `ready` event:

```
accessor = new Accessor(appEnvironment)   // main/index.ts — module load
  └─ new Preference(...)
       └─ init() → _getSystemLanguage() → app.getLocale()
```

`app.getLocale()` is only reliable **after** `ready`; before that it returns `''` on Linux. The old matcher then did:

```js
const primary = systemLocale.split('-')[0]            // '' for an empty locale
supportedLanguages.find(lang => lang.startsWith(primary))  // every string startsWith('') → 'en'
```

So an empty locale silently resolved to the first supported language (`en`), and system-language detection never had a chance to pick `de`.

## Fix

- New pure, unit-tested helper `matchSystemLocale()` in `common/i18n.ts`: normalizes OS locales (`de_DE.UTF-8` → `de`), matches by exact BCP-47 tag then primary subtag, and returns `null` for empty / `C` / `POSIX` locales — so an empty string can never accidentally match a language.
- `_getSystemLanguage()` now consults several sources that **are** available before `ready` and takes the first supported match: `app.getLocale()` → `app.getPreferredSystemLanguages()` → POSIX env vars (`LC_ALL` / `LC_MESSAGES` / `LANG`).
- An existing explicit/persisted language choice is still respected — detection only runs on first launch (no preferences file yet).

## Also in this PR

- **Locale parity:** added the missing `preferences.search.items.autoNormalizeLineEndings` key to `en.json` (the other 8 locales already had it).
- **Docs:** added `docs/i18n/CONTRIBUTING-de.md` (German translation of the contributing guide), linked it from `CONTRIBUTING.md`, refreshed the stale “Translation (currently unavailable)” note, and added the existing German (:de:) and Arabic (:ar:) README translations to the Translations list in `README.md`.

## Testing

- New `test/unit/specs/system-locale.spec.ts` (incl. the empty-locale regression) — green.
- `pnpm exec vitest run` (new + existing i18n specs): **8 passed**.
- `vue-tsc --noEmit`: clean.
- `eslint`: 0 errors.

> Note: I wasn't able to attach a screen recording — the Electron runtime / native modules don't build in my environment (no `node-gyp`). The behavior change is covered by the unit tests; happy to add a recording if a maintainer wants one.

No linked issue — found while investigating why German didn't appear automatically. Targeting `develop` per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)