### PR TITLE
feat(muya): implement focus mode (dim inactive blocks)

### DIFF
--- a/packages/muya/e2e/tests/helpers/selectors.ts
+++ b/packages/muya/e2e/tests/helpers/selectors.ts
@@ -8,6 +8,9 @@
 export const editor = {
     container: '#editor',
     root: '.mu-editor',
+    // Editor root carries this class while focus mode is enabled (toggled by
+    // `Muya#setFocusMode` / applied at construction for `focusMode: true`).
+    focusModeRoot: '.mu-editor.mu-focus-mode',
     paragraph: '.mu-paragraph',
     atxHeading: '.mu-atx-heading',
     setextHeading: '.mu-setext-heading',

--- a/packages/muya/e2e/tests/options/focus-mode.spec.ts
+++ b/packages/muya/e2e/tests/options/focus-mode.spec.ts
@@ -2,52 +2,85 @@ import { expect, test } from '../fixtures/muya';
 import { editor } from '../helpers/selectors';
 
 /**
- * `focusMode: true` constructor option.
+ * `focusMode` option + `Muya#setFocusMode`.
  *
- * Current state of the codebase: `focusMode` is declared in
- * `IMuyaOptions`, defaulted to `false`, and reserved a class name
- * `CLASS_NAMES.MU_FOCUS_MODE` ('mu-focus-mode') — but no code path
- * actually applies that class to the DOM when the option is enabled.
- * This makes focus-mode currently a no-op option.
+ * Focus mode dims every top-level block except the one holding the cursor.
+ * It is driven by the `mu-focus-mode` class on the `.mu-editor` root:
+ *   - applied at construction when `new Muya(el, { focusMode: true })`
+ *     (source: `packages/core/src/muya.ts::getContainer`),
+ *   - toggled at runtime by `muya.setFocusMode(bool)`.
+ * The dimming itself lives in CSS (`.mu-focus-mode .mu-container > *`).
  *
- * What this spec asserts (the option *is* respected by the constructor):
- *   1. `new Muya(container, { focusMode: true })` boots without crashing.
- *   2. `muya.options.focusMode === true` after rebuild.
- *   3. The active paragraph can still be focused and typed into.
- *
- * What this spec deliberately does NOT assert: a visual marker on
- * non-active paragraphs. There is no such marker today. See BACKLOG
- * Phase 5 follow-up — once focus-mode renders a marker class, this
- * spec should be tightened to assert it.
+ * This used to be a no-op (the option was declared and the class reserved but
+ * never applied); these specs lock in the implemented behavior.
  */
 test.describe('options / focus-mode', () => {
-    test('focusMode: true — rebuild boots, option reflected, editor usable', async ({ page }) => {
+    test('focusMode: true — root carries mu-focus-mode, option reflected, editor usable', async ({ page }) => {
         await page.evaluate(() => {
             window.__e2e!.rebuildMuya({ focusMode: true });
             window.muya!.setContent('# heading\n\nparagraph A\n\nparagraph B\n');
         });
+
         const focusModeOption = await page.evaluate(() => window.muya!.options.focusMode);
         expect(focusModeOption).toBe(true);
+
+        // The class is applied to the editor root at construction.
+        await expect(page.locator(editor.focusModeRoot)).toBeVisible();
 
         // Sanity: editor renders multiple blocks and can be focused.
         await expect(page.locator(editor.atxHeading).first()).toBeVisible();
         await expect(page.locator(editor.paragraph).nth(0)).toContainText('paragraph A');
         await expect(page.locator(editor.paragraph).nth(1)).toContainText('paragraph B');
 
-        // Click into paragraph B; the editor should remain alive.
+        // Click into paragraph B; the editor should remain alive and the active
+        // block keeps full opacity while the others are dimmed.
         await page.locator(editor.paragraph).nth(1).click();
         const focused = await page.evaluate(() => {
             const active = window.muya!.editor.activeContentBlock;
             return active != null;
         });
         expect(focused).toBe(true);
+
+        const dimmed = await page.evaluate(() => {
+            const blocks = Array.from(document.querySelectorAll('.mu-container > *')) as HTMLElement[];
+            return blocks.map((b) => {
+                const isActive = b.classList.contains('mu-active');
+                return { isActive, opacity: getComputedStyle(b).opacity };
+            });
+        });
+        // Exactly one top-level block (the active one) is at full opacity; the
+        // rest are dimmed to 0.25.
+        const active = dimmed.filter(b => b.isActive);
+        const inactive = dimmed.filter(b => !b.isActive);
+        expect(active.length).toBe(1);
+        expect(active[0].opacity).toBe('1');
+        expect(inactive.length).toBeGreaterThan(0);
+        for (const b of inactive)
+            expect(b.opacity).toBe('0.25');
     });
 
-    test('focusMode: false (default) — option reflected as false', async ({ page }) => {
+    test('focusMode: false (default) — option reflected as false, no class', async ({ page }) => {
         await page.evaluate(() => {
             window.__e2e!.rebuildMuya({ focusMode: false });
         });
+
         const value = await page.evaluate(() => window.muya!.options.focusMode);
         expect(value).toBe(false);
+
+        await expect(page.locator(editor.root)).toBeVisible();
+        await expect(page.locator(editor.focusModeRoot)).toHaveCount(0);
+    });
+
+    test('setFocusMode toggles the class and option at runtime', async ({ page }) => {
+        await page.evaluate(() => window.__e2e!.rebuildMuya({ focusMode: false }));
+        await expect(page.locator(editor.focusModeRoot)).toHaveCount(0);
+
+        await page.evaluate(() => window.muya!.setFocusMode(true));
+        expect(await page.evaluate(() => window.muya!.options.focusMode)).toBe(true);
+        await expect(page.locator(editor.focusModeRoot)).toBeVisible();
+
+        await page.evaluate(() => window.muya!.setFocusMode(false));
+        expect(await page.evaluate(() => window.muya!.options.focusMode)).toBe(false);
+        await expect(page.locator(editor.focusModeRoot)).toHaveCount(0);
     });
 });

--- a/packages/muya/e2e/tests/options/focus-mode.spec.ts
+++ b/packages/muya/e2e/tests/options/focus-mode.spec.ts
@@ -41,22 +41,18 @@ test.describe('options / focus-mode', () => {
         });
         expect(focused).toBe(true);
 
-        const dimmed = await page.evaluate(() => {
-            const blocks = Array.from(document.querySelectorAll('.mu-container > *')) as HTMLElement[];
-            return blocks.map((b) => {
-                const isActive = b.classList.contains('mu-active');
-                return { isActive, opacity: getComputedStyle(b).opacity };
-            });
-        });
         // Exactly one top-level block (the active one) is at full opacity; the
-        // rest are dimmed to 0.25.
-        const active = dimmed.filter(b => b.isActive);
-        const inactive = dimmed.filter(b => !b.isActive);
-        expect(active.length).toBe(1);
-        expect(active[0].opacity).toBe('1');
-        expect(inactive.length).toBeGreaterThan(0);
-        for (const b of inactive)
-            expect(b.opacity).toBe('0.25');
+        // rest are dimmed to 0.25. Use auto-retrying `toHaveCSS` so the
+        // `opacity 0.2s` transition has settled before we read the value.
+        const activeBlock = page.locator('.mu-container > .mu-active');
+        await expect(activeBlock).toHaveCount(1);
+        await expect(activeBlock).toHaveCSS('opacity', '1');
+
+        const inactiveBlocks = page.locator('.mu-container > :not(.mu-active)');
+        const inactiveCount = await inactiveBlocks.count();
+        expect(inactiveCount).toBeGreaterThan(0);
+        for (let i = 0; i < inactiveCount; i++)
+            await expect(inactiveBlocks.nth(i)).toHaveCSS('opacity', '0.25');
     });
 
     test('focusMode: false (default) — option reflected as false, no class', async ({ page }) => {

--- a/packages/muya/src/__tests__/focusMode.spec.ts
+++ b/packages/muya/src/__tests__/focusMode.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for focus mode. marktext muyajs declared a `focusMode` option and
+// reserved the `mu-focus-mode` class name but never applied it — focus mode was
+// a complete no-op. `Muya#setFocusMode` now toggles `mu-focus-mode` on the
+// editor container (and the constructor applies it when `focusMode: true` is
+// passed), with the dimming itself driven by CSS in blockSyntax.css. These
+// tests lock in the class-toggling contract; the visual dimming is verified by
+// the e2e suite.
+
+const FOCUS_MODE_CLASS = 'mu-focus-mode';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(options: Partial<ConstructorParameters<typeof Muya>[1]> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown: '# heading\n\nparagraph A\n\nparagraph B\n', ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('muya focus mode', () => {
+    it('does not apply mu-focus-mode by default', () => {
+        const muya = bootMuya();
+        expect(muya.options.focusMode).toBe(false);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(false);
+    });
+
+    it('applies mu-focus-mode at construction when focusMode: true', () => {
+        const muya = bootMuya({ focusMode: true });
+        expect(muya.options.focusMode).toBe(true);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(true);
+    });
+
+    it('setFocusMode(false) removes the class and clears the option', () => {
+        const muya = bootMuya({ focusMode: true });
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(true);
+
+        muya.setFocusMode(false);
+        expect(muya.options.focusMode).toBe(false);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(false);
+    });
+
+    it('setFocusMode(true) adds the class and sets the option', () => {
+        const muya = bootMuya();
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(false);
+
+        muya.setFocusMode(true);
+        expect(muya.options.focusMode).toBe(true);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(true);
+    });
+
+    it('toggling is idempotent (re-adding keeps a single class)', () => {
+        const muya = bootMuya();
+        muya.setFocusMode(true);
+        muya.setFocusMode(true);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(true);
+
+        muya.setFocusMode(false);
+        muya.setFocusMode(false);
+        expect(muya.domNode.classList.contains(FOCUS_MODE_CLASS)).toBe(false);
+    });
+});

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -853,3 +853,18 @@ pre.mu-active.mu-fenced-code::after {
 .mu-container figure.mu-footnote > i.mu-footnote-backlink:hover {
     color: var(--theme-color);
 }
+
+/* Focus mode (mirrors marktext muyajs `.ag-focus-mode`): when the editor
+   container carries `mu-focus-mode`, dim every top-level block and restore full
+   opacity on the active one. `mu-active` is applied to the whole ancestor chain
+   of the focused content block, so the top-level block containing the cursor
+   keeps `opacity: 1`. The class is toggled by `Muya#setFocusMode`. */
+.mu-focus-mode .mu-container > * {
+    opacity: 0.25;
+
+    transition: opacity 0.2s ease-in-out;
+}
+
+.mu-focus-mode .mu-container > .mu-active {
+    opacity: 1;
+}

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -176,6 +176,21 @@ export class Muya {
         this.editor.focus();
     }
 
+    /**
+     * Toggle focus mode (mirrors marktext muyajs `setFocusMode`). When enabled,
+     * every top-level block except the one holding the cursor is dimmed via the
+     * `mu-focus-mode` class on the editor container; the dimming itself lives in
+     * the stylesheet (`.mu-focus-mode .mu-container > * { opacity }`).
+     */
+    setFocusMode(focusMode: boolean) {
+        if (focusMode)
+            this.domNode.classList.add(CLASS_NAMES.MU_FOCUS_MODE);
+        else
+            this.domNode.classList.remove(CLASS_NAMES.MU_FOCUS_MODE);
+
+        this.options.focusMode = focusMode;
+    }
+
     selectAll() {
         this.editor.selection.selectAll();
     }
@@ -376,7 +391,7 @@ export class Muya {
  * [ensureContainerDiv ensure container element is div]
  */
 function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
-    const { spellcheckEnabled, hideQuickInsertHint } = options;
+    const { spellcheckEnabled, hideQuickInsertHint, focusMode } = options;
     const newContainer = document.createElement('div');
     const attrs = originContainer.attributes;
     // Copy attrs from origin container to new container
@@ -386,6 +401,11 @@ function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
 
     if (!hideQuickInsertHint)
         newContainer.classList.add(CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT);
+
+    // Apply focus mode at construction when initially enabled; `setFocusMode`
+    // toggles it thereafter.
+    if (focusMode)
+        newContainer.classList.add(CLASS_NAMES.MU_FOCUS_MODE);
 
     newContainer.classList.add(CLASS_NAMES.MU_EDITOR);
 


### PR DESCRIPTION
## Summary

Focus mode was a **declared no-op** in `packages/muya` (`@muyajs/core`): the `focusMode` option was declared in `IMuyaOptions`, the class name `CLASS_NAMES.MU_FOCUS_MODE` (`mu-focus-mode`) was reserved, but **nothing applied that class and there was no dimming CSS**. The e2e spec even documented this. This PR implements it, matching the legacy `packages/muyajs` engine.

## What changed

- **`muya.ts` — `Muya#setFocusMode(focusMode: boolean)`** (inserted right after `focus()` to avoid the block-operations region that's being edited in parallel). Toggles `mu-focus-mode` on `this.domNode` and stores `this.options.focusMode`, mirroring legacy muyajs `setFocusMode`. The class is also applied at construction in `getContainer` when `focusMode: true` is passed initially.
- **CSS dimming** (`src/assets/styles/blockSyntax.css`). Under `.mu-focus-mode`, every top-level block (`.mu-container > *`) fades to `opacity: 0.25` with a smooth `opacity 0.2s ease-in-out` transition, and the active block keeps `opacity: 1`. muya applies `mu-active` to the focused content block's full ancestor chain (`scrollPage` + the outermost top-level block), so the top-level block containing the cursor stays at full opacity — mirroring legacy `.ag-focus-mode .ag-paragraph { opacity: .25 }` / `.ag-focus-mode .ag-active { opacity: 1 }`. Unlike muyajs (where every block shared `ag-paragraph`), muya's blocks have per-type classes (`mu-paragraph`, `mu-atx-heading`, `mu-block-quote`, …), so the selector targets the top-level children of `.mu-container` directly.

## Test coverage

- **Unit (`src/__tests__/focusMode.spec.ts`, happy-dom)** — boots muya with `{ focusMode: true }` and asserts `domNode` carries `mu-focus-mode`; `setFocusMode(false)` removes it and clears `options.focusMode`; `setFocusMode(true)` re-adds it; toggling is idempotent; default is off.
- **E2E (`e2e/tests/options/focus-mode.spec.ts`)** — rewritten from documenting the no-op to asserting the class is applied at construction, that clicking a block leaves exactly one active block at `opacity: 1` while the rest are dimmed to `0.25`, and that `setFocusMode` toggles the class at runtime. Added a `focusModeRoot` selector to the shared selectors helper.

## Verification (all green)

`pnpm -C packages/muya lint` (0 errors), `lint:types`, `check-circular`, `test` (417 passed), `test:spec` (1347 passed). E2E runs in CI via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)