### PR TITLE
feat(muya): add spellcheck word-replacement API

### DIFF
--- a/packages/muya/src/__tests__/replaceCurrentWord.spec.ts
+++ b/packages/muya/src/__tests__/replaceCurrentWord.spec.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for muya.replaceCurrentWordInlineUnsafe — the spellcheck word
+// replacement API added for the muyajs -> @muyajs/core desktop migration.
+// Legacy muyajs exposed `_replaceCurrentWordInlineUnsafe(word, replacement)`;
+// the desktop spell checker calls it when the user picks a suggestion from the
+// misspelled-word context menu (Chromium has already selected the whole word).
+//
+// The method finds the word at the cursor, asserts it matches `word`, replaces
+// it inline through the text setter (which dispatches a json edit op), and
+// places the cursor after the replacement. State flushes on rAF, so markdown
+// assertions wait via vi.waitFor.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Place the cursor inside the first content block at `offset` and mark it as
+// the active block — mirrors the editor state after a click lands the caret.
+function placeCursorAt(muya: Muya, offset: number): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    first.setCursor(offset, offset, true);
+    return first;
+}
+
+describe('muya.replaceCurrentWordInlineUnsafe()', () => {
+    it('replaces the misspelled word at the cursor and updates markdown', async () => {
+        const muya = bootMuya('teh quick brown fox\n');
+        // Cursor sits inside `teh`.
+        placeCursorAt(muya, 1);
+
+        const ok = muya.replaceCurrentWordInlineUnsafe('teh', 'the');
+        expect(ok).toBe(true);
+
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('the quick brown fox');
+        });
+        expect(muya.getMarkdown()).not.toContain('teh');
+    });
+
+    it('replaces a word in the middle of the line', async () => {
+        const muya = bootMuya('the quikc brown fox\n');
+        // Cursor inside `quikc` (offset of the `i`).
+        placeCursorAt(muya, 'the qu'.length);
+
+        const ok = muya.replaceCurrentWordInlineUnsafe('quikc', 'quick');
+        expect(ok).toBe(true);
+
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('the quick brown fox');
+        });
+    });
+
+    it('places the cursor after the replacement', () => {
+        const muya = bootMuya('teh end\n');
+        const block = placeCursorAt(muya, 0);
+
+        muya.replaceCurrentWordInlineUnsafe('teh', 'the');
+
+        const cursor = block.getCursor();
+        expect(cursor).not.toBeNull();
+        // `the` is 3 chars, so the caret should sit at offset 3.
+        expect(cursor!.start.offset).toBe(3);
+        expect(cursor!.end.offset).toBe(3);
+    });
+
+    it('is a no-op when the word at the cursor does not match (Chromium mismatch)', async () => {
+        const muya = bootMuya('teh quick\n');
+        placeCursorAt(muya, 1);
+
+        const ok = muya.replaceCurrentWordInlineUnsafe('different', 'the');
+        expect(ok).toBe(false);
+
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.getMarkdown()).toContain('teh quick');
+    });
+
+    it('returns false when there is no active content block', () => {
+        const muya = bootMuya('teh quick\n');
+        muya.editor.activeContentBlock = null;
+
+        expect(muya.replaceCurrentWordInlineUnsafe('teh', 'the')).toBe(false);
+    });
+
+    it('returns false when there is no cursor in the active block', () => {
+        const muya = bootMuya('teh quick\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.editor.activeContentBlock = first;
+        // No selection set — getCursor() returns null.
+        document.getSelection()?.removeAllRanges();
+
+        expect(muya.replaceCurrentWordInlineUnsafe('teh', 'the')).toBe(false);
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -20,6 +20,82 @@ import {
 
 // const debug = logger('block.content:')
 
+// Word boundary regexes ported from legacy muyajs
+// (lib/contentState/core.js), which in turn derive from VSCode's wordHelper.
+// Used by `extractWord` to find the word at the cursor for spell-check
+// replacement.
+const WORD_SEPARATORS = /[`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]/g;
+const WORD_DEFINITION = /-?\d*\.\d\w*|[^`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]+/g;
+
+/**
+ * Extract the word at the given offset from the text.
+ *
+ * Ported from legacy muyajs `extractWord` (lib/contentState/core.js).
+ *
+ * @param text The line text.
+ * @param offset Normalized cursor offset (e.g. `ab|c def` -> 2).
+ * @returns The matched word with its `left`/`right` offsets, or null when the
+ * cursor is not inside a word.
+ */
+function extractWord(
+    text: string,
+    offset: number,
+): { left: number; right: number; word: string } | null {
+    if (!text || text.length === 0) {
+        return null;
+    }
+    else if (offset < 0) {
+        offset = 0;
+    }
+    else if (offset >= text.length) {
+        offset = text.length - 1;
+    }
+
+    // Matches all words starting at a good position.
+    WORD_DEFINITION.lastIndex = text.lastIndexOf(' ', offset - 1) + 1;
+    let match: RegExpExecArray | null = null;
+    let left = -1;
+    // eslint-disable-next-line no-cond-assign
+    while ((match = WORD_DEFINITION.exec(text))) {
+        if (match && match.index <= offset) {
+            if (WORD_DEFINITION.lastIndex > offset)
+                left = match.index;
+        }
+        else {
+            break;
+        }
+    }
+    WORD_DEFINITION.lastIndex = 0;
+
+    // Cursor is between two word separators (e.g. `*|*` or ` |*`).
+    if (left <= -1)
+        return null;
+
+    // Find word ending.
+    WORD_SEPARATORS.lastIndex = offset;
+    match = WORD_SEPARATORS.exec(text);
+    let right = -1;
+    if (match)
+        right = match.index;
+
+    WORD_SEPARATORS.lastIndex = 0;
+
+    // The last word in the string is a special case.
+    if (right < 0) {
+        return {
+            left,
+            right: text.length,
+            word: text.slice(left),
+        };
+    }
+
+    return {
+        left,
+        right,
+        word: text.slice(left, right),
+    };
+}
+
 class Content extends TreeNode {
     public _text: string;
     public isComposed: boolean;
@@ -430,6 +506,48 @@ class Content extends TreeNode {
 
             this.setCursor(offset, offset, true);
         }
+    }
+
+    /**
+     * Replace the word at/around the current cursor with `replacement`.
+     *
+     * Ported from legacy muyajs `ContentState._replaceCurrentWordInlineUnsafe`
+     * (lib/contentState/marktext.js). Used by the desktop spell checker: right
+     * clicking a misspelled word selects the whole word via Chromium, and
+     * choosing a suggestion replaces it inline. `extractWord` mirrors the
+     * VSCode-derived word boundaries muyajs relied on.
+     *
+     * Unsafe: the caller asserts that exactly the word `word` is selected. If
+     * the word found at the cursor does not match `word` the call is a no-op
+     * (returns false) — this guards against a Chromium selection mismatch.
+     *
+     * @param word The expected word at the cursor; the whole word must be selected.
+     * @param replacement The replacement text.
+     * @returns True when the replacement was applied.
+     */
+    replaceCurrentWordInlineUnsafe(word: string, replacement: string): boolean {
+        const cursor = this.getCursor();
+        if (cursor == null)
+            return false;
+
+        const { text } = this;
+        // Use the start offset of the (possibly whole-word) selection as the
+        // probe point, matching the legacy `start.offset` behaviour.
+        const wordInfo = extractWord(text, cursor.start.offset);
+        if (wordInfo == null)
+            return false;
+
+        const { left, right, word: selectedWord } = wordInfo;
+        if (selectedWord !== word)
+            return false;
+
+        // Reuse the text setter so the change dispatches a json edit op.
+        this.text = text.substring(0, left) + replacement + text.substring(right);
+
+        const offset = left + replacement.length;
+        this.setCursor(offset, offset, true);
+
+        return true;
     }
 
     keydownHandler = (event: Event) => {

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -21,7 +21,7 @@ import {
 // const debug = logger('block.content:')
 
 // Word boundary regexes ported from legacy muyajs
-// (lib/contentState/core.js), which in turn derive from VSCode's wordHelper.
+// (lib/marktext/spellchecker.js), which in turn derive from VSCode's wordHelper.
 // Used by `extractWord` to find the word at the cursor for spell-check
 // replacement.
 const WORD_SEPARATORS = /[`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]/g;
@@ -30,7 +30,7 @@ const WORD_DEFINITION = /-?\d*\.\d\w*|[^`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]+/g
 /**
  * Extract the word at the given offset from the text.
  *
- * Ported from legacy muyajs `extractWord` (lib/contentState/core.js).
+ * Ported from legacy muyajs `extractWord` (lib/marktext/spellchecker.js).
  *
  * @param text The line text.
  * @param offset Normalized cursor offset (e.g. `ab|c def` -> 2).

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -268,6 +268,27 @@ export class Muya {
     }
 
     /**
+     * Replace the word at the current cursor with `replacement`, then place the
+     * cursor after the replacement.
+     *
+     * Mirrors legacy muyajs `_replaceCurrentWordInlineUnsafe`. The desktop spell
+     * checker calls this when the user picks a suggestion from the misspelled-word
+     * context menu (Chromium has already selected the whole word). Unsafe: the
+     * call is a no-op unless the word at the cursor matches `word`.
+     *
+     * @param word The expected (misspelled) word at the cursor.
+     * @param replacement The replacement word.
+     * @returns True when the replacement was applied.
+     */
+    replaceCurrentWordInlineUnsafe(word: string, replacement: string): boolean {
+        const block = this.editor.activeContentBlock;
+        if (!block)
+            return false;
+
+        return block.replaceCurrentWordInlineUnsafe(word, replacement);
+    }
+
+    /**
      * Return the current selection, or null when the editor has no selection.
      */
     getSelection() {


### PR DESCRIPTION
## Why

The desktop spell checker shows a context menu of suggestions for a misspelled word; choosing one calls the editor to replace the word at the cursor. Legacy `muyajs` exposed `_replaceCurrentWordInlineUnsafe(word, replacement)` for exactly this. `@muyajs/core` had no equivalent, which blocks the desktop migration off legacy `packages/muyajs`.

## What

Adds `Muya.replaceCurrentWordInlineUnsafe(word: string, replacement: string): boolean` (`packages/muya/src/muya.ts`), delegating to a new method of the same name on the active content block (`packages/muya/src/block/base/content.ts`).

### Semantics (faithful to legacy muyajs)

- Reads the cursor in the active content block and probes the word at the cursor start offset via `extractWord`, the VSCode-derived word-boundary helper ported from legacy `muyajs` (`lib/contentState/core.js`).
- **Unsafe**: asserts the word found at the cursor equals the expected `word`. When it does not match (e.g. a Chromium selection mismatch), the call is a safe **no-op** and returns `false`.
- Replaces the word through the `Content` `text` setter, so the edit dispatches a json1 op and stays in sync with document state (it does **not** bypass state sync).
- Places the cursor immediately after the replacement.
- No-ops safely (returns `false`) when there is no active content block or no cursor.

The public method is inserted immediately after `Muya.format(type)` to stay clear of parallel edits elsewhere in `muya.ts`.

## Tests

New happy-dom vitest spec `packages/muya/src/__tests__/replaceCurrentWord.spec.ts` boots a real `Muya`, sets the cursor inside a known misspelled word, calls the API, and asserts `getMarkdown()` reflects the replacement (state flushes on rAF, awaited via `vi.waitFor`). Also covers cursor-after-replacement positioning and the no-op paths (word mismatch, no active block, no cursor).

## Verification

All green in `packages/muya`:

- `pnpm lint` — 0 errors
- `pnpm lint:types` — clean
- `pnpm check-circular` — no circular dependency
- `pnpm test` — 441 passed
- `pnpm test:spec` — 1347 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)