### PR TITLE
test(parity): failing-test scoreboard for #4406 muyajs→@muyajs/core gaps

### DIFF
--- a/packages/desktop/test/PARITY_QA.md
+++ b/packages/desktop/test/PARITY_QA.md
@@ -1,0 +1,83 @@
+# Parity manual-QA checklist (muyajs → @muyajs/core)
+
+Some parity gaps from the desktop migration to `@muyajs/core` (PR #4406) cannot
+be exercised reliably in a headless / xvfb CI run — they need a real OS
+clipboard with bitmap data, a real drag-and-drop gesture, or the native
+screenshot tool. They are tracked here as precise manual checklists instead of
+automated tests.
+
+Run these on a packaged or `pnpm run dev` build. Each entry maps to a row in
+[`PARITY_SCOREBOARD.md`](./PARITY_SCOREBOARD.md). When a fix lands, perform the
+steps; the entry passes when the **Expected (after fix)** result is observed.
+
+> Every entry currently FAILS on `develop` (the gap is present). That is the
+> point of the scoreboard — these are the regressions the fix PRs must close.
+
+---
+
+## PG4 — Drag-and-drop image insertion (local file + web link)
+
+**Why manual:** drag-and-drop needs a real `DataTransfer` with `files` /
+`text/uri-list` and a genuine drop gesture over the editor; Playwright/Electron
+cannot synthesize an OS-level file drop into the contenteditable reliably.
+
+### Steps — local image file
+1. Open a document (ideally a saved `.md` so assets-folder behaviour applies).
+2. From the OS file manager, drag a `.png` / `.jpg` file over the editor body
+   and drop it inside a paragraph.
+
+**Expected (after fix):** a loading placeholder appears, then an inline image
+renders. With `Preferences → Image → insert action = "copy to folder"` the file
+is copied into the document's assets folder and the link points there (not the
+original absolute path).
+
+**Current (gap):** nothing is inserted — the drop is a no-op.
+
+### Steps — web-link image
+1. In a browser, drag an image (or its URL) over the editor and drop it.
+
+**Expected (after fix):** `![](<url>)` is inserted and the image renders.
+
+**Current (gap):** nothing is inserted.
+
+---
+
+## PG5 — Binary/bitmap clipboard image paste (screenshot, browser "Copy Image")
+
+**Why manual:** this needs a real bitmap on the OS clipboard (no file path). The
+engine-unit half — that a synthetic `clipboardData.files` PNG is persisted via
+`imageAction` — is covered in
+`packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (PG5). The full
+OS-clipboard + macOS `screencapture` integration can only be verified by hand.
+
+### Steps — browser "Copy Image"
+1. In a browser, right-click an image → **Copy Image** (puts a bitmap, not a
+   file path, on the clipboard).
+2. Focus the editor and paste (Cmd/Ctrl+V).
+
+**Expected (after fix):** the bitmap is inserted as an inline image and
+persisted per the insert-action preference.
+
+**Current (gap):** nothing is inserted.
+
+### Steps — macOS screenshot integration
+1. macOS only. Trigger the in-app screenshot capture (Function/menu that runs
+   `screencapture -i -c`), select a region.
+2. The captured bitmap lands on the clipboard and the app auto-pastes it.
+
+**Expected (after fix):** the screenshot is inserted as an inline image.
+
+**Current (gap):** nothing is inserted — the screenshot-and-insert feature is
+silently dead.
+
+---
+
+## Notes for fixers
+
+- After closing PG4 / PG5, consider adding a Playwright spec that drives the
+  engine paste/drop handler with a synthetic `DataTransfer` where the platform
+  allows it, and keep this manual entry only for the OS-integration parts that
+  remain un-automatable.
+- PG5 already has an engine-unit regression test; closing the engine half flips
+  that `it.fails` to passing. This manual entry covers the desktop OS-clipboard
+  delivery the unit test cannot reach.

--- a/packages/desktop/test/PARITY_SCOREBOARD.md
+++ b/packages/desktop/test/PARITY_SCOREBOARD.md
@@ -1,0 +1,82 @@
+# Parity scoreboard — muyajs → @muyajs/core (PR #4406 follow-ups)
+
+This is a **failing-test scoreboard**. The desktop app migrated from the legacy
+`packages/muyajs` engine to `@muyajs/core` (`packages/muya`) in PR #4406. That
+migration left **15 confirmed functional-parity gaps**. This board encodes each
+one as a regression test that **fails on `develop` today** (proving the gap) but
+is marked as an *expected failure* so the test suites stay GREEN.
+
+## How it works
+
+- **muya engine unit tests** (`packages/muya/src/**/__tests__/parity*.spec.ts`)
+  use vitest `it.fails(...)`: the assertion describes the correct
+  (pre-migration) behaviour and fails today, which vitest counts as a *pass*.
+  When a fix lands and the behaviour becomes correct, the test starts passing
+  and `it.fails` then **errors** — forcing the fixer to delete `.fails`.
+- **desktop e2e tests** (`packages/desktop/test/e2e/parity-*.spec.ts`) use
+  Playwright `test.fail()`: the test runs headless and currently fails, which
+  Playwright counts as a *pass*. When the fix lands, remove `test.fail()`.
+- **manual-QA** entries (`packages/desktop/test/PARITY_QA.md`) cover gaps that
+  cannot be driven headless (real OS clipboard bitmaps, drag-and-drop gestures).
+
+**Every test name starts with its gap id** (`PG3: …`) so a fix PR can
+`grep -rn "PG3:"` to find and flip its entry.
+
+## Flipping a gap to green (for fix PRs)
+
+1. Implement the fix.
+2. `grep -rn "PGn:"` to locate the test(s).
+3. Remove the `it.fails` → `it` (muya) or delete `test.fail()` (desktop e2e),
+   or run + check off the manual-QA entry.
+4. Confirm the test now PASSES, update the **Status** column here to ✅.
+
+## Scoreboard
+
+> **Gaps remaining: 15 / 15.** All entries are xfail (failing as expected).
+
+| Gap | Severity | Behaviour lost | Test location(s) | Mechanism | Status |
+|-----|----------|----------------|------------------|-----------|--------|
+| **PG1** | major | `selection-change` lacks block affiliation / ancestor type → native Paragraph & Format menu state is dead | `packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts` (`PG1:` ×2) · `packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts` (`PG1:`) | `it.fails` + `test.fail()` | ❌ xfail |
+| **PG2** | major | source-mode → WYSIWYG caret not restored (`handleFileChange` drops `muyaIndexCursor`) | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG2:`) | `test.fail()` | ❌ xfail |
+| **PG3** | major | `autoCheck` preference not consumed (task-list checkbox cascade lost) | `packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts` (`PG3:` ×2) | `it.fails` | ❌ xfail |
+| **PG4** | major | drag-drop image insertion (local file + web link) absent | `packages/desktop/test/PARITY_QA.md` § PG4 | manual-QA | ❌ xfail |
+| **PG5** | major | binary/bitmap clipboard image paste lost (screenshot, browser "Copy Image") | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG5:`) · `packages/desktop/test/PARITY_QA.md` § PG5 | `it.fails` + manual-QA | ❌ xfail |
+| **PG6** | major | pasted image FILE bypasses `imageAction` (copy-to-assets / upload preference ignored) | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG6:` ×2) | `it.fails` | ❌ xfail |
+| **PG7** | major | export loads core CSS from CDN instead of inlining it (unstyled offline) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG7:` ×2) | `it.fails` | ❌ xfail |
+| **PG8** | major | exported headings carry no `id` (dead TOC / `[TOC]` anchors) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG8:` ×2) | `it.fails` | ❌ xfail |
+| **PG9** | major | "Copy as Rich Text" pastes HTML *source* not rich text (no `copyAsRich` path) | `packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts` (`PG9:` ×2) | `it.fails` | ❌ xfail |
+| **PG10** | minor | `preview-image` never emitted — select-image + Space full-screen preview lost | `packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts` (`PG10:` ×2) | `it.fails` | ❌ xfail |
+| **PG11** | minor | `heading-copy-link` never emitted — hover-to-copy-anchor affordance gone | `packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts` (`PG11:` ×2) | `it.fails` | ❌ xfail |
+| **PG12** | minor | `hideLinkPopup` preference not consumed — link hover popover not gated | `packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts` (`PG12:`) | `it.fails` (+ control) | ❌ xfail |
+| **PG13** | minor | `insertParagraph` anchors to outermost not immediate block in nested structures | `packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts` (`PG13:` ×2) | `it.fails` | ❌ xfail |
+| **PG14** | minor | first undo after source-mode doesn't revert the edit as one step | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG14:`) | `test.fail()` | ❌ xfail |
+| **PG15** | minor | undo back to on-disk content doesn't restore the saved/clean indicator | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG15:`) | `test.fail()` | ❌ xfail |
+
+### Severity tally
+
+- **major:** PG1, PG2, PG3, PG4, PG5, PG6, PG7, PG8, PG9 (9)
+- **minor:** PG10, PG11, PG12, PG13, PG14, PG15 (6)
+
+## Running the suites
+
+```bash
+# muya engine xfail tests (suite must stay GREEN: it.fails entries count as pass)
+pnpm -C packages/muya test
+
+# a single gap's engine tests
+pnpm -C packages/muya exec vitest run src/state/__tests__/parityExportHtml.spec.ts
+
+# desktop parity e2e (needs `pnpm run build:unpack` first; suite stays GREEN)
+pnpm -C packages/desktop exec playwright test \
+  test/e2e/parity-pg1-menu-state.spec.ts \
+  test/e2e/parity-source-undo-saved.spec.ts \
+  --config test/e2e/playwright.config.ts
+```
+
+## Provenance
+
+Gap analysis: the adversarially-verified `d2-parity-review` of PR #4406
+(`PG01..PG16` + `PG-COPYRICH`). After de-duplication there are 15 distinct
+gaps (the legacy "Space preview" and "insert-paragraph anchor" gaps each
+appeared twice; `copyAsRich` is counted as one of the 15). The `PGn` numbering
+on this board is the canonical 1–15 list, not the raw review ids.

--- a/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
+++ b/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, setSourceMarkdown, waitForMenuReady } from './helpers'
+
+// PARITY SCOREBOARD — gap PG1 (file PG01), desktop e2e half.
+//
+// The engine-unit half lives in
+// packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts.
+//
+// Legacy muyajs `selectionChange` carried the ancestor block `affiliation`
+// chain + block markdown types, which `createApplicationMenuState`
+// (store/editor.ts) turned into Paragraph-menu check marks. With @muyajs/core
+// the `selection-change` payload has no affiliation chain, so the affiliation
+// map the store builds stays empty and the Paragraph-menu check marks never
+// light up. Here we read the live application-menu `checked` state after
+// placing the caret in a heading.
+//
+// This RUNS but currently fails (the menu item never gets checked), so it is
+// marked `test.fail()`. When the engine restores affiliation and the store
+// lights the check mark, remove the `test.fail()`.
+
+const headingMenuChecked = async(app: ElectronApplication, id: string): Promise<boolean> => {
+  return await app.evaluate(({ Menu }, menuId) => {
+    const menu = Menu.getApplicationMenu()
+    if (!menu) return false
+    const item = menu.getMenuItemById(menuId)
+    return !!(item && item.checked)
+  }, id)
+}
+
+// A heading renders `span.mu-atxheading-content`, not `mu-paragraph-content`,
+// so the paragraph-only `placeCaretInEditor` helper would not place the caret
+// here. Collapse the selection inside the heading's content span and nudge the
+// engine to recompute its active block (same keyup trick the helper uses).
+const placeCaretInHeading = async(page: Page): Promise<boolean> => {
+  const ok = await page.evaluate(() => {
+    const root = document.querySelector('.editor-component') as HTMLElement | null
+    if (!root) return false
+    const span = root.querySelector('h1 span.mu-content') as HTMLElement | null
+    if (!span) return false
+    root.focus()
+    const range = document.createRange()
+    range.selectNodeContents(span)
+    range.collapse(false)
+    const sel = window.getSelection()
+    if (!sel) return false
+    sel.removeAllRanges()
+    sel.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+    root.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true, cancelable: true }))
+    return true
+  })
+  await page.waitForTimeout(150)
+  return ok
+}
+
+test.describe('Parity PG1 — Paragraph menu reflects the current block', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('seed\n')
+    app = launched.app
+    page = launched.page
+    await waitForMenuReady(app)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test.fail()
+  test('PG1: placing the caret in an H1 checks heading1MenuItem in the Paragraph menu', async() => {
+    await setSourceMarkdown(page, app, '# A heading\n')
+    // Sanity: the heading rendered and the caret landed inside it (so a `false`
+    // result below is the affiliation gap, not a missed caret placement).
+    await expect(page.locator('.editor-component h1')).toBeVisible()
+    const placed = await placeCaretInHeading(page)
+    expect(placed).toBe(true)
+    // Give the selection-change → menu-state IPC round-trip time to settle.
+    await page.waitForTimeout(400)
+
+    const checked = await headingMenuChecked(app, 'heading1MenuItem')
+    // Desired: the Paragraph menu shows H1 as the active block type.
+    expect(checked).toBe(true)
+  })
+})

--- a/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
+++ b/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from '@playwright/test'
+import {
+  launchWithMarkdown,
+  waitForMenuReady,
+  enterSourceMode,
+  exitSourceMode,
+  setSourceMarkdown,
+  sendIpcToRenderer,
+  getMarkdownContent,
+  typeIntoEditor,
+  placeCaretInEditor
+} from './helpers'
+
+// PARITY SCOREBOARD — desktop gaps PG2 (file PG02), PG14 (file PG15),
+// PG15 (file PG16). Each RUNS headless but currently fails, so each is marked
+// `test.fail()`. When the corresponding fix lands, remove the `test.fail()`.
+
+// Trigger an editor undo through the same IPC channel the Edit › Undo menu item
+// uses (`mt::editor-edit-action` → bus `undo` → editor.undo()). More reliable
+// than synthesizing the Cmd/Ctrl+Z keystroke against the contenteditable.
+const undo = async(app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> => {
+  await sendIpcToRenderer(app, 'mt::editor-edit-action', 'undo')
+}
+
+test.describe('Parity PG2 — WYSIWYG caret restored after a source-mode edit', () => {
+  // handleFileChange drops `muyaIndexCursor`/`blocks` and the engine has no
+  // index→path cursor conversion, so the source-mode editing position is lost
+  // on the handoff back to WYSIWYG and no meaningful caret is restored.
+  test.fail()
+  test('PG2: the caret lands in the block the source-mode cursor was on', async() => {
+    const { app, page } = await launchWithMarkdown(
+      'first para\n\nsecond para\n\nthird para here\n'
+    )
+    await waitForMenuReady(app)
+
+    await enterSourceMode(page, app)
+    await page.evaluate(() => {
+      const cm = (
+        document.querySelector('.source-code .CodeMirror') as Element & {
+          CodeMirror: { setCursor(p: { line: number; ch: number }): void; focus(): void }
+        }
+      ).CodeMirror
+      // Line 4 = "third para here"; place the source cursor inside it.
+      cm.setCursor({ line: 4, ch: 6 })
+      cm.focus()
+    })
+    await page.waitForTimeout(200)
+    await exitSourceMode(page, app)
+    await page.waitForTimeout(500)
+
+    const enclosingText = await page.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel || sel.rangeCount === 0) return ''
+      let node: Node | null = sel.getRangeAt(0).startContainer
+      while (node && node !== document.body) {
+        if (node instanceof HTMLElement && node.matches('p, h1, h2, h3, li')) {
+          return node.textContent || ''
+        }
+        node = node.parentNode
+      }
+      return ''
+    })
+
+    // Desired: the caret is restored into the "third para here" block.
+    expect(enclosingText).toContain('third para')
+    await app.close()
+  })
+})
+
+test.describe('Parity PG14 — first undo after source mode reverts the edit in one step', () => {
+  // On source-mode exit the engine rebuilds the document via setContent (which
+  // does NOT record an undo op) then restores the pre-source op stack, so the
+  // bulk source-mode change is not a single undo boundary.
+  test.fail()
+  test('PG14: one undo after exiting source mode reverts the source-mode change', async() => {
+    const { app, page } = await launchWithMarkdown('base\n')
+    await waitForMenuReady(app)
+
+    // Bulk source-mode edit.
+    await setSourceMarkdown(page, app, 'base\n\nSOURCE ADDED LINE\n')
+    await page.waitForTimeout(500)
+    expect((await getMarkdownContent(page, app)).trim()).toContain('SOURCE ADDED LINE')
+
+    // First undo after the source-mode handoff.
+    await undo(app)
+    await page.waitForTimeout(600)
+
+    // Desired: the document reverts to the exact pre-source-mode content in a
+    // single undo step.
+    expect((await getMarkdownContent(page, app)).trim()).toBe('base')
+    await app.close()
+  })
+})
+
+test.describe('Parity PG15 — undo back to on-disk content restores the saved indicator', () => {
+  // The desktop feeds the store a synthetic history whose id is regenerated on
+  // every json-change (including undo), so the saved-id comparison never
+  // matches again and the tab stays marked dirty even when content == disk.
+  test.fail()
+  test('PG15: undoing an edit back to disk content clears the unsaved indicator', async() => {
+    const { app, page } = await launchWithMarkdown('hello world\n')
+    await waitForMenuReady(app)
+
+    await placeCaretInEditor(page)
+    await typeIntoEditor(page, ' EXTRA')
+    await page.waitForTimeout(500)
+
+    // Sanity: the edit dirtied the tab and changed the content.
+    expect(await page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved'))).toBe(true)
+    expect((await getMarkdownContent(page, app)).trim()).toContain('EXTRA')
+
+    // Undo back to the on-disk content.
+    await undo(app)
+    await page.waitForTimeout(600)
+    // Content is restored to disk...
+    expect((await getMarkdownContent(page, app)).trim()).toBe('hello world')
+
+    // Desired: ...and the saved/clean indicator comes back (tab no longer
+    // marked unsaved). Today the tab stays dirty.
+    const stillUnsaved = await page.evaluate(
+      () => !!document.querySelector('.editor-tabs li.unsaved')
+    )
+    expect(stillUnsaved).toBe(false)
+    await app.close()
+  })
+})

--- a/packages/muya/eslint.config.mjs
+++ b/packages/muya/eslint.config.mjs
@@ -56,6 +56,11 @@ function typescriptPreset() {
 // classes (`fake as unknown as Table`); policing the double-cast pattern
 // there adds noise without safety. Disable only `no-restricted-syntax` —
 // `ts/no-explicit-any` and `ts/naming-convention` stay on for tests.
+//
+// The parity-scoreboard specs name every test after its gap id
+// (`PG3: …`) so fix PRs can grep + flip the `it.fails` marker. Allow that
+// uppercase `PG` prefix through `prefer-lowercase-title`; all other test
+// titles still have to start lowercase.
 function testFileDoubleCastOverride() {
     return {
         files: [
@@ -66,6 +71,7 @@ function testFileDoubleCastOverride() {
         ],
         rules: {
             'no-restricted-syntax': 'off',
+            'test/prefer-lowercase-title': ['error', { allowedPrefixes: ['PG'] }],
         },
     };
 }

--- a/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
+++ b/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// PARITY SCOREBOARD — gap PG11 (file PG10, "heading-copy-link").
+//
+// Legacy `packages/muyajs` rendered a hover affordance
+// (`i.icon.ag-copy-header-link`) on each heading and dispatched
+// `heading-copy-link` { key } when clicked; the desktop renderer copied the
+// heading's GitHub slug/anchor to the clipboard (`copyGithubSlug`).
+//
+// `@muyajs/core` renders no copy-anchor affordance on headings and never emits
+// `heading-copy-link`; the desktop subscription was removed and documented as
+// a gap. `copyGithubSlug` is now unreachable dead code.
+//
+// This asserts the DESIRED hover-copy affordance + emit and is expected to
+// FAIL today (the affordance element isn't rendered, so the event can't fire).
+// When the engine restores the affordance + emit, drop the `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// The legacy affordance class was `ag-copy-header-link`; the rewrite would use
+// the `mu-` prefix. Match either so this test survives the exact class choice.
+const COPY_LINK_SELECTOR
+    = '.ag-copy-header-link, .mu-copy-header-link, [class*="copy-header-link"]';
+
+describe('parity PG11: heading hover-to-copy-anchor affordance', () => {
+    it.fails(
+        'PG11: a heading renders a copy-link affordance',
+        () => {
+            const muya = bootMuya('# Getting Started\n');
+            const affordance = muya.domNode.querySelector(COPY_LINK_SELECTOR);
+
+            // Desired: the heading exposes a hover-copy-anchor affordance.
+            expect(affordance).toBeTruthy();
+        },
+    );
+
+    it.fails(
+        'PG11: activating the heading copy affordance emits heading-copy-link with the block key',
+        () => {
+            const muya = bootMuya('# Getting Started\n');
+
+            const handler = vi.fn();
+            muya.on('heading-copy-link', handler);
+
+            const affordance = muya.domNode.querySelector<HTMLElement>(COPY_LINK_SELECTOR);
+            // The affordance must exist to drive the click; its absence is the
+            // gap. Guard so the assertion below fails with a clear message
+            // rather than a null-deref.
+            affordance?.dispatchEvent(
+                new MouseEvent('click', { bubbles: true, cancelable: true }),
+            );
+
+            // Desired: clicking the affordance emits heading-copy-link carrying
+            // the heading's block key so the host can copy its anchor/slug.
+            expect(handler).toHaveBeenCalledTimes(1);
+            const payload = handler.mock.calls[0]?.[0];
+            expect(payload?.key).toBeTruthy();
+        },
+    );
+});

--- a/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
+++ b/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
@@ -18,7 +18,7 @@ import { Muya } from '../muya';
 // FAIL today (the affordance element isn't rendered, so the event can't fire).
 // When the engine restores the affordance + emit, drop the `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -29,10 +29,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level handlers registered during init — and removes the host
+    // node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -44,7 +45,7 @@ function bootMuya(markdown: string): Muya {
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
+++ b/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
@@ -21,7 +21,7 @@ import { Muya } from '../muya';
 // This asserts the DESIRED immediate-anchor behaviour and is expected to FAIL
 // today. When the engine restores the immediate-anchor path, drop the `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -32,10 +32,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level handlers registered during init — and removes the host
+    // node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -47,7 +48,7 @@ function bootMuya(markdown: string): Muya {
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
+++ b/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// PARITY SCOREBOARD — gap PG13 (file PG11/PG13, "insert-paragraph anchor").
+//
+// Legacy `packages/muyajs` `insertParagraph(location, text, outMost=false)`
+// chose the insertion anchor via `getAnchor(block)` (the IMMEDIATE enclosing
+// block) for the context-menu / Paragraph-menu Insert-Paragraph path, and only
+// used `findOutMostBlock` for the explicit "Create Paragraph Below" action. So
+// inserting a paragraph while the cursor sat inside a list item / blockquote
+// landed the new paragraph as an inner sibling, INSIDE the structure.
+//
+// `@muyajs/core`'s `insertParagraph(location, text)` ALWAYS resolves the target
+// via `_outmostBlockAtCursor()` → `outMostBlock` (the OUTERMOST container). So
+// in a nested list/blockquote the new paragraph lands AFTER the entire outer
+// block (at document root) instead of as an inner sibling.
+//
+// This asserts the DESIRED immediate-anchor behaviour and is expected to FAIL
+// today. When the engine restores the immediate-anchor path, drop the `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Find the leaf content block whose text matches `text` and place the cursor on
+// it (the way a click sets `activeContentBlock`).
+function placeCursorOn(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: { text?: string; constructor: { blockName?: string }; children?: { forEach: (cb: (b: unknown) => void) => void } }) => {
+        if (
+            (block.constructor as { blockName?: string }).blockName?.endsWith('.content')
+            && block.text === text
+        ) {
+            target = block as unknown as Content;
+        }
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    muya.editor.activeContentBlock = target;
+    return target;
+}
+
+interface StateNode { name: string; text?: string; children?: StateNode[] }
+
+// Does any block at the TOP level of the document carry this text directly?
+function topLevelHasParagraph(muya: Muya, text: string): boolean {
+    return (muya.getState() as unknown as StateNode[]).some(
+        node => node.name === 'paragraph' && node.text === text,
+    );
+}
+
+// Is the text present anywhere in the (nested) document state?
+function existsAnywhere(muya: Muya, text: string): boolean {
+    return JSON.stringify(muya.getState()).includes(text);
+}
+
+describe('parity PG13: insertParagraph anchors to the immediate block in nested structures', () => {
+    it.fails(
+        'PG13: inserting after a nested list item keeps the new paragraph inside the list, not at document root',
+        async () => {
+            const muya = bootMuya('- outer\n\n  - inner1\n  - inner2\n');
+            placeCursorOn(muya, 'inner1');
+
+            muya.insertParagraph('after', 'INNERSIBLING');
+
+            await vi.waitFor(() => {
+                expect(existsAnywhere(muya, 'INNERSIBLING')).toBe(true);
+            });
+
+            // Desired: the new paragraph is an INNER sibling — the top-level
+            // block count is unchanged (still just the one bullet-list) and the
+            // paragraph is NOT a root-level sibling. Today it lands at root.
+            expect(muya.getState().length).toBe(1);
+            expect(topLevelHasParagraph(muya, 'INNERSIBLING')).toBe(false);
+        },
+    );
+
+    it.fails(
+        'PG13: inserting after a paragraph inside a blockquote stays inside the blockquote',
+        async () => {
+            const muya = bootMuya('> quoted line\n');
+            placeCursorOn(muya, 'quoted line');
+
+            muya.insertParagraph('after', 'QUOTESIBLING');
+
+            await vi.waitFor(() => {
+                expect(existsAnywhere(muya, 'QUOTESIBLING')).toBe(true);
+            });
+
+            // Desired: still a single top-level block (the blockquote) with the
+            // new paragraph nested inside it. Today it lands after the quote at
+            // document root.
+            expect(muya.getState().length).toBe(1);
+            expect(muya.getState()[0].name).toBe('block-quote');
+            expect(topLevelHasParagraph(muya, 'QUOTESIBLING')).toBe(false);
+        },
+    );
+});

--- a/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import type TaskListItem from '../../taskListItem';
+import type TaskListCheckbox from '../index';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// PARITY SCOREBOARD — gap PG3 (file PG03).
+//
+// Legacy `packages/muyajs` read `muya.options.autoCheck` in
+// `clickCtrl.js#listItemCheckBoxClick`: toggling a task-list checkbox with
+// `autoCheck` on cascaded the state to all descendant checkboxes
+// (`updateChildrenCheckBoxState`) and re-derived ancestors
+// (`updateParentsCheckBoxState`).
+//
+// `@muyajs/core` still accepts `autoCheck` (construction + setOptions) but
+// NOTHING reads it — `grep autoCheck packages/muya/src` finds only the type
+// decl + default. The checkbox click handler
+// (`block/gfm/taskListCheckbox/index.ts`) toggles only the clicked item via
+// `update(checked, 'user')`, so enabling `autoCheck` has no cascade effect.
+//
+// We drive the checkbox's `update(checked, 'user')` directly — that is exactly
+// what the DOM click handler invokes — and assert the DESIRED cascade. These
+// are expected to FAIL today. When the engine consumes `autoCheck`, drop the
+// `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {
+        markdown,
+        ...options,
+    } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// A parent task item with two nested children, all unchecked. State shape:
+//   task-list > task-list-item(meta.checked) > [ paragraph, task-list > ... ]
+const NESTED_TASKS = '- [ ] parent\n\n  - [ ] child1\n  - [ ] child2\n';
+
+// Collect every task-list-item block in document order [parent, child1, child2].
+function taskItems(muya: Muya): TaskListItem[] {
+    const items: TaskListItem[] = [];
+    const visit = (block: { constructor: { blockName?: string }; children?: { forEach: (cb: (b: unknown) => void) => void } }) => {
+        if ((block.constructor as { blockName?: string }).blockName === 'task-list-item')
+            items.push(block as unknown as TaskListItem);
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return items;
+}
+
+// The checkbox is attached to its task-list-item via `appendAttachment`.
+function checkboxOf(item: TaskListItem): TaskListCheckbox {
+    let found: TaskListCheckbox | null = null;
+    (item.attachments as unknown as { forEach: (cb: (a: TaskListCheckbox) => void) => void }).forEach((a) => {
+        if ((a.constructor as { blockName?: string }).blockName === 'task-list-checkbox')
+            found = a;
+    });
+    if (!found)
+        throw new Error('task-list-checkbox attachment not found');
+    return found;
+}
+
+// Read the checked flags off the document state, in order
+// [parent, child1, child2].
+function checkedFlags(muya: Muya): boolean[] {
+    const flags: boolean[] = [];
+    const walk = (nodes: ReturnType<Muya['getState']>) => {
+        for (const node of nodes) {
+            const n = node as { name: string; meta?: { checked?: boolean }; children?: unknown };
+            if (n.name === 'task-list-item')
+                flags.push(!!n.meta?.checked);
+            if (Array.isArray(n.children))
+                walk(n.children as ReturnType<Muya['getState']>);
+        }
+    };
+    walk(muya.getState());
+    return flags;
+}
+
+describe('parity PG3: autoCheck task-list cascade', () => {
+    it.fails(
+        'PG3: autoCheck cascades the toggle to descendant task items',
+        async () => {
+            const muya = bootMuya(NESTED_TASKS, { autoCheck: true });
+            const [parent] = taskItems(muya);
+            expect(checkedFlags(muya)).toEqual([false, false, false]);
+
+            // Equivalent to clicking the parent checkbox (the real DOM handler
+            // calls `update(checked, 'user')`).
+            checkboxOf(parent).update(true, 'user');
+
+            // Desired: checking the parent cascades to both children.
+            await vi.waitFor(() => {
+                expect(checkedFlags(muya)).toEqual([true, true, true]);
+            });
+        },
+    );
+
+    it.fails(
+        'PG3: autoCheck re-derives the parent when all descendants become checked',
+        async () => {
+            const muya = bootMuya(NESTED_TASKS, { autoCheck: true });
+            const [, child1, child2] = taskItems(muya);
+            expect(checkedFlags(muya)).toEqual([false, false, false]);
+
+            checkboxOf(child1).update(true, 'user');
+            checkboxOf(child2).update(true, 'user');
+
+            // Desired: when every child is checked, the parent becomes checked.
+            await vi.waitFor(() => {
+                expect(checkedFlags(muya)).toEqual([true, true, true]);
+            });
+        },
+    );
+});

--- a/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
@@ -24,7 +24,7 @@ import { Muya } from '../../../../muya';
 // are expected to FAIL today. When the engine consumes `autoCheck`, drop the
 // `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -35,10 +35,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level handlers registered during init — and removes the host
+    // node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -53,7 +54,7 @@ function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya
         ...options,
     } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts
@@ -1,0 +1,97 @@
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// PARITY SCOREBOARD — gap PG9 (file PG-COPYRICH).
+//
+// Legacy `packages/muyajs` "Copy as Rich Text" put the rendered HTML into
+// `text/html` (so pasting into Word / email yields formatted rich text) plus
+// the markdown source into `text/plain`.
+//
+// `@muyajs/core` exposes no `copyAsRich` path. The desktop renderer maps
+// `copyAsRich` → `copyAsHtml`, whose `copyHandler` branch does
+// `setData('text/html', '')` + `setData('text/plain', html)` — pasting yields
+// the raw HTML markup as literal text, NOT rich text. The engine's `normal`
+// copyType already does the rich thing (`text/html = html`,
+// `text/plain = text`) but is not exposed as a method/copyType.
+//
+// These tests assert the DESIRED `copyAsRich` behaviour and are expected to
+// FAIL today (the branch doesn't exist, so `copyHandler` writes nothing for
+// `copyType = 'copyAsRich'`). When the engine adds the `copyAsRich` copyType +
+// `copyAsRich()` method, drop the `.fails`.
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim so the test can run under Node.
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const Clipboard = (await import('../index')).default;
+
+function makeEvent() {
+    const setData = vi.fn();
+    return {
+        event: { clipboardData: { setData } } as unknown as ClipboardEvent,
+        setData,
+    };
+}
+
+function makeClipboard(html: string, text: string) {
+    const clipboard = new Clipboard({} as Muya);
+    clipboard.getClipboardData = () => ({ html, text });
+    return clipboard;
+}
+
+describe('parity PG9: copyAsRich writes rendered HTML as rich text', () => {
+    it.fails(
+        'PG9: copyAsRich sets text/html=rendered html AND text/plain=text',
+        () => {
+            const html = '<h1>Title</h1><p><strong>bold</strong></p>';
+            const text = '# Title\n\n**bold**';
+            const clipboard = makeClipboard(html, text);
+            clipboard.copyType = 'copyAsRich';
+            const { event, setData } = makeEvent();
+
+            clipboard.copyHandler(event);
+
+            // Desired: rich-text contract — html in the html slot (so a
+            // rich-text target renders it), source in the plain slot.
+            expect(setData).toHaveBeenCalledWith('text/html', html);
+            expect(setData).toHaveBeenCalledWith('text/plain', text);
+        },
+    );
+
+    it.fails(
+        'PG9: copyAsRich puts the rendered HTML in the text/html slot (unlike copyAsHtml)',
+        () => {
+            const html = '<p>rich</p>';
+            const text = 'rich';
+
+            // copyAsHtml (the current mapping target) blanks text/html and puts
+            // the markup into text/plain — pasting yields literal markup.
+            const asHtmlClip = makeClipboard(html, text);
+            asHtmlClip.copyType = 'copyAsHtml';
+            const asHtml = makeEvent();
+            asHtmlClip.copyHandler(asHtml.event);
+            const asHtmlHtmlSlot = asHtml.setData.mock.calls.find(
+                c => c[0] === 'text/html',
+            )?.[1];
+            expect(asHtmlHtmlSlot).toBe('');
+
+            // copyAsRich must instead place the real rendered HTML in the html
+            // slot so a rich-text target renders it.
+            const asRichClip = makeClipboard(html, text);
+            asRichClip.copyType = 'copyAsRich';
+            const asRich = makeEvent();
+            asRichClip.copyHandler(asRich.event);
+            const asRichHtmlSlot = asRich.setData.mock.calls.find(
+                c => c[0] === 'text/html',
+            )?.[1];
+            expect(asRichHtmlSlot).toBe(html);
+        },
+    );
+});

--- a/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
@@ -1,0 +1,176 @@
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// PARITY SCOREBOARD — gaps PG5 (file PG05) + PG6 (file PG06).
+//
+// PG6: legacy `packages/muyajs` routed a pasted image FILE through
+// `imageAction(imagePath, id)` so the user's `imageInsertAction` preference
+// (copy-to-assets / upload / keep-path) applied. `@muyajs/core`'s path-paste
+// branch calls `insertImagePath(anchorBlock, imagePath)`, which writes
+// `![](rawPath)` verbatim and NEVER invokes `options.imageAction` — so a
+// pasted image file is linked from its original on-disk location and the
+// document is non-portable.
+//
+// PG5: legacy `packages/muyajs` `pasteImage()` had a binary/bitmap branch:
+// when no clipboard file path resolved, it read the in-memory image File via
+// `clipboardData.items[i].getAsFile()` + `FileReader.readAsDataURL` and
+// persisted it via `imageAction(file, id)`. `@muyajs/core`'s `pasteHandler`
+// has no `getAsFile`/`FileReader`/`clipboardData.files` path at all, so a
+// bitmap-only clipboard (screenshot, browser "Copy Image") inserts nothing.
+//
+// Both assert the DESIRED behaviour and are expected to FAIL today. When the
+// engine restores the `imageAction`-routed paste, drop the `.fails`.
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim so the test can run under Node
+// (same stub as clipboardFilePath.spec / copyHandler.spec).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+// Keep the real `resolveClipboardImagePath` (the decision under test) but neuter
+// `normalizePastedHTML`, whose DOMPurify call needs a DOM the default `node`
+// test environment doesn't provide.
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return {
+        ...actual,
+        normalizePastedHTML: async (html: string) => html,
+    };
+});
+
+const Clipboard = (await import('../index')).default;
+
+function makeAnchorBlock(initialText = '', cursor = 0) {
+    const block = {
+        text: initialText,
+        blockName: 'paragraph.content',
+        getCursor: () => ({
+            start: { offset: cursor },
+            end: { offset: cursor },
+        }),
+        setCursor: vi.fn(),
+        getAnchor: () => null,
+    };
+    return block as unknown as Content & { setCursor: ReturnType<typeof vi.fn> };
+}
+
+function makeClipboard(options: Record<string, unknown>, anchorBlock: Content) {
+    const clipboard = new Clipboard({ options } as unknown as Muya);
+    Object.defineProperty(clipboard, 'selection', {
+        get: () => ({
+            getSelection: () => ({
+                isSelectionInSameBlock: true,
+                anchorBlock,
+            }),
+        }),
+    });
+    return clipboard;
+}
+
+// A paste event with optional text/html data and optional in-memory image
+// `files`/`items` (the bitmap clipboard case for PG5).
+function makePasteEvent(
+    data: Record<string, string> = {},
+    files: File[] = [],
+) {
+    const getData = vi.fn((type: string) => data[type] ?? '');
+    const items = files.map(file => ({
+        kind: 'file',
+        type: file.type,
+        getAsFile: () => file,
+    }));
+    return {
+        event: {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+            clipboardData: { getData, files, items },
+        } as unknown as ClipboardEvent,
+        getData,
+    };
+}
+
+describe('parity PG6: pasted image FILE routes through imageAction', () => {
+    it.fails(
+        'PG6: a resolved clipboard image path is persisted via options.imageAction (insert preference)',
+        async () => {
+            const clipboardFilePath = vi.fn().mockResolvedValue('/abs/photo.png');
+            // The user's insert preference moves the file into the assets dir and
+            // returns the rewritten src. With the gap, this is never called.
+            const imageAction = vi
+                .fn()
+                .mockResolvedValue('assets/photo.png');
+            const anchorBlock = makeAnchorBlock('', 0);
+            const clipboard = makeClipboard(
+                { clipboardFilePath, imageAction },
+                anchorBlock,
+            );
+            const { event } = makePasteEvent();
+
+            await clipboard.pasteHandler(event);
+
+            // Desired: imageAction was invoked with the resolved source path so
+            // the copy-to-assets / upload preference can apply.
+            expect(imageAction).toHaveBeenCalledTimes(1);
+            const arg = imageAction.mock.calls[0][0];
+            const src = typeof arg === 'string' ? arg : arg?.src;
+            expect(src).toBe('/abs/photo.png');
+        },
+    );
+
+    it.fails(
+        'PG6: the persisted (rewritten) src — not the raw on-disk path — is inserted',
+        async () => {
+            const clipboardFilePath = vi.fn().mockResolvedValue('/abs/photo.png');
+            const imageAction = vi.fn().mockResolvedValue('assets/photo.png');
+            const anchorBlock = makeAnchorBlock('', 0);
+            const clipboard = makeClipboard(
+                { clipboardFilePath, imageAction },
+                anchorBlock,
+            );
+            const { event } = makePasteEvent();
+
+            await clipboard.pasteHandler(event);
+
+            // Desired: the assets-relative src returned by imageAction is what
+            // lands in the document (portable). Today the raw absolute path is
+            // written verbatim.
+            expect(anchorBlock.text).toBe('![](assets/photo.png)');
+        },
+    );
+});
+
+describe('parity PG5: binary/bitmap clipboard image paste', () => {
+    it.fails(
+        'PG5: a bitmap-only clipboard (no file path) inserts an image via imageAction',
+        async () => {
+            // No clipboardFilePath hook resolves a path: the only data is an
+            // in-memory PNG File (the screenshot / "Copy Image" case).
+            const clipboardFilePath = vi.fn().mockResolvedValue('');
+            const imageAction = vi.fn().mockResolvedValue('assets/pasted.png');
+            const anchorBlock = makeAnchorBlock('', 0);
+            const clipboard = makeClipboard(
+                { clipboardFilePath, imageAction },
+                anchorBlock,
+            );
+            const pngFile = new File([new Uint8Array([0x89, 0x50, 0x4E, 0x47])], 'image.png', {
+                type: 'image/png',
+            });
+            const { event } = makePasteEvent({}, [pngFile]);
+
+            await clipboard.pasteHandler(event);
+
+            // Desired: the binary image is persisted through imageAction and an
+            // image is inserted. Today nothing is read from clipboardData.files
+            // and nothing is inserted.
+            expect(imageAction).toHaveBeenCalledTimes(1);
+            expect(anchorBlock.text).toBe('![](assets/pasted.png)');
+        },
+    );
+});

--- a/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
+++ b/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// PARITY SCOREBOARD — gap PG12 (file PG12).
+//
+// Legacy `packages/muyajs` read `muya.options.hideLinkPopup` in
+// `eventHandler/mouseEvent.js`: the link-hover handler only dispatched
+// `muya-link-tools` (the link-edit/jump popover) when `!hideLinkPopup`. So
+// `hideLinkPopup: true` suppressed the popover on link hover.
+//
+// `@muyajs/core` still accepts `hideLinkPopup` (construction + setOptions) but
+// `editor/linkMouseEvents.ts#overHandler` emits `muya-link-tools`
+// UNCONDITIONALLY — it never reads the option. `grep hideLinkPopup
+// packages/muya/src` finds only the type decl + default. So the popover always
+// appears on hover even with `hideLinkPopup: true`.
+//
+// The gap test asserts the DESIRED suppression and is expected to FAIL today.
+// A positive control proves the harness actually drives the hover emit. When
+// the engine gates the popover on `hideLinkPopup`, drop the `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {
+        markdown,
+        ...options,
+    } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Return the rendered link wrapper, forced into preview mode (the preceding
+// source-marker sibling carries `.mu-hide`, which `isPopoverTarget` requires).
+function previewLink(muya: Muya): HTMLElement {
+    const link = muya.domNode.querySelector<HTMLElement>(`span.${CLASS_NAMES.MU_LINK}`)!;
+    link.previousElementSibling?.classList.add(CLASS_NAMES.MU_HIDE);
+    return link;
+}
+
+function hover(link: HTMLElement): void {
+    link.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, cancelable: true }));
+}
+
+// A `muya-link-tools` payload with a truthy `reference` opens the popover; a
+// null reference hides it. Count only the popover-opening emits.
+function countOpenEmits(handler: ReturnType<typeof vi.fn>): number {
+    return handler.mock.calls.filter(c => c[0]?.reference).length;
+}
+
+describe('parity PG12: hideLinkPopup gates the link hover popover', () => {
+    it('control: with hideLinkPopup=false, hovering a preview link opens the popover', () => {
+        const muya = bootMuya('[hello](https://example.com)\n', { hideLinkPopup: false });
+        const link = previewLink(muya);
+
+        const handler = vi.fn();
+        muya.on('muya-link-tools', handler);
+        hover(link);
+
+        expect(countOpenEmits(handler)).toBe(1);
+    });
+
+    it.fails(
+        'PG12: with hideLinkPopup=true, hovering a preview link does NOT open the popover',
+        () => {
+            const muya = bootMuya('[hello](https://example.com)\n', { hideLinkPopup: true });
+            const link = previewLink(muya);
+
+            const handler = vi.fn();
+            muya.on('muya-link-tools', handler);
+            hover(link);
+
+            // Desired: the popover stays suppressed when the preference is set.
+            // Today the emitter ignores the option and opens it anyway.
+            expect(countOpenEmits(handler)).toBe(0);
+        },
+    );
+});

--- a/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
+++ b/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
@@ -21,7 +21,7 @@ import { Muya } from '../../muya';
 // A positive control proves the harness actually drives the hover emit. When
 // the engine gates the popover on `hideLinkPopup`, drop the `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -32,10 +32,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level handlers registered during init — and removes the host
+    // node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -50,7 +51,7 @@ function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya
         ...options,
     } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
+++ b/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// PARITY SCOREBOARD — gap PG10 (file PG09/PG14, "Space preview").
+//
+// Legacy `packages/muyajs` dispatched `preview-image` { data: src } from
+// `keyboard.js` when an image was selected and the user pressed Space; the
+// desktop renderer opened the full-screen `SimpleImageViewer`.
+//
+// `@muyajs/core` never emits `preview-image`: the image-selected keydown
+// handler (`selection/index.ts`) only acts on Backspace/Delete/Enter — Space
+// falls through to native handling (inserts a space) — and the desktop's
+// `preview-image` subscription is dead code. The Cmd/Ctrl-click preview path
+// survives via `format-click`, so only the keyboard affordance is lost.
+//
+// This asserts the DESIRED Space-to-preview emit and is expected to FAIL
+// today. When the engine restores the `preview-image` emit, drop the `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Boot an image and inject the loaded <img> the renderer would have produced
+// (the async image-load path never resolves under happy-dom). Returns the muya
+// instance and the <img>.
+function bootImage(src: string): { muya: Muya; img: HTMLImageElement } {
+    const muya = bootMuya(`![alt](${src})`);
+    const wrapper = muya.domNode.querySelector<HTMLElement>(
+        `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+    )!;
+    const container = wrapper.querySelector<HTMLElement>(
+        `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+    )!;
+    const img = document.createElement('img');
+    img.setAttribute('src', src);
+    container.appendChild(img);
+    return { muya, img };
+}
+
+// Plain-click the image to populate `selection.selectedImage` (the same state a
+// real user click leaves behind before pressing Space).
+function selectImage(img: HTMLImageElement): void {
+    img.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+describe('parity PG10: Space previews a selected image', () => {
+    it.fails(
+        'PG10: pressing Space with an image selected emits preview-image',
+        () => {
+            const src = 'https://example.com/pic.png';
+            const { muya, img } = bootImage(src);
+            selectImage(img);
+            // Sanity: the click populated the selected-image state.
+            expect(muya.editor.selection.selectedImage).toBeTruthy();
+
+            const handler = vi.fn();
+            muya.on('preview-image', handler);
+
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: ' ',
+                    bubbles: true,
+                    cancelable: true,
+                }),
+            );
+
+            // Desired: the engine emits preview-image so the host can open the
+            // full-screen viewer. Today nothing fires (Space inserts a space).
+            expect(handler).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it.fails(
+        'PG10: the preview-image payload carries the selected image src',
+        () => {
+            const src = 'https://example.com/pic.png';
+            const { muya, img } = bootImage(src);
+            selectImage(img);
+
+            let payload: unknown = null;
+            muya.on('preview-image', (p: unknown) => {
+                payload = p;
+            });
+
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: ' ',
+                    bubbles: true,
+                    cancelable: true,
+                }),
+            );
+
+            // Desired: the payload exposes the image src (legacy shape was
+            // `{ data: src }`); the exact key may differ but the src must be
+            // recoverable from the payload.
+            expect(JSON.stringify(payload)).toContain(src);
+        },
+    );
+});

--- a/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
+++ b/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
@@ -19,7 +19,7 @@ import { Muya } from '../../muya';
 // This asserts the DESIRED Space-to-preview emit and is expected to FAIL
 // today. When the engine restores the `preview-image` emit, drop the `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -30,10 +30,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level keydown/click handlers registered by selection — and
+    // removes the host node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -45,7 +46,7 @@ function bootMuya(markdown: string): Muya {
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
@@ -25,7 +25,7 @@ import { Muya } from '../../muya';
 // FAIL today. When the engine restores the ancestor affiliation / block-type
 // info, drop the `.fails`.
 
-const bootedHosts: HTMLElement[] = [];
+const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
 let hadVersion = false;
 
@@ -36,10 +36,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    while (bootedHosts.length) {
-        const host = bootedHosts.pop()!;
-        host.remove();
-    }
+    // `destroy()` detaches the engine's DOM listeners — including the
+    // `document`-level keydown/click handlers registered by selection — and
+    // removes the host node, so listeners don't leak across tests.
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -51,7 +52,7 @@ function bootMuya(markdown: string): Muya {
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
-    bootedHosts.push(muya.domNode);
+    bootedMuyas.push(muya);
     return muya;
 }
 

--- a/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// PARITY SCOREBOARD — gap PG1 (file PG01).
+//
+// Legacy `packages/muyajs` emitted `selectionChange` with an `affiliation`
+// chain of the ancestor PARAGRAPH-type blocks plus per-block `.type` (the
+// markdown block type: `h1`, `p`, `pre`, …) and `.functionType`
+// (`codeContent`, `cellContent`, …). The desktop store
+// (`createApplicationMenuState`) consumed those to light up the Paragraph-menu
+// check marks, the Loose/Task-list toggles, table/code-fence detection, and to
+// disable the Format menu inside code.
+//
+// `@muyajs/core`'s `selection-change` payload exposes only flat caret/range
+// info: { anchor, focus, anchorBlock, anchorPath, focusBlock, focusPath,
+// isCollapsed, isSelectionInSameBlock, direction, type, selectedImage,
+// cursorCoords, formats }. There is NO `affiliation` ancestor chain, and
+// `type` is the selection kind ('Caret' | 'Range'), never the block markdown
+// type. Net effect: the native Paragraph/Format menu state is dead.
+//
+// These tests assert the DESIRED (pre-migration) shape — they are expected to
+// FAIL today. When the engine restores the ancestor affiliation / block-type
+// info, drop the `.fails`.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function emitSelectionFor(muya: Muya, content: Content): Record<string, unknown> {
+    let payload: Record<string, unknown> | null = null;
+    muya.on('selection-change', (p: unknown) => {
+        payload = p as Record<string, unknown>;
+    });
+    muya.editor.selection.setSelection({
+        anchor: { offset: 0 },
+        focus: { offset: 0 },
+        block: content,
+        path: content.path,
+    } as Parameters<typeof muya.editor.selection.setSelection>[0]);
+    if (!payload)
+        throw new Error('selection-change was not emitted');
+    return payload;
+}
+
+describe('parity PG1: selection-change block affiliation', () => {
+    it.fails(
+        'PG1: selection-change payload exposes the ancestor block affiliation chain',
+        () => {
+            const muya = bootMuya('# Heading\n\nbody\n');
+            const heading = muya.editor.scrollPage!.firstContentInDescendant()!;
+            const payload = emitSelectionFor(muya, heading);
+
+            // Desired: the payload carries an `affiliation` map/list of the
+            // ancestor block types so the desktop Paragraph menu can light up.
+            // Today the key is entirely absent.
+            expect('affiliation' in payload).toBe(true);
+        },
+    );
+
+    it.fails(
+        'PG1: selection-change exposes the current block markdown type (h1), not just the selection kind',
+        () => {
+            const muya = bootMuya('# Heading\n\nbody\n');
+            const heading = muya.editor.scrollPage!.firstContentInDescendant()!;
+            const payload = emitSelectionFor(muya, heading);
+
+            // Desired: a consumer can learn the cursor sits in an `h1` heading
+            // (so `heading1MenuItem` can be checked). Today `type` is the
+            // selection kind 'Caret' / 'Range' and no field reports `h1`.
+            const flat = JSON.stringify(payload);
+            expect(flat).toContain('h1');
+        },
+    );
+});

--- a/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownToHtml } from '../markdownToHtml';
+
+// PARITY SCOREBOARD — gaps PG7 (file PG07) + PG8 (file PG08).
+//
+// PG7: legacy `packages/muyajs` `ExportHtml.generate` inlined
+// github-markdown-css, the prism theme, and katex CSS as `<style>…</style>`
+// blocks (via `?inline` imports), so exported HTML/PDF/print was fully
+// self-contained and rendered offline. `@muyajs/core`'s
+// `MarkdownToHtml.generate` instead links those three core stylesheets from
+// external CDNs (`<link rel="stylesheet" href="https://…">`). Offline / behind
+// CSP / air-gapped, the standalone HTML export is unstyled.
+//
+// PG8: legacy export rendered each heading as `<hN id="{slug}">` (matching the
+// `getHtmlToc` `<a href="#{slug}">` anchors), so in-document [TOC] / TOC links
+// worked. `@muyajs/core` renders via stock `marked` with no heading-id
+// renderer, so exported `<h1>..<h6>` carry NO id and every TOC anchor is dead.
+//
+// These assert the DESIRED export output and are expected to FAIL today. When
+// the engine inlines base CSS (PG7) / injects heading ids (PG8), drop the
+// `.fails`.
+
+const SAMPLE = '# Getting Started\n\n## Installation\n\nSome **body** text.\n';
+
+async function generateExport(markdown: string): Promise<string> {
+    // `MarkdownToHtml` works without a Muya instance (muya is optional); the
+    // export path the desktop wrapper uses calls `.generate({ title, extraCSS })`.
+    return new MarkdownToHtml(markdown).generate({ title: 'Doc' });
+}
+
+describe('parity PG7: export inlines base stylesheets (offline-safe)', () => {
+    it.fails(
+        'PG7: generated HTML inlines github-markdown-css as a <style> block, not a CDN <link>',
+        async () => {
+            const out = await generateExport(SAMPLE);
+
+            // Desired: the markdown-body CSS is inlined so the file renders
+            // offline. Today it is a CDN <link> only.
+            expect(out).toContain('.markdown-body');
+            expect(out).not.toMatch(
+                /<link[^>]+href="https:\/\/cdnjs\.cloudflare\.com[^>]+github-markdown-css/,
+            );
+        },
+    );
+
+    it.fails(
+        'PG7: generated HTML does not depend on any external CDN stylesheet',
+        async () => {
+            const out = await generateExport(SAMPLE);
+
+            // Desired: zero external stylesheet links — fully self-contained.
+            expect(out).not.toMatch(/<link[^>]+rel="stylesheet"[^>]+href="https:\/\//);
+        },
+    );
+});
+
+describe('parity PG8: exported headings carry slug ids (live TOC anchors)', () => {
+    it.fails(
+        'PG8: exported <h1>..<hN> carry an id attribute',
+        async () => {
+            const out = await generateExport(SAMPLE);
+
+            // Desired: headings are emitted with ids so TOC `href="#slug"`
+            // anchors resolve. Today headings have no id at all.
+            expect(out).toMatch(/<h1[^>]*\sid="[^"]+"/);
+            expect(out).toMatch(/<h2[^>]*\sid="[^"]+"/);
+        },
+    );
+
+    it.fails(
+        'PG8: the heading id matches the marktext slug of the heading text',
+        async () => {
+            const out = await generateExport(SAMPLE);
+
+            // The legacy export + getHtmlToc both slugged "Getting Started" to
+            // "getting-started"; the export must emit the same id so anchors
+            // line up.
+            expect(out).toMatch(/<h1[^>]*\sid="getting-started"/);
+            expect(out).toMatch(/<h2[^>]*\sid="installation"/);
+        },
+    );
+});


### PR DESCRIPTION
## What

Foundation PR for the desktop migration to `@muyajs/core` (#4406). It encodes all **15 confirmed functional-parity gaps** as regression tests that **fail on `develop` today** (proving each gap), marked as expected-failures so both suites stay GREEN. Later fix PRs flip each entry to passing by removing its marker.

**This PR is tests + docs only — no behavior change.**

## Mechanism

- **muya engine** (`packages/muya/src/**/__tests__/parity*.spec.ts`): vitest `it.fails(...)` — asserts the correct (pre-migration) behavior, fails today (counts as pass). When a fix lands the test passes and `it.fails` then *errors*, forcing the fixer to delete `.fails`.
- **desktop e2e** (`packages/desktop/test/e2e/parity-*.spec.ts`): Playwright `test.fail()` — runs headless and currently fails (counts as pass). Remove `test.fail()` to flip green.
- **manual-QA** (`packages/desktop/test/PARITY_QA.md`): precise checklists for gaps not drivable headless (real OS clipboard bitmaps, drag-drop gestures).
- Every test name is prefixed with its gap id (`PGn:`) so fix PRs can `grep -rn "PGn:"` and flip it.
- The visible board is [`packages/desktop/test/PARITY_SCOREBOARD.md`](packages/desktop/test/PARITY_SCOREBOARD.md).

## The 15 gaps and their test locations

| Gap | Sev | Test location · marker |
|----|----|----|
| **PG1** selection-change affiliation | major | `packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts` `it.fails` · `packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts` `test.fail()` |
| **PG2** source→WYSIWYG caret not restored | major | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` `PG2:` `test.fail()` |
| **PG3** autoCheck cascade lost | major | `packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts` `it.fails` |
| **PG4** drag-drop image insertion absent | major | `packages/desktop/test/PARITY_QA.md` § PG4 (manual-QA) |
| **PG5** binary/bitmap clipboard paste lost | major | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` `PG5:` `it.fails` + `PARITY_QA.md` § PG5 |
| **PG6** pasted image FILE bypasses imageAction | major | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` `PG6:` `it.fails` |
| **PG7** export CSS from CDN not inlined | major | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` `PG7:` `it.fails` |
| **PG8** exported headings carry no id | major | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` `PG8:` `it.fails` |
| **PG9** copyAsRich pastes HTML source not rich | major | `packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts` `it.fails` |
| **PG10** preview-image not emitted (Space) | minor | `packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts` `it.fails` |
| **PG11** heading-copy-link not emitted | minor | `packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts` `it.fails` |
| **PG12** hideLinkPopup not consumed | minor | `packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts` `it.fails` (+ positive control) |
| **PG13** insertParagraph nested anchor | minor | `packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts` `it.fails` |
| **PG14** first undo after source-mode | minor | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` `PG14:` `test.fail()` |
| **PG15** undo doesn't restore saved indicator | minor | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` `PG15:` `test.fail()` |

## How fix PRs flip a gap green

1. Implement the fix.
2. `grep -rn "PGn:"` to find the test(s).
3. `it.fails`→`it` (muya) or delete `test.fail()` (desktop e2e), or run + tick the manual-QA entry.
4. Confirm it now PASSES; update the Status column in `PARITY_SCOREBOARD.md`.

## Verification

- muya: `lint` (0 err) · `lint:types` · `check-circular` · `test` (512 pass + 20 xfail) · `test:spec` (1347 pass) — all GREEN.
- desktop: `build:unpack` · `typecheck` · `lint` (0 err) · `test` (560 pass) · the 4 parity e2e (all xfail/GREEN) — all GREEN.
- Each `it.fails`/`test.fail` was confirmed to fail for the *right reason* (the asserted gap) by temporarily removing the marker.

A small scoped eslint tweak lets the greppable `PG` test-title prefix through antfu's `prefer-lowercase-title` rule (spec files only); no safety rule relaxed.

Refs #4406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)