### PR TITLE
fix(renderer): improve graphite contrast and unify accent colors (#4377)

### DIFF
--- a/packages/desktop/src/renderer/src/assets/styles/index.css
+++ b/packages/desktop/src/renderer/src/assets/styles/index.css
@@ -202,6 +202,15 @@ body {
   background-color: var(--themeColor);
 }
 
+.el-radio__input.is-checked .el-radio__inner {
+  border-color: var(--themeColor);
+  background-color: var(--themeColor);
+}
+
+.el-radio__input.is-checked + .el-radio__label {
+  color: var(--editorColor);
+}
+
 .el-dialog,
 .el-dialog.ag-dialog-table {
   border-radius: 8px;
@@ -219,6 +228,11 @@ input.el-input__inner {
   background: var(--inputBgColor);
   border: 1px solid var(--editorColor10);
   color: var(--editorColor80);
+}
+
+.el-input.is-focus .el-input__wrapper,
+.el-input__wrapper.is-focus {
+  box-shadow: 0 0 0 1px var(--themeColor) inset;
 }
 
 .el-input-number.is-controls-right span.el-input-number__decrease,

--- a/packages/desktop/src/renderer/src/assets/themes/graphite.theme.css
+++ b/packages/desktop/src/renderer/src/assets/themes/graphite.theme.css
@@ -77,7 +77,7 @@
   --sideBarTextColor: rgba(43, 48, 50, 0.6);
   --sideBarBgColor: #ececec;
   --sideBarItemHoverBgColor: rgba(255, 255, 255, 0.03);
-  --itemBgColor: rgba(43, 48, 50, 0.5);
+  --itemBgColor: #e5e5e5;
 
   --floatFontColor: rgba(43, 48, 50, 0.7);
   --floatBgColor: rgb(237, 237, 238);

--- a/packages/desktop/src/renderer/src/prefComponents/common/bool/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/common/bool/index.vue
@@ -130,4 +130,9 @@ span.el-switch__label {
 .el-switch:not(.is-checked) .el-switch__core::after {
   background: var(--iconColor);
 }
+
+.el-switch.is-checked .el-switch__core {
+  border-color: var(--themeColor);
+  background-color: var(--themeColor);
+}
 </style>

--- a/packages/desktop/src/renderer/src/prefComponents/common/select/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/common/select/index.vue
@@ -124,11 +124,19 @@ li.el-select-dropdown__item.hover,
 li.el-select-dropdown__item:hover {
   background: var(--floatHoverColor);
 }
+li.el-select-dropdown__item.selected,
+li.el-select-dropdown__item.is-selected {
+  color: var(--themeColor);
+  background: var(--themeColor10);
+}
 div.el-select-dropdown {
   background: var(--floatBgColor);
   border-color: var(--floatBorderColor);
   & .popper__arrow {
     display: none;
   }
+}
+.el-select__wrapper.is-focused {
+  box-shadow: 0 0 0 1px var(--themeColor) inset;
 }
 </style>


### PR DESCRIPTION
## Summary

Closes #4377.

Two readability issues reported on the Graphite theme:

1. **"New File" / "Open Folder" buttons are almost unreadable.** Graphite was the only light theme that used a dark semi-transparent `--itemBgColor`, which on a light page background mixed to muddy gray and killed the contrast against the muted blue `--themeColor` text. Aligned with every other light theme by switching to a solid light value (`#e5e5e5`, same as ayu-light).
2. **Toggle vs. slider accents are inconsistent.** The slider was already customized to follow `--themeColor`, but `el-switch` only customized the off state, leaving the checked state to fall back to Element Plus's default `#409eff`. The same `--el-color-primary` fallback affected `el-radio`, `el-select`, and `el-input` focus rings, so this PR unifies them all to `--themeColor`.

### Changes

- `assets/themes/graphite.theme.css`: `--itemBgColor` → `#e5e5e5`.
- `prefComponents/common/bool/index.vue`: checked `el-switch__core` uses `--themeColor`.
- `assets/styles/index.css`:
  - checked `el-radio__inner` uses `--themeColor`; label text stays `--editorColor` so the active option isn't visually shouting.
  - `el-input` focus wrapper uses a `--themeColor` inset box-shadow.
- `prefComponents/common/select/index.vue`:
  - `el-select-dropdown__item.is-selected` gets `color: var(--themeColor)` + `background: var(--themeColor10)`.
  - `el-select__wrapper.is-focused` uses a `--themeColor` inset box-shadow.

The Element Plus accent-unification fixes are theme-agnostic — every theme benefits, Graphite is just the most jarring case.

## Test plan

- [x] Switch to **Graphite**: confirm "New File" (Recent page) and "Open Folder" (empty sidebar) button text is clearly readable.
- [x] Open Preferences → General: confirm toggle (`Always Open Files in New Tab`, etc.), radio (`Startup Action`), dropdown (`Auto Save`), and any text input all use the same theme accent color on active/focus/selected states.
- [x] Spot-check Dark, Dracula, Nord, Gruvbox-Light to confirm the accent unification looks right in non-Graphite themes too.
- [x] `pnpm run lint` and `pnpm run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)