### PR TITLE
fix(muyajs): preserve nested lists of differing types (#4341)

### DIFF
--- a/packages/desktop/test/e2e/data/nested-mixed-lists.md
+++ b/packages/desktop/test/e2e/data/nested-mixed-lists.md
@@ -1,0 +1,17 @@
+# Nested mixed lists fixture
+
+Regression coverage for marktext#4341.
+
+1. Eat a carrot.
+2. Find an application:
+   - New
+   - Open
+   - Save
+3. Profit.
+
+- Outer bullet
+- Container item:
+  1. First step
+  2. Second step
+  3. Third step
+- Trailing bullet

--- a/packages/desktop/test/e2e/fixture-render.spec.ts
+++ b/packages/desktop/test/e2e/fixture-render.spec.ts
@@ -99,3 +99,14 @@ runFixture('formatted', 'test/e2e/data/formatted.md', async({ page }) => {
   expect(em).toBeGreaterThan(0)
   expect(code).toBeGreaterThan(0)
 })
+
+// Regression coverage for marktext#4341 — a ul nested inside an ol li (and
+// vice versa) was rewritten into a paragraph by the legacy muya lexer.
+runFixture('nested-mixed-lists', 'test/e2e/data/nested-mixed-lists.md', async({ page }) => {
+  await page.waitForSelector('.editor-component ol li ul li', { state: 'attached', timeout: 10000 })
+  await page.waitForSelector('.editor-component ul li ol li', { state: 'attached', timeout: 10000 })
+  const ulInOl = await page.locator('.editor-component ol > li ul > li').count()
+  const olInUl = await page.locator('.editor-component ul > li ol > li').count()
+  expect(ulInOl).toBeGreaterThanOrEqual(3)
+  expect(olInUl).toBeGreaterThanOrEqual(3)
+})

--- a/packages/desktop/test/unit/data/common/Lists.md
+++ b/packages/desktop/test/unit/data/common/Lists.md
@@ -17,6 +17,7 @@ To start an ordered list, write this:
 4. any number, +, -, or * will keep the list going.
    
    * just indent by 4 spaces (or tab) to make a sub-list
+     
      1. keep indenting for more sub lists
    
    * here i'm back to the second level

--- a/packages/desktop/test/unit/specs/markdown-nested-mixed-lists.spec.ts
+++ b/packages/desktop/test/unit/specs/markdown-nested-mixed-lists.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import ContentState from 'muya/lib/contentState'
+import EventCenter from 'muya/lib/eventHandler/event'
+import ExportMarkdown from 'muya/lib/utils/exportMarkdown'
+import { MUYA_DEFAULT_OPTION } from 'muya/lib/config'
+
+interface MuyaCtx {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  eventCenter: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  contentState: any
+}
+
+const createMuyaContext = (): MuyaCtx => {
+  const ctx = {} as MuyaCtx
+  ctx.options = Object.assign({}, MUYA_DEFAULT_OPTION, { endOfLine: 'lf' })
+  ctx.eventCenter = new EventCenter()
+  ctx.contentState = new ContentState(ctx, ctx.options)
+  return ctx
+}
+
+const roundTrip = (markdown: string): string => {
+  const ctx = createMuyaContext()
+  ctx.contentState.importMarkdown(markdown)
+  const blocks = ctx.contentState.getBlocks()
+  return new ExportMarkdown(blocks).generate()
+}
+
+// Regression test for marktext#4341 — a list whose type differs from its
+// enclosing list item (ul inside ol, or ol inside ul) was being rewritten
+// into a paragraph by the legacy muya lexer, losing the list structure.
+describe('Muya parser — nested mixed lists (#4341)', () => {
+  it('preserves a bullet list nested inside an ordered list item', () => {
+    const markdown = `1. Eat a carrot.
+2. Find an application:
+   - New
+   - Open
+   - Save
+`
+    expect(roundTrip(markdown)).to.equal(markdown)
+  })
+
+  it('preserves an ordered list nested inside a bullet list item', () => {
+    const markdown = `- Outer bullet
+- Container item:
+  1. First step
+  2. Second step
+  3. Third step
+`
+    expect(roundTrip(markdown)).to.equal(markdown)
+  })
+
+  it('produces a ul block inside the ol li block tree (not a paragraph)', () => {
+    const ctx = createMuyaContext()
+    ctx.contentState.importMarkdown(`1. Eat a carrot.
+2. Find an application:
+   - New
+   - Open
+   - Save
+`)
+    const blocks = ctx.contentState.getBlocks()
+    const ol = blocks.find((b: { type: string }) => b.type === 'ol')
+    expect(ol, 'expected a top-level ol block').toBeDefined()
+    const secondLi = ol.children[1]
+    expect(secondLi.type).toBe('li')
+    const nestedUl = secondLi.children.find((c: { type: string }) => c.type === 'ul')
+    expect(nestedUl, 'expected a ul nested inside the second ol li').toBeDefined()
+    expect(nestedUl.children.length).toBe(3)
+  })
+})

--- a/packages/muyajs/lib/parser/marked/lexer.js
+++ b/packages/muyajs/lib/parser/marked/lexer.js
@@ -347,23 +347,6 @@ Lexer.prototype.token = function(
       bull = cap[2]
       let isOrdered = bull.length > 1
 
-      // Nested list that differs from the prev list type (on the same line) should be parsed as just a text block.
-
-      if (prevListIsOrdered !== null && prevListIsOrdered !== isOrdered) {
-        // Should parse this as just a text block
-        cap = cap[0].match(this.rules.item)
-
-        this.tokens.push({
-          type: 'paragraph',
-          text: cursorAnchorFocus + cap[0].trimEnd()
-        })
-        // Recurse for any valid nested lists of the same type
-        if (cap.length > 1) {
-          this.token(cap.slice(1).join('\n'), false, prevListIsOrdered, checkCursorSignature)
-        }
-        continue
-      }
-
       this.tokens.push({
         type: 'list_start',
         ordered: isOrdered,


### PR DESCRIPTION
## Summary

- **Fixes #4341** — a `ul` nested inside an `ol` `li` (and vice versa) was being silently rewritten as a paragraph by the legacy muya lexer, losing the list structure on import.
- Root cause: the guard at `packages/muyajs/lib/parser/marked/lexer.js:350-365` (introduced in the electron-vite refactor #4001, commit `85607dd2`) treated any nested list whose type differed from its enclosing list as a paragraph. Sibling mixed lists are handled by a separate code path (`lexer.js:419-453`) and were unaffected.
- The fix is a single-block deletion of that guard; the existing CommonMark code path then handles nested mixed lists correctly.

## Tests

- **New vitest spec** (`packages/desktop/test/unit/specs/markdown-nested-mixed-lists.spec.ts`) — round-trips `ul`-in-`ol` and `ol`-in-`ul`, plus a structural check that the imported block tree actually contains a nested `ul` inside the `ol li` (rather than a paragraph). Confirmed RED on `develop`, GREEN after the fix.
- **New Playwright fixture** (`packages/desktop/test/e2e/data/nested-mixed-lists.md` + a new `runFixture('nested-mixed-lists', ...)` block in `fixture-render.spec.ts`) — loads the fixture in the Electron window and asserts `.editor-component ol li ul li` (and the inverse) DOM shape. Confirmed RED on `develop`, GREEN after the fix.
- **`Lists.md` fixture adjustment** — the deeply-nested ordered sub-list inside a `*` item now has a blank line before it. This brings the input in line with the canonical loose-form serialization the exporter emits for a loose-parent context; without this, the previous test was only passing because the buggy parser was collapsing that nested list into a paragraph.

## Test plan

- [x] `pnpm -C packages/desktop run test:unit` — 553 passed (10 files), incl. the new spec.
- [x] `pnpm -C packages/desktop exec playwright test test/e2e/fixture-render.spec.ts` — 10/10 passed.
- [x] `pnpm -C packages/desktop exec playwright test test/e2e/paragraph-blocks.spec.ts test/e2e/editor-input.spec.ts` — 13 passed, 2 pre-existing skips.
- [x] `pnpm run lint` — 0 errors (existing warnings unchanged).
- [x] `pnpm run typecheck` — clean.
- [ ] Reviewer: open the new fixture in `pnpm run dev`, confirm the inner bullets and numbers render as nested lists (not paragraph text), and that the `Lists` fixture still renders the deeply-nested case correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)