### PR TITLE
feat(muya): serialize/restore undo history

### DIFF
--- a/packages/muya/src/__tests__/historySerialization.spec.ts
+++ b/packages/muya/src/__tests__/historySerialization.spec.ts
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for the undo-history serialization API added for the
+// muyajs -> @muyajs/core desktop migration: getHistory / setHistory /
+// clearHistory. The desktop shell persists each tab's undo/redo history
+// across tab switches — it reads getHistory() before deactivating a tab and
+// restores it via setHistory() when the tab is re-selected.
+//
+// Block-tree mutations dispatch json1 ops that flow through the History
+// recorder on the next animation frame (see JSONState._emitStateChange and
+// History._record), so assertions on getState()/getMarkdown() and on the
+// recorded stacks are wrapped in vi.waitFor to await that flush.
+//
+// History._record coalesces ops recorded within `options.delay` (1s) of the
+// previous one into a single undo entry, so tests call `cutoff()` between
+// edits to force one undo entry per edit and keep stack-depth assertions
+// deterministic. The live-DOM selection that History reads while applying an
+// undo can point at a block removed by the re-render, so we re-seat the
+// cursor on a known-attached block right before each undo()/redo().
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Block-level ops resolve their target via the active content block's
+// outMostBlock — the way the editor tracks the cursor after a click. Set it
+// directly to simulate the cursor sitting in the first block, and seat the
+// live DOM caret there so History reads a valid selection.
+function placeCursorOnFirstBlock(muya: Muya): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    first.setCursor(0, 0, true);
+    return first;
+}
+
+// Undo entries coalesce within options.delay; cutoff() forces the next edit
+// into its own undo entry so depth assertions are deterministic.
+function undoDepth(muya: Muya): number {
+    // @ts-expect-error — reach into the private stack for test assertions.
+    return muya.editor.history._stack.undo.length;
+}
+
+describe('muya history serialization api', () => {
+    it('getHistory() returns a JSON-serializable snapshot of the undo/redo stacks', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'one');
+        await vi.waitFor(() => {
+            expect(undoDepth(muya)).toBe(1);
+        });
+
+        const snapshot = muya.getHistory();
+        // It must survive a JSON round-trip with no loss (no live block refs,
+        // functions, or DOM nodes leaking into the serialized form).
+        expect(() => JSON.stringify(snapshot)).not.toThrow();
+        expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot);
+
+        expect(snapshot.stack.undo).toHaveLength(1);
+        expect(snapshot.stack.redo).toHaveLength(0);
+        // The recorded selection is path-only — no live anchorBlock / focusBlock.
+        const recorded = snapshot.stack.undo[0];
+        expect(Array.isArray(recorded.operation)).toBe(true);
+        if (recorded.selection) {
+            expect(recorded.selection).not.toHaveProperty('anchorBlock');
+            expect(recorded.selection).not.toHaveProperty('focusBlock');
+            expect(Array.isArray(recorded.selection.anchorPath)).toBe(true);
+        }
+    });
+
+    it('setHistory(getHistory()) then undo() reproduces the snapshot-point state', async () => {
+        const muya = bootMuya('# Title\n');
+
+        // Make two edits, capturing the markdown + a history snapshot after the
+        // SECOND one — this is the state the desktop persists when a tab is
+        // deactivated (document + undo stack both at the same point).
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'one');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('one');
+            expect(undoDepth(muya)).toBe(1);
+        });
+        muya.editor.history.cutoff();
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'two');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('two');
+            expect(undoDepth(muya)).toBe(2);
+        });
+
+        const snapshot = muya.getHistory();
+        expect(snapshot.stack.undo).toHaveLength(2);
+
+        // Simulate the tab round-trip: the in-memory history is dropped (as it
+        // is when another tab takes over the editor) while the document stays
+        // put, then the persisted snapshot is restored.
+        muya.clearHistory();
+        expect(undoDepth(muya)).toBe(0);
+        muya.setHistory(snapshot);
+        expect(undoDepth(muya)).toBe(2);
+
+        // Undoing twice against the restored stack must walk the document back
+        // through "two" then "one" to the original "# Title" — proving the
+        // restored ops reproduce the prior document states losslessly.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('one');
+            expect(md).not.toContain('two');
+        });
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('# Title');
+        });
+        expect(muya.editor.history.canUndo()).toBe(false);
+        expect(muya.editor.history.canRedo()).toBe(true);
+    });
+
+    it('restored history round-trips through redo() back to the snapshot state', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'alpha');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('alpha');
+            expect(undoDepth(muya)).toBe(1);
+        });
+        const markdownAtSnapshot = muya.getMarkdown();
+        // Persist exactly as the desktop shell would — through JSON.
+        const snapshot = JSON.parse(JSON.stringify(muya.getHistory()));
+
+        muya.setHistory(snapshot);
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('# Title');
+        });
+
+        // redo must restore the exact pre-undo document state, proving the
+        // serialized op is lossless in both directions.
+        placeCursorOnFirstBlock(muya);
+        muya.redo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toBe(markdownAtSnapshot);
+        });
+    });
+
+    it('clearHistory() empties both stacks', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'one');
+        await vi.waitFor(() => {
+            expect(undoDepth(muya)).toBe(1);
+        });
+
+        muya.clearHistory();
+        expect(muya.editor.history.canUndo()).toBe(false);
+        expect(muya.editor.history.canRedo()).toBe(false);
+        expect(muya.getHistory().stack.undo).toHaveLength(0);
+        expect(muya.getHistory().stack.redo).toHaveLength(0);
+    });
+});

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -2,7 +2,7 @@ import type { JSONOp, JSONOpComponent, JSONOpList } from 'ot-json1';
 import type Content from '../block/base/content';
 import type Format from '../block/base/format';
 import type { Muya } from '../muya';
-import type { ISelection } from '../selection/types';
+import type { IHistorySelection } from '../selection/types';
 import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import * as otText from 'ot-text-unicode';
@@ -162,7 +162,7 @@ export class Editor {
         firstLeafBlock.setCursor(0, 0, needUpdated);
     }
 
-    updateContents(operations: JSONOp, selection: Nullable<ISelection>, source: string) {
+    updateContents(operations: JSONOp, selection: Nullable<IHistorySelection>, source: string) {
         const { muya } = this;
         // ot-json1 no-op (`null`) is forwarded to dispatch — JSONState
         // short-circuits internally so listeners still see a json-change

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -1,6 +1,6 @@
 import type { JSONOpList } from 'ot-json1';
 import type { Muya } from '../muya';
-import type { ISelection } from '../selection/types';
+import type { IHistorySelection } from '../selection/types';
 import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import * as json1 from 'ot-json1';
@@ -15,7 +15,7 @@ interface IOptions {
 
 interface IOperation {
     operation: JSONOpList;
-    selection: Nullable<ISelection>;
+    selection: Nullable<IHistorySelection>;
 }
 
 interface IStack {
@@ -29,14 +29,14 @@ interface IStack {
 // `anchorPath` / `focusPath` via `scrollPage.queryBlock(path)` when no block
 // instance is present, so a path-only selection restores the caret losslessly.
 interface ISerializableSelection {
-    anchor: ISelection['anchor'];
-    focus: ISelection['focus'];
-    anchorPath: ISelection['anchorPath'];
-    focusPath: ISelection['focusPath'];
-    isCollapsed: ISelection['isCollapsed'];
-    isSelectionInSameBlock: ISelection['isSelectionInSameBlock'];
-    direction: ISelection['direction'];
-    type: ISelection['type'];
+    anchor: IHistorySelection['anchor'];
+    focus: IHistorySelection['focus'];
+    anchorPath: IHistorySelection['anchorPath'];
+    focusPath: IHistorySelection['focusPath'];
+    isCollapsed: IHistorySelection['isCollapsed'];
+    isSelectionInSameBlock: IHistorySelection['isSelectionInSameBlock'];
+    direction: IHistorySelection['direction'];
+    type: IHistorySelection['type'];
 }
 
 interface ISerializableOperation {
@@ -70,7 +70,7 @@ const DEFAULT_OPTIONS = {
 class History {
     private _lastRecorded: number = 0;
     private _ignoreChange: boolean = false;
-    private _selectionStack: (Nullable<ISelection>)[] = [];
+    private _selectionStack: (Nullable<IHistorySelection>)[] = [];
     private _stack: IStack = {
         undo: [],
         redo: [],
@@ -192,7 +192,7 @@ class History {
 
     // Strip the live block references and keep only plain paths + offsets.
     private _toSerializableSelection(
-        selection: Nullable<ISelection>,
+        selection: Nullable<IHistorySelection>,
     ): Nullable<ISerializableSelection> {
         if (selection == null)
             return selection;
@@ -213,17 +213,17 @@ class History {
     // are intentionally omitted: the only consumers of a restored selection
     // are `editor.updateContents` and `selection._setCursor`, both of which
     // re-resolve the target block from `anchorPath` / `focusPath` via
-    // `scrollPage.queryBlock` when no block instance is present. We therefore
-    // return an `ISelection`-shaped value with the (non-serializable) block
-    // fields left off; the single cast documents that deliberate gap rather
-    // than fabricating fake `ContentBlock` instances.
+    // `scrollPage.queryBlock` when no block instance is present. The return
+    // type is `IHistorySelection`, whose `anchorBlock` / `focusBlock` are
+    // optional, so the missing block fields are part of the contract rather
+    // than an unsound cast over fabricated `ContentBlock` instances.
     private _fromSerializableSelection(
         selection: Nullable<ISerializableSelection>,
-    ): Nullable<ISelection> {
+    ): Nullable<IHistorySelection> {
         if (selection == null)
             return selection;
 
-        const restored = {
+        return {
             anchor: deepClone(selection.anchor),
             focus: deepClone(selection.focus),
             anchorPath: deepClone(selection.anchorPath),
@@ -233,9 +233,6 @@ class History {
             direction: selection.direction,
             type: selection.type,
         };
-
-        // eslint-disable-next-line no-restricted-syntax -- block fields are intentionally absent; re-resolved from the paths on apply (see comment above).
-        return restored as unknown as ISelection;
     }
 
     cutoff() {

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -5,6 +5,7 @@ import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import * as json1 from 'ot-json1';
 import { asDoc } from '../state';
+import { deepClone } from '../utils';
 
 interface IOptions {
     delay: number;
@@ -20,6 +21,39 @@ interface IOperation {
 interface IStack {
     undo: IOperation[];
     redo: IOperation[];
+}
+
+// A JSON-serializable view of an ISelection. The live `anchorBlock` /
+// `focusBlock` references are dropped — they are an in-memory optimization
+// only. `Selection._setCursor` re-resolves the target block from
+// `anchorPath` / `focusPath` via `scrollPage.queryBlock(path)` when no block
+// instance is present, so a path-only selection restores the caret losslessly.
+interface ISerializableSelection {
+    anchor: ISelection['anchor'];
+    focus: ISelection['focus'];
+    anchorPath: ISelection['anchorPath'];
+    focusPath: ISelection['focusPath'];
+    isCollapsed: ISelection['isCollapsed'];
+    isSelectionInSameBlock: ISelection['isSelectionInSameBlock'];
+    direction: ISelection['direction'];
+    type: ISelection['type'];
+}
+
+interface ISerializableOperation {
+    operation: JSONOpList;
+    selection: Nullable<ISerializableSelection>;
+}
+
+// The public, JSON-serializable shape returned by `getHistory` and accepted by
+// `setHistory`. Mirrors the private `_stack` plus the bookkeeping pointers
+// (`lastRecorded`, `selectionStack`) needed to round-trip the recording state.
+export interface ISerializedHistory {
+    stack: {
+        undo: ISerializableOperation[];
+        redo: ISerializableOperation[];
+    };
+    lastRecorded: number;
+    selectionStack: (Nullable<ISerializableSelection>)[];
 }
 
 enum HistoryAction {
@@ -96,6 +130,112 @@ class History {
 
     clear() {
         this._stack = { undo: [], redo: [] };
+        this._selectionStack = [];
+        this._lastRecorded = 0;
+    }
+
+    /**
+     * Return a deep, JSON-serializable snapshot of the undo/redo history.
+     *
+     * The ot-json1 ops are plain JSON arrays and are deep-cloned as-is.
+     * Selections drop their live `anchorBlock` / `focusBlock` references and
+     * keep only the serializable `anchorPath` / `focusPath` + offsets; the
+     * caret is re-resolved from those paths on restore (see
+     * `_toSerializableSelection`). The result can be `JSON.stringify`-d, stored
+     * on a desktop tab, and handed back to `setHistory` to restore the exact
+     * undo/redo state — `setHistory(getHistory())` followed by `undo()`
+     * reproduces the prior document state.
+     */
+    getHistory(): ISerializedHistory {
+        return {
+            stack: {
+                undo: this._stack.undo.map(op => this._toSerializableOperation(op)),
+                redo: this._stack.redo.map(op => this._toSerializableOperation(op)),
+            },
+            lastRecorded: this._lastRecorded,
+            selectionStack: this._selectionStack.map(sel =>
+                this._toSerializableSelection(sel),
+            ),
+        };
+    }
+
+    /**
+     * Restore a snapshot previously produced by `getHistory`. Replaces the
+     * undo/redo stacks and recording bookkeeping. The restored selections are
+     * path-only; `Selection.setSelection` / `_setCursor` resolve the live
+     * block from the path when the op is later applied by `undo` / `redo`.
+     */
+    setHistory(history: ISerializedHistory) {
+        this._stack = {
+            undo: history.stack.undo.map(op => this._fromSerializableOperation(op)),
+            redo: history.stack.redo.map(op => this._fromSerializableOperation(op)),
+        };
+        this._lastRecorded = history.lastRecorded ?? 0;
+        this._selectionStack = (history.selectionStack ?? []).map(sel =>
+            this._fromSerializableSelection(sel),
+        );
+    }
+
+    private _toSerializableOperation(op: IOperation): ISerializableOperation {
+        return {
+            operation: deepClone(op.operation),
+            selection: this._toSerializableSelection(op.selection),
+        };
+    }
+
+    private _fromSerializableOperation(op: ISerializableOperation): IOperation {
+        return {
+            operation: deepClone(op.operation),
+            selection: this._fromSerializableSelection(op.selection),
+        };
+    }
+
+    // Strip the live block references and keep only plain paths + offsets.
+    private _toSerializableSelection(
+        selection: Nullable<ISelection>,
+    ): Nullable<ISerializableSelection> {
+        if (selection == null)
+            return selection;
+
+        return {
+            anchor: deepClone(selection.anchor),
+            focus: deepClone(selection.focus),
+            anchorPath: deepClone(selection.anchorPath),
+            focusPath: deepClone(selection.focusPath),
+            isCollapsed: selection.isCollapsed,
+            isSelectionInSameBlock: selection.isSelectionInSameBlock,
+            direction: selection.direction,
+            type: selection.type,
+        };
+    }
+
+    // Rebuild a selection without live block references. The block instances
+    // are intentionally omitted: the only consumers of a restored selection
+    // are `editor.updateContents` and `selection._setCursor`, both of which
+    // re-resolve the target block from `anchorPath` / `focusPath` via
+    // `scrollPage.queryBlock` when no block instance is present. We therefore
+    // return an `ISelection`-shaped value with the (non-serializable) block
+    // fields left off; the single cast documents that deliberate gap rather
+    // than fabricating fake `ContentBlock` instances.
+    private _fromSerializableSelection(
+        selection: Nullable<ISerializableSelection>,
+    ): Nullable<ISelection> {
+        if (selection == null)
+            return selection;
+
+        const restored = {
+            anchor: deepClone(selection.anchor),
+            focus: deepClone(selection.focus),
+            anchorPath: deepClone(selection.anchorPath),
+            focusPath: deepClone(selection.focusPath),
+            isCollapsed: selection.isCollapsed,
+            isSelectionInSameBlock: selection.isSelectionInSameBlock,
+            direction: selection.direction,
+            type: selection.type,
+        };
+
+        // eslint-disable-next-line no-restricted-syntax -- block fields are intentionally absent; re-resolved from the paths on apply (see comment above).
+        return restored as unknown as ISelection;
     }
 
     cutoff() {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -180,6 +180,35 @@ export class Muya {
     }
 
     /**
+     * Return a JSON-serializable snapshot of the undo/redo history.
+     *
+     * Used by the desktop shell to persist each tab's editing history across
+     * tab switches: read it before deactivating a tab, store it, and hand it
+     * back to `setHistory` when the tab is re-selected. The ot-json1 ops are
+     * deep-cloned plain JSON; selections are reduced to their serializable
+     * paths/offsets (live block references are dropped and re-resolved on
+     * restore). Lossless round-trip: `setHistory(getHistory())` then `undo()`
+     * reproduces the prior document state.
+     */
+    getHistory() {
+        return this.editor.history.getHistory();
+    }
+
+    /**
+     * Restore a history snapshot previously produced by `getHistory`.
+     */
+    setHistory(history: ReturnType<Muya['getHistory']>) {
+        this.editor.history.setHistory(history);
+    }
+
+    /**
+     * Clear the undo/redo history (e.g. after loading a fresh document).
+     */
+    clearHistory() {
+        this.editor.history.clear();
+    }
+
+    /**
      * Search value in current document.
      * @param {string} value
      * @param {object} opts

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -36,3 +36,14 @@ export interface ISelection {
     direction: string;
     type: string;
 }
+
+// An `ISelection` whose live `anchorBlock` / `focusBlock` references are
+// optional. The history stacks store selections that may have lost their block
+// instances after a serialize/restore round-trip (those references are an
+// in-memory optimization re-resolved from `anchorPath` / `focusPath` on apply).
+// A full `ISelection` is assignable to this type, so live selections captured
+// via `getSelection()` still fit without any cast.
+export type IHistorySelection = Omit<ISelection, 'anchorBlock' | 'focusBlock'> & {
+    anchorBlock?: ContentBlock;
+    focusBlock?: ContentBlock;
+};


### PR DESCRIPTION
## Why

The desktop shell preserves each open file's undo/redo history across tab switches: it reads the editor's history, stores it on the tab, and restores it when the tab is re-selected. `@muyajs/core`'s `History` had no public serialize/restore API, so this couldn't work during the desktop migration off legacy `packages/muyajs`.

## What

Adds a JSON-serializable view of the `History` undo/redo stacks plus the three delegating methods on `Muya`.

### `History`
- **`getHistory()`** — returns a deep, JSON-serializable snapshot of the undo/redo stacks plus the `lastRecorded` / `selectionStack` recording bookkeeping.
- **`setHistory(history)`** — restores a snapshot. Round-trip is lossless: `setHistory(getHistory())` then `undo()` reproduces the prior document states.
- **`clear()`** — now also resets `selectionStack` / `lastRecorded` (previously only the stacks).

### `Muya` (`src/muya.ts`)
- **`getHistory()` / `setHistory()` / `clearHistory()`** delegating to `editor.history`, inserted immediately after `redo()`.

## Serialization approach

`ot-json1` ops are plain JSON arrays and are deep-cloned (`structuredClone`) as-is.

The recorded **selection** (`ISelection`) is the only non-serializable part: it carries live `anchorBlock` / `focusBlock` `ContentBlock` references. The snapshot **drops those block references** and keeps only the already-serializable `anchorPath` / `focusPath` arrays plus the `anchor` / `focus` offsets and flags.

This is lossless because the live blocks are an in-memory optimization only — every consumer of a restored selection re-resolves the target block **from the path**:
- `editor.updateContents` resolves the cursor block via `scrollPage.queryBlock(anchorPath)`.
- `selection._setCursor` falls back to `scrollPage.queryBlock(anchorPath / focusPath)` whenever no block instance is present.

So a path-only restored selection restores the caret exactly. No selection-restore limitation.

## Tests

New happy-dom vitest spec (`src/__tests__/historySerialization.spec.ts`) following the `getTOC.spec.ts` boot pattern (edits flushed on rAF via `vi.waitFor`):
- `getHistory()` is JSON-round-trippable (`JSON.parse(JSON.stringify(...))` equals the snapshot) and the recorded selection carries no live block fields.
- `setHistory(getHistory())` after dropping the in-memory history, then undoing twice, walks the document back through both edits to its original state — proving lossless reproduction of prior states.
- restored history round-trips back through `redo()` to the snapshot document (persisted through `JSON.stringify` exactly as the desktop would).
- `clearHistory()` empties both stacks.

## Verify

All green in `packages/muya`:

- `lint` — 0 errors (26 pre-existing warnings, unchanged from `develop`)
- `lint:types` — clean
- `check-circular` — no circular dependency
- `test` — 439 passed (4 new)
- `test:spec` — 1347 passed (CommonMark + GFM conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)