### PR TITLE
fix(website): serve prerendered docs pages via static-assets cache

### DIFF
--- a/packages/website/open-next.config.ts
+++ b/packages/website/open-next.config.ts
@@ -1,3 +1,10 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare'
+import staticAssetsIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache'
 
-export default defineCloudflareConfig({})
+// Every route in this app is statically prerendered (`dynamic = 'force-static'`),
+// so we serve the cached HTML directly from Workers static assets. The default
+// "dummy" incremental cache would 404 dynamic SSG routes like /docs/[...slug]
+// because the worker has no place to look up their prerendered HTML at runtime.
+export default defineCloudflareConfig({
+  incrementalCache: staticAssetsIncrementalCache
+})

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -11,7 +11,7 @@
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
     "type-check": "tsc --noEmit",
-    "cf:build": "opennextjs-cloudflare build",
+    "cf:build": "opennextjs-cloudflare build && opennextjs-cloudflare populateCache local",
     "cf:preview": "opennextjs-cloudflare preview",
     "cf:deploy": "opennextjs-cloudflare deploy"
   },


### PR DESCRIPTION
## Summary

- The Docs link on https://marktext.me/ landed on a 404 page because `/docs/[...slug]` (dynamic SSG) had nowhere to look up its prerendered HTML at runtime.
- Root cause: `open-next.config.ts` used `defineCloudflareConfig({})`, which defaults `incrementalCache` to `"dummy"`. Top-level static pages (`/`, `/docs`) are bundled directly into the Worker so they kept working — only routes that need a cache lookup (the 30+ `/docs/[...slug]` pages from `generateStaticParams`) fell through to the 404 handler.
- Fix: switch to `static-assets-incremental-cache` (every route here is `dynamic = 'force-static'`, no revalidation), and chain `opennextjs-cloudflare populateCache local` onto `cf:build` so the prerendered HTML lands in `.open-next/assets/cdn-cgi/_next_cache/` and gets uploaded by `wrangler deploy` / `wrangler versions upload`. The CI workflow is unchanged.

## Test plan

- [x] `pnpm --filter marktext-website run type-check` passes
- [x] `pnpm --filter marktext-website run lint` passes
- [x] `pnpm --filter marktext-website run cf:build` chains the populate step and writes cache files into `.open-next/assets/cdn-cgi/_next_cache/`
- [x] `pnpm --filter marktext-website exec wrangler dev --local` serves `/docs/introduction`, `/docs/dev/overview`, `/docs/changelog` with HTTP 200 and `x-nextjs-cache: HIT`
- [ ] After merge to `develop`, click **Docs** on https://marktext.me/ and confirm `/docs/introduction` renders instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)