### PR TITLE
feat(muya): add ImagePathPicker floating autocomplete UI

### DIFF
--- a/packages/muya/src/index.ts
+++ b/packages/muya/src/index.ts
@@ -14,6 +14,8 @@ export { CodeBlockLanguageSelector } from './ui/codeBlockLanguageSelector';
 export { EmojiSelector } from './ui/emojiSelector';
 export { FootnoteTool } from './ui/footnoteTool';
 export { ImageEditTool } from './ui/imageEditTool';
+export { ImagePathPicker } from './ui/imagePicker';
+export type { IImagePathSuggestion } from './ui/imagePicker';
 export { ImageResizeBar } from './ui/imageResizeBar';
 export { ImageToolBar } from './ui/imageToolbar';
 export { InlineFormatToolbar } from './ui/inlineFormatToolbar';

--- a/packages/muya/src/ui/imageEditTool/__tests__/imageEditToolAutocomplete.spec.ts
+++ b/packages/muya/src/ui/imageEditTool/__tests__/imageEditToolAutocomplete.spec.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImageEditTool } from '..';
+import EventCenter from '../../../event';
+
+// Verifies the ImageEditTool ↔ ImagePathPicker wiring: as the user types in
+// the image src input, the tool should call the host's `imagePathAutoComplete`
+// hook and re-dispatch the result through the `muya-image-picker` event that
+// the floating picker subscribes to.
+//
+// We run BaseFloat for real (so the src input is actually rendered) but mock
+// the slice of Muya the tool touches. We do NOT call init() or build a block
+// tree — the src input render path only needs i18n + the muya-image-selector
+// payload.
+
+function makeFakeMuya(imagePathAutoComplete?: (src: string) => Promise<unknown[]>): {
+    muya: Muya;
+    eventCenter: EventCenter;
+} {
+    const eventCenter = new EventCenter();
+    const editorDomNode = document.createElement('div');
+    const editorWrapper = document.createElement('div');
+    editorWrapper.appendChild(editorDomNode);
+    document.body.appendChild(editorWrapper);
+
+    const muya = {
+        domNode: editorDomNode,
+        eventCenter,
+        i18n: { t: (s: string) => s },
+        ui: { shownFloat: new Set() },
+        options: { imagePathAutoComplete },
+    } as unknown as Muya;
+
+    return { muya, eventCenter };
+}
+
+function stubReference(): HTMLElement {
+    const el = document.createElement('span');
+    el.getBoundingClientRect = () =>
+        ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => '' }) as DOMRect;
+    document.body.appendChild(el);
+    return el;
+}
+
+function openTool(eventCenter: EventCenter, src: string) {
+    eventCenter.emit('muya-image-selector', {
+        block: { replaceImage: vi.fn() },
+        reference: stubReference(),
+        imageInfo: { imageId: 'id', token: { attrs: { src, alt: '', title: '' } } },
+    });
+}
+
+async function nextTick() {
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('imageEditTool — imagePathAutoComplete wiring', () => {
+    let tool: ImageEditTool;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+        tool?.hide();
+        vi.restoreAllMocks();
+    });
+
+    it('calls imagePathAutoComplete with the current src value and dispatches muya-image-picker on keyup', async () => {
+        const suggestions = [{ text: 'photo.png', iconClass: 'icon-image' }];
+        const autocomplete = vi.fn().mockResolvedValue(suggestions);
+        const { muya, eventCenter } = makeFakeMuya(autocomplete);
+        tool = new ImageEditTool(muya, { imagePathAutoComplete: autocomplete } as never);
+
+        const pickerEvents: unknown[] = [];
+        eventCenter.subscribe('muya-image-picker', (payload: unknown) => {
+            pickerEvents.push(payload);
+        });
+
+        openTool(eventCenter, '/some/dir/ph');
+
+        const input = tool.container!.querySelector('input.src') as HTMLInputElement;
+        expect(input).not.toBeNull();
+
+        input.dispatchEvent(new KeyboardEvent('keyup', { key: 'h' }));
+        await nextTick();
+
+        expect(autocomplete).toHaveBeenCalledWith('/some/dir/ph');
+        expect(pickerEvents.length).toBe(1);
+        const payload = pickerEvents[0] as { list: unknown[]; reference: HTMLElement };
+        expect(payload.list).toEqual(suggestions);
+        expect(payload.reference).toBe(input);
+    });
+
+    it('does not call imagePathAutoComplete when the hook is absent', async () => {
+        const { muya, eventCenter } = makeFakeMuya(undefined);
+        tool = new ImageEditTool(muya);
+
+        const pickerSpy = vi.fn();
+        eventCenter.subscribe('muya-image-picker', pickerSpy);
+
+        openTool(eventCenter, '/some/dir/ph');
+        const input = tool.container!.querySelector('input.src') as HTMLInputElement;
+        input.dispatchEvent(new KeyboardEvent('keyup', { key: 'h' }));
+        await nextTick();
+
+        expect(pickerSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/ui/imageEditTool/index.ts
+++ b/packages/muya/src/ui/imageEditTool/index.ts
@@ -2,14 +2,16 @@ import type { VNode } from 'snabbdom';
 import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
 import type { ImageToken } from '../../inlineRenderer/types';
+import type { IImagePathSuggestion } from '../imagePicker';
 import type { IBaseOptions } from '../types';
 import { EVENT_KEYS, isWin, URL_REG } from '../../config';
 import { getUniqueId, isHTMLInputElement, isKeyboardEvent } from '../../utils';
-import { query } from '../../utils/dom';
 
+import { query } from '../../utils/dom';
 import { getImageInfo, getImageSrc } from '../../utils/image';
 import { h, patch } from '../../utils/snabbdom';
 import BaseFloat from '../baseFloat';
+import { ImagePathPicker } from '../imagePicker';
 import './index.css';
 
 /**
@@ -28,8 +30,15 @@ interface IState {
  * Image edit tool options
  */
 type Options = {
-    /** Custom image path picker function */
+    /** Custom image path picker function (one-shot native file dialog) */
     imagePathPicker?: () => Promise<string>;
+    /**
+     * Local image path autocomplete hook. Given the current src input value,
+     * returns a list of path suggestions to show in the floating
+     * {@link ImagePathPicker}. Mirrors the legacy `imagePathAutoComplete`
+     * option — typically backed by a filesystem directory listing.
+     */
+    imagePathAutoComplete?: (src: string) => Promise<IImagePathSuggestion[]>;
     /** Image upload action handler */
     imageAction?: (state: IState) => Promise<string>;
 } & IBaseOptions;
@@ -161,16 +170,117 @@ export class ImageEditTool extends BaseFloat {
     }
 
     /**
-     * Handle Enter key press to confirm changes
+     * Locate the floating image-path picker if it is currently open.
+     * Plugins are registered privately on Muya, so we resolve the instance via
+     * the shared `ui.shownFloat` registry (the same pattern tableColumnToolbar
+     * uses to find the format picker). Returns null when the picker plugin is
+     * not registered or not currently shown.
+     */
+    private _getOpenImagePathPicker(): ImagePathPicker | null {
+        for (const tool of this.muya.ui.shownFloat) {
+            if (tool instanceof ImagePathPicker && tool.status)
+                return tool;
+        }
+        return null;
+    }
+
+    /**
+     * Handle keydown on the src input.
+     * When the autocomplete picker is open, arrow keys / Tab / Enter drive the
+     * picker (navigate + choose) instead of confirming. Otherwise Enter
+     * confirms the change, mirroring the legacy `srcInputKeyDown` behavior.
      * @param event - Keyboard event
      */
-    private _handleEnter(event: Event) {
+    private _handleSrcKeyDown(event: Event) {
         if (!isKeyboardEvent(event))
             return;
 
-        event.stopPropagation();
-        if (event.key === EVENT_KEYS.Enter)
-            this._handleConfirm();
+        const picker = this._getOpenImagePathPicker();
+        if (!picker) {
+            if (event.key === EVENT_KEYS.Enter) {
+                event.stopPropagation();
+                this._handleConfirm();
+            }
+            return;
+        }
+
+        switch (event.key) {
+            case EVENT_KEYS.ArrowUp:
+                event.preventDefault();
+                picker.step('previous');
+                break;
+
+            case EVENT_KEYS.ArrowDown:
+            case EVENT_KEYS.Tab:
+                event.preventDefault();
+                picker.step('next');
+                break;
+
+            case EVENT_KEYS.Enter:
+                event.preventDefault();
+                event.stopPropagation();
+                if (picker.activeItem)
+                    picker.selectItem(picker.activeItem);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Handle keyup on the src input.
+     * Re-queries the `imagePathAutoComplete` hook (debounced via the browser's
+     * natural keystroke cadence) and dispatches `muya-image-picker` so the
+     * floating picker refreshes its suggestions. Navigation keys are ignored so
+     * they don't re-trigger a fetch while the user is moving through the list.
+     * @param event - Keyboard event
+     */
+    private async _handleSrcKeyUp(event: Event) {
+        if (!isKeyboardEvent(event) || !this.options.imagePathAutoComplete)
+            return;
+
+        const { key } = event;
+        if (
+            key === EVENT_KEYS.ArrowUp
+            || key === EVENT_KEYS.ArrowDown
+            || key === EVENT_KEYS.Tab
+            || (key === EVENT_KEYS.Enter
+                && !this._state.src.endsWith('/')
+                && !this._state.src.endsWith('\\'))
+        ) {
+            return;
+        }
+
+        const { eventCenter } = this.muya;
+        const value = this._state.src;
+        const reference = this.container
+            ? query<HTMLInputElement>('input.src', this.container)
+            : null;
+
+        // Write the chosen suggestion back into the src input. The new value is
+        // the directory portion of the current path plus the chosen basename,
+        // matching the legacy ImageSelector autocomplete UX.
+        const cb = (item: IImagePathSuggestion) => {
+            if (!reference)
+                return;
+
+            const { text } = item;
+            let basePath = '';
+            const pathSep = value.match(/(?:\/|\\)[^/\\]*$/);
+            if (pathSep && pathSep[0])
+                basePath = value.substring(0, pathSep.index! + 1);
+
+            const newValue = basePath + text;
+            const len = newValue.length;
+            reference.value = newValue;
+            this._state.src = newValue;
+            reference.focus();
+            reference.setSelectionRange(len, len);
+        };
+
+        const list = value ? await this.options.imagePathAutoComplete(value) : [];
+        eventCenter.emit('muya-image-picker', { reference, list, cb });
     }
 
     /**
@@ -263,6 +373,17 @@ export class ImageEditTool extends BaseFloat {
     }
 
     /**
+     * Hide the tool and dismiss the autocomplete picker alongside it so a
+     * confirm/close never leaves a dangling suggestions dropdown.
+     */
+    override hide() {
+        const picker = this._getOpenImagePathPicker();
+        if (picker)
+            picker.hide();
+        super.hide();
+    }
+
+    /**
      * Handle click on "more" button to open file picker
      * Updates the src input with selected path
      */
@@ -305,7 +426,8 @@ export class ImageEditTool extends BaseFloat {
             on: {
                 input: event => this._handleSrcInput(event),
                 paste: event => this._handleSrcInput(event),
-                keydown: event => this._handleEnter(event),
+                keydown: event => this._handleSrcKeyDown(event),
+                keyup: event => this._handleSrcKeyUp(event),
             },
         });
 

--- a/packages/muya/src/ui/imageEditTool/index.ts
+++ b/packages/muya/src/ui/imageEditTool/index.ts
@@ -79,6 +79,9 @@ export class ImageEditTool extends BaseFloat {
     /** The block containing the image */
     private _block: Format | null = null;
 
+    /** Monotonic counter used to drop out-of-order imagePathAutoComplete responses */
+    private _autoCompleteSeq = 0;
+
     /** Current editing state */
     private _state: IState = {
         alt: '',
@@ -207,12 +210,17 @@ export class ImageEditTool extends BaseFloat {
         switch (event.key) {
             case EVENT_KEYS.ArrowUp:
                 event.preventDefault();
+                // Stop the editor's BaseScrollFloat keydown handler (bound on
+                // muya.domNode) from also stepping the picker — otherwise the
+                // active item advances twice per keypress.
+                event.stopPropagation();
                 picker.step('previous');
                 break;
 
             case EVENT_KEYS.ArrowDown:
             case EVENT_KEYS.Tab:
                 event.preventDefault();
+                event.stopPropagation();
                 picker.step('next');
                 break;
 
@@ -266,10 +274,14 @@ export class ImageEditTool extends BaseFloat {
                 return;
 
             const { text } = item;
+            // Derive the directory prefix from the CURRENT input value — the
+            // user may have kept typing after the suggestions were fetched, so
+            // the value captured on keyup can be stale.
+            const current = reference.value;
             let basePath = '';
-            const pathSep = value.match(/(?:\/|\\)[^/\\]*$/);
+            const pathSep = current.match(/(?:\/|\\)[^/\\]*$/);
             if (pathSep && pathSep[0])
-                basePath = value.substring(0, pathSep.index! + 1);
+                basePath = current.substring(0, pathSep.index! + 1);
 
             const newValue = basePath + text;
             const len = newValue.length;
@@ -279,7 +291,12 @@ export class ImageEditTool extends BaseFloat {
             reference.setSelectionRange(len, len);
         };
 
+        // Guard against out-of-order resolution: if the user types again before
+        // a slower earlier request resolves, drop the stale response.
+        const seq = ++this._autoCompleteSeq;
         const list = value ? await this.options.imagePathAutoComplete(value) : [];
+        if (seq !== this._autoCompleteSeq)
+            return;
         eventCenter.emit('muya-image-picker', { reference, list, cb });
     }
 

--- a/packages/muya/src/ui/imagePicker/__tests__/imagePicker.spec.ts
+++ b/packages/muya/src/ui/imagePicker/__tests__/imagePicker.spec.ts
@@ -106,7 +106,7 @@ describe('imagePathPicker — render on muya-image-picker event', () => {
         eventCenter.emit('muya-image-picker', { reference, list, cb });
         await nextTick();
 
-        const second = picker.floatBox!.querySelector('[data-label="second.png"]') as HTMLElement;
+        const second = picker.floatBox!.querySelector('[data-index="1"]') as HTMLElement;
         second.click();
 
         expect(cb).toHaveBeenCalledTimes(1);

--- a/packages/muya/src/ui/imagePicker/__tests__/imagePicker.spec.ts
+++ b/packages/muya/src/ui/imagePicker/__tests__/imagePicker.spec.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ImagePathPicker } from '..';
+import EventCenter from '../../../event';
+
+// Smoke + integration tests for the ImagePathPicker floating autocomplete UI.
+//
+// The picker is a BaseScrollFloat subclass driven entirely by the
+// `muya-image-picker` event: the ImageEditTool fetches suggestions from the
+// host's `imagePathAutoComplete` hook and dispatches them here. We mock the
+// slice of Muya the picker touches (eventCenter, domNode, i18n, ui) and run
+// BaseFloat/BaseScrollFloat for real so the snabbdom render path is exercised
+// end-to-end in happy-dom.
+
+function makeFakeMuya(): { muya: Muya; eventCenter: EventCenter } {
+    const eventCenter = new EventCenter();
+    const editorDomNode = document.createElement('div');
+    const editorWrapper = document.createElement('div');
+    editorWrapper.appendChild(editorDomNode);
+    document.body.appendChild(editorWrapper);
+
+    const shownFloat = new Set();
+    // Mirror Ui.listen so `status` flips when the float shows/hides.
+    eventCenter.subscribe('muya-float', (tool: unknown, status: boolean) => {
+        status ? shownFloat.add(tool) : shownFloat.delete(tool);
+    });
+
+    const muya = {
+        domNode: editorDomNode,
+        eventCenter,
+        i18n: { t: (s: string) => s },
+        ui: { shownFloat },
+        options: {},
+    } as unknown as Muya;
+
+    return { muya, eventCenter };
+}
+
+function stubReference(): HTMLElement {
+    const input = document.createElement('input');
+    // BaseFloat computes position off the reference; happy-dom has no layout,
+    // so a stubbed rect keeps autoUpdate from throwing.
+    input.getBoundingClientRect = () =>
+        ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => '' }) as DOMRect;
+    document.body.appendChild(input);
+    return input;
+}
+
+async function nextTick() {
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('imagePathPicker — plugin shape', () => {
+    it('exposes a stable static pluginName so Muya.use registers it under "imagePathPicker"', () => {
+        expect(ImagePathPicker.pluginName).toBe('imagePathPicker');
+    });
+});
+
+describe('imagePathPicker — render on muya-image-picker event', () => {
+    let muya: Muya;
+    let eventCenter: EventCenter;
+    let picker: ImagePathPicker;
+
+    beforeEach(() => {
+        ({ muya, eventCenter } = makeFakeMuya());
+        picker = new ImagePathPicker(muya);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders one list item per suggestion and marks the first active', async () => {
+        const reference = stubReference();
+        const list = [
+            { text: 'a.png', iconClass: 'icon-image' },
+            { text: 'sub', iconClass: 'icon-folder', type: 'directory' },
+        ];
+
+        eventCenter.emit('muya-image-picker', { reference, list, cb: () => {} });
+        await nextTick();
+
+        const items = picker.floatBox!.querySelectorAll('li.item');
+        expect(items.length).toBe(2);
+        expect(items[0].classList.contains('active')).toBe(true);
+        expect(items[0].querySelector('.text')?.textContent).toBe('a.png');
+        // Icon class is rendered when supplied.
+        expect(items[1].querySelector('.icon-wrapper span.icon-folder')).not.toBeNull();
+        expect(picker.status).toBe(true);
+    });
+
+    it('hides instead of showing when the suggestion list is empty', async () => {
+        const reference = stubReference();
+        eventCenter.emit('muya-image-picker', { reference, list: [], cb: () => {} });
+        await nextTick();
+
+        expect(picker.status).toBe(false);
+    });
+
+    it('invokes the selection callback with the chosen item on click', async () => {
+        const reference = stubReference();
+        const cb = vi.fn();
+        const list = [{ text: 'first.png' }, { text: 'second.png' }];
+
+        eventCenter.emit('muya-image-picker', { reference, list, cb });
+        await nextTick();
+
+        const second = picker.floatBox!.querySelector('[data-label="second.png"]') as HTMLElement;
+        second.click();
+
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith(list[1]);
+    });
+
+    it('moves the active item with step("next") and selects it via the active item', async () => {
+        const reference = stubReference();
+        const cb = vi.fn();
+        const list = [{ text: 'one.png' }, { text: 'two.png' }, { text: 'three.png' }];
+
+        eventCenter.emit('muya-image-picker', { reference, list, cb });
+        await nextTick();
+
+        picker.step('next');
+        expect(picker.activeItem).toBe(list[1]);
+
+        picker.selectItem(picker.activeItem);
+        expect(cb).toHaveBeenCalledWith(list[1]);
+    });
+});

--- a/packages/muya/src/ui/imagePicker/index.css
+++ b/packages/muya/src/ui/imagePicker/index.css
@@ -21,6 +21,10 @@
 .mu-image-picker-wrapper .mu-list-picker .item {
     display: flex;
     align-items: center;
+
+    /* override codeBlockLanguageSelector's global `.mu-list-picker .item`
+       justify-content: space-between, which would push icon/text apart */
+    justify-content: flex-start;
     height: 28px;
     padding: 0 10px;
 

--- a/packages/muya/src/ui/imagePicker/index.css
+++ b/packages/muya/src/ui/imagePicker/index.css
@@ -1,0 +1,60 @@
+.mu-image-picker-wrapper {
+    z-index: 100000;
+}
+
+.mu-image-picker-wrapper .mu-list-picker {
+    box-sizing: border-box;
+    width: 450px;
+    max-height: 156px;
+    padding: 8px 0;
+    overflow-y: auto;
+
+    font-size: 14px;
+}
+
+.mu-image-picker-wrapper .mu-list-picker ul,
+.mu-image-picker-wrapper .mu-list-picker li {
+    margin: 0;
+    padding: 0;
+}
+
+.mu-image-picker-wrapper .mu-list-picker .item {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 10px;
+
+    list-style: none;
+}
+
+.mu-image-picker-wrapper .mu-list-picker:hover .active {
+    background: transparent;
+}
+
+.mu-image-picker-wrapper .mu-list-picker .item:hover,
+.mu-image-picker-wrapper .mu-list-picker .item.active {
+    background-color: var(--float-hover-color);
+}
+
+.mu-image-picker-wrapper .mu-list-picker .item .icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+}
+
+.mu-image-picker-wrapper .mu-list-picker .item .icon-wrapper span::before {
+    font-size: 14px;
+}
+
+.mu-image-picker-wrapper .mu-list-picker .item .text {
+    flex: 1;
+    overflow: hidden;
+
+    color: var(--editor-color);
+    font-size: 14px;
+    line-height: 28px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/packages/muya/src/ui/imagePicker/index.ts
+++ b/packages/muya/src/ui/imagePicker/index.ts
@@ -1,0 +1,129 @@
+import type { VNode } from 'snabbdom';
+import type { Muya } from '../../index';
+import { query } from '../../utils/dom';
+
+import { h, patch } from '../../utils/snabbdom';
+import BaseScrollFloat from '../baseScrollFloat';
+
+import './index.css';
+
+/**
+ * A single path suggestion produced by the `imagePathAutoComplete` hook.
+ * `text` is the basename rendered (and written back into the src input);
+ * `iconClass` selects a font-icon class, `type` distinguishes files from
+ * directories. Extra keys are tolerated so callers can carry metadata.
+ */
+export interface IImagePathSuggestion {
+    text: string;
+    iconClass?: string;
+    type?: string;
+    [key: string]: unknown;
+}
+
+/** Payload of the `muya-image-picker` event the ImageEditTool dispatches. */
+interface IImagePickerEvent {
+    reference: HTMLElement | null;
+    list: IImagePathSuggestion[];
+    cb: (item: IImagePathSuggestion) => void;
+}
+
+const defaultOptions = {
+    placement: 'bottom-start' as const,
+    offsetOptions: {
+        mainAxis: 0,
+        crossAxis: 0,
+        alignmentAxis: 0,
+    },
+    showArrow: false,
+};
+
+/**
+ * Floating autocomplete dropdown that suggests local image file paths as the
+ * user edits an image's `src` in the {@link ImageEditTool}. It is a faithful
+ * port of the legacy `packages/muyajs/lib/ui/imagePicker` plugin: it listens
+ * for the `muya-image-picker` event, renders a scrollable filtered list, and
+ * supports arrow-key navigation plus Enter/click to choose. The chosen path is
+ * written back through the callback supplied in the event payload.
+ *
+ * The list itself is produced by the host application via the
+ * `imagePathAutoComplete` option on the ImageEditTool — muya only renders the
+ * result and reports the selection.
+ */
+export class ImagePathPicker extends BaseScrollFloat {
+    static pluginName = 'imagePathPicker';
+
+    private _oldVNode: VNode | null = null;
+    public override renderArray: IImagePathSuggestion[] = [];
+    public override activeItem: IImagePathSuggestion | null = null;
+
+    constructor(muya: Muya, options = {}) {
+        const name = 'mu-list-picker';
+        const opts = Object.assign({}, defaultOptions, options);
+        super(muya, name, opts);
+        this.floatBox!.classList.add('mu-image-picker-wrapper');
+        this.listen();
+    }
+
+    override listen() {
+        super.listen();
+        const { eventCenter } = this.muya;
+        eventCenter.on('muya-image-picker', ({ reference, list, cb }: IImagePickerEvent) => {
+            if (reference && list.length) {
+                this.show(reference, cb);
+                this.renderArray = list;
+                this.activeItem = list[0];
+                this.render();
+            }
+            else {
+                this.hide();
+            }
+        });
+    }
+
+    render() {
+        const { renderArray, _oldVNode: oldVNode, scrollElement, activeItem } = this;
+        const children = renderArray.map((item) => {
+            const { text, iconClass } = item;
+            // Icons are font-icon classes (parity placeholder for the legacy
+            // inline SVGs — see PR notes). When the host omits `iconClass` we
+            // simply render the text without an icon.
+            const iconContent = iconClass
+                ? [h('div.icon-wrapper', h(`span.${iconClass}`))]
+                : [];
+            const textEle = h('div.text', text);
+            const selector = activeItem === item ? 'li.item.active' : 'li.item';
+
+            return h(
+                selector,
+                {
+                    dataset: {
+                        label: text,
+                    },
+                    on: {
+                        click: () => {
+                            this.selectItem(item);
+                        },
+                    },
+                },
+                [...iconContent, textEle],
+            );
+        });
+
+        const vnode = h('ul', children);
+
+        if (oldVNode)
+            patch(oldVNode, vnode);
+        else
+            patch(scrollElement!, vnode);
+
+        this._oldVNode = vnode;
+    }
+
+    getItemElement(item: IImagePathSuggestion): HTMLElement | null {
+        const { text } = item;
+
+        return query<HTMLElement>(`[data-label="${text}"]`, this.floatBox!);
+    }
+}
+
+export default ImagePathPicker;

--- a/packages/muya/src/ui/imagePicker/index.ts
+++ b/packages/muya/src/ui/imagePicker/index.ts
@@ -82,7 +82,7 @@ export class ImagePathPicker extends BaseScrollFloat {
 
     render() {
         const { renderArray, _oldVNode: oldVNode, scrollElement, activeItem } = this;
-        const children = renderArray.map((item) => {
+        const children = renderArray.map((item, index) => {
             const { text, iconClass } = item;
             // Icons are font-icon classes (parity placeholder for the legacy
             // inline SVGs — see PR notes). When the host omits `iconClass` we
@@ -96,8 +96,11 @@ export class ImagePathPicker extends BaseScrollFloat {
             return h(
                 selector,
                 {
+                    // Index-based lookup — file names can contain quotes/brackets
+                    // (unsafe in an attribute selector) and duplicate basenames
+                    // would otherwise collide on a text-based attribute.
                     dataset: {
-                        label: text,
+                        index: String(index),
                     },
                     on: {
                         click: () => {
@@ -120,9 +123,11 @@ export class ImagePathPicker extends BaseScrollFloat {
     }
 
     getItemElement(item: IImagePathSuggestion): HTMLElement | null {
-        const { text } = item;
+        const index = this.renderArray.indexOf(item);
+        if (index < 0)
+            return null;
 
-        return query<HTMLElement>(`[data-label="${text}"]`, this.floatBox!);
+        return query<HTMLElement>(`[data-index="${index}"]`, this.floatBox!);
     }
 }
 


### PR DESCRIPTION
## Parity gap

The legacy engine (`packages/muyajs`) ships an **ImagePathPicker** — a floating autocomplete dropdown that suggests **local image file paths** as the user edits an image's `src` (legacy: `packages/muyajs/lib/ui/imagePicker/index.js`, wired from `packages/muyajs/lib/ui/imageSelector`). The new `packages/muya` (`@muyajs/core`) had **no equivalent floating UI** — only a one-shot `imagePathPicker` file-dialog callback on the ImageEditTool, and no `imagePathAutoComplete` hook. This PR closes that gap as part of the desktop migration off legacy muya.

## What's added

### `ImagePathPicker` plugin — `packages/muya/src/ui/imagePicker/`
A `BaseScrollFloat` subclass (`static pluginName = 'imagePathPicker'`) that faithfully mirrors the legacy UX:
- Subscribes to the `muya-image-picker` event (`{ reference, list, cb }`).
- Renders a scrollable, filtered list of suggestions (`{ text, iconClass?, type?, … }`).
- Arrow-Up / Arrow-Down / Tab navigation + Enter / click to choose (inherited from `BaseScrollFloat`).
- Reports the chosen item via the callback supplied in the event payload.
- Follows new-muya conventions exactly (4-space indent, semicolons, `I`-prefixed interfaces, `_`-prefixed privates, snabbdom `h`/`patch`, `query`).

Exported from `packages/muya/src/index.ts` (with `IImagePathSuggestion`), placed in path-sorted order between `ImageEditTool` and `ImageResizeBar`.

### `imagePathAutoComplete` hook + ImageEditTool wiring
- New option on the ImageEditTool `Options` type (declared alongside the existing `imagePathPicker` / `imageAction`):
  `imagePathAutoComplete?: (src: string) => Promise<IImagePathSuggestion[]>`.
- On **keyup** in the src input, the tool calls `imagePathAutoComplete(currentSrc)` and dispatches `muya-image-picker` so the floating picker refreshes (navigation keys are skipped to avoid re-fetching mid-navigation). The chosen path is written back as `directory-portion + basename`, matching the legacy autocomplete behavior.
- On **keydown**, when the picker is open, Arrow/Tab/Enter drive the picker (navigate + choose) instead of confirming; otherwise Enter confirms as before.
- The picker is dismissed when the tool hides, so confirm/close never leaves a dangling dropdown.
- All existing ImageEditTool behavior (file-dialog `imagePathPicker`, `imageAction` upload flow, direct replace, file-protocol normalization) is unchanged.

The cross-plugin handle to the open picker is resolved via `muya.ui.shownFloat` (the same registry `tableColumnToolbar` already uses to find the format picker) — no edits to `packages/muya/src/muya.ts` (which is being changed in parallel).

## Placeholder note (icons)

The legacy plugin rendered inline SVG assets (`folder.svg` / `image.svg` / `upload.svg`) mapped from `iconClass`. The new engine ships **no inline SVG assets** for UI plugins (icons are font-icon CSS classes, e.g. `codeBlockLanguageSelector`). So the picker renders `iconClass` directly as a `span.<iconClass>` font icon and omits the icon when none is supplied. A host wanting the exact legacy folder/image/upload glyphs should provide the corresponding icon-font classes (or a follow-up can add dedicated assets).

## Tests

happy-dom vitest specs (following the existing `footnoteTool` UI-plugin test pattern):
- `packages/muya/src/ui/imagePicker/__tests__/imagePicker.spec.ts` — stable `pluginName`; renders one item per suggestion (first active, icon class applied); hides on empty list; click invokes the callback; `step('next')` + select drives the active item.
- `packages/muya/src/ui/imageEditTool/__tests__/imageEditToolAutocomplete.spec.ts` — typing in the src input calls `imagePathAutoComplete` with the current value and dispatches `muya-image-picker` with the result + reference; no dispatch when the hook is absent.

## Verify (all green)

`pnpm -C packages/muya`: **lint** (0 errors), **lint:types**, **check-circular**, **test** (395 passed), **test:spec** (1347 passed).

> Note: `lint:css` is unaffected by this change — it crashes on the pre-existing `assets/styles/exportStyle.css` via a `stylelint-order` plugin version incompatibility, independent of the new CSS (which mirrors `codeBlockLanguageSelector/index.css` ordering). It is not part of the required verify set.

## Remaining integration note

The wiring is complete on the muya side. The desktop renderer must, when registering plugins, pass an `imagePathAutoComplete` implementation (a filesystem directory listing returning `{ text, iconClass, type }[]`) alongside the existing `imagePathPicker` option — the same data source the legacy app fed to its `imagePathAutoComplete`. Without it, the ImageEditTool behaves exactly as before (no picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)