### PR TITLE
feat(muya): add cursorCoords + active formats to selection-change

### DIFF
--- a/packages/muya/src/selection/__tests__/selectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectionChange.spec.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// Coverage for the selection-change payload extras added for the
+// muyajs -> @muyajs/core desktop migration: `cursorCoords` (typewriter-mode
+// scrolling) and `formats` (active inline formats, for lighting up the
+// desktop toolbar). The legacy engine put both on its `selectionChange`
+// event; the desktop reads `changes.cursorCoords.y` and the format list.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('selection-change payload', () => {
+    it('includes cursorCoords and a formats array', () => {
+        const muya = bootMuya('hello world\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+
+        let payload: Record<string, unknown> | null = null;
+        muya.on('selection-change', (p: unknown) => {
+            payload = p as Record<string, unknown>;
+        });
+
+        muya.editor.selection.setSelection({
+            anchor: { offset: 0 },
+            focus: { offset: 5 },
+            block: first,
+            path: first.path,
+        });
+
+        expect(payload).not.toBeNull();
+        // cursorCoords is a DOMRect | null (null under happy-dom, which has no
+        // real layout) — assert the key is present so the desktop typewriter
+        // path always receives it.
+        expect(payload!).toHaveProperty('cursorCoords');
+        expect(Array.isArray(payload!.formats)).toBe(true);
+    });
+});

--- a/packages/muya/src/selection/__tests__/selectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectionChange.spec.ts
@@ -63,4 +63,26 @@ describe('selection-change payload', () => {
         expect(payload!).toHaveProperty('cursorCoords');
         expect(Array.isArray(payload!.formats)).toBe(true);
     });
+
+    it('reports the active inline format when the cursor is inside bold text', () => {
+        const muya = bootMuya('**bold**\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+
+        let payload: Record<string, unknown> | null = null;
+        muya.on('selection-change', (p: unknown) => {
+            payload = p as Record<string, unknown>;
+        });
+
+        // `**bold**` — place the selection inside the bolded word (offsets 3–5).
+        muya.editor.selection.setSelection({
+            anchor: { offset: 3 },
+            focus: { offset: 5 },
+            block: first,
+            path: first.path,
+        });
+
+        expect(payload).not.toBeNull();
+        const formats = payload!.formats as Array<{ type: string }>;
+        expect(formats.some(f => f.type === 'strong')).toBe(true);
+    });
 });

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -305,6 +305,20 @@ class Selection {
             selectedImage,
         } = this;
 
+        // Backport of marktext's `selectionChange` payload extras the desktop
+        // relies on: `cursorCoords` for typewriter-mode scrolling and the
+        // active inline formats at the cursor for lighting up the toolbar.
+        const cursorCoords = Selection.getCursorCoords();
+        // Duck-type the Format block — a value import of Format here would
+        // create a selection -> format circular dependency.
+        const anchorBlockRef = this.anchorBlock as Format | null;
+        const formats
+            = isSelectionInSameBlock
+                && anchorBlockRef
+                && typeof anchorBlockRef.getFormatsInRange === 'function'
+                ? anchorBlockRef.getFormatsInRange().formats
+                : [];
+
         this.muya.eventCenter.emit('selection-change', {
             anchor,
             focus,
@@ -317,6 +331,8 @@ class Selection {
             direction,
             type,
             selectedImage,
+            cursorCoords,
+            formats,
         });
     }
 

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -37,7 +37,7 @@ class Selection {
         };
     }
 
-    static getCursorCoords() {
+    static getCursorCoords(preferEnd = false) {
         const sel = document.getSelection();
         let range;
         let rect = null;
@@ -54,8 +54,11 @@ class Selection {
                             : null;
                 }
 
+                // For a forward range selection the caret sits at the END, so
+                // prefer the last client rect; otherwise the first rect is the
+                // caret (collapsed cursor or backward selection).
                 if (rects?.length)
-                    rect = rects[0];
+                    rect = preferEnd ? rects[rects.length - 1] : rects[0];
             }
         }
 
@@ -308,7 +311,9 @@ class Selection {
         // Backport of marktext's `selectionChange` payload extras the desktop
         // relies on: `cursorCoords` for typewriter-mode scrolling and the
         // active inline formats at the cursor for lighting up the toolbar.
-        const cursorCoords = Selection.getCursorCoords();
+        // Follow the caret (focus end) for forward selections so typewriter
+        // scrolling tracks the cursor rather than the selection start.
+        const cursorCoords = Selection.getCursorCoords(direction === 'forward');
         // Duck-type the Format block — a value import of Format here would
         // create a selection -> format circular dependency.
         const anchorBlockRef = this.anchorBlock as Format | null;


### PR DESCRIPTION
## Background

Part of the **muyajs → @muyajs/core engine migration**. The desktop editor
relies on two extras the legacy engine put on its `selectionChange` event
payload, which `@muyajs/core`'s `selection-change` did not carry:

1. **`cursorCoords`** — the caret's screen rect. The desktop typewriter mode
   scrolls using `changes.cursorCoords.y`.
2. **`formats`** — the active inline formats at the cursor, used to light up
   the desktop format toolbar (legacy emitted these via a `selectionFormats`
   event).

## What this adds

In `Selection.setSelection`, the emitted `selection-change` payload now also
includes:
- `cursorCoords: Selection.getCursorCoords()` (a `DOMRect | null`).
- `formats`: the active inline-format tokens at the cursor when the selection
  is within a single formattable block, else `[]`.

`formats` is computed by duck-typing the anchor block's `getFormatsInRange`
(a value import of `Format` into `selection/index.ts` would create a
`selection → format` circular dependency — verified via `check-circular`).

`heading-copy-link` and `format-click`/`preview-image` (other legacy
interaction events) are tracked separately and will land in a follow-up.

## Tests

New happy-dom spec `src/selection/__tests__/selectionChange.spec.ts` asserting
the payload carries `cursorCoords` and a `formats` array.

## Verification

- `pnpm -C packages/muya lint` → 0 errors
- `pnpm -C packages/muya lint:types` ✓
- `pnpm -C packages/muya check-circular` ✓ (no `selection → format` cycle)
- `pnpm -C packages/muya test` → 404 passed
- `pnpm -C packages/muya test:spec` → 1347 passed (conformance unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)