### PR TITLE
fix: make Muya UI plugin registration idempotent

### DIFF
--- a/packages/desktop/test/unit/specs/muya-plugin-registration.spec.ts
+++ b/packages/desktop/test/unit/specs/muya-plugin-registration.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import Muya from 'muya/lib'
+
+interface PluginEntry {
+  plugin: {
+    pluginName?: string
+  }
+  options: Record<string, unknown>
+}
+
+describe('Muya UI plugin registration', () => {
+  beforeEach(() => {
+    Muya.plugins = []
+  })
+
+  it('keeps one registration per pluginName', () => {
+    class ToolbarPlugin {
+      static pluginName = 'toolbar'
+    }
+
+    Muya.use(ToolbarPlugin, { placement: 'top' })
+    Muya.use(ToolbarPlugin, { placement: 'bottom' })
+
+    const plugins = Muya.plugins as PluginEntry[]
+
+    expect(plugins).to.have.length(1)
+    expect(plugins[0].plugin).to.equal(ToolbarPlugin)
+    expect(plugins[0].options).to.deep.equal({ placement: 'bottom' })
+  })
+
+  it('updates the constructor and options when a pluginName is re-registered', () => {
+    class InitialPlugin {
+      static pluginName = 'linkTools'
+    }
+
+    class ReplacementPlugin {
+      static pluginName = 'linkTools'
+    }
+
+    Muya.use(InitialPlugin, { jumpClick: 'initial' })
+    Muya.use(ReplacementPlugin, { jumpClick: 'replacement' })
+
+    const plugins = Muya.plugins as PluginEntry[]
+
+    expect(plugins).to.have.length(1)
+    expect(plugins[0].plugin).to.equal(ReplacementPlugin)
+    expect(plugins[0].options).to.deep.equal({ jumpClick: 'replacement' })
+  })
+})

--- a/packages/muyajs/lib/index.js
+++ b/packages/muyajs/lib/index.js
@@ -18,6 +18,18 @@ class Muya {
   static plugins = []
 
   static use(plugin, options = {}) {
+    const pluginName = plugin && plugin.pluginName
+    if (pluginName) {
+      const registeredIndex = this.plugins.findIndex(({ plugin: Plugin }) => Plugin.pluginName === pluginName)
+      if (registeredIndex !== -1) {
+        this.plugins[registeredIndex] = {
+          plugin,
+          options
+        }
+        return
+      }
+    }
+
     this.plugins.push({
       plugin,
       options

--- a/packages/website/content/docs/dev/ARCHITECTURE.md
+++ b/packages/website/content/docs/dev/ARCHITECTURE.md
@@ -38,7 +38,22 @@ There are two entry points to the application:
 
 ### How Muya work
 
-TBD
+Muya is initialized by the renderer and owns the live WYSIWYG editor surface. The
+renderer registers the built-in Muya UI plugins, such as toolbars, pickers, and
+front menus, before creating the editor instance. Each UI plugin is a class with
+a static `pluginName`; `Muya.use(plugin, options)` stores that class and the
+options object, then a new Muya instance creates the plugin during editor
+startup.
+
+`pluginName` is the registration identity for these built-in UI extensions. A
+plugin can be registered again to update its constructor or options without
+duplicating the global registry. This is useful for renderer remounts and keeps
+the existing plugin seam predictable while the broader plugin architecture is
+still being designed.
+
+This registration path is not yet a full external plugin system. It does not
+load third-party packages, expose a marketplace, or define sandboxing and
+lifecycle APIs. Those remain part of the larger plugin work.
 
 - Overview about Muya components
 - How Muya work internal


### PR DESCRIPTION
## Summary

Refs #375.

This keeps the existing Muya UI plugin registration seam predictable by treating `pluginName` as the registration identity. If the renderer registers the same built-in UI plugin again, `Muya.use()` now updates the existing entry instead of appending a duplicate.

This is intentionally a small foundation change for the current built-in UI plugin path. It does not add third-party package loading, plugin marketplace behavior, sandboxing, or a full external plugin lifecycle.

## Changes

- Make legacy `Muya.use(plugin, options)` idempotent by `plugin.pluginName`.
- Add a unit test covering duplicate registration and option replacement.
- Document the current built-in Muya UI plugin registration seam in the architecture docs.

## Validation

- `npx pnpm@10.33.4 -C packages/desktop exec vitest run test/unit/specs/muya-plugin-registration.spec.ts`
- `npx pnpm@10.33.4 -C packages/desktop exec vitest run test/unit/specs/markdown-basic.spec.ts`
- `npx pnpm@10.33.4 typecheck`
- `npx pnpm@10.33.4 lint`
- `git diff --check`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

</details>
<!-- /Issuehunt content-->