### PR TITLE
feat(muya): expose themeable CSS variables and diagram theming

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -593,6 +593,33 @@ figure.mu-math-block div.mu-math-preview > svg {
     width: 100%;
 }
 
+/* Diagram SVG recoloring — port of marktext's legacy theme block
+   (packages/muyajs/themes/default.css `figure[data-role] svg …`, ~lines
+   689-720) adapted to muya's DOM and kebab-cased vars. Mermaid and
+   vega-lite render an inline <svg> inside `.mu-diagram-preview`; these
+   rules rewrite the renderer's default black-on-white fills/strokes to the
+   editor's theme colors so diagrams follow the active theme (including
+   dark themes that override `--editor-bg-color` / `--editor-color`).
+   Additive and entirely theme-driven — on the bundled light theme
+   `--editor-bg-color` is white and `--editor-color` is the editor text
+   color, matching the diagrams' original look. */
+figure.mu-diagram-block .mu-diagram-preview svg rect[fill='#ffffff'],
+figure.mu-diagram-block .mu-diagram-preview svg path[fill='#ffffff'] {
+    fill: var(--editor-bg-color);
+}
+
+figure.mu-diagram-block .mu-diagram-preview svg text[fill='#000000'],
+figure.mu-diagram-block .mu-diagram-preview svg path[fill='#000000'],
+figure.mu-diagram-block .mu-diagram-preview svg use[fill='black'],
+figure.mu-diagram-block .mu-diagram-preview svg use[fill='#000000'] {
+    fill: var(--editor-color);
+}
+
+figure.mu-diagram-block .mu-diagram-preview svg rect[stroke='#000000'],
+figure.mu-diagram-block .mu-diagram-preview svg path[stroke='#000000'] {
+    stroke: var(--editor-color);
+}
+
 figure.mu-active.mu-math-block > div.mu-math-preview,
 figure.mu-active.mu-diagram-block > div.mu-diagram-preview {
     position: absolute;

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -4,7 +4,7 @@
 
 .mu-container {
     box-sizing: border-box;
-    max-width: 800px;
+    max-width: var(--editor-area-width, 800px);
     min-height: 100%;
     margin: 0 auto;
     padding: 0 50px 100px;
@@ -43,26 +43,32 @@
 }
 
 .mu-container h1 {
+    color: var(--h1-color, var(--editor-color-80));
     font-size: 1.875em;
 }
 
 .mu-container h2 {
+    color: var(--h2-color, var(--editor-color-80));
     font-size: 1.5em;
 }
 
 .mu-container h3 {
+    color: var(--h3-color, var(--editor-color-80));
     font-size: 1.375em;
 }
 
 .mu-container h4 {
+    color: var(--h4-color, var(--editor-color-80));
     font-size: 1.25em;
 }
 
 .mu-container h5 {
+    color: var(--h5-color, var(--editor-color-80));
     font-size: 1.125em;
 }
 
 .mu-container h6 {
+    color: var(--h6-color, var(--editor-color-80));
     font-size: 1em;
 }
 
@@ -74,7 +80,7 @@
     margin-left: 0;
     padding: 0 1em;
 
-    color: var(--editor-color-50);
+    color: var(--blockquote-text-color, var(--editor-color-50));
 
     font-size: 1em;
 }
@@ -88,7 +94,7 @@
     width: 3px;
     height: calc(100% - 1em);
 
-    background: var(--editor-color-30);
+    background: var(--blockquote-border-color, var(--editor-color-30));
 
     content: '';
 }
@@ -111,7 +117,7 @@
     width: 100%;
     height: 1px;
 
-    background: var(--editor-color-10);
+    background: var(--hr-color, var(--editor-color-10));
 
     content: '';
 }
@@ -309,6 +315,13 @@ ol.mu-order-list {
 
 ul.mu-bullet-list {
     list-style: disc outside none;
+}
+
+/* list markers — default to `inherit` (current text color) so the bundled
+   light theme is unchanged; themes can recolor the bullets / numbers. */
+ol.mu-order-list > li::marker,
+ul.mu-bullet-list > li::marker {
+    color: var(--list-marker-color, inherit);
 }
 
 ul.mu-bullet-list:first-child,

--- a/packages/muya/src/assets/styles/index.css
+++ b/packages/muya/src/assets/styles/index.css
@@ -10,6 +10,9 @@
     --editor-color-10: rgb(0 0 0 / 10%);
     --editor-color-04: rgb(0 0 0 / 3%);
     --editor-bg-color: rgb(255 255 255 / 100%);
+
+    /* width of the centered editing column (`.mu-container` max-width) */
+    --editor-area-width: 800px;
     --delete-color: #ff6969;
     --icon-color: #6b737b;
     --code-block-bg-color: rgb(0 0 0 / 3%);
@@ -20,10 +23,33 @@
     --button-border: 1px solid #dcdfe6;
     --button-bg-color-hover: linear-gradient(#f9f9f9, #f2f2f2);
     --button-border-hover: var(--button-border);
+
+    /* active / focus button variants — default to the resting button look so
+       the bundled light theme is unchanged; desktop themes can override. */
+    --button-bg-color-active: var(--button-bg-color);
+    --button-border-active: var(--button-border);
+    --button-border-focus: var(--button-border);
     --float-bg-color: #fff;
     --float-hover-color: rgb(0 0 0 / 4%);
     --float-border-color: rgb(0 0 0 / 10%);
     --float-shadow: rgb(15 15 15 / 3%) 0 0 0 1px, rgb(15 15 15 / 4%) 0 3px 6px, rgb(15 15 15 / 5%) 0 9px 24px;
+
+    /* markdown element colors — defaults mirror the current hardcoded /
+       opacity-tier values so the bundled light theme renders identically.
+       Desktop themes drive these via their own kebab-cased overrides. */
+    --link-color: rgb(20 86 240);
+    --h1-color: var(--editor-color-80);
+    --h2-color: var(--editor-color-80);
+    --h3-color: var(--editor-color-80);
+    --h4-color: var(--editor-color-80);
+    --h5-color: var(--editor-color-80);
+    --h6-color: var(--editor-color-80);
+    --blockquote-text-color: var(--editor-color-50);
+    --blockquote-border-color: var(--editor-color-30);
+    --strong-color: inherit;
+    --em-color: inherit;
+    --list-marker-color: inherit;
+    --hr-color: var(--editor-color-10);
 }
 
 /*

--- a/packages/muya/src/assets/styles/index.css
+++ b/packages/muya/src/assets/styles/index.css
@@ -36,7 +36,9 @@
 
     /* markdown element colors — defaults mirror the current hardcoded /
        opacity-tier values so the bundled light theme renders identically.
-       Desktop themes drive these via their own kebab-cased overrides. */
+       Consumers override them per theme. The desktop themes currently use
+       camelCase names (e.g. --linkColor, --h1Color); they will be migrated
+       to these kebab-case names as part of the muyajs -> @muyajs/core move. */
     --link-color: rgb(20 86 240);
     --h1-color: var(--editor-color-80);
     --h2-color: var(--editor-color-80);

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -17,7 +17,7 @@
 /* link and auto-link and reference link */
 a.mu-inline-rule,
 span.mu-inline-rule.mu-link {
-    color: rgb(20 86 240);
+    color: var(--link-color, rgb(20 86 240));
 }
 
 /* Note: previously this rule also set `pointer-events: none` to suppress
@@ -29,6 +29,16 @@ span.mu-inline-rule.mu-link {
 
 .mu-link-in-bracket {
     color: var(--editor-color-50);
+}
+
+/* strong and emphasis — default to `inherit` (the surrounding editor color)
+   so the bundled light theme is unchanged; themes can recolor them. */
+strong.mu-inline-rule {
+    color: var(--strong-color, inherit);
+}
+
+em.mu-inline-rule {
+    color: var(--em-color, inherit);
 }
 
 /* inline code */


### PR DESCRIPTION
## What & why

Part of the **muyajs → @muyajs/core migration**: makes `packages/muya`'s CSS
**themeable** so the desktop app's 32 themes can later drive it via CSS custom
properties (the same way the legacy `packages/muyajs` engine is themed today).

Scope is strictly CSS under `packages/muya/src/assets/styles/` — no `.ts` files
touched. The **default light theme renders identically**: every new variable is
applied as `var(--name, <fallback>)` where the fallback is muya's exact current
hardcoded / opacity-tier value, so nothing changes visually until a theme
overrides a variable.

## C1 — themeable CSS custom properties

New variables defined in `index.css` `:root` (defaults in parentheses) and used
at their call sites:

| Variable | Default (fallback) | Usage site |
|---|---|---|
| `--editor-area-width` | `800px` | `.mu-container` max-width |
| `--link-color` | `rgb(20 86 240)` | `a.mu-inline-rule`, `span.mu-inline-rule.mu-link` |
| `--h1-color` … `--h6-color` | `var(--editor-color-80)` | each `.mu-container h1…h6` |
| `--blockquote-text-color` | `var(--editor-color-50)` | `.mu-container blockquote` |
| `--blockquote-border-color` | `var(--editor-color-30)` | `.mu-container blockquote::before` |
| `--hr-color` | `var(--editor-color-10)` | `.mu-thematic-break::before` |
| `--strong-color` | `inherit` | `strong.mu-inline-rule` |
| `--em-color` | `inherit` | `em.mu-inline-rule` |
| `--list-marker-color` | `inherit` | order/bullet list `::marker` |
| `--button-bg-color-active` | `var(--button-bg-color)` | `:root` (theme hook) |
| `--button-border-active` | `var(--button-border)` | `:root` (theme hook) |
| `--button-border-focus` | `var(--button-border)` | `:root` (theme hook) |

Notes:
- `strong`/`em`/list markers previously had **no** explicit color (they inherit
  the editor color). Defaulting the new vars to `inherit` keeps that behavior
  exactly while giving themes a recolor hook.
- muya has no hardcoded `:active`/`:focus` button styles in these files, so the
  button active/focus vars are added as `:root` hooks (defaulting to the resting
  button look) for desktop-theme parity rather than rewriting nonexistent rules.
- The variable **names mirror the desktop themes' existing camelCase set**
  (`--h1Color`, `--blockquoteTextColor`, `--linkColor`, `--editorAreaWidth`, …),
  kebab-cased to match muya's convention, so the eventual wiring is 1:1.

## C2 — diagram SVG per-theme recoloring

Ported marktext's legacy block (`packages/muyajs/themes/default.css`
`figure[data-role] svg …`, ~lines 689-720) into `blockSyntax.css`, adapted to
muya's **live DOM** (`figure.mu-diagram-block .mu-diagram-preview svg`) and
kebab-cased vars (`--editor-bg-color`, `--editor-color`). Mermaid and vega-lite
render an inline `<svg>` whose default black-on-white `fill`/`stroke` values are
rewritten to the editor's theme colors, so diagrams follow the active theme —
including dark themes that override those two vars. The rules are additive and
entirely theme-driven; on the bundled light theme `--editor-bg-color` is white
and `--editor-color` is the editor text color, so diagrams look unchanged.

## Verification

- `pnpm -C packages/muya lint:types` — pass
- `pnpm -C packages/muya build` — pass
- `pnpm -C packages/muya test` — 388 passed
- `pnpm -C packages/muya test:spec` — 1347 passed
- `pnpm -C packages/muya lint` (ESLint, CI-gated) — 0 errors

> **Note on `lint:css`:** `pnpm -C packages/muya lint:css` currently crashes
> (`TypeError: Cannot read properties of undefined (reading 'unprefixed')`) on a
> **clean `develop` checkout, before any change in this PR** — it is a
> pre-existing tooling issue: `stylelint-config-rational-order@0.1.2` bundles
> `stylelint-order@2.2.1` / `stylelint@^9`, which is incompatible with the
> installed `stylelint@17`'s PostCSS AST. CI's `muya-lint` workflow runs only
> `lint` + `lint:types`, not `lint:css`, so it is not gated there. The CSS in
> this PR was validated against `stylelint-config-standard` (plus the repo's
> custom rule overrides) with **zero violations**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)