### PR TITLE
feat(muya): add block duplicate/insert/delete public API

### DIFF
--- a/packages/muya/src/__tests__/blockEditing.spec.ts
+++ b/packages/muya/src/__tests__/blockEditing.spec.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for the programmatic block-editing API added for the
+// muyajs -> @muyajs/core desktop migration: duplicate / insertParagraph /
+// deleteParagraph. These drive the desktop Edit/Paragraph menu actions,
+// which previously had no public entrypoint on @muyajs/core.
+//
+// Block-tree mutations dispatch json1 ops that flush to the document state on
+// the next animation frame (see JSONState._emitStateChange), so assertions on
+// getState() are wrapped in vi.waitFor to await that flush.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Block-level ops resolve their target via the active content block's
+// outMostBlock — the way the editor tracks the cursor after a click. Set it
+// directly to simulate the cursor sitting in the first block.
+function placeCursorOnFirstBlock(muya: Muya): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    return first;
+}
+
+describe('muya block editing api', () => {
+    it('duplicate() copies the current block in place', async () => {
+        const muya = bootMuya('# Title\n\nbody\n');
+        placeCursorOnFirstBlock(muya);
+        muya.duplicate();
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(3);
+            expect(after[0].name).toBe('atx-heading');
+            expect(after[1].name).toBe('atx-heading');
+            expect(after[2].name).toBe('paragraph');
+        });
+    });
+
+    it('insertParagraph() inserts an empty paragraph after by default', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph();
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(2);
+            expect(after[0].name).toBe('atx-heading');
+            expect(after[1].name).toBe('paragraph');
+        });
+    });
+
+    it('insertParagraph("before", text) inserts before with the given text', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('before', 'intro');
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(2);
+            expect(after[0].name).toBe('paragraph');
+            expect(after[1].name).toBe('atx-heading');
+        });
+        expect(muya.getMarkdown()).toContain('intro');
+    });
+
+    it('deleteParagraph() removes the current block and keeps the rest', async () => {
+        const muya = bootMuya('# Title\n\nbody\n');
+        placeCursorOnFirstBlock(muya);
+        muya.deleteParagraph();
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(1);
+            expect(after[0].name).toBe('paragraph');
+        });
+    });
+
+    it('deleteParagraph() on the only block leaves a single empty paragraph', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.deleteParagraph();
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(1);
+            expect(after[0].name).toBe('paragraph');
+        });
+    });
+});

--- a/packages/muya/src/__tests__/blockEditing.spec.ts
+++ b/packages/muya/src/__tests__/blockEditing.spec.ts
@@ -14,8 +14,12 @@ import { Muya } from '../muya';
 // getState() are wrapped in vi.waitFor to await that flush.
 
 const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
 
 beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
     window.MUYA_VERSION = 'test';
 });
 
@@ -24,7 +28,10 @@ afterEach(() => {
         const host = bootedHosts.pop()!;
         host.remove();
     }
-    delete (window as Partial<Window>).MUYA_VERSION;
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
 });
 
 function bootMuya(markdown: string): Muya {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1,9 +1,13 @@
+import type Content from './block/base/content';
+import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
 import type { ITocItem } from './state/getTOC';
 import type { TState } from './state/types';
 import type { IMuyaOptions } from './types';
 import Format from './block/base/format';
+import { ScrollPage } from './block/scrollPage';
+import emptyStates from './config/emptyStates';
 import {
     CLASS_NAMES,
     MUYA_DEFAULT_OPTIONS,
@@ -14,6 +18,7 @@ import EventCenter from './event/index';
 import I18n from './i18n/index';
 import { getTOC } from './state/getTOC';
 import { Ui } from './ui/ui';
+import { deepClone } from './utils';
 import './assets/styles/blockSyntax.css';
 import './assets/styles/index.css';
 import './assets/styles/inlineSyntax.css';
@@ -276,6 +281,82 @@ export class Muya {
      */
     pasteAsPlainText() {
         this.editor.clipboard.pasteAsPlainText();
+    }
+
+    /**
+     * The outer-most block at the current cursor — the target for block-level
+     * operations. Uses the persisted active content block (which survives the
+     * menu/IPC round-trip), falling back to the selection anchor.
+     */
+    private _outmostBlockAtCursor(): Parent | null {
+        const content = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
+
+        return content?.outMostBlock ?? null;
+    }
+
+    /**
+     * Duplicate the block at the current cursor, placing the cursor in the
+     * copy. No-op when there is no current block.
+     */
+    duplicate() {
+        const block = this._outmostBlockAtCursor();
+        if (!block)
+            return;
+
+        const state = deepClone(block.getState());
+        const dupBlock = ScrollPage.loadBlock(state.name).create(this, state);
+        block.parent!.insertAfter(dupBlock, block);
+        dupBlock.lastContentInDescendant()?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Insert an empty paragraph relative to the block at the current cursor.
+     * @param location Insert `before` or `after` the current block (default `after`).
+     * @param text Initial text of the new paragraph.
+     */
+    insertParagraph(location: 'before' | 'after' = 'after', text = '') {
+        const block = this._outmostBlockAtCursor();
+        if (!block)
+            return;
+
+        const state = deepClone(emptyStates.paragraph);
+        state.text = text;
+        const newBlock = ScrollPage.loadBlock('paragraph').create(this, state);
+        if (location === 'before')
+            block.parent!.insertBefore(newBlock, block);
+        else
+            block.parent!.insertAfter(newBlock, block);
+
+        newBlock.lastContentInDescendant()?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Delete the block at the current cursor, moving the cursor to an adjacent
+     * block, or to a fresh empty paragraph when it was the only block.
+     */
+    deleteParagraph() {
+        const block = this._outmostBlockAtCursor();
+        if (!block)
+            return;
+
+        let cursorBlock: Content | null = null;
+        if (block.prev) {
+            cursorBlock = block.prev.lastContentInDescendant();
+        }
+        else if (block.next) {
+            cursorBlock = block.next.firstContentInDescendant();
+        }
+        else {
+            const newBlock = ScrollPage.loadBlock('paragraph').create(
+                this,
+                deepClone(emptyStates.paragraph),
+            );
+            block.parent!.insertAfter(newBlock, block);
+            cursorBlock = newBlock.lastContentInDescendant();
+        }
+
+        block.remove();
+        cursorBlock?.setCursor(0, 0, true);
     }
 
     destroy() {


### PR DESCRIPTION
## Background

Part of the **muyajs → @muyajs/core engine migration**. The desktop Edit and
Paragraph menus drive block-structure operations that, in the legacy engine,
went through `contentState`. The new `@muyajs/core` only performs these via
the paragraph front-menu UI — there is no public programmatic entrypoint.
This PR adds the self-contained subset.

## What this adds (on the `Muya` class)

- `duplicate()` — duplicate the block at the cursor, placing the cursor in the copy.
- `insertParagraph(location = 'after', text = '')` — insert an empty paragraph before/after the current block.
- `deleteParagraph()` — delete the current block, moving the cursor to an adjacent block (or a fresh empty paragraph when it was the only block).

They resolve the target block via the active content block's `outMostBlock`
(which persists across the menu/IPC round-trip) and reuse the exact block
primitives the front menu already uses (`ScrollPage.loadBlock().create`,
`Parent.insertAfter/insertBefore`, `remove`), so behavior matches the
existing UI path.

`updateParagraph` (block-type conversion: headings/lists/quote/code/…),
`createTable` and `insertImage` are the remaining A1 pieces and will land in
follow-up PRs.

## Tests

New happy-dom spec `src/__tests__/blockEditing.spec.ts` covering duplicate /
insert (before+after, with text) / delete (incl. the only-block case).
Assertions await the `requestAnimationFrame` json-state flush via `vi.waitFor`.

## Verification

- `pnpm -C packages/muya lint` → 0 errors (pre-existing complexity warnings only)
- `pnpm -C packages/muya lint:types` ✓
- `pnpm -C packages/muya check-circular` ✓
- `pnpm -C packages/muya test` → 393 passed (388 + 5 new)
- `pnpm -C packages/muya test:spec` → 1347 passed (conformance unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)