### PR TITLE
chore(website): tighten middleware matcher; drop unused 'use client'

### DIFF
--- a/packages/website/src/components/docs/DocsTabs.tsx
+++ b/packages/website/src/components/docs/DocsTabs.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import type { DocTabId } from '@/lib/docs-nav'
 import { DOC_TABS, firstPageOfTab } from '@/lib/docs-nav'

--- a/packages/website/src/middleware.ts
+++ b/packages/website/src/middleware.ts
@@ -14,7 +14,7 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  // Skip Next.js static + image internals so the middleware doesn't redirect
-  // chunk requests (they come from the apex anyway, but be explicit).
-  matcher: ['/((?!_next/static|_next/image|favicon\\.ico).*)']
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|favicon\\.png|sitemap\\.xml|robots\\.txt|docs-index\\.json|assets/|docs/).*)'
+  ]
 }


### PR DESCRIPTION
## Summary

Two unrelated micro-cleanups bundled together.

- **`middleware.ts`**: extend the matcher exclusion list with `/assets/`, `/docs/`, `/docs-index.json`, `/sitemap.xml`, `/robots.txt`, `/favicon.png`. The middleware exists only to 301 `www.marktext.me/*` → `marktext.me/*`; with these out, the Cloudflare Worker no longer wakes up for static-asset / static-route requests (the apex versions return immediately anyway).
- **`DocsTabs.tsx`**: not a client component — it renders `<Link>` plus a couple of static SVGs, no hooks, no state. Drop `'use client'` so it stays in the RSC tree.

## Test plan

- [x] `pnpm --filter marktext-website type-check`
- [x] `pnpm --filter marktext-website lint`
- [x] `pnpm --filter marktext-website build` (37 static pages)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)