### PR TITLE
refactor(website): simplify landing page (helpers, types, data-driven blocks)

### DIFF
--- a/packages/website/src/app/globals.css
+++ b/packages/website/src/app/globals.css
@@ -1233,3 +1233,44 @@ h2.sec-title {
     padding: 28px 22px 36px;
   }
 }
+
+.grid-3.grid-2 {
+  grid-template-columns: 1fr 1fr;
+}
+.card--lg {
+  padding: 34px;
+}
+.card--lg h3 {
+  font-size: 21px;
+}
+.card--lg > p {
+  font-size: 15px;
+}
+.card--lg .mini--lg {
+  font-size: 13px;
+  line-height: 1.8;
+}
+.platforms--start {
+  justify-content: flex-start;
+  margin-top: 16px;
+}
+.plat--compact {
+  min-width: 0;
+  padding: 12px 18px;
+}
+.plat--compact b {
+  font-size: 14px;
+}
+.block--top-tight {
+  padding-top: 40px;
+}
+.kicker--center {
+  justify-content: center;
+}
+.hero-cta--center {
+  justify-content: center;
+  margin-top: 28px;
+}
+.hero-note--cta {
+  margin-top: 24px;
+}

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
-import { THEME_STORAGE_KEY } from '@/lib/sections'
+import { DEFAULT_THEME, THEME_STORAGE_KEY } from '@/lib/sections'
 import './globals.css'
 
 const geistSans = Geist({
@@ -85,12 +85,12 @@ const jsonLd = {
   softwareVersion: 'latest'
 }
 
-// Inline before paint to avoid theme flash; mirrors useTheme's storage key.
-const themeBootstrap = `(function(){try{var t=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});if(!t)t='dark';document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme','dark');}})();`
+// Inline before paint to avoid theme flash.
+const themeBootstrap = `(function(){try{var t=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});if(!t)t=${JSON.stringify(DEFAULT_THEME)};document.documentElement.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-theme',${JSON.stringify(DEFAULT_THEME)});}})();`
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" data-theme="dark" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en" data-theme={DEFAULT_THEME} className={`${geistSans.variable} ${geistMono.variable}`}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
       </head>

--- a/packages/website/src/components/Brand.tsx
+++ b/packages/website/src/components/Brand.tsx
@@ -1,0 +1,10 @@
+import { SECTIONS, hash } from '@/lib/sections'
+
+export default function Brand() {
+  return (
+    <a className="brand" href={hash(SECTIONS.top)}>
+      <img className="mark" src="/assets/logo.png" alt="MarkText logo" width={28} height={28} />
+      MarkText
+    </a>
+  )
+}

--- a/packages/website/src/components/Download.tsx
+++ b/packages/website/src/components/Download.tsx
@@ -1,44 +1,40 @@
+import type { ReactNode } from 'react'
 import { DOWNLOAD } from '@/lib/downloads'
+import { EXT_LINK } from '@/lib/links'
 import { SECTIONS } from '@/lib/sections'
 import { LinuxIcon, MacIcon, WindowsIcon } from './Icons'
 
+type Platform = { icon: ReactNode; label: string; sub: string }
+
+const PLATFORMS: Platform[] = [
+  { icon: <MacIcon />, label: 'macOS', sub: '.dmg · Apple Silicon & Intel' },
+  { icon: <WindowsIcon />, label: 'Windows', sub: '.exe · x64 & ARM64' },
+  { icon: <LinuxIcon />, label: 'Linux', sub: '.AppImage · .deb · .rpm' }
+]
+
 export default function Download() {
   return (
-    <section className="block" id={SECTIONS.download.slice(1)}>
+    <section className="block" id={SECTIONS.download}>
       <div className="wrap">
         <div className="cta reveal">
           <div className="cta-glow" />
-          <span className="kicker" style={{ justifyContent: 'center' }}>
-            Free download
-          </span>
+          <span className="kicker kicker--center">Free download</span>
           <h2>
             Start writing in <span className="grad-text">two minutes</span>.
           </h2>
           <p>One download. No account, no subscription. Every desktop you write on.</p>
           <div className="platforms">
-            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
-              <MacIcon />
-              <div>
-                <b>macOS</b>
-                <span>.dmg · Apple Silicon &amp; Intel</span>
-              </div>
-            </a>
-            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
-              <WindowsIcon />
-              <div>
-                <b>Windows</b>
-                <span>.exe · x64 &amp; ARM64</span>
-              </div>
-            </a>
-            <a className="plat" href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
-              <LinuxIcon />
-              <div>
-                <b>Linux</b>
-                <span>.AppImage · .deb · .rpm</span>
-              </div>
-            </a>
+            {PLATFORMS.map((p) => (
+              <a className="plat" key={p.label} href={DOWNLOAD.releases} {...EXT_LINK}>
+                {p.icon}
+                <div>
+                  <b>{p.label}</b>
+                  <span>{p.sub}</span>
+                </div>
+              </a>
+            ))}
           </div>
-          <div className="hero-note" style={{ marginTop: 24 }}>
+          <div className="hero-note hero-note--cta">
             <span>
               Or install via Homebrew: <code className="inline">brew install --cask mark-text</code>
             </span>

--- a/packages/website/src/components/Extensions.tsx
+++ b/packages/website/src/components/Extensions.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { SECTIONS } from '@/lib/sections'
+import { SECTIONS, type RevealDelay } from '@/lib/sections'
 import FeatureCard from './FeatureCard'
 import {
   CodeIcon,
@@ -15,7 +15,7 @@ type Card = {
   title: string
   description: string
   mini: ReactNode
-  delay?: 'd1' | 'd2'
+  delay?: RevealDelay
 }
 
 const CARDS: Card[] = [
@@ -113,7 +113,7 @@ const CARDS: Card[] = [
 
 export default function Extensions() {
   return (
-    <section className="block" id={SECTIONS.extensions.slice(1)}>
+    <section className="block" id={SECTIONS.extensions}>
       <div className="wrap">
         <div className="sec-head center reveal">
           <span className="kicker">Markdown, extended</span>
@@ -126,10 +126,10 @@ export default function Extensions() {
           {CARDS.map((c) => (
             <FeatureCard
               key={c.title}
-              className={`card reveal${c.delay ? ` ${c.delay}` : ''}`}
               icon={c.icon}
               title={c.title}
               description={c.description}
+              delay={c.delay}
             >
               <div className="mini">{c.mini}</div>
             </FeatureCard>

--- a/packages/website/src/components/FeatItem.tsx
+++ b/packages/website/src/components/FeatItem.tsx
@@ -1,15 +1,16 @@
 import type { ReactNode } from 'react'
+import { revealClass, type RevealDelay } from '@/lib/sections'
 
 type Props = {
   icon: ReactNode
   title: ReactNode
   description: ReactNode
-  delay?: 'd1' | 'd2' | 'd3' | 'd4'
+  delay?: RevealDelay
 }
 
 export default function FeatItem({ icon, title, description, delay }: Props) {
   return (
-    <div className={`feat-item reveal${delay ? ` ${delay}` : ''}`}>
+    <div className={revealClass(delay, 'feat-item')}>
       <div className="ic">{icon}</div>
       <div>
         <h4>{title}</h4>

--- a/packages/website/src/components/FeatureCard.tsx
+++ b/packages/website/src/components/FeatureCard.tsx
@@ -1,31 +1,22 @@
-import type { CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import { revealClass, type RevealDelay } from '@/lib/sections'
 
 type Props = {
   icon: ReactNode
   title: ReactNode
   description: ReactNode
-  className?: string
-  style?: CSSProperties
-  titleStyle?: CSSProperties
-  descStyle?: CSSProperties
+  delay?: RevealDelay
+  variant?: 'lg'
   children?: ReactNode
 }
 
-export default function FeatureCard({
-  icon,
-  title,
-  description,
-  className = 'card reveal',
-  style,
-  titleStyle,
-  descStyle,
-  children
-}: Props) {
+export default function FeatureCard({ icon, title, description, delay, variant, children }: Props) {
+  const base = variant === 'lg' ? 'card card--lg' : 'card'
   return (
-    <div className={className} style={style}>
+    <div className={revealClass(delay, base)}>
       <div className="ic-lg">{icon}</div>
-      <h3 style={titleStyle}>{title}</h3>
-      <p style={descStyle}>{description}</p>
+      <h3>{title}</h3>
+      <p>{description}</p>
       {children}
     </div>
   )

--- a/packages/website/src/components/FocusExport.tsx
+++ b/packages/website/src/components/FocusExport.tsx
@@ -5,17 +5,14 @@ export default function FocusExport() {
   return (
     <section className="block">
       <div className="wrap">
-        <div className="grid-3" style={{ gridTemplateColumns: '1fr 1fr' }}>
+        <div className="grid-3 grid-2">
           <FeatureCard
-            className="card reveal"
-            style={{ padding: 34 }}
+            variant="lg"
             icon={<TargetIcon />}
             title="Focus & typewriter mode"
-            titleStyle={{ fontSize: 21 }}
             description="Dim everything but the line you're writing, and keep it locked to center. Distraction-free by design."
-            descStyle={{ fontSize: 15 }}
           >
-            <div className="mini" style={{ fontSize: 13, lineHeight: 1.8 }}>
+            <div className="mini mini--lg">
               <span style={{ opacity: 0.3 }}>The paragraph above fades back.</span>
               <br />
               <span style={{ color: 'var(--text)' }}>
@@ -28,29 +25,21 @@ export default function FocusExport() {
           </FeatureCard>
 
           <FeatureCard
-            className="card reveal d1"
-            style={{ padding: 34 }}
+            variant="lg"
+            delay="d1"
             icon={<ExportIcon />}
             title="Export anywhere"
-            titleStyle={{ fontSize: 21 }}
             description={
               <>
                 Turn any document into a polished <strong>PDF</strong> or self-contained{' '}
                 <strong>HTML</strong> file — your theme included.
               </>
             }
-            descStyle={{ fontSize: 15 }}
           >
-            <div className="platforms" style={{ justifyContent: 'flex-start', marginTop: 16 }}>
-              <div className="plat" style={{ minWidth: 0, padding: '12px 18px' }}>
-                <b style={{ fontSize: 14 }}>PDF</b>
-              </div>
-              <div className="plat" style={{ minWidth: 0, padding: '12px 18px' }}>
-                <b style={{ fontSize: 14 }}>HTML</b>
-              </div>
-              <div className="plat" style={{ minWidth: 0, padding: '12px 18px' }}>
-                <b style={{ fontSize: 14 }}>.md</b>
-              </div>
+            <div className="platforms platforms--start">
+              <div className="plat plat--compact"><b>PDF</b></div>
+              <div className="plat plat--compact"><b>HTML</b></div>
+              <div className="plat plat--compact"><b>.md</b></div>
             </div>
           </FeatureCard>
         </div>

--- a/packages/website/src/components/Footer.tsx
+++ b/packages/website/src/components/Footer.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { DOWNLOAD } from '@/lib/downloads'
-import { SECTIONS } from '@/lib/sections'
+import { EXT_LINK } from '@/lib/links'
+import { SECTIONS, hash } from '@/lib/sections'
+import Brand from './Brand'
 import { GitHubIcon } from './Icons'
 
 export default function Footer() {
@@ -9,55 +11,36 @@ export default function Footer() {
       <div className="wrap">
         <div className="foot-grid">
           <div className="foot-brand">
-            <a className="brand" href={SECTIONS.top}>
-              <img className="mark" src="/assets/logo.png" alt="MarkText logo" width={28} height={28} />
-              MarkText
-            </a>
+            <Brand />
             <p>
               A simple, elegant open-source Markdown editor. Made by the community, free forever.
             </p>
           </div>
           <div className="foot-col">
             <h5>Product</h5>
-            <a href={SECTIONS.preview}>Real-time preview</a>
-            <a href={SECTIONS.themes}>Themes</a>
-            <a href={SECTIONS.extensions}>Markdown support</a>
-            <a href={SECTIONS.download}>Download</a>
-            <a href={SECTIONS.support}>Support the project</a>
+            <a href={hash(SECTIONS.preview)}>Real-time preview</a>
+            <a href={hash(SECTIONS.themes)}>Themes</a>
+            <a href={hash(SECTIONS.extensions)}>Markdown support</a>
+            <a href={hash(SECTIONS.download)}>Download</a>
+            <a href={hash(SECTIONS.support)}>Support the project</a>
           </div>
           <div className="foot-col">
             <h5>Resources</h5>
             <Link href="/docs">Documentation</Link>
-            <a href={DOWNLOAD.releases} target="_blank" rel="noopener noreferrer">
-              Releases
-            </a>
-            <a href={DOWNLOAD.contributing} target="_blank" rel="noopener noreferrer">
-              Contributing
-            </a>
-            <a href={DOWNLOAD.issues} target="_blank" rel="noopener noreferrer">
-              Issues
-            </a>
+            <a href={DOWNLOAD.releases} {...EXT_LINK}>Releases</a>
+            <a href={DOWNLOAD.contributing} {...EXT_LINK}>Contributing</a>
+            <a href={DOWNLOAD.issues} {...EXT_LINK}>Issues</a>
           </div>
           <div className="foot-col">
             <h5>Community</h5>
-            <a href={DOWNLOAD.repo} target="_blank" rel="noopener noreferrer">
-              GitHub
-            </a>
-            <a href={DOWNLOAD.twitter} target="_blank" rel="noopener noreferrer">
-              Twitter / X
-            </a>
+            <a href={DOWNLOAD.repo} {...EXT_LINK}>GitHub</a>
+            <a href={DOWNLOAD.twitter} {...EXT_LINK}>Twitter / X</a>
           </div>
         </div>
         <div className="foot-bot">
           <span>© 2017–2026 MarkText · Released under the MIT License</span>
           <div className="foot-social">
-            <a
-              className="icon-btn"
-              href={DOWNLOAD.repo}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub"
-            >
+            <a className="icon-btn" href={DOWNLOAD.repo} {...EXT_LINK} aria-label="GitHub">
               <GitHubIcon />
             </a>
           </div>

--- a/packages/website/src/components/Hero.tsx
+++ b/packages/website/src/components/Hero.tsx
@@ -2,6 +2,8 @@
 
 import { useRef } from 'react'
 import { DOWNLOAD } from '@/lib/downloads'
+import { EXT_LINK } from '@/lib/links'
+import { revealClass } from '@/lib/sections'
 import { useTilt } from '@/hooks/useTilt'
 import MockWindow from './MockWindow'
 import { CheckIcon, DownloadIcon, GitHubIcon } from './Icons'
@@ -14,36 +16,26 @@ export default function Hero() {
   return (
     <header className="hero">
       <div className="wrap">
-        <div className="eyebrow reveal">
+        <div className={revealClass(undefined, 'eyebrow')}>
           <span className="tag">v0.19.0</span> Free &amp; open source forever
         </div>
-        <h1 className="hero-title reveal d1">
+        <h1 className={revealClass('d1', 'hero-title')}>
           Write in Markdown. <span className="grad-text">Stay in flow.</span>
         </h1>
-        <p className="hero-sub reveal d2">
+        <p className={revealClass('d2', 'hero-sub')}>
           Realtime preview, beautiful typography, and zero distractions.
         </p>
-        <div className="hero-cta reveal d3">
-          <a
-            className="btn btn-primary btn-lg"
-            href={DOWNLOAD.releases}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+        <div className={revealClass('d3', 'hero-cta')}>
+          <a className="btn btn-primary btn-lg" href={DOWNLOAD.releases} {...EXT_LINK}>
             <DownloadIcon />
             Download for free
           </a>
-          <a
-            className="btn btn-ghost btn-lg"
-            href={DOWNLOAD.repo}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a className="btn btn-ghost btn-lg" href={DOWNLOAD.repo} {...EXT_LINK}>
             <GitHubIcon />
             Star on GitHub
           </a>
         </div>
-        <div className="hero-note reveal d4">
+        <div className={revealClass('d4', 'hero-note')}>
           <span>
             <CheckIcon /> macOS · Windows · Linux
           </span>
@@ -55,7 +47,7 @@ export default function Hero() {
           </span>
         </div>
 
-        <div className="stage reveal d2" id="stage" ref={stageRef}>
+        <div className={revealClass('d2', 'stage')} id="stage" ref={stageRef}>
           <div className="stage-glow" />
           <MockWindow title="product-launch.md" showActions windowId="heroWin" windowRef={winRef}>
             <h1>

--- a/packages/website/src/components/Icons.tsx
+++ b/packages/website/src/components/Icons.tsx
@@ -117,13 +117,6 @@ export const FrontmatterIcon = (props: IconProps) => (
   </svg>
 )
 
-export const SunSmallIcon = (props: IconProps) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
-    <circle cx="12" cy="12" r="4" />
-    <path d="M12 2v2M12 20v2M2 12h2M20 12h2" />
-  </svg>
-)
-
 export const TargetIcon = (props: IconProps) => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
     <circle cx="12" cy="12" r="3" />

--- a/packages/website/src/components/Nav.tsx
+++ b/packages/website/src/components/Nav.tsx
@@ -3,9 +3,11 @@
 import { useRef } from 'react'
 import Link from 'next/link'
 import { DOWNLOAD } from '@/lib/downloads'
-import { SECTIONS } from '@/lib/sections'
+import { EXT_LINK } from '@/lib/links'
+import { SECTIONS, hash } from '@/lib/sections'
 import { useToggleTheme } from '@/hooks/useTheme'
 import { useNavShrink } from '@/hooks/useNavShrink'
+import Brand from './Brand'
 import { GitHubIcon, MoonIcon, SunIcon } from './Icons'
 
 export default function Nav() {
@@ -15,16 +17,13 @@ export default function Nav() {
 
   return (
     <nav className="nav" id="nav" ref={navRef}>
-      <a className="brand" href={SECTIONS.top}>
-        <img className="mark" src="/assets/logo.png" alt="MarkText logo" width={28} height={28} />
-        MarkText
-      </a>
+      <Brand />
       <div className="nav-links">
-        <a href={SECTIONS.preview}>Features</a>
-        <a href={SECTIONS.themes}>Themes</a>
-        <a href={SECTIONS.extensions}>Markdown</a>
+        <a href={hash(SECTIONS.preview)}>Features</a>
+        <a href={hash(SECTIONS.themes)}>Themes</a>
+        <a href={hash(SECTIONS.extensions)}>Markdown</a>
         <Link href="/docs">Docs</Link>
-        <a href={SECTIONS.support}>Support</a>
+        <a href={hash(SECTIONS.support)}>Support</a>
       </div>
       <div className="nav-right">
         <button
@@ -38,15 +37,10 @@ export default function Nav() {
           <MoonIcon className="theme-moon" />
           <SunIcon className="theme-sun" />
         </button>
-        <a className="icon-btn" href={DOWNLOAD.repo} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+        <a className="icon-btn" href={DOWNLOAD.repo} {...EXT_LINK} aria-label="GitHub">
           <GitHubIcon />
         </a>
-        <a
-          className="btn btn-primary"
-          href={DOWNLOAD.releases}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a className="btn btn-primary" href={DOWNLOAD.releases} {...EXT_LINK}>
           Download
         </a>
       </div>

--- a/packages/website/src/components/Preview.tsx
+++ b/packages/website/src/components/Preview.tsx
@@ -5,7 +5,7 @@ import { BoltIcon, GridSmallIcon, LinesIcon } from './Icons'
 
 export default function Preview() {
   return (
-    <section className="block" id={SECTIONS.preview.slice(1)}>
+    <section className="block" id={SECTIONS.preview}>
       <div className="wrap">
         <div className="split">
           <div className="split-text">

--- a/packages/website/src/components/Stats.tsx
+++ b/packages/website/src/components/Stats.tsx
@@ -1,24 +1,25 @@
+import { revealClass, type RevealDelay } from '@/lib/sections'
+
+type Stat = { value: string; label: string; delay?: RevealDelay }
+
+const STATS: Stat[] = [
+  { value: '56.6k', label: 'GitHub stars' },
+  { value: '146', label: 'Contributors', delay: 'd1' },
+  { value: '3', label: 'Platforms supported', delay: 'd2' },
+  { value: 'MIT', label: 'Free & open source', delay: 'd3' }
+]
+
 export default function Stats() {
   return (
-    <section className="block" style={{ paddingTop: 40 }}>
+    <section className="block block--top-tight">
       <div className="wrap">
         <div className="stats">
-          <div className="stat reveal">
-            <div className="n grad-text">56.6k</div>
-            <div className="l">GitHub stars</div>
-          </div>
-          <div className="stat reveal d1">
-            <div className="n grad-text">146</div>
-            <div className="l">Contributors</div>
-          </div>
-          <div className="stat reveal d2">
-            <div className="n grad-text">3</div>
-            <div className="l">Platforms supported</div>
-          </div>
-          <div className="stat reveal d3">
-            <div className="n grad-text">MIT</div>
-            <div className="l">Free &amp; open source</div>
-          </div>
+          {STATS.map((s) => (
+            <div className={revealClass(s.delay, 'stat')} key={s.label}>
+              <div className="n grad-text">{s.value}</div>
+              <div className="l">{s.label}</div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/packages/website/src/components/Support.tsx
+++ b/packages/website/src/components/Support.tsx
@@ -1,10 +1,11 @@
 import { DOWNLOAD } from '@/lib/downloads'
+import { EXT_LINK } from '@/lib/links'
 import { SECTIONS } from '@/lib/sections'
 import { HeartIcon } from './Icons'
 
 export default function Support() {
   return (
-    <section className="block" id={SECTIONS.support.slice(1)}>
+    <section className="block" id={SECTIONS.support}>
       <div className="wrap">
         <div className="sec-head center reveal">
           <span className="kicker">Support</span>
@@ -13,13 +14,8 @@ export default function Support() {
             Built by volunteers. If it earns a place in your workflow, sponsorship keeps development
             going.
           </p>
-          <div className="hero-cta" style={{ justifyContent: 'center', marginTop: 28 }}>
-            <a
-              className="btn btn-primary btn-lg"
-              href={DOWNLOAD.sponsor}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+          <div className="hero-cta hero-cta--center">
+            <a className="btn btn-primary btn-lg" href={DOWNLOAD.sponsor} {...EXT_LINK}>
               <HeartIcon />
               Sponsor on GitHub
             </a>
@@ -28,13 +24,7 @@ export default function Support() {
 
         <div className="sponsors-wall reveal d1">
           <span className="sponsors-label">Sponsored by</span>
-          <a
-            className="sponsor-logo"
-            href={DOWNLOAD.serpapi}
-            target="_blank"
-            rel="noopener noreferrer"
-            title="SerpApi"
-          >
+          <a className="sponsor-logo" href={DOWNLOAD.serpapi} {...EXT_LINK} title="SerpApi">
             <img src="/assets/serpapi.png" alt="SerpApi" loading="lazy" />
           </a>
         </div>

--- a/packages/website/src/components/Themes.tsx
+++ b/packages/website/src/components/Themes.tsx
@@ -1,6 +1,6 @@
 import { SECTIONS } from '@/lib/sections'
 import FeatItem from './FeatItem'
-import { CodeIcon, SunSmallIcon } from './Icons'
+import { CodeIcon, SunIcon } from './Icons'
 
 type Swatch = {
   name: string
@@ -21,7 +21,7 @@ const SWATCHES: Swatch[] = [
 
 export default function Themes() {
   return (
-    <section className="block" id={SECTIONS.themes.slice(1)}>
+    <section className="block" id={SECTIONS.themes}>
       <div className="wrap">
         <div className="split rev">
           <div className="split-text">
@@ -36,7 +36,7 @@ export default function Themes() {
             <div className="feat-list">
               <FeatItem
                 delay="d1"
-                icon={<SunSmallIcon />}
+                icon={<SunIcon />}
                 title="Light & dark, instantly"
                 description="Switch with a keystroke, or follow your system."
               />

--- a/packages/website/src/hooks/useTheme.ts
+++ b/packages/website/src/hooks/useTheme.ts
@@ -1,14 +1,14 @@
 'use client'
 
 import { useCallback } from 'react'
-import { THEME_STORAGE_KEY } from '@/lib/sections'
+import { DEFAULT_THEME, THEME_STORAGE_KEY } from '@/lib/sections'
 
 type Theme = 'dark' | 'light'
 
 export function useToggleTheme(): () => void {
   return useCallback(() => {
     const current =
-      (document.documentElement.getAttribute('data-theme') as Theme | null) || 'dark'
+      (document.documentElement.getAttribute('data-theme') as Theme | null) || DEFAULT_THEME
     const next: Theme = current === 'dark' ? 'light' : 'dark'
     document.documentElement.setAttribute('data-theme', next)
     try {

--- a/packages/website/src/lib/links.ts
+++ b/packages/website/src/lib/links.ts
@@ -1,0 +1,1 @@
+export const EXT_LINK = { target: '_blank', rel: 'noopener noreferrer' } as const

--- a/packages/website/src/lib/sections.ts
+++ b/packages/website/src/lib/sections.ts
@@ -1,10 +1,22 @@
 export const SECTIONS = {
-  top: '#top',
-  preview: '#preview',
-  extensions: '#extensions',
-  themes: '#themes',
-  support: '#support',
-  download: '#download'
+  top: 'top',
+  preview: 'preview',
+  extensions: 'extensions',
+  themes: 'themes',
+  support: 'support',
+  download: 'download'
 } as const
 
+export type SectionId = (typeof SECTIONS)[keyof typeof SECTIONS]
+
+export const hash = (id: SectionId) => `#${id}` as const
+
+export type RevealDelay = 'd1' | 'd2' | 'd3' | 'd4'
+
+export function revealClass(delay?: RevealDelay, extra?: string): string {
+  const base = extra ? `${extra} reveal` : 'reveal'
+  return delay ? `${base} ${delay}` : base
+}
+
 export const THEME_STORAGE_KEY = 'marktext-theme'
+export const DEFAULT_THEME = 'dark'


### PR DESCRIPTION
## Summary

Internal cleanups to the landing page (`app/page.tsx` + `components/*.tsx`). The rendered page is the same — same layout, same copy, same animations, same Tailwind/CSS output. Smaller diffs going forward.

- **`lib/sections.ts`**: `SECTIONS` now stores plain ids (no leading `#`); add `hash(id)`, `revealClass(delay?, extra?)`, the `RevealDelay` union and a `DEFAULT_THEME` constant. Consumers stop calling `.slice(1)` to recover the id, and stop building `"reveal d1"` by hand.
- **`lib/links.ts`**: a shared `EXT_LINK = { target: '_blank', rel: 'noopener noreferrer' } as const` that replaces 12+ hand-written triples across Nav / Footer / Hero / Download / Support.
- **`Brand` component**: factor the logo + wordmark block out of `Nav` and `Footer` (the two copies were verbatim).
- **`FeatureCard`**: drop the `style` / `titleStyle` / `descStyle` / `className` escape hatches. Expose `delay?: RevealDelay` + `variant?: 'lg'` instead. `FocusExport` switches to the variant + new `mini--lg` / `platforms--start` / `plat--compact` CSS modifier classes, removing several inline-style triplets.
- **`Stats` / `Download`**: render from a `STATS[]` / `PLATFORMS[]` data table instead of repeated JSX blocks.
- **Themes**: the duplicate `SunSmallIcon` is dropped from `Icons.tsx`; `Themes.tsx` uses `SunIcon` instead.
- **`useTheme` + `app/layout.tsx`**: read `DEFAULT_THEME` from `sections.ts` so the inline boot script no longer hard-codes the `'dark'` literal in three places.
- **`globals.css`**: add the new modifier classes (`.card--lg`, `.plat--compact`, `.platforms--start`, `.block--top-tight`, `.kicker--center`, `.hero-cta--center`, `.hero-note--cta`, `.grid-3.grid-2`, `.mini--lg`) that replace inline style triplets.

## Test plan

- [x] `pnpm --filter marktext-website type-check`
- [x] `pnpm --filter marktext-website lint`
- [x] `pnpm --filter marktext-website build` (37 static pages)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)