### PR TITLE
fix(website): open download buttons in new tab pointing to releases page

### DIFF
--- a/packages/website/src/components/Download.tsx
+++ b/packages/website/src/components/Download.tsx
@@ -16,21 +16,21 @@ export default function Download() {
           </h2>
           <p>One download. No account, no subscription. Every desktop you write on.</p>
           <div className="platforms">
-            <a className="plat" href={DOWNLOAD.mac} target="_blank" rel="noopener noreferrer">
+            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
               <MacIcon />
               <div>
                 <b>macOS</b>
                 <span>.dmg · Apple Silicon &amp; Intel</span>
               </div>
             </a>
-            <a className="plat" href={DOWNLOAD.windows} target="_blank" rel="noopener noreferrer">
+            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
               <WindowsIcon />
               <div>
                 <b>Windows</b>
                 <span>.exe · x64 &amp; ARM64</span>
               </div>
             </a>
-            <a className="plat" href={DOWNLOAD.linux} target="_blank" rel="noopener noreferrer">
+            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
               <LinuxIcon />
               <div>
                 <b>Linux</b>

--- a/packages/website/src/components/Nav.tsx
+++ b/packages/website/src/components/Nav.tsx
@@ -41,7 +41,12 @@ export default function Nav() {
         <a className="icon-btn" href={DOWNLOAD.repo} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
           <GitHubIcon />
         </a>
-        <a className="btn btn-primary" href={SECTIONS.download}>
+        <a
+          className="btn btn-primary"
+          href={DOWNLOAD.releases}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Download
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Nav-bar **Download** button used to scroll to the in-page download section; it now opens the GitHub releases page in a new tab.
- The three platform tiles in the landing-page download section (macOS / Windows / Linux) used to link directly to the latest-release asset URLs (`.dmg` / `.exe` / `.AppImage`). They now all open the releases page in a new tab so visitors can pick the right asset for their CPU/architecture themselves.
- All four targets now use the already-defined `DOWNLOAD.releases` constant (`https://github.com/marktext/marktext/releases`).

## Test plan
- [ ] `pnpm --filter marktext-website dev`, open the landing page, click the nav-bar **Download** button — verify it opens `https://github.com/marktext/marktext/releases` in a new tab.
- [ ] Scroll to the "Free download" section; click each of the macOS / Windows / Linux tiles — verify each opens the releases page in a new tab.
- [ ] Confirm no other links on the page changed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)