### PR TITLE
feat(muya): add invalidateImageCache

### DIFF
--- a/packages/muya/src/__tests__/invalidateImageCache.spec.ts
+++ b/packages/muya/src/__tests__/invalidateImageCache.spec.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for `muya.invalidateImageCache()` — the public API the desktop
+// shell calls to force inline images to reload (e.g. after a watched image
+// file changes on disk, or on the `mt::invalidate-image-cache` IPC).
+//
+// The inline renderer memoises loaded images in two maps keyed by src:
+//   - `loadImageMap` (skipped on the next render once `isSuccess` is true)
+//   - `urlMap` (resolved/inflight URLs)
+// `invalidateImageCache()` clears both and re-renders every content block so
+// `loadImageAsync` runs afresh. happy-dom's `Image` never fires load/error
+// for a `file://` src, so we seed the caches by hand rather than relying on a
+// real load resolving.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function renderer(muya: Muya) {
+    return muya.editor.inlineRenderer.renderer;
+}
+
+describe('muya.invalidateImageCache()', () => {
+    it('exposes the method on the Muya instance', () => {
+        const muya = bootMuya('# hi');
+        expect(typeof muya.invalidateImageCache).toBe('function');
+    });
+
+    it('clears the loadImageMap and urlMap caches', () => {
+        const muya = bootMuya('![alt](/tmp/pic.png)');
+        const { loadImageMap, urlMap } = renderer(muya);
+
+        loadImageMap.set('file:///tmp/pic.png', {
+            id: 'img-1',
+            isSuccess: true,
+            url: 'file:///tmp/pic.png',
+            width: 320,
+            height: 240,
+        });
+        urlMap.set('file:///tmp/pic.png', 'data:image/png;base64,AAAA');
+
+        expect(loadImageMap.size).toBe(1);
+        expect(urlMap.size).toBe(1);
+
+        muya.invalidateImageCache();
+
+        expect(loadImageMap.size).toBe(0);
+        expect(urlMap.size).toBe(0);
+    });
+
+    it('re-renders content blocks so inline images load again', async () => {
+        const muya = bootMuya('![alt](/tmp/pic.png)');
+        const inlineRenderer = muya.editor.inlineRenderer;
+        const { loadImageMap } = renderer(muya);
+
+        loadImageMap.set('file:///tmp/pic.png', {
+            id: 'img-1',
+            isSuccess: true,
+            url: 'file:///tmp/pic.png',
+        });
+
+        const patchSpy = vi.spyOn(inlineRenderer, 'patch');
+
+        muya.invalidateImageCache();
+
+        // The image cache is flushed synchronously...
+        expect(loadImageMap.size).toBe(0);
+        // ...and the content block carrying the image is re-patched, which
+        // re-runs `loadImageAsync` for it.
+        await vi.waitFor(() => {
+            expect(patchSpy).toHaveBeenCalled();
+        });
+
+        patchSpy.mockRestore();
+    });
+
+    it('does not throw on a document with no images', () => {
+        const muya = bootMuya('just a paragraph, no images here');
+        expect(() => muya.invalidateImageCache()).not.toThrow();
+        expect(renderer(muya).loadImageMap.size).toBe(0);
+        expect(renderer(muya).urlMap.size).toBe(0);
+    });
+
+    it('does not throw on an empty document', () => {
+        const muya = bootMuya('');
+        expect(() => muya.invalidateImageCache()).not.toThrow();
+    });
+});

--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -35,6 +35,30 @@ class InlineRenderer {
         return tokenizer(text, { hasBeginRules, labels, options, highlights });
     }
 
+    /**
+     * Flush every cached image and force inline images to reload.
+     *
+     * The renderer memoises loaded images in `loadImageMap` (keyed by src,
+     * skipped on the next render once `isSuccess` is true) and resolved URLs
+     * in `urlMap`. When an image file changes on disk the cached entry would
+     * otherwise keep the stale bitmap, so clearing both maps and re-rendering
+     * every content block re-runs `loadImageAsync`, which loads the source
+     * afresh. Mirrors legacy muyajs `StateRender.invalidateImageCache`.
+     */
+    invalidateImageCache() {
+        this.renderer.loadImageMap.clear();
+        this.renderer.urlMap.clear();
+
+        const { scrollPage } = this.muya.editor;
+        if (!scrollPage)
+            return;
+
+        scrollPage.breadthFirstTraverse((node) => {
+            if (node.isContent())
+                node.update();
+        });
+    }
+
     patch(block: Format, cursor?: ICursor, highlights: IHighlight[] = []) {
         this.collectReferenceDefinitions();
         const { domNode } = block;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -369,6 +369,19 @@ export class Muya {
     }
 
     /**
+     * Flush every cached inline image and force them to reload.
+     *
+     * The renderer memoises loaded images, so an image whose file changed on
+     * disk would otherwise keep showing the stale bitmap. Desktop calls this
+     * after a watched image file changes or on the `mt::invalidate-image-cache`
+     * IPC; it clears the image caches and re-renders all content blocks so the
+     * images load afresh.
+     */
+    invalidateImageCache() {
+        this.editor.inlineRenderer.invalidateImageCache();
+    }
+
+    /**
      * Copy the current document as Markdown to the clipboard.
      */
     copyAsMarkdown() {


### PR DESCRIPTION
## Why

The desktop shell calls `editor.invalidateImageCache()` to force inline images to reload — e.g. after a watched image file changes on disk, or on the `mt::invalidate-image-cache` IPC. `@muyajs/core` memoises loaded images but had no way to flush and re-render them, so an image whose file changed on disk would keep showing the stale bitmap. This is part of the desktop migration off legacy `packages/muyajs` (which already exposes `StateRender.invalidateImageCache`).

## What

- **`InlineRenderer.invalidateImageCache()`** (`src/inlineRenderer/index.ts`): clears the renderer's `loadImageMap` and `urlMap` image caches, then re-renders every content block via `scrollPage.breadthFirstTraverse(...).update()`. Re-rendering re-runs `loadImageAsync`, which — with the caches now empty — loads each image source afresh. This follows the existing `ScrollPage.updateRefLinkAndImage` traversal pattern.
- **`Muya.invalidateImageCache()`** (`src/muya.ts`): public delegating wrapper, inserted immediately after `hideAllFloatTools()`.
- happy-dom vitest spec at `src/__tests__/invalidateImageCache.spec.ts`: seeds the cache maps, calls `muya.invalidateImageCache()`, and asserts both maps are cleared, the API is present, content blocks are re-patched (via `vi.waitFor`), and it does not throw on image-free / empty documents.

## Behavior

`invalidateImageCache()` is a no-op-safe flush: the image caches are cleared synchronously and every content block is re-rendered so inline images reload from their source. Documents with no images (or empty documents) are handled without error.

## Verification

All green in `packages/muya`:

- `lint` — 0 errors (pre-existing complexity warnings only, none in touched files)
- `lint:types` — clean
- `check-circular` — no circular dependency
- `test` — 446 passed
- `test:spec` — 1347 passed (CommonMark + GFM conformance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)