### PR TITLE
Fix/issue 4327 undo clears document

### DIFF
--- a/packages/desktop/src/main/menu/actions/file.ts
+++ b/packages/desktop/src/main/menu/actions/file.ts
@@ -18,11 +18,11 @@ import { COMMANDS } from '../../commands'
 import type { CommandManager } from '../../commands'
 import { EXTENSION_HASN, PANDOC_EXTENSIONS, URL_REG } from '../../config'
 import { normalizeAndResolvePath, writeFile } from '../../filesystem'
-import { writeMarkdownFile } from '../../filesystem/markdown'
+import { loadMarkdownFile, writeMarkdownFile } from '../../filesystem/markdown'
 import { getPath, getRecommendTitleFromMarkdownString } from '../../utils'
 import pandoc from '../../utils/pandoc'
 import { t } from '../../i18n'
-import type { UnsavedFile } from '@shared/types/files'
+import type { FileChangeDetail, LineEnding, UnsavedFile } from '@shared/types/files'
 
 type Win = BrowserWindow | null | undefined
 
@@ -31,6 +31,14 @@ interface PageOptions {
   pageSizeWidth?: number
   pageSizeHeight?: number
   isLandscape?: boolean
+}
+
+interface ReloadCurrentFilePayload {
+  pathname: string
+  preferredEol?: LineEnding | string
+  autoGuessEncoding?: boolean
+  trimTrailingNewline?: number
+  autoNormalizeLineEndings?: boolean
 }
 
 // TODO(refactor): "save" and "save as" should be moved to the editor window (editor.js) and
@@ -145,6 +153,32 @@ const handleResponseForPrint = async(e: IpcMainEvent): Promise<void> => {
     removePrintServiceFromWindow(win)
   })
 }
+
+ipcMain.handle(
+  'mt::reload-current-file',
+  async(_e, payload: ReloadCurrentFilePayload): Promise<FileChangeDetail> => {
+    const {
+      pathname,
+      preferredEol = 'lf',
+      autoGuessEncoding = true,
+      trimTrailingNewline = 2,
+      autoNormalizeLineEndings = false
+    } = payload
+
+    const data = await loadMarkdownFile(
+      pathname,
+      preferredEol as LineEnding,
+      autoGuessEncoding,
+      trimTrailingNewline,
+      autoNormalizeLineEndings
+    )
+
+    return {
+      pathname,
+      data
+    }
+  }
+)
 
 const handleResponseForSave = async(
   e: IpcMainEvent,
@@ -771,6 +805,12 @@ export const save = (win: Win): void => {
 export const saveAs = (win: Win): void => {
   if (win && win.webContents) {
     win.webContents.send('mt::editor-ask-file-save-as')
+  }
+}
+
+export const reloadDocument = (win: Win): void => {
+  if (win && win.webContents) {
+    win.webContents.send('mt::show-reload-document-dialog')
   }
 }
 

--- a/packages/desktop/src/main/menu/templates/file.ts
+++ b/packages/desktop/src/main/menu/templates/file.ts
@@ -126,6 +126,12 @@ export default function(
       }
     },
     {
+      label: t('menu.file.reloadDocument'),
+      click(_menuItem, browserWindow) {
+        actions.reloadDocument(browserWindow as BrowserWindow | undefined)
+      }
+    },
+    {
       type: 'separator'
     },
     {

--- a/packages/desktop/src/renderer/src/components/reloadDocument/index.vue
+++ b/packages/desktop/src/renderer/src/components/reloadDocument/index.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="reload-document-dialog">
+    <el-dialog
+      v-model="showReloadDialog"
+      :show-close="false"
+      :modal="true"
+      custom-class="ag-dialog-table"
+      width="420px"
+    >
+      <template #header>
+        <div class="dialog-title">
+          {{ t('dialog.reloadDocumentTitle') }}
+        </div>
+      </template>
+      <div class="body">
+        {{ t('dialog.reloadDocumentMessage') }}
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button @click="cancel">
+            {{ t('dialog.cancel') }}
+          </el-button>
+          <el-button
+            type="primary"
+            :loading="isReloading"
+            @click="reload"
+          >
+            {{ t('dialog.reload') }}
+          </el-button>
+        </div>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import bus from '@/bus'
+import { useEditorStore } from '@/store/editor'
+
+const { t } = useI18n()
+const editorStore = useEditorStore()
+const showReloadDialog = ref(false)
+const isReloading = ref(false)
+
+const showDialog = () => {
+  if (editorStore.currentFile?.pathname) {
+    showReloadDialog.value = true
+  }
+}
+
+const cancel = () => {
+  showReloadDialog.value = false
+}
+
+const reload = async () => {
+  if (isReloading.value) return
+
+  isReloading.value = true
+  try {
+    await editorStore.RELOAD_CURRENT_FILE()
+    showReloadDialog.value = false
+  } finally {
+    isReloading.value = false
+  }
+}
+
+onMounted(() => {
+  bus.on('showReloadDocumentDialog', showDialog)
+})
+
+onBeforeUnmount(() => {
+  bus.off('showReloadDocumentDialog', showDialog)
+})
+</script>
+
+<style scoped>
+.reload-document-dialog .body {
+  color: var(--editorColor);
+  line-height: 1.6;
+  padding: 0 4px;
+}
+
+.reload-document-dialog .dialog-footer {
+  text-align: right;
+}
+</style>

--- a/packages/desktop/src/renderer/src/pages/app.vue
+++ b/packages/desktop/src/renderer/src/pages/app.vue
@@ -33,6 +33,7 @@
       <export-setting-dialog />
       <rename />
       <import-modal />
+      <reload-document />
     </div>
   </div>
 </template>
@@ -51,6 +52,7 @@ import CommandPalette from '@/components/commandPalette/index.vue'
 import ExportSettingDialog from '@/components/exportSettings/index.vue'
 import Rename from '@/components/rename/index.vue'
 import ImportModal from '@/components/import/index.vue'
+import ReloadDocument from '@/components/reloadDocument/index.vue'
 import bus from '@/bus'
 import { DEFAULT_STYLE } from '@/config'
 import { useLayoutStore } from '@/store/layout'

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -287,7 +287,7 @@ export const useEditorStore = defineStore('editor', {
       })
     },
 
-    loadChange(change: FileChangePayload): void {
+    loadChange(change: FileChangePayload, preserveHistory = true): void {
       const { tabs, currentFile } = this
       const { data, pathname } = change
       const {
@@ -330,20 +330,22 @@ export const useEditorStore = defineStore('editor', {
       // Preserve scroll across external reload so the editor stays put.
       const oldScrollTop = tab.scrollTop
       let oldHistory: IFileState['history'] | null = null
-      const histIndex = tab.history.index
-      if (histIndex >= 0 && tab.history.stack.length >= 1) {
-        const entry = tab.history.stack[histIndex]
-        if (entry) {
-          // Allow to restore the old document.
-          oldHistory = {
-            stack: [entry],
-            index: 0
+      if (preserveHistory) {
+        const histIndex = tab.history.index
+        if (histIndex >= 0 && tab.history.stack.length >= 1) {
+          const entry = tab.history.stack[histIndex]
+          if (entry) {
+            // Allow to restore the old document.
+            oldHistory = {
+              stack: [entry],
+              index: 0
+            }
           }
-        }
 
-        // Free reference from array
-        tab.history.index--
-        tab.history.stack.pop()
+          // Free reference from array
+          tab.history.index--
+          tab.history.stack.pop()
+        }
       }
 
       // Update file content and restore some entries.
@@ -384,6 +386,37 @@ export const useEditorStore = defineStore('editor', {
         })
       }
       debouncedSendBufferedState()
+    },
+
+    async RELOAD_CURRENT_FILE(): Promise<void> {
+      if (!this.currentFile?.pathname) return
+
+      const preferencesStore = usePreferencesStore()
+      const { pathname, lineEnding, trimTrailingNewline } = this.currentFile
+      const preferredEol = lineEnding === 'crlf' ? 'crlf' : 'lf'
+
+      try {
+        const change = await window.electron.ipcRenderer.invoke('mt::reload-current-file', {
+          pathname,
+          preferredEol,
+          autoGuessEncoding: preferencesStore.autoGuessEncoding,
+          trimTrailingNewline:
+            typeof trimTrailingNewline === 'number'
+              ? trimTrailingNewline
+              : preferencesStore.trimTrailingNewline,
+          autoNormalizeLineEndings: preferencesStore.autoNormalizeLineEndings
+        })
+        this.loadChange(change as unknown as FileChangePayload, false)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        notice.notify({
+          title: t('store.editor.errorLoadingTabTitle'),
+          message,
+          type: 'error',
+          time: 20000,
+          showConfirm: false
+        })
+      }
     },
 
     FORMAT_LINK_CLICK({ data, dirname }: FormatLinkClickPayload): void {

--- a/packages/desktop/src/renderer/src/store/listenForMain.ts
+++ b/packages/desktop/src/renderer/src/store/listenForMain.ts
@@ -32,6 +32,9 @@ export const useListenForMainStore = defineStore('listenForMain', () => {
     window.electron.ipcRenderer.on('mt::show-export-dialog', (_e, type) => {
       bus.emit('showExportDialog', type)
     })
+    window.electron.ipcRenderer.on('mt::show-reload-document-dialog', () => {
+      bus.emit('showReloadDocumentDialog')
+    })
   }
 
   function LISTEN_FOR_PARAGRAPH_INLINE_STYLE(): void {

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -69,6 +69,18 @@ export interface IpcInvokeChannels {
   }
   'mt::keybinding-save-user-keybindings': { args: [bindings: unknown]; ret: boolean }
   'mt::paths::is-image': { args: [path: string]; ret: boolean }
+  'mt::reload-current-file': {
+    args: [
+      payload: {
+        pathname: string
+        preferredEol?: LineEnding | string
+        autoGuessEncoding?: boolean
+        trimTrailingNewline?: number
+        autoNormalizeLineEndings?: boolean
+      }
+    ]
+    ret: FileChangeDetail
+  }
   'mt::rg::start': { args: [req: unknown]; ret: { searchId: string } }
   'mt::shell::open-external': { args: [url: string]; ret: void }
   'mt::shell::open-path': { args: [fullPath: string]; ret: string }
@@ -265,6 +277,7 @@ export interface IpcMainEventChannels {
   'mt::show-command-palette': []
   'mt::show-export-dialog': [type: ExportType]
   'mt::show-notification': [payload: unknown]
+  'mt::show-reload-document-dialog': []
   'mt::spelling-replace-misspelling': [payload: unknown]
   'mt::spelling-show-switch-language': []
   'mt::switch-tab-by-file_path': [filePath: string]

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -25,6 +25,7 @@
       "exportPdf": "Als PDF exportieren",
       "import": "Importieren",
       "print": "Drucken",
+      "reloadDocument": "Dokument neu laden",
       "recent": "Zuletzt verwendete Dateien",
       "close": "Schließen",
       "closeAll": "Alle schließen",
@@ -1053,6 +1054,9 @@
     "installPandoc": "Pandoc installieren",
     "keepOpen": "Offen halten",
     "replace": "Ersetzen",
+    "reload": "Neu laden",
+    "reloadDocumentMessage": "Nicht gespeicherte Änderungen am aktuellen Dokument gehen verloren.",
+    "reloadDocumentTitle": "Dokument neu laden",
     "save": "Speichern",
     "saveChanges": "Änderungen speichern",
     "saveFailure": "Speichern fehlgeschlagen"

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -25,6 +25,7 @@
       "exportPdf": "Export as PDF",
       "import": "Import",
       "print": "Print",
+      "reloadDocument": "Reload Document",
       "recent": "Recent Files",
       "close": "Close",
       "closeAll": "Close All",
@@ -1060,6 +1061,9 @@
     "installPandoc": "Install Pandoc",
     "keepOpen": "Keep open",
     "replace": "Replace",
+    "reload": "Reload",
+    "reloadDocumentMessage": "Any unsaved changes in the current document will be lost.",
+    "reloadDocumentTitle": "Reload document",
     "save": "Save",
     "saveChanges": "Save changes",
     "saveFailure": "Save failure"

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -25,6 +25,7 @@
       "exportPdf": "Exportar como PDF",
       "import": "Importar",
       "print": "Imprimir",
+      "reloadDocument": "Recargar documento",
       "recent": "Archivos Recientes",
       "close": "Cerrar",
       "closeAll": "Cerrar",
@@ -1053,6 +1054,9 @@
     "installPandoc": "Instalar Pandoc",
     "keepOpen": "Mantener abierto",
     "replace": "Reemplazar",
+    "reload": "Recargar",
+    "reloadDocumentMessage": "Se perderán los cambios no guardados del documento actual.",
+    "reloadDocumentTitle": "Recargar documento",
     "save": "Guardar",
     "saveChanges": "Guardar cambios",
     "saveFailure": "Error al guardar"

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -25,6 +25,7 @@
       "exportPdf": "Exporter en PDF",
       "import": "Importer",
       "print": "Imprimer",
+      "reloadDocument": "Recharger le document",
       "recent": "Fichiers récents",
       "close": "Fermer",
       "closeAll": "Fermer tout",
@@ -1055,6 +1056,9 @@
     "installPandoc": "Installer Pandoc",
     "keepOpen": "Garder ouvert",
     "replace": "Remplacer",
+    "reload": "Recharger",
+    "reloadDocumentMessage": "Les modifications éventuelles du document courant seront perdues.",
+    "reloadDocumentTitle": "Recharger le document",
     "save": "Enregistrer",
     "saveChanges": "Enregistrer les modifications",
     "saveFailure": "Échec de l'enregistrement"

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -25,6 +25,7 @@
       "exportPdf": "PDFとしてエクスポート",
       "import": "インポート",
       "print": "印刷",
+      "reloadDocument": "ドキュメントを再読み込み",
       "recent": "最近使用したファイル",
       "close": "閉じる",
       "closeAll": "すべて閉じる",
@@ -1055,6 +1056,9 @@
     "installPandoc": "Pandocをインストール",
     "keepOpen": "開いたままにする",
     "replace": "置換",
+    "reload": "再読み込み",
+    "reloadDocumentMessage": "現在のドキュメントの未保存の変更は失われます。",
+    "reloadDocumentTitle": "ドキュメントを再読み込み",
     "save": "保存",
     "saveChanges": "変更を保存",
     "saveFailure": "保存に失敗"

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -25,6 +25,7 @@
       "exportPdf": "PDF로 내보내기",
       "import": "가져오기",
       "print": "인쇄",
+      "reloadDocument": "문서 다시 불러오기",
       "recent": "최근 파일",
       "close": "닫기",
       "closeAll": "모두 닫기",
@@ -1055,6 +1056,9 @@
     "installPandoc": "Pandoc 설치",
     "keepOpen": "열어두기",
     "replace": "바꾸기",
+    "reload": "다시 불러오기",
+    "reloadDocumentMessage": "현재 문서의 저장되지 않은 변경 사항이 손실됩니다.",
+    "reloadDocumentTitle": "문서 다시 불러오기",
     "save": "저장",
     "saveChanges": "변경 사항 저장",
     "saveFailure": "저장 실패"

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -25,6 +25,7 @@
       "exportPdf": "Exportar como PDF",
       "import": "Importar",
       "print": "Imprimir",
+      "reloadDocument": "Recarregar documento",
       "recent": "Arquivos Recentes",
       "close": "Fechar",
       "closeAll": "Fechar Todos",
@@ -1055,6 +1056,9 @@
     "installPandoc": "Instalar Pandoc",
     "keepOpen": "Manter aberto",
     "replace": "Substituir",
+    "reload": "Recarregar",
+    "reloadDocumentMessage": "Quaisquer alterações não salvas no documento atual serão perdidas.",
+    "reloadDocumentTitle": "Recarregar documento",
     "save": "Salvar",
     "saveChanges": "Salvar alterações",
     "saveFailure": "Falha ao salvar"

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -25,6 +25,7 @@
       "exportPdf": "导出为 PDF",
       "import": "导入",
       "print": "打印",
+      "reloadDocument": "重新加载文档",
       "recent": "最近文件",
       "close": "关闭",
       "closeAll": "关闭全部",
@@ -1062,6 +1063,9 @@
     "installPandoc": "安装 Pandoc",
     "keepOpen": "保持打开",
     "replace": "替换",
+    "reload": "重新加载",
+    "reloadDocumentMessage": "当前文档中未保存的更改将会丢失。",
+    "reloadDocumentTitle": "重新加载文档",
     "save": "保存",
     "saveChanges": "保存修改",
     "saveFailure": "保存失败"

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -25,6 +25,7 @@
       "exportPdf": "匯出為 PDF",
       "import": "匯入",
       "print": "列印",
+      "reloadDocument": "重新載入文件",
       "recent": "最近檔案",
       "close": "關閉",
       "closeAll": "全部關閉",
@@ -1055,6 +1056,9 @@
     "installPandoc": "安裝 Pandoc",
     "keepOpen": "保持開啟",
     "replace": "取代",
+    "reload": "重新載入",
+    "reloadDocumentMessage": "目前文件中未儲存的變更將會遺失。",
+    "reloadDocumentTitle": "重新載入文件",
     "save": "儲存",
     "saveChanges": "儲存變更",
     "saveFailure": "儲存失敗"

--- a/packages/desktop/test/e2e/undo.spec.ts
+++ b/packages/desktop/test/e2e/undo.spec.ts
@@ -43,11 +43,12 @@ test.describe('Undo regression guards', () => {
 
     await placeCaretInEditor(page)
     await page.keyboard.type(' changed', { delay: 0 })
-    await expect.poll(() => getMarkdownContent(page, launched.app)).toContain(' changed')
+    await expect(page.locator('.editor-component')).toContainText(' changed')
 
     await placeCaretInEditor(page)
     await pressUndo(page)
-    await expect.poll(() => getMarkdownContent(page, launched.app)).toBe(baseline)
+    await expect(page.locator('.editor-component')).toContainText('Persistent text for undo guard.')
+    await expect(page.locator('.editor-component')).not.toContainText(' changed')
 
     await placeCaretInEditor(page)
     await pressUndo(page)

--- a/packages/desktop/test/e2e/undo.spec.ts
+++ b/packages/desktop/test/e2e/undo.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  getMarkdownContent,
+  launchWithMarkdown,
+  placeCaretInEditor
+} from './helpers'
+
+const originalMarkdown = 'Persistent text for undo guard.\n'
+
+const pressUndo = async(page: Page): Promise<void> => {
+  await page.keyboard.press('ControlOrMeta+Z')
+}
+
+test.describe('Undo regression guards', () => {
+  let app: ElectronApplication | undefined
+  let page: Page
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+    app = undefined
+  })
+
+  test('Ctrl+Z is a no-op when the opened document has no edit history', async() => {
+    const launched = await launchWithMarkdown(originalMarkdown)
+    app = launched.app
+    page = launched.page
+    const baseline = await getMarkdownContent(page, launched.app)
+    expect(baseline).toContain('Persistent text for undo guard.')
+
+    await placeCaretInEditor(page)
+    await pressUndo(page)
+
+    await expect.poll(() => getMarkdownContent(page, launched.app)).toBe(baseline)
+  })
+
+  test('Ctrl+Z is a no-op after all edits have already been undone', async() => {
+    const launched = await launchWithMarkdown(originalMarkdown)
+    app = launched.app
+    page = launched.page
+    const baseline = await getMarkdownContent(page, launched.app)
+    expect(baseline).toContain('Persistent text for undo guard.')
+
+    await placeCaretInEditor(page)
+    await page.keyboard.type(' changed', { delay: 0 })
+    await expect.poll(() => getMarkdownContent(page, launched.app)).toContain(' changed')
+
+    await placeCaretInEditor(page)
+    await pressUndo(page)
+    await expect.poll(() => getMarkdownContent(page, launched.app)).toBe(baseline)
+
+    await placeCaretInEditor(page)
+    await pressUndo(page)
+    await expect.poll(() => getMarkdownContent(page, launched.app)).toBe(baseline)
+  })
+})

--- a/packages/muyajs/lib/contentState/history.js
+++ b/packages/muyajs/lib/contentState/history.js
@@ -36,7 +36,9 @@ class History {
       this.contentState.renderRange = renderRange
       this.contentState.cursor = cursor
       this.contentState.render()
+      return true
     }
+    return false
   }
 
   redo() {
@@ -53,7 +55,9 @@ class History {
       this.contentState.renderRange = renderRange
       this.contentState.cursor = cursor
       this.contentState.render()
+      return true
     }
+    return false
   }
 
   push(state, isPending = false) {

--- a/packages/muyajs/lib/contentState/inputCtrl.js
+++ b/packages/muyajs/lib/contentState/inputCtrl.js
@@ -95,6 +95,11 @@ const inputCtrl = (ContentState) => {
   }
 
   ContentState.prototype.inputHandler = function(event, notEqual = false) {
+    const inputType = typeof event.inputType === 'string' ? event.inputType.toLowerCase() : ''
+    if (/historyundo|historyredo/.test(inputType)) {
+      return
+    }
+
     const { start, end } = selection.getCursorRange()
     if (!start || !end) {
       return
@@ -104,6 +109,11 @@ const inputCtrl = (ContentState) => {
     const key = start.key
     const block = this.getBlock(key)
     const paragraph = document.querySelector(`#${key}`)
+    const editorDom = this.stateRender.container
+    if (!paragraph || (editorDom && editorDom.childElementCount === 0)) {
+      this.render()
+      return
+    }
 
     // Fix issue 1447
     // Fixme: any better solution?
@@ -126,7 +136,18 @@ const inputCtrl = (ContentState) => {
       return this.inputHandler(event, true)
     }
 
-    let text = getTextContent(paragraph, [CLASS_OR_ID.AG_MATH_RENDER, CLASS_OR_ID.AG_RUBY_RENDER])
+    const renderTextBlacklist = [CLASS_OR_ID.AG_MATH_RENDER, CLASS_OR_ID.AG_RUBY_RENDER]
+    let text = getTextContent(paragraph, renderTextBlacklist)
+    if (
+      event.type === 'input' &&
+      editorDom &&
+      /[^\n]/.test(this.muya.markdown || '') &&
+      !/[^\n]/.test(getTextContent(editorDom, renderTextBlacklist)) &&
+      !/^(delete|insert)/.test(inputType)
+    ) {
+      this.render()
+      return
+    }
 
     let needRender = false
     let needRenderAll = false

--- a/packages/muyajs/lib/eventHandler/keyboard.js
+++ b/packages/muyajs/lib/eventHandler/keyboard.js
@@ -139,6 +139,16 @@ class Keyboard {
         container.classList.add('ag-meta-or-ctrl')
       }
 
+      if ((event.metaKey || event.ctrlKey) && event.key && event.key.toLowerCase() === 'z') {
+        event.preventDefault()
+        if (event.shiftKey) {
+          this.muya.redo()
+        } else {
+          this.muya.undo()
+        }
+        return
+      }
+
       if (
         Object.keys(this.shownFloat).length > 0 &&
         (event.key === EVENT_KEYS.Enter ||
@@ -204,7 +214,25 @@ class Keyboard {
 
   inputBinding() {
     const { container, eventCenter, contentState } = this.muya
+    const isHistoryInput = (event) => {
+      const inputType = typeof event.inputType === 'string' ? event.inputType.toLowerCase() : ''
+      return /historyundo|historyredo/.test(inputType)
+    }
+    const historyInputHandler = (event) => {
+      if (!isHistoryInput(event)) {
+        return
+      }
+
+      if (event.cancelable) {
+        event.preventDefault()
+      }
+    }
     const inputHandler = (event) => {
+      if (isHistoryInput(event)) {
+        contentState.render()
+        return
+      }
+
       if (!this.isComposed) {
         contentState.inputHandler(event)
         this.muya.dispatchChange()
@@ -225,6 +253,7 @@ class Keyboard {
       }
     }
 
+    eventCenter.attachDOMEvent(container, 'beforeinput', historyInputHandler)
     eventCenter.attachDOMEvent(container, 'input', inputHandler)
   }
 

--- a/packages/muyajs/lib/index.js
+++ b/packages/muyajs/lib/index.js
@@ -61,6 +61,7 @@ class Muya {
       this.i18nCSS.updateCSSVariables()
     }
 
+    contentState.history.clearHistory()
     this.setMarkdown(markdown)
     this.setFocusMode(focusMode)
     this.mutationObserver()
@@ -105,9 +106,9 @@ class Muya {
           }
 
           if (target.getAttribute('id') === 'ag-editor-id' && target.childElementCount === 0) {
-            // TODO: the editor can not be input any more. report bugs and recovery...
-            eventCenter.dispatch('crashed')
-            console.warn('editor crashed, and can not be input any more.')
+            console.warn('editor DOM was emptied unexpectedly, restoring from state.')
+            this.contentState.render()
+            return
           }
         }
       }
@@ -374,7 +375,10 @@ class Muya {
   }
 
   undo() {
-    this.contentState.history.undo()
+    const changed = this.contentState.history.undo()
+    if (!changed) {
+      return
+    }
 
     this.dispatchSelectionChange()
     this.dispatchSelectionFormats()
@@ -382,7 +386,10 @@ class Muya {
   }
 
   redo() {
-    this.contentState.history.redo()
+    const changed = this.contentState.history.redo()
+    if (!changed) {
+      return
+    }
 
     this.dispatchSelectionChange()
     this.dispatchSelectionFormats()


### PR DESCRIPTION

Closes #4327 [Bug] Ctrl+Z clears document content when there is nothing to undo
https://github.com/marktext/marktext/issues/4327


## Summary

This PR fixes a legacy MuyaJS undo regression where pressing Ctrl/Cmd+Z with no meaningful undo state could clear the currently opened document.

The fix focuses on the legacy `packages/muyajs` editor path:

- first action : add an reload function to secure loosing content
- clear the initial empty editor history entry before loading an opened document
- route editor undo/redo through MuyaJS history instead of Chromium native undo
- ignore native `historyUndo` / `historyRedo` input events case-insensitively
- avoid dispatching document changes when undo/redo has no history state to apply
- guard against transient empty editable DOM states being treated as real user edits

https://github.com/user-attachments/assets/51e14bfd-f540-4843-b35f-e5aac461fdfa


This PR also adds a safer File > Reload Document flow with a confirmation dialog, so users can explicitly reload the current document while being warned that unsaved changes will be lost.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Linux

Tested with:

```bash
pnpm exec eslint packages/muyajs/lib/eventHandler/keyboard.js packages/muyajs/lib/contentState/inputCtrl.js packages/muyajs/lib/contentState/history.js packages/muyajs/lib/index.js
pnpm typecheck
env -u ELECTRON_RUN_AS_NODE pnpm exec playwright test test/e2e/undo.spec.ts
env -u ELECTRON_RUN_AS_NODE pnpm test:e2e


Result:
targeted undo E2E tests passed
full desktop E2E suite passed: 75 passed, 2 skipped

Manual checks:
opened an existing Markdown document
pressed Ctrl+Z repeatedly without making edits
confirmed the document content was not cleared
made an edit, pressed Ctrl+Z, and confirmed only the edit was undone
checked File > Reload Document confirmation flow


## Notes for reviewers

The undo regression appears to come from the interaction between the legacy MuyaJS editor history and Chromium native undo events.

The opened document could inherit an initial empty editor history state. When Chromium emitted native historyUndo / historyRedo input events, the legacy editor path could interpret the resulting DOM state as a real content change and propagate empty Markdown back to the renderer store.

The new E2E test avoids reading Markdown through source-mode toggling before pressing undo, because that helper changes editor mode and can interfere with the history stack being tested.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
