### PR TITLE
feat(muya): add createTable / insertImage / setCursor API

### DIFF
--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import type Parent from '../block/base/parent';
+import type { ITableState, TState } from '../state/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+import { isTableState } from '../state/types';
+
+// Coverage for the programmatic editing API added for the muyajs ->
+// @muyajs/core desktop migration: createTable / insertImage / setCursor.
+// These complete the block-editing surface the desktop drives (table insert,
+// image insert from the image tool, and programmatic cursor placement).
+//
+// Tree/text mutations dispatch json1 ops that flush to the document state on
+// the next animation frame (see JSONState._emitStateChange), so assertions on
+// getState()/getMarkdown() are wrapped in vi.waitFor to await that flush.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Place a collapsed caret on the first content block (and mark it active so the
+// block-level ops resolve their target the same way the editor does after a
+// click).
+function placeCursorOnFirstBlock(muya: Muya, offset = 0): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    first.setCursor(offset, offset, true);
+    muya.editor.activeContentBlock = first;
+    return first;
+}
+
+function firstBlock(muya: Muya): TState {
+    return muya.getState()[0];
+}
+
+function firstTable(muya: Muya): ITableState {
+    const b = firstBlock(muya);
+    if (!isTableState(b))
+        throw new Error(`expected a table, got ${b.name}`);
+    return b;
+}
+
+describe('muya.createTable()', () => {
+    it('replaces the current block with a table of the requested dimensions', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        muya.createTable({ rows: 3, columns: 4 });
+        await vi.waitFor(() => {
+            const b = firstTable(muya);
+            expect(b.children.length).toBe(3); // rows (header + 2 body)
+            expect(b.children.every(row => row.children.length === 4)).toBe(true); // columns
+        });
+    });
+
+    it('builds empty cells with align none', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        muya.createTable({ rows: 2, columns: 2 });
+        await vi.waitFor(() => {
+            const cells = firstTable(muya).children.flatMap(row => row.children);
+            expect(cells.every(c => c.name === 'table.cell')).toBe(true);
+            expect(cells.every(c => c.text === '')).toBe(true);
+            expect(cells.every(c => c.meta.align === 'none')).toBe(true);
+        });
+    });
+
+    it('places the cursor in the first cell of the new table', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        muya.createTable({ rows: 2, columns: 2 });
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('table');
+        });
+        const sel = muya.editor.selection.getSelection();
+        expect(sel).not.toBeNull();
+        // The caret lands on a table-cell content block.
+        expect(sel!.anchorBlock.blockName).toBe('table.cell.content');
+    });
+
+    it('is a no-op when there is no current block', () => {
+        const muya = bootMuya('hello\n');
+        muya.editor.activeContentBlock = null;
+        muya.editor.selection.anchorBlock = null;
+        expect(() => muya.createTable({ rows: 2, columns: 2 })).not.toThrow();
+        expect(firstBlock(muya).name).toBe('paragraph');
+    });
+});
+
+describe('muya.insertImage()', () => {
+    it('inserts an inline image at the cursor', async () => {
+        const muya = bootMuya('hello\n');
+        placeCursorOnFirstBlock(muya, 5); // caret at end of "hello"
+        muya.insertImage({ src: 'https://example.com/cat.png' });
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('https://example.com/cat.png');
+            expect(md).toContain('![');
+        });
+    });
+
+    it('derives alt text from the file name when none is given', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya, 0);
+        muya.insertImage({ src: '/tmp/photos/sunset.jpg' });
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('![sunset](');
+        });
+    });
+
+    it('uses the provided alt text', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya, 0);
+        muya.insertImage({ src: 'https://example.com/x.png', alt: 'My Pic' });
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('![My Pic](https://example.com/x.png)');
+        });
+    });
+
+    it('percent-encodes spaces in local paths', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya, 0);
+        muya.insertImage({ src: '/my photos/a b.png', alt: 'pic' });
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('/my%20photos/a%20b.png');
+        });
+    });
+
+    it('is a no-op when there is no active formattable block', () => {
+        const muya = bootMuya('hello\n');
+        muya.editor.activeContentBlock = null;
+        muya.editor.selection.anchorBlock = null;
+        expect(() => muya.insertImage({ src: 'https://example.com/x.png' })).not.toThrow();
+        expect(muya.getMarkdown()).not.toContain('![');
+    });
+});
+
+describe('muya.setCursor()', () => {
+    it('positions the caret in the same block (anchor/focus/path shape)', async () => {
+        const muya = bootMuya('hello world\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.setCursor({
+            anchor: { offset: 3 },
+            focus: { offset: 3 },
+            anchorPath: first.path,
+            focusPath: first.path,
+        });
+        await vi.waitFor(() => {
+            const sel = muya.editor.selection.getSelection();
+            expect(sel).not.toBeNull();
+            expect(sel!.anchorBlock).toBe(first);
+            expect(sel!.anchor.offset).toBe(3);
+        });
+    });
+
+    it('accepts the start/end/path shape', async () => {
+        const muya = bootMuya('hello world\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.setCursor({
+            start: { offset: 2 },
+            end: { offset: 2 },
+            path: first.path,
+        });
+        await vi.waitFor(() => {
+            const sel = muya.editor.selection.getSelection();
+            expect(sel!.anchorBlock).toBe(first);
+            expect(sel!.anchor.offset).toBe(2);
+        });
+    });
+
+    it('resolves the target block across two paragraphs', async () => {
+        const muya = bootMuya('first\n\nsecond\n');
+        const blocks = muya.editor.scrollPage!;
+        const secondPara = blocks.find(1) as Parent;
+        const secondContent = secondPara.firstContentInDescendant()!;
+        muya.setCursor({
+            anchor: { offset: 1 },
+            focus: { offset: 1 },
+            anchorPath: secondContent.path,
+            focusPath: secondContent.path,
+        });
+        await vi.waitFor(() => {
+            const sel = muya.editor.selection.getSelection();
+            expect(sel!.anchorBlock).toBe(secondContent);
+            expect(sel!.anchor.offset).toBe(1);
+        });
+    });
+
+    it('does not throw and leaves the document intact for an unresolvable path', () => {
+        const muya = bootMuya('hello\n');
+        expect(() => muya.setCursor({
+            anchor: { offset: 0 },
+            focus: { offset: 0 },
+            anchorPath: [99, 'text'],
+            focusPath: [99, 'text'],
+        })).not.toThrow();
+    });
+});

--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -111,6 +111,46 @@ describe('muya.createTable()', () => {
         expect(() => muya.createTable({ rows: 2, columns: 2 })).not.toThrow();
         expect(firstBlock(muya).name).toBe('paragraph');
     });
+
+    it('clamps zero/negative dimensions to a valid table (rows >= 2, columns >= 1)', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        // rows = 0 would otherwise build a table with no rows and crash
+        // `Table.columnCount` (which reads `firstChild.firstChild`).
+        expect(() => muya.createTable({ rows: 0, columns: 0 })).not.toThrow();
+        await vi.waitFor(() => {
+            const b = firstTable(muya);
+            expect(b.children.length).toBe(2); // header + one body row
+            expect(b.children.every(row => row.children.length === 1)).toBe(true);
+        });
+    });
+
+    it('coerces non-finite / fractional dimensions to integers', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        expect(() =>
+            muya.createTable({ rows: Number.NaN, columns: Number.POSITIVE_INFINITY }),
+        ).not.toThrow();
+        await vi.waitFor(() => {
+            const b = firstTable(muya);
+            // NaN -> clamped to 2 rows; Infinity column count is not finite so it
+            // also normalises to the minimum of 1 column rather than allocating
+            // an array of non-integer length.
+            expect(b.children.length).toBe(2);
+            expect(b.children.every(row => row.children.length === 1)).toBe(true);
+        });
+    });
+
+    it('floors fractional dimensions instead of building a ragged table', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        muya.createTable({ rows: 3.9, columns: 2.9 });
+        await vi.waitFor(() => {
+            const b = firstTable(muya);
+            expect(b.children.length).toBe(3); // floor(3.9)
+            expect(b.children.every(row => row.children.length === 2)).toBe(true); // floor(2.9)
+        });
+    });
 });
 
 describe('muya.insertImage()', () => {
@@ -158,6 +198,34 @@ describe('muya.insertImage()', () => {
         muya.editor.selection.anchorBlock = null;
         expect(() => muya.insertImage({ src: 'https://example.com/x.png' })).not.toThrow();
         expect(muya.getMarkdown()).not.toContain('![');
+    });
+
+    it('embeds a well-formed base64 data URL verbatim', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya, 0);
+        const dataUrl
+            = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+        muya.insertImage({ src: dataUrl, alt: 'dot' });
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain(`![dot](${dataUrl})`);
+        });
+    });
+
+    it('does not embed a malformed data: src verbatim (aligns with strict DATA_URL_REG)', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya, 0);
+        // `data:image/` prefix with no comma/payload — the old loose
+        // `^data:image/` check would have embedded it verbatim. It must instead
+        // fall through to the plain-path branch (spaces and '#' percent-encoded).
+        const malformed = 'data:image/png not-a-real#payload';
+        muya.insertImage({ src: malformed, alt: 'bad' });
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            // Treated as a plain path: spaces and '#' are percent-encoded, so the
+            // raw malformed string is not present verbatim.
+            expect(md).not.toContain(`(${malformed})`);
+            expect(md).toContain('data:image/png%20not-a-real%23payload');
+        });
     });
 });
 

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -388,6 +388,12 @@ export const isWin
 // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
 export const URL_REG
     = /^http(s)?:\/\/([\w\-.~]+\.[a-z]{2,}|[0-9.]+|localhost|\[[a-f0-9.:]+\])(:\d{1,5})?\/\S+/i;
+// A fully-formed base64/percent-encoded image data URL, e.g.
+// `data:image/png;base64,iVBORw0KGg...`. Mirrors legacy muyajs `DATA_URL_REG`
+// and `utils/image.ts` `getImageSrc`, so a bare `data:image/` prefix is not
+// treated as a safe-to-embed source.
+export const DATA_URL_REG
+    = /^data:image\/[\w+-]+(?:;[\w-]+=[\w-]+|;base64)*,[a-zA-Z0-9+/]+={0,2}$/;
 export const PREVIEW_DOMPURIFY_CONFIG = {
     // do not forbid `class` because `code` element use class to present language
     FORBID_ATTR: ['style', 'contenteditable'],

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -11,6 +11,7 @@ import { ScrollPage } from './block/scrollPage';
 import emptyStates from './config/emptyStates';
 import {
     CLASS_NAMES,
+    DATA_URL_REG,
     MUYA_DEFAULT_OPTIONS,
     URL_REG,
 } from './config/index';
@@ -472,16 +473,28 @@ export class Muya {
      * is in (legacy `createTableInFigure`/`createFigure`). The table has `rows`
      * rows × `columns` columns with the first row as the header; every cell is
      * empty with `align: 'none'`. The cursor lands in the first cell. No-op when
-     * there is no current block.
+     * there is no current block. `rows`/`columns` are coerced to integers and
+     * clamped to a valid GFM shape (`rows >= 2`, `columns >= 1`) so invalid
+     * input (e.g. `rows: 0`, non-finite, or fractional values) still yields a
+     * usable table instead of an invalid state.
      */
     createTable({ rows, columns }: { rows: number; columns: number }) {
         const block = this._outmostBlockAtCursor();
         if (!block)
             return;
 
+        // Coerce and clamp to a valid GFM table shape. A GFM table needs a
+        // header row plus at least one body row (rows >= 2) and at least one
+        // column (columns >= 1). Garbage input (NaN/Infinity/floats/negatives)
+        // is normalised rather than producing an invalid state — `rows = 0`
+        // would otherwise build a table with no rows and crash `columnCount`
+        // (which reads `firstChild.firstChild`).
+        const safeRows = Math.max(2, Number.isFinite(rows) ? Math.floor(rows) : 0);
+        const safeColumns = Math.max(1, Number.isFinite(columns) ? Math.floor(columns) : 0);
+
         const makeRow = (): ITableState['children'][number] => ({
             name: 'table.row',
-            children: Array.from({ length: columns }, () => ({
+            children: Array.from({ length: safeColumns }, () => ({
                 name: 'table.cell' as const,
                 meta: { align: 'none' },
                 text: '',
@@ -490,7 +503,7 @@ export class Muya {
 
         const state: ITableState = {
             name: 'table',
-            children: Array.from({ length: rows }, makeRow),
+            children: Array.from({ length: safeRows }, makeRow),
         };
 
         const newTable = ScrollPage.loadBlock('table').create(this, state);
@@ -522,12 +535,16 @@ export class Muya {
             alt = match?.[1] ?? '';
         }
 
-        // Only percent-encode plain paths; leave full URLs / data URLs as-is.
-        // Mirrors legacy `insertImage` / `replaceImage` src handling.
+        // Only percent-encode plain paths; leave full URLs / well-formed data
+        // URLs as-is. Mirrors legacy `insertImage` / `replaceImage` src
+        // handling — `DATA_URL_REG` requires the full `data:image/<type>...,<payload>`
+        // shape (the same regex `utils/image.ts` `getImageSrc` uses), so a bare
+        // `data:image/` prefix is not embedded verbatim and instead falls through
+        // to the plain-path branch.
         let imgUrl: string;
         if (URL_REG.test(src))
             imgUrl = encodeURI(src);
-        else if (/^data:image\//.test(src))
+        else if (DATA_URL_REG.test(src))
             imgUrl = src;
         else
             imgUrl = src.replace(/ /g, encodeURI(' ')).replace(/#/g, encodeURIComponent('#'));

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -2,8 +2,9 @@ import type Content from './block/base/content';
 import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
+import type { ICursor } from './selection/types';
 import type { ITocItem } from './state/getTOC';
-import type { IBulletListState, IOrderListState, ITaskListState, TState } from './state/types';
+import type { IBulletListState, IOrderListState, ITableState, ITaskListState, TState } from './state/types';
 import type { IMuyaOptions } from './types';
 import Format from './block/base/format';
 import { ScrollPage } from './block/scrollPage';
@@ -11,6 +12,7 @@ import emptyStates from './config/emptyStates';
 import {
     CLASS_NAMES,
     MUYA_DEFAULT_OPTIONS,
+    URL_REG,
 } from './config/index';
 import { Editor } from './editor/index';
 
@@ -463,6 +465,143 @@ export class Muya {
 
         block.remove();
         cursorBlock?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Insert a GFM table at the current cursor, replacing the block the cursor
+     * is in (legacy `createTableInFigure`/`createFigure`). The table has `rows`
+     * rows × `columns` columns with the first row as the header; every cell is
+     * empty with `align: 'none'`. The cursor lands in the first cell. No-op when
+     * there is no current block.
+     */
+    createTable({ rows, columns }: { rows: number; columns: number }) {
+        const block = this._outmostBlockAtCursor();
+        if (!block)
+            return;
+
+        const makeRow = (): ITableState['children'][number] => ({
+            name: 'table.row',
+            children: Array.from({ length: columns }, () => ({
+                name: 'table.cell' as const,
+                meta: { align: 'none' },
+                text: '',
+            })),
+        });
+
+        const state: ITableState = {
+            name: 'table',
+            children: Array.from({ length: rows }, makeRow),
+        };
+
+        const newTable = ScrollPage.loadBlock('table').create(this, state);
+        block.replaceWith(newTable);
+        newTable.firstContentInDescendant()?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Insert an inline image at the current cursor in the active formattable
+     * block, mirroring legacy `insertImage`. The `![alt](src)` markdown is
+     * written through the `Format` block's text setter so it dispatches a JSON
+     * op (state stays in sync) rather than mutating the DOM directly. No-op when
+     * there is no active formattable (`Format`) block — e.g. inside a code block
+     * or with no cursor.
+     */
+    insertImage({ src = '', alt = '' }: { src?: string; alt?: string }) {
+        const block = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
+        if (!(block instanceof Format))
+            return;
+
+        const cursor = block.getCursor();
+        if (cursor == null)
+            return;
+
+        // Derive a sensible alt from the file name when none is provided,
+        // matching legacy `insertImage`.
+        if (!alt) {
+            const match = /[/\\]?([^./\\]+)\.[a-z]+$/i.exec(src);
+            alt = match?.[1] ?? '';
+        }
+
+        // Only percent-encode plain paths; leave full URLs / data URLs as-is.
+        // Mirrors legacy `insertImage` / `replaceImage` src handling.
+        let imgUrl: string;
+        if (URL_REG.test(src))
+            imgUrl = encodeURI(src);
+        else if (/^data:image\//.test(src))
+            imgUrl = src;
+        else
+            imgUrl = src.replace(/ /g, encodeURI(' ')).replace(/#/g, encodeURIComponent('#'));
+
+        const { start, end } = cursor;
+        const { text } = block;
+        // When there is a selection, use it as the alt text (legacy behaviour).
+        const imageAlt = start.offset !== end.offset ? text.substring(start.offset, end.offset) : alt;
+        const imageText = `![${imageAlt}](${imgUrl})`;
+
+        // The `text` setter diffs against the old value and dispatches a JSON op.
+        block.text = text.substring(0, start.offset) + imageText + text.substring(end.offset);
+        // Re-render and place the caret on the alt text (offset of `![`).
+        block.setCursor(start.offset + 2, start.offset + 2 + imageAlt.length, true);
+    }
+
+    /**
+     * Set the cursor programmatically. The desktop passes a cursor like
+     * `{ anchor, focus, anchorPath, focusPath }` (and may use `{ start, end }`
+     * / `block` / `path`). Resolves the target block(s) by path on the live tree
+     * and restores the selection the same way `Editor.updateContents` does —
+     * `block.setCursor` for the same-block case, `selection.setSelection` with
+     * resolved block instances for the cross-block case. Passing bare paths to
+     * `setSelection` does not work (it needs a block's `domNode`), so we always
+     * resolve and pass the block instance. No-op when the target can't be
+     * resolved.
+     */
+    setCursor(cursor: ICursor) {
+        const { scrollPage } = this.editor;
+        if (!scrollPage)
+            return;
+
+        // Accept both the `{ anchor, focus, anchorPath, focusPath }` and the
+        // `{ start, end, path }`/`block` shapes of ICursor.
+        const anchor = cursor.anchor ?? cursor.start ?? null;
+        const focus = cursor.focus ?? cursor.end ?? anchor;
+        const anchorPath = cursor.anchorPath ?? cursor.path;
+        const focusPath = cursor.focusPath ?? cursor.path ?? anchorPath;
+
+        if (!anchor || !focus)
+            return;
+
+        // queryBlock mutates its path argument (path.shift()) — pass copies.
+        const anchorBlock
+            = cursor.anchorBlock
+                ?? cursor.block
+                ?? (anchorPath ? scrollPage.queryBlock([...anchorPath]) : null);
+        const focusBlock
+            = cursor.focusBlock
+                ?? cursor.block
+                ?? (focusPath ? scrollPage.queryBlock([...focusPath]) : null);
+
+        if (anchorBlock == null || !anchorBlock.isContent())
+            return;
+
+        // Same-block, mirror Editor.updateContents' selection-restore.
+        if (anchorBlock === focusBlock || focusBlock == null) {
+            const begin = Math.min(anchor.offset, focus.offset);
+            const last = Math.max(anchor.offset, focus.offset);
+            anchorBlock.setCursor(begin, last, true);
+            return;
+        }
+
+        if (!focusBlock.isContent())
+            return;
+
+        this.editor.selection.setSelection({
+            anchor,
+            focus,
+            anchorBlock,
+            anchorPath: anchorBlock.path,
+            focusBlock,
+            focusPath: focusBlock.path,
+        });
     }
 
     /**


### PR DESCRIPTION
## Motivation

The desktop app is migrating off the legacy `packages/muyajs` engine onto
`packages/muya` (`@muyajs/core`). The block-editing API the desktop menus
drive (`duplicate` / `insertParagraph` / `deleteParagraph` / `updateParagraph`)
already landed in `develop`; this PR adds the remaining three methods so the
Table/Image/Cursor desktop actions have a public entrypoint on `@muyajs/core`.

All three are added on `Muya` (`packages/muya/src/muya.ts`), adjacent to the
existing `deleteParagraph()`.

## What's added

### `createTable({ rows, columns })`
Builds the equivalent muya `ITableState` of the legacy `createTableInFigure`:
`rows` total rows × `columns` columns, the first row as the header, every row a
`table.row` with `table.cell` children (`meta.align: 'none'`, empty text).
Creates it via `ScrollPage.loadBlock('table').create(...)` and replaces the
block at the cursor (`_outmostBlockAtCursor()` → `block.replaceWith(...)`),
placing the caret in the first cell. Matches muya's `replaceBlockByLabel('table')`
/ `Table.create` conventions.

### `insertImage({ src, alt })`
Inserts an inline image at the cursor in the active `Format` block. The
`![alt](src)` markdown is written through the block's `text` setter so it
dispatches a JSON op (state stays in sync) rather than bypassing state sync.
Derives `alt` from the file name when none is given and percent-encodes plain
paths (leaving full URLs / data URLs intact), mirroring legacy `insertImage`
and muya's `replaceImage`. No-ops safely when there is no active formattable
block (e.g. inside a code block, or no cursor).

### `setCursor(cursor)`
Sets the cursor programmatically. Resolves the target block(s) by path on the
live tree (`editor.scrollPage.queryBlock(path)`) and restores the selection the
same way `Editor.updateContents` does: `block.setCursor(begin, end, true)` for
the same-block case, falling back to `editor.selection.setSelection({...})` with
**resolved block instances** for cross-block (passing bare paths does not work —
`Selection._setCursor` needs a block's `domNode`). Accepts both the
`{ anchor, focus, anchorPath, focusPath }` and `{ start, end, path }` / `block`
`ICursor` shapes.

## Tests

`packages/muya/src/__tests__/createTableImageCursor.spec.ts` (happy-dom,
state flushes on rAF → `vi.waitFor`):
- `createTable`: correct dimensions, empty cells with `align: 'none'`, caret in
  the first cell, no-op without a current block.
- `insertImage`: image markdown in the document (`getMarkdown` contains the
  src), alt derivation, explicit alt, space percent-encoding, no-op without an
  active formattable block.
- `setCursor`: caret positioned in the same block (both `ICursor` shapes),
  cross-block resolution, and a no-op for an unresolvable path.

## Verification

All green from `packages/muya`:

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm lint:types` — clean
- `pnpm check-circular` — no circular dependency
- `pnpm test` — 454 passed (+13)
- `pnpm test:spec` — 1347 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)