### PR TITLE
fix(muyajs): null-guard list block paths to prevent renderer crash (#4346)

### DIFF
--- a/packages/desktop/test/e2e/issue-4346.spec.ts
+++ b/packages/desktop/test/e2e/issue-4346.spec.ts
@@ -1,0 +1,123 @@
+// Regression guard for issue #4346: Cannot destructure property
+// 'bulletMarkerOrDelimiter' of 'block2.children[0]' as it is undefined.
+//
+// Adjacent-stack reproduction covers the same null-block-guard family the
+// original stack lives in (Muya.dispatchChange -> getMarkdown ->
+// ExportMarkdown.generate). The bug surface is list/backspace mutation in
+// packages/muyajs/lib/contentState/ + packages/muyajs/lib/utils/exportMarkdown.js.
+import { test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  launchWithMarkdown,
+  placeCaretInEditor,
+  setSourceMarkdown,
+  clearRendererErrors,
+  expectNoRendererErrors
+} from './helpers'
+
+test.describe('Issue #4346: list-block null guards', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('# Repro\n\n', { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  test('select-all delete inside a single-item list does not crash', async() => {
+    await setSourceMarkdown(page, app, '# Doc\n\n- only item\n')
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+    await page.keyboard.press('ControlOrMeta+A')
+    await page.waitForTimeout(50)
+    await page.keyboard.press('Delete')
+    await page.waitForTimeout(200)
+    await page.keyboard.type(' ', { delay: 10 })
+    await page.waitForTimeout(300)
+    await expectNoRendererErrors(app)
+  })
+
+  test('backspace through every list item until list is empty does not crash', async() => {
+    await setSourceMarkdown(page, app, '# Doc\n\n- a\n- b\n- c\n')
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+    await page.evaluate(() => {
+      const items = document.querySelectorAll('.editor-component ul li span.ag-paragraph')
+      const last = items[items.length - 1] as HTMLElement | null
+      if (!last) return
+      const range = document.createRange()
+      range.selectNodeContents(last)
+      range.collapse(false)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    })
+    await page.waitForTimeout(100)
+    for (let i = 0; i < 60; i++) {
+      await page.keyboard.press('Backspace')
+      await page.waitForTimeout(20)
+    }
+    await page.keyboard.type('x', { delay: 10 })
+    await page.waitForTimeout(300)
+    await expectNoRendererErrors(app)
+  })
+
+  test('task list to bullet list transitions do not crash', async() => {
+    await setSourceMarkdown(page, app, '# Doc\n\n- [ ] task one\n- [x] task two\n- regular item\n')
+    await page.waitForTimeout(400)
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+    await page.evaluate(() => {
+      const items = document.querySelectorAll('.editor-component li span.ag-paragraph')
+      const last = items[items.length - 1] as HTMLElement | null
+      if (!last) return
+      const range = document.createRange()
+      range.selectNodeContents(last)
+      range.collapse(true) // start
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+    })
+    await page.waitForTimeout(100)
+    for (let i = 0; i < 30; i++) {
+      await page.keyboard.press('Backspace')
+      await page.waitForTimeout(15)
+    }
+    await page.keyboard.type('z', { delay: 5 })
+    await page.waitForTimeout(300)
+    await expectNoRendererErrors(app)
+  })
+
+  test('paste HTML with empty list does not crash', async() => {
+    const html = '<p>Before</p><ul></ul><ul><li></li></ul><ol></ol><p>After</p>'
+    await page.evaluate((h) => {
+      const target = document.querySelector('.editor-component span.ag-paragraph') as HTMLElement | null
+      if (!target) return
+      const range = document.createRange()
+      range.selectNodeContents(target)
+      range.collapse(false)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+      const dt = new DataTransfer()
+      dt.setData('text/html', h)
+      dt.setData('text/plain', 'Before After')
+      target.dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
+      )
+    }, html)
+    await page.waitForTimeout(500)
+    await page.keyboard.type(' more', { delay: 5 })
+    await page.waitForTimeout(300)
+    await expectNoRendererErrors(app)
+  })
+})

--- a/packages/muyajs/lib/contentState/backspaceCtrl.js
+++ b/packages/muyajs/lib/contentState/backspaceCtrl.js
@@ -144,6 +144,13 @@ const backspaceCtrl = (ContentState) => {
 
     const startBlock = this.getBlock(start.key)
     const endBlock = this.getBlock(end.key)
+    // Guard against transient state where the cursor still references a block
+    // that was just removed by a list mutation (#4346). Without these blocks
+    // there is nothing meaningful to delete in this pass; let the next
+    // selection-change settle and re-issue.
+    if (!startBlock || !endBlock) {
+      return
+    }
     const maybeLastRow = this.getParent(endBlock)
     const startOutmostBlock = this.findOutMostBlock(startBlock)
     const endOutmostBlock = this.findOutMostBlock(endBlock)

--- a/packages/muyajs/lib/contentState/formatCtrl.js
+++ b/packages/muyajs/lib/contentState/formatCtrl.js
@@ -162,6 +162,11 @@ const formatCtrl = (ContentState) => {
     }
 
     const startBlock = this.getBlock(start.key)
+    // Guard against transient state where the cursor still references a block
+    // that was just removed by a list mutation (#4346).
+    if (!startBlock) {
+      return { formats: [], tokens: [], neighbors: [] }
+    }
     const formats = []
     const neighbors = []
     let tokens = []

--- a/packages/muyajs/lib/utils/exportMarkdown.js
+++ b/packages/muyajs/lib/utils/exportMarkdown.js
@@ -112,7 +112,9 @@ class ExportMarkdown {
           this.isLooseParentList = true
 
           // Start a new list without separation due changing the bullet or ordered list delimiter starts a new list.
-          const { bulletMarkerOrDelimiter } = block.children[0]
+          // Guard against transient empty-children state during list mutation (#4346).
+          const firstChild = block.children[0]
+          const bulletMarkerOrDelimiter = firstChild ? firstChild.bulletMarkerOrDelimiter : undefined
           if (lastListBullet && lastListBullet !== bulletMarkerOrDelimiter) {
             insertNewLine = false
           }
@@ -131,7 +133,9 @@ class ExportMarkdown {
           this.isLooseParentList = true
 
           // Start a new list without separation due changing the bullet or ordered list delimiter starts a new list.
-          const { bulletMarkerOrDelimiter } = block.children[0]
+          // Guard against transient empty-children state during list mutation (#4346).
+          const firstChild = block.children[0]
+          const bulletMarkerOrDelimiter = firstChild ? firstChild.bulletMarkerOrDelimiter : undefined
           if (lastListBullet && lastListBullet !== bulletMarkerOrDelimiter) {
             insertNewLine = false
           }


### PR DESCRIPTION
## Summary
- Adds null guards to three list-mutation surfaces in muyajs that crashed the renderer when a list item was deleted/transformed (Issue #4346)
- Regression guard: `packages/desktop/test/e2e/issue-4346.spec.ts` reproduces the adjacent-stack crash via task-list -> bullet-list backspace; turns red without the fix, green with it
- No public API change; only adds defensive checks

## Root cause
When a list item is mutated (Backspace through empty list, task-list <-> bullet transitions, paste empty `<ul></ul>`) the contentState transiently holds references to blocks whose `children` array is empty or whose `startBlock` has been removed. Three sites destructured / read fields on the resulting null:

- `packages/muyajs/lib/utils/exportMarkdown.js` ul/ol case destructured `block.children[0]` -> the originally reported `Cannot destructure property 'bulletMarkerOrDelimiter' of 'block2.children[0]' as it is undefined`
- `packages/muyajs/lib/contentState/formatCtrl.js` `selectionFormats` destructured `text` from a null `startBlock`
- `packages/muyajs/lib/contentState/backspaceCtrl.js` `backspaceHandler` read `.type` from a null block

Each site now short-circuits when its block is missing, deferring to the next selection-change cycle once state settles.

## Closes
Closes #4346

## Test plan
- [ ] `pnpm -C packages/desktop exec playwright test test/e2e/issue-4346.spec.ts` -- 4/4 pass with this PR (verified red without the fix)
- [ ] Existing crash regression guards still green: `crash-range-offset.spec.ts`, `crash-selection-change.spec.ts`, `crash-update-paragraph.spec.ts`
- [ ] Editor input / inline-format / paragraph-blocks e2e suites still green
- [ ] `pnpm run typecheck` clean

Generated with Claude Code