### PR TITLE
fix(muya): insertParagraph immediate-block anchoring in nested blocks (PG13)

### DIFF
--- a/packages/muya/src/__tests__/blockEditing.spec.ts
+++ b/packages/muya/src/__tests__/blockEditing.spec.ts
@@ -52,6 +52,26 @@ function placeCursorOnFirstBlock(muya: Muya): Content {
     return first;
 }
 
+// Place the cursor on the leaf content block whose text matches `text`, the way
+// a click sets `activeContentBlock`. Used to exercise nested-block anchoring.
+function placeCursorOn(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: { text?: string; constructor: { blockName?: string }; children?: { forEach: (cb: (b: unknown) => void) => void } }) => {
+        if (
+            (block.constructor as { blockName?: string }).blockName?.endsWith('.content')
+            && block.text === text
+        ) {
+            target = block as unknown as Content;
+        }
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    muya.editor.activeContentBlock = target;
+    return target;
+}
+
 describe('muya block editing api', () => {
     it('duplicate() copies the current block in place', async () => {
         const muya = bootMuya('# Title\n\nbody\n');
@@ -89,6 +109,22 @@ describe('muya block editing api', () => {
             expect(after[1].name).toBe('atx-heading');
         });
         expect(muya.getMarkdown()).toContain('intro');
+    });
+
+    it('insertParagraph("after", text, true) anchors at the outermost block in nested structures', async () => {
+        // The explicit "Create Paragraph Below" caller passes outMost=true, so a
+        // cursor inside a blockquote inserts the new paragraph AFTER the whole
+        // blockquote at document root — not as an inner sibling.
+        const muya = bootMuya('> quoted line\n');
+        placeCursorOn(muya, 'quoted line');
+        muya.insertParagraph('after', 'OUTERSIBLING', true);
+        await vi.waitFor(() => {
+            const after = muya.getState();
+            expect(after.length).toBe(2);
+            expect(after[0].name).toBe('block-quote');
+            expect(after[1].name).toBe('paragraph');
+        });
+        expect(muya.getMarkdown()).toContain('OUTERSIBLING');
     });
 
     it('deleteParagraph() removes the current block and keeps the rest', async () => {

--- a/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
+++ b/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
@@ -13,13 +13,17 @@ import { Muya } from '../muya';
 // inserting a paragraph while the cursor sat inside a list item / blockquote
 // landed the new paragraph as an inner sibling, INSIDE the structure.
 //
-// `@muyajs/core`'s `insertParagraph(location, text)` ALWAYS resolves the target
-// via `_outmostBlockAtCursor()` → `outMostBlock` (the OUTERMOST container). So
-// in a nested list/blockquote the new paragraph lands AFTER the entire outer
-// block (at document root) instead of as an inner sibling.
+// `@muyajs/core`'s `insertParagraph(location, text)` originally ALWAYS resolved
+// the target via `_outmostBlockAtCursor()` → `outMostBlock` (the OUTERMOST
+// container), so in a nested list/blockquote the new paragraph landed AFTER the
+// entire outer block (at document root) instead of as an inner sibling.
 //
-// This asserts the DESIRED immediate-anchor behaviour and is expected to FAIL
-// today. When the engine restores the immediate-anchor path, drop the `.fails`.
+// The engine now restores the immediate-anchor path: `insertParagraph` gained a
+// third `outMost` flag (default `false`) that anchors to the IMMEDIATE block at
+// the cursor, matching the legacy context-menu "Insert Paragraph Before/After"
+// behaviour. The explicit "Create Paragraph Below" caller passes `outMost=true`
+// to keep anchoring at the outermost container. These specs assert the restored
+// immediate-anchor behaviour and now PASS.
 
 const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
@@ -87,7 +91,7 @@ function existsAnywhere(muya: Muya, text: string): boolean {
 }
 
 describe('parity PG13: insertParagraph anchors to the immediate block in nested structures', () => {
-    it.fails(
+    it(
         'PG13: inserting after a nested list item keeps the new paragraph inside the list, not at document root',
         async () => {
             const muya = bootMuya('- outer\n\n  - inner1\n  - inner2\n');
@@ -107,7 +111,7 @@ describe('parity PG13: insertParagraph anchors to the immediate block in nested 
         },
     );
 
-    it.fails(
+    it(
         'PG13: inserting after a paragraph inside a blockquote stays inside the blockquote',
         async () => {
             const muya = bootMuya('> quoted line\n');

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -467,6 +467,21 @@ export class Muya {
     }
 
     /**
+     * The immediate block-level parent of the active content leaf — the
+     * paragraph/heading block that directly wraps the cursor. This mirrors the
+     * legacy `getAnchor`/`getParent` anchor used by the context-menu
+     * "Insert Paragraph Before/After" path, so a new paragraph lands as an
+     * inner sibling inside a list item / blockquote rather than jumping out to
+     * the outermost container. Uses the persisted active content block (which
+     * survives the menu/IPC round-trip), falling back to the selection anchor.
+     */
+    private _immediateBlockAtCursor(): Parent | null {
+        const content = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
+
+        return content?.parent ?? null;
+    }
+
+    /**
      * Duplicate the block at the current cursor, placing the cursor in the
      * copy. No-op when there is no current block.
      */
@@ -485,9 +500,16 @@ export class Muya {
      * Insert an empty paragraph relative to the block at the current cursor.
      * @param location Insert `before` or `after` the current block (default `after`).
      * @param text Initial text of the new paragraph.
+     * @param outMost When `true`, anchor the new paragraph to the OUTERMOST
+     *   container (the legacy "Create Paragraph Below" behaviour). When `false`
+     *   (default), anchor to the IMMEDIATE block at the cursor so the paragraph
+     *   stays as an inner sibling inside a list item / blockquote — the legacy
+     *   context-menu "Insert Paragraph Before/After" behaviour.
      */
-    insertParagraph(location: 'before' | 'after' = 'after', text = '') {
-        const block = this._outmostBlockAtCursor();
+    insertParagraph(location: 'before' | 'after' = 'after', text = '', outMost = false) {
+        const block = outMost
+            ? this._outmostBlockAtCursor()
+            : this._immediateBlockAtCursor();
         if (!block)
             return;
 


### PR DESCRIPTION
## Summary

Follow-up to #4406 (desktop migration to `@muyajs/core`). Flips parity scoreboard gap **PG13** from #4407.

The new engine's `insertParagraph(location, text)` always resolved `_outmostBlockAtCursor()`, so when the cursor sat inside a nested list item / blockquote the new paragraph was inserted adjacent to the **outermost** container instead of as an inner sibling next to the **immediate** block. The legacy `packages/muyajs` `insertParagraph(location, text, outMost=false)` took a 3rd `outMost` flag and, when false (the context-menu "Insert Paragraph Before/After" path), anchored at the immediate parent block (`getAnchor`/`getParent`).

## Change

- `insertParagraph(location, text, outMost = false)` — re-adds the third `outMost` flag.
  - `outMost === false` (default): anchor to the **immediate** block-level parent of the active content leaf (`_immediateBlockAtCursor()` → `content.parent`), so a new paragraph stays as an inner sibling inside the list item / blockquote.
  - `outMost === true`: keep the existing **outermost-container** behaviour used by "Create Paragraph Below" (`editor.vue` already calls `insertParagraph('after', '', true)`).
- Top-level paragraphs are unaffected — the immediate parent and the outermost block coincide there.

## Tests

- `parityInsertParagraphNested.spec.ts` (PG13 ×2): `it.fails` → `it`, now passing (nested list stays nested; blockquote sibling stays inside the quote).
- `blockEditing.spec.ts`: added a regression locking the `outMost=true` path (cursor in a blockquote + `outMost=true` inserts after the whole quote at document root).
- Full muya suite green: `lint` (0 errors), `lint:types`, `check-circular`, `test` (515 pass / 18 expected-fail), `test:spec` (1347 pass). `lint:css` has a pre-existing failure on `develop` unrelated to this change (separate branch handles it).

## Wave-2 desktop note

This is engine-only (`packages/muya`); desktop `editor.vue` is untouched. For full parity, the **wave-2 desktop context-menu "Insert Paragraph Before/After"** path (`handleInsertParagraph` → `insertParagraph(location)`) must pass the **non-outmost** anchor — i.e. call `insertParagraph(location, '', false)` (or rely on the new `false` default). The "Create Paragraph Below" caller must keep passing `true`.

Closes parity gap PG13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)