### PR TITLE
fix(release): add repository field for electron-builder

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -26,6 +26,10 @@
     }
   ],
   "homepage": "https://github.com/marktext/marktext",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marktext/marktext.git"
+  },
   "scripts": {
     "minify-locales": "tsx ../../scripts/minify-locales.ts",
     "rebuild-native": "electron-rebuild -f",


### PR DESCRIPTION
## Summary

After the monorepo split (#4302), electron-builder runs from `packages/desktop/` where there is no sibling `.git/config` to auto-detect the repo. Without an explicit `repository` field in `packages/desktop/package.json`, publish-config inference returns null and `computeChannelNames` crashes while generating updater metadata:

```
TypeError: Cannot read properties of null (reading 'channel')
  at computeChannelNames (app-builder-lib/.../updateInfoBuilder.ts:47)
```

#4361 restored local builds but didn't surface this because the crash happens in the updater-metadata path, not the install path.

This adds the canonical GitHub `repository` entry. Cherry-picked from the `release/v0.19.1` branch — validated by the v0.19.1 release run that now produces `latest.yml` / `latest-mac.yml` / `latest-linux.yml` correctly across all 5 platforms.

## Test plan
- [x] v0.19.1 release run on the `release/v0.19.1` branch succeeded end-to-end with this fix (4 platforms first try + 1 ARM64 rerun for an unrelated flake; publish step generated all 24 expected assets)
- [ ] PR CI (lint + typecheck + tests) passes