### PR TITLE
fix(muya): consume autoCheck + hideLinkPopup options (PG3/PG12)

### DIFF
--- a/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
@@ -13,16 +13,12 @@ import { Muya } from '../../../../muya';
 // (`updateChildrenCheckBoxState`) and re-derived ancestors
 // (`updateParentsCheckBoxState`).
 //
-// `@muyajs/core` still accepts `autoCheck` (construction + setOptions) but
-// NOTHING reads it — `grep autoCheck packages/muya/src` finds only the type
-// decl + default. The checkbox click handler
-// (`block/gfm/taskListCheckbox/index.ts`) toggles only the clicked item via
-// `update(checked, 'user')`, so enabling `autoCheck` has no cascade effect.
+// `block/gfm/taskListCheckbox/index.ts#update` now reads `muya.options.autoCheck`
+// and, for a `user` toggle, cascades the state to every descendant task item and
+// re-derives each ancestor — restoring parity.
 //
 // We drive the checkbox's `update(checked, 'user')` directly — that is exactly
-// what the DOM click handler invokes — and assert the DESIRED cascade. These
-// are expected to FAIL today. When the engine consumes `autoCheck`, drop the
-// `.fails`.
+// what the DOM click handler invokes — and assert the cascade.
 
 const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
@@ -104,7 +100,7 @@ function checkedFlags(muya: Muya): boolean[] {
 }
 
 describe('parity PG3: autoCheck task-list cascade', () => {
-    it.fails(
+    it(
         'PG3: autoCheck cascades the toggle to descendant task items',
         async () => {
             const muya = bootMuya(NESTED_TASKS, { autoCheck: true });
@@ -122,7 +118,7 @@ describe('parity PG3: autoCheck task-list cascade', () => {
         },
     );
 
-    it.fails(
+    it(
         'PG3: autoCheck re-derives the parent when all descendants become checked',
         async () => {
             const muya = bootMuya(NESTED_TASKS, { autoCheck: true });

--- a/packages/muya/src/block/gfm/taskListCheckbox/index.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/index.ts
@@ -1,5 +1,7 @@
 import type { Muya } from '../../../muya';
 import type { ITaskListItemMeta } from '../../../state/types';
+import type { Nullable } from '../../../types';
+import type Parent from '../../base/parent';
 import type TaskList from '../taskList';
 import type TaskListItem from '../taskListItem';
 import { isFirefox } from '../../../config';
@@ -9,6 +11,100 @@ import logger from '../../../utils/logger';
 import TreeNode from '../../base/treeNode';
 
 const debug = logger('tasklistCheckbox:');
+
+// Block-name discriminators used by the autoCheck cascade to narrow the
+// generic `TreeNode`/`Parent` tree shapes without a double-cast.
+function isTaskListItem(node: Nullable<TreeNode>): node is TaskListItem {
+    return !!node && node.blockName === 'task-list-item';
+}
+
+function isTaskList(node: Nullable<TreeNode>): node is TaskList {
+    return !!node && node.blockName === 'task-list';
+}
+
+function isCheckbox(node: TreeNode): node is TaskListCheckbox {
+    return node.blockName === TaskListCheckbox.blockName;
+}
+
+// Find the `task-list-checkbox` attachment of a `task-list-item`.
+function checkboxOf(item: TaskListItem): TaskListCheckbox | null {
+    let found: TaskListCheckbox | null = null;
+    item.attachments.forEach((attachment: Parent) => {
+        if (isCheckbox(attachment))
+            found = attachment;
+    });
+
+    return found;
+}
+
+// Set a task item's checked state, dispatching the OT op (`TaskListItem.checked`
+// setter) and syncing its checkbox DOM. No-op when already in the target state.
+function setItemChecked(item: TaskListItem, checked: boolean): void {
+    if (item.checked === checked)
+        return;
+
+    item.checked = checked;
+    const checkbox = checkboxOf(item);
+    if (checkbox)
+        checkbox.syncDom(checked);
+}
+
+// The nested `task-list` directly under a `task-list-item`, if any. A task item
+// holds a leading paragraph plus an optional nested list of sub-tasks.
+function nestedTaskListOf(item: TaskListItem): TaskList | null {
+    let nested: TaskList | null = null;
+    item.children.forEach((child: TreeNode) => {
+        if (isTaskList(child))
+            nested = child;
+    });
+
+    return nested;
+}
+
+// Cascade `checked` to every descendant task item (depth-first).
+function cascadeToDescendants(item: TaskListItem, checked: boolean): void {
+    const nested = nestedTaskListOf(item);
+    if (!nested)
+        return;
+
+    nested.children.forEach((child: TreeNode) => {
+        if (!isTaskListItem(child))
+            return;
+
+        setItemChecked(child, checked);
+        cascadeToDescendants(child, checked);
+    });
+}
+
+// A parent item is checked iff every sibling in its task-list is checked.
+function allSiblingsChecked(list: TaskList): boolean {
+    let all = true;
+    list.children.forEach((child: TreeNode) => {
+        if (isTaskListItem(child) && !child.checked)
+            all = false;
+    });
+
+    return all;
+}
+
+// Re-derive each ancestor task item: walking up from the toggled item's list,
+// set every enclosing item to the computed state until one is unchanged.
+function rederiveAncestors(item: TaskListItem): void {
+    let list = item.parent;
+
+    while (isTaskList(list)) {
+        const ancestor = list.parent;
+        if (!isTaskListItem(ancestor))
+            return;
+
+        const computed = allSiblingsChecked(list);
+        if (ancestor.checked === computed)
+            return;
+
+        setItemChecked(ancestor, computed);
+        list = ancestor.parent;
+    }
+}
 
 // The Task List Item component is Firefox compatible, because in Firefox,
 // the input element is not clickable in the contenteditable element(li),
@@ -88,25 +184,54 @@ class TaskListCheckbox extends TreeNode {
     }
 
     update = (checked: boolean, source = 'api') => {
+        const taskListItem = this.parent as TaskListItem;
+        const taskList = taskListItem!.parent as TaskList;
+
+        this._applyChecked(checked, source);
+
+        // marktext `clickCtrl.js#listItemCheckBoxClick` cascaded a user toggle
+        // through `muya.options.autoCheck`: checking/unchecking an item set the
+        // same state on every descendant task item, then re-derived each
+        // ancestor (checked iff all its siblings are checked). `source === 'api'`
+        // is the silent, OT-free path used by the cascade itself, so it never
+        // recurses.
+        if (source !== 'api' && this.muya.options.autoCheck) {
+            cascadeToDescendants(taskListItem, checked);
+            rederiveAncestors(taskListItem);
+        }
+
+        taskList.orderIfNecessary();
+    };
+
+    // Reflect `checked` onto this checkbox's DOM and onto its task-list-item
+    // state. A `user` source dispatches the OT `replace` op (via the
+    // `TaskListItem.checked` setter); an `api` source mutates the state
+    // silently so the cascade can update many items without op spam.
+    private _applyChecked(checked: boolean, source: string) {
+        this.syncDom(checked);
+
+        const taskListItem = this.parent as TaskListItem;
+        if (source === 'api')
+            taskListItem.meta.checked = checked;
+        else
+            taskListItem.checked = checked;
+    }
+
+    // Sync only this checkbox's DOM + internal flag to `checked`. Used by the
+    // autoCheck cascade, which has already mutated the owning item's state (and
+    // dispatched the OT op) via the `TaskListItem.checked` setter, so this must
+    // not touch state again.
+    syncDom(checked: boolean) {
+        this._checked = checked;
         operateClassName(
             this.domNode!,
             checked ? 'add' : 'remove',
             'mu-checkbox-checked',
         );
-        const taskListItem = this.parent as TaskListItem;
-        const taskList = taskListItem!.parent as TaskList;
 
         if (isHTMLInputElement(this.domNode) && this.domNode.checked !== checked && !isFirefox)
             this.domNode.checked = checked;
-
-        // No need to trigger the OT operation If the source is `api`.
-        if (source === 'api')
-            taskListItem.meta.checked = checked;
-        else
-            taskListItem.checked = checked;
-
-        taskList.orderIfNecessary();
-    };
+    }
 
     detachDOMEvents() {
         for (const id of this._eventIds)

--- a/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
+++ b/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
@@ -11,15 +11,10 @@ import { Muya } from '../../muya';
 // `muya-link-tools` (the link-edit/jump popover) when `!hideLinkPopup`. So
 // `hideLinkPopup: true` suppressed the popover on link hover.
 //
-// `@muyajs/core` still accepts `hideLinkPopup` (construction + setOptions) but
-// `editor/linkMouseEvents.ts#overHandler` emits `muya-link-tools`
-// UNCONDITIONALLY — it never reads the option. `grep hideLinkPopup
-// packages/muya/src` finds only the type decl + default. So the popover always
-// appears on hover even with `hideLinkPopup: true`.
-//
-// The gap test asserts the DESIRED suppression and is expected to FAIL today.
-// A positive control proves the harness actually drives the hover emit. When
-// the engine gates the popover on `hideLinkPopup`, drop the `.fails`.
+// `editor/linkMouseEvents.ts#overHandler` now reads `muya.options.hideLinkPopup`
+// and returns early when it is set, so the popover is suppressed on hover —
+// restoring parity. The gap test below asserts that suppression; the positive
+// control proves the harness actually drives the hover emit.
 
 const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
@@ -85,7 +80,7 @@ describe('parity PG12: hideLinkPopup gates the link hover popover', () => {
         expect(countOpenEmits(handler)).toBe(1);
     });
 
-    it.fails(
+    it(
         'PG12: with hideLinkPopup=true, hovering a preview link does NOT open the popover',
         () => {
             const muya = bootMuya('[hello](https://example.com)\n', { hideLinkPopup: true });

--- a/packages/muya/src/editor/linkMouseEvents.ts
+++ b/packages/muya/src/editor/linkMouseEvents.ts
@@ -80,6 +80,13 @@ export function attachLinkMouseHandlers(muya: Muya): void {
     const { eventCenter, domNode } = muya;
 
     const overHandler = (event: Event) => {
+        // marktext `eventHandler/mouseEvent.js` gated the link-tools dispatch
+        // on `!hideLinkPopup`: when the user sets `hideLinkPopup: true`, the
+        // hover popover is suppressed entirely. Read it live so a runtime
+        // `setOptions({ hideLinkPopup })` toggle takes effect immediately.
+        if (muya.options?.hideLinkPopup)
+            return;
+
         const wrapper = findLinkWrapper(event.target);
         if (!wrapper || !isPopoverTarget(wrapper))
             return;


### PR DESCRIPTION
Follow-up to #4406 (@muyajs/core parity). Both options were plumbed into the
new engine (`muya.options` via `setOptions`) but never consumed; this PR wires
them in and flips the corresponding parity-scoreboard specs (#4407) from
`it.fails` to `it`.

## PG3 — `autoCheck` task-list cascade
Legacy muyajs read `autoCheck` in `clickCtrl.js#listItemCheckBoxClick`: toggling
a task-list checkbox cascaded the state to all descendant items and re-derived
ancestors. The new engine merged `autoCheck` into options but never read it.

`block/gfm/taskListCheckbox/index.ts#update` now, for a `user` toggle with
`autoCheck` on, sets every descendant task item to the same checked state and
re-derives each ancestor (checked iff all its siblings are checked). Cascaded
items mutate state via the `TaskListItem.checked` setter so each still dispatches
its OT replace op; their checkboxes sync via a new `syncDom` helper. Tree
narrowing uses block-name type guards (no double-cast).

## PG12 — `hideLinkPopup` link-hover gate
Legacy muyajs gated the `muya-link-tools` dispatch on `!hideLinkPopup`. The new
`linkMouseEvents.ts#overHandler` emitted unconditionally.

`overHandler` now reads `muya.options.hideLinkPopup` live and returns early when
set, so a runtime `setOptions({ hideLinkPopup })` toggle takes effect
immediately.

## Tests / gates
- `parityAutoCheck.spec.ts` (×2) and `parityHideLinkPopup.spec.ts` (×1) flipped
  to passing; the hideLinkPopup positive control stays green.
- `pnpm -C packages/muya lint` (0 errors), `lint:types`, `check-circular`,
  `test` (515 passed), `test:spec` (1347 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)