### PR TITLE
fix(muya): guard empty ul/ol in ExportMarkdown to prevent inputHandler crash

### DIFF
--- a/packages/desktop/test/unit/specs/export-markdown.spec.ts
+++ b/packages/desktop/test/unit/specs/export-markdown.spec.ts
@@ -73,3 +73,87 @@ describe('ExportMarkdown.normalizeTable', () => {
     expect(() => exporter.normalizeTable(table, '')).not.to.throw()
   })
 })
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Block = Record<string, any>
+
+const makeListItem = (text: string, bulletMarkerOrDelimiter = '-'): Block => ({
+  type: 'li',
+  isLooseListItem: false,
+  bulletMarkerOrDelimiter,
+  children: [
+    {
+      type: 'p',
+      children: [{ type: 'span', text }]
+    }
+  ]
+})
+
+// Regression guard for issues #4319, #4344, #4346 — getMarkdown threw
+// `TypeError: Cannot destructure property 'bulletMarkerOrDelimiter' of
+// 'block.children[0]' as it is undefined` whenever the document momentarily
+// contained an empty `ul` or `ol` block (an interim state during edits that
+// remove every list item). The exporter must not crash; an empty list must
+// serialize to nothing.
+describe('ExportMarkdown.translateBlocks2Markdown — empty list blocks', () => {
+  it('does not crash on an empty ul block (#4346)', () => {
+    const blocks: Block[] = [
+      {
+        type: 'ul',
+        listType: 'bullet',
+        children: []
+      }
+    ]
+    const exporter = new ExportMarkdown(blocks)
+    expect(() => exporter.generate()).not.to.throw()
+    expect(exporter.generate()).to.equal('')
+  })
+
+  it('does not crash on an empty ol block (#4344)', () => {
+    const blocks: Block[] = [
+      {
+        type: 'ol',
+        listType: 'order',
+        start: 1,
+        children: []
+      }
+    ]
+    const exporter = new ExportMarkdown(blocks)
+    expect(() => exporter.generate()).not.to.throw()
+    expect(exporter.generate()).to.equal('')
+  })
+
+  it('does not crash when a list is preceded by a heading (#4319)', () => {
+    const blocks: Block[] = [
+      {
+        type: 'h1',
+        headingStyle: 'atx',
+        marker: '#',
+        children: [{ text: '# heading' }]
+      },
+      {
+        type: 'ul',
+        listType: 'bullet',
+        children: []
+      }
+    ]
+    const exporter = new ExportMarkdown(blocks)
+    expect(() => exporter.generate()).not.to.throw()
+    const md = exporter.generate()
+    expect(md).to.include('# heading')
+  })
+
+  it('still exports a non-empty list correctly after the guard', () => {
+    const blocks: Block[] = [
+      {
+        type: 'ul',
+        listType: 'bullet',
+        children: [makeListItem('first'), makeListItem('second')]
+      }
+    ]
+    const exporter = new ExportMarkdown(blocks)
+    const md = exporter.generate()
+    expect(md).to.include('first')
+    expect(md).to.include('second')
+  })
+})

--- a/packages/muyajs/lib/utils/exportMarkdown.js
+++ b/packages/muyajs/lib/utils/exportMarkdown.js
@@ -108,6 +108,14 @@ class ExportMarkdown {
           break
         }
         case 'ul': {
+          // An empty ul can appear transiently during list edits (Backspace at
+          // the start of the only item, Enter on an empty item) — see issues
+          // #4319, #4344, #4346. Skip serialization rather than destructure
+          // `children[0].bulletMarkerOrDelimiter` on undefined.
+          if (!block.children || block.children.length === 0 || !block.children[0]) {
+            lastListBullet = ''
+            break
+          }
           let insertNewLine = this.isLooseParentList
           this.isLooseParentList = true
 
@@ -127,6 +135,10 @@ class ExportMarkdown {
           break
         }
         case 'ol': {
+          if (!block.children || block.children.length === 0 || !block.children[0]) {
+            lastListBullet = ''
+            break
+          }
           let insertNewLine = this.isLooseParentList
           this.isLooseParentList = true
 

--- a/packages/muyajs/lib/utils/exportMarkdown.js
+++ b/packages/muyajs/lib/utils/exportMarkdown.js
@@ -9,6 +9,28 @@
  * The output markdown needs to obey the standards of these Spec.
  */
 
+// Diagnostic hook for the unsolved "empty ul/ol" crash (#4319/#4344/#4346).
+// Logs once per session with a sanitized block-tree dump so the next user who
+// trips the guard can attach the trigger context to a follow-up issue.
+let emptyListWarned = false
+const warnEmptyListOnce = (kind, block, allBlocks) => {
+  if (emptyListWarned) return
+  emptyListWarned = true
+  try {
+    const summarize = (blks) =>
+      blks.map((b) => {
+        const head = `${b.type}#${b.key}`
+        if (!Array.isArray(b.children) || b.children.length === 0) return head + '[]'
+        return head + '(' + summarize(b.children).join(',') + ')'
+      })
+    console.warn(
+      `[muya] empty ${kind} block (key=${block.key}) reached ExportMarkdown — ` +
+        'see issue #4346. Tree summary: ' +
+        summarize(allBlocks || []).join(' | ')
+    )
+  } catch (_e) { /* ignore */ }
+}
+
 class ExportMarkdown {
   constructor(blocks, listIndentation = 1, isGitlabCompatibilityEnabled = false) {
     this.blocks = blocks
@@ -108,11 +130,23 @@ class ExportMarkdown {
           break
         }
         case 'ul': {
-          // An empty ul can appear transiently during list edits (Backspace at
-          // the start of the only item, Enter on an empty item) — see issues
-          // #4319, #4344, #4346. Skip serialization rather than destructure
-          // `children[0].bulletMarkerOrDelimiter` on undefined.
+          // Defensive guard for an empty `ul`/`ol` block — see issues #4319,
+          // #4344, #4346. All three are crash dialogs filed against v0.19.0
+          // with the identical stack:
+          //   TypeError: Cannot destructure property 'bulletMarkerOrDelimiter'
+          //   of 'block.children[0]' as it is undefined.
+          //       at ExportMarkdown.translateBlocks2Markdown
+          //       at Muya.getMarkdown ← Muya.dispatchChange ← inputHandler
+          // No reproduction has been found in develop despite an extensive
+          // probe (38 targeted recipes + 400 fuzz iterations across nested
+          // lists, undo/redo, paste, source-mode round-trips, IME); the
+          // controllers all maintain the `ul/ol always has children`
+          // invariant for known user actions. The guard prevents the dialog
+          // spam + data-loss risk while we wait for a reproducer; the
+          // one-shot console.warn ships the block tree so the next user
+          // report includes the trigger context.
           if (!block.children || block.children.length === 0 || !block.children[0]) {
+            warnEmptyListOnce('ul', block, this.blocks)
             lastListBullet = ''
             break
           }
@@ -136,6 +170,7 @@ class ExportMarkdown {
         }
         case 'ol': {
           if (!block.children || block.children.length === 0 || !block.children[0]) {
+            warnEmptyListOnce('ol', block, this.blocks)
             lastListBullet = ''
             break
           }


### PR DESCRIPTION
## Summary

`ExportMarkdown.translateBlocks2Markdown` destructures `block.children[0].bulletMarkerOrDelimiter` on every `ul`/`ol`. Three independent v0.19.0 crash reports filed in the past week — #4319 (macOS), #4344 (Windows), #4346 (Linux) — show identical stack traces where the destructure throws because `block.children` is empty. The crash fires from `Muya.dispatchChange → getMarkdown` under `HTMLDivElement.inputHandler`, so it repeats on every keystroke and pops the "Unexpected error" dialog until the window is closed (with data-loss risk if autosave was enabled).

## What this PR does

1. **Defensive guard**: skip the `ul`/`ol` branch of `translateBlocks2Markdown` when `block.children` is empty/falsy. An empty list serializes to the empty string. Both the `ul` and `ol` cases get the same guard.
2. **One-shot diagnostic `console.warn`**: the first time the guard catches an empty list in a session, dump a sanitized block-tree summary (`type#key(...)` form) so the next user who hits this can attach the trigger context to a follow-up issue.

## Honest scope: this is a defensive fix, not a root-cause fix

After landing the guard I ran an extensive search for the actual trigger path in current `develop`:

- **38 targeted recipes** covering Backspace/Enter/Tab/Shift+Tab on lone, middle, nested, and triple-nested list items; `Ctrl+A → Delete/type`; paste of empty `<ul></ul>`, malformed `<ol><li></li></ol>`, plain-text list source; source-mode round-trip; undo/redo across list mutations; IME composition events; quick-insert menu; task-list toggles; reset-to-paragraph.
- **400 fuzz iterations** of random keystrokes against a 3-item list.

Every recipe walked the block tree on every `getMarkdown` call (verified by an instrumented `generate()` running 2–38× per recipe). **None ever saw an empty `ul`/`ol`.** Code-trace of every place that mutates `parent.children` (`enterCtrl.js:163,197`, `backspaceCtrl.js:569,615`, `paragraphCtrl.handleListMenu:137-149`, `tabCtrl.indentListItem/unindentListItem`, `inputCtrl.removeBlocks`) shows the invariant `ul/ol always has children` is maintained for known user actions — each mutation either guarantees a remaining child or calls `removeBlock(parent)` synchronously in the same tick.

So: the trigger is something I cannot exercise from Playwright — a corrupted document state on disk, native clipboard data my synthesized `DataTransfer` doesn't model, plugin-side mutations, or a platform-specific event path that bypasses the controllers. The maintainer's own comment on #4319 says no reproduction is known. The "right" controller-level fix is unwriteable until someone catches the trigger.

This PR is the narrowest sensible mitigation:
- Stops the user-visible dialog spam + data-loss risk **today**.
- The diagnostic warn collects the missing piece (tree shape at the moment of the crash) from the next user who hits it, so the next reporter has actionable info to attach.

## Test plan

- [x] Unit specs in `packages/desktop/test/unit/specs/export-markdown.spec.ts` — three deliberately-constructed empty-list block trees (empty `ul`, empty `ol`, empty list after heading) plus a non-empty regression guard. RED → GREEN verified: before the guard, all three throw the exact `TypeError: Cannot destructure property 'bulletMarkerOrDelimiter' of 'block.children[0]' as it is undefined.` from the user reports.
- [x] Full unit suite (`pnpm run test:unit`): 554 / 554 pass.
- [x] `pnpm run lint`: 0 errors.
- [x] `pnpm run typecheck`: clean.
- [ ] **No Playwright spec is added** — see "Honest scope" above. Adding one would be misleading (it would pass without the guard).

Closes #4319
Closes #4344
Closes #4346

🤖 Generated with [Claude Code](https://claude.com/claude-code)