### PR TITLE
feat(muya): expose block affiliation in selection-change (PG1)

### DIFF
--- a/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
@@ -73,32 +73,81 @@ function emitSelectionFor(muya: Muya, content: Content): Record<string, unknown>
 }
 
 describe('parity PG1: selection-change block affiliation', () => {
-    it.fails(
+    it(
         'PG1: selection-change payload exposes the ancestor block affiliation chain',
         () => {
             const muya = bootMuya('# Heading\n\nbody\n');
             const heading = muya.editor.scrollPage!.firstContentInDescendant()!;
             const payload = emitSelectionFor(muya, heading);
 
-            // Desired: the payload carries an `affiliation` map/list of the
-            // ancestor block types so the desktop Paragraph menu can light up.
-            // Today the key is entirely absent.
+            // The payload carries an `affiliation` list of the ancestor block
+            // types so the desktop Paragraph menu can light up.
             expect('affiliation' in payload).toBe(true);
+            expect(Array.isArray(payload.affiliation)).toBe(true);
         },
     );
 
-    it.fails(
+    it(
         'PG1: selection-change exposes the current block markdown type (h1), not just the selection kind',
         () => {
             const muya = bootMuya('# Heading\n\nbody\n');
             const heading = muya.editor.scrollPage!.firstContentInDescendant()!;
             const payload = emitSelectionFor(muya, heading);
 
-            // Desired: a consumer can learn the cursor sits in an `h1` heading
-            // (so `heading1MenuItem` can be checked). Today `type` is the
-            // selection kind 'Caret' / 'Range' and no field reports `h1`.
-            const flat = JSON.stringify(payload);
-            expect(flat).toContain('h1');
+            // A consumer can learn the cursor sits in an `h1` heading (so
+            // `heading1MenuItem` can be checked) — the affiliation chain reports
+            // the markdown block type, separate from the selection kind
+            // (`type` stays 'Caret' / 'Range').
+            const affiliation = payload.affiliation as Array<{ type: string }>;
+            expect(affiliation.map(entry => entry.type)).toContain('h1');
+            // The selection kind is still the flat caret/range type.
+            expect(payload.type).toBe('Caret');
+        },
+    );
+
+    it(
+        'PG1: selection-change exposes per-endpoint content-leaf block info (type + functionType)',
+        () => {
+            const muya = bootMuya('```js\nconst a = 1\n```\n');
+            // `firstContentInDescendant` of a code block is the language-input
+            // leaf; the code text lives in the last content leaf.
+            const codeLeaf = muya.editor.scrollPage!.lastContentInDescendant()!;
+            const payload = emitSelectionFor(muya, codeLeaf);
+
+            // The desktop store keys `isCodeFences` / `isCodeContent` off
+            // `start.type === 'span' && block.functionType === 'codeContent'`.
+            const info = payload.anchorBlockInfo as {
+                type: string;
+                functionType?: string;
+            };
+            expect(info.type).toBe('span');
+            expect(info.functionType).toBe('codeContent');
+            // The fenced code block contributes a `pre`-typed affiliation entry.
+            const affiliation = payload.affiliation as Array<{ type: string }>;
+            expect(affiliation.map(entry => entry.type)).toContain('pre');
+        },
+    );
+
+    it(
+        'PG1: selection-change surfaces list context (ul / li / loose / task) in affiliation',
+        () => {
+            const muya = bootMuya('- [ ] task\n');
+            const leaf = muya.editor.scrollPage!.firstContentInDescendant()!;
+            const payload = emitSelectionFor(muya, leaf);
+            const affiliation = payload.affiliation as Array<{
+                type: string;
+                listType?: string;
+                listItemType?: string;
+                isLooseListItem?: boolean;
+            }>;
+            const list = affiliation.find(entry => entry.type === 'ul');
+            const item = affiliation.find(entry => entry.type === 'li');
+
+            expect(list).toBeTruthy();
+            expect(list!.listType).toBe('task');
+            expect(list!.isLooseListItem).toBe(false);
+            expect(item).toBeTruthy();
+            expect(item!.listItemType).toBe('task');
         },
     );
 });

--- a/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts
@@ -150,4 +150,41 @@ describe('parity PG1: selection-change block affiliation', () => {
             expect(item!.listItemType).toBe('task');
         },
     );
+
+    it(
+        'PG1: ordered-list items report listItemType "order" (not misclassified as bullet)',
+        () => {
+            const muya = bootMuya('1. one\n2. two\n');
+            const leaf = muya.editor.scrollPage!.firstContentInDescendant()!;
+            const payload = emitSelectionFor(muya, leaf);
+            const affiliation = payload.affiliation as Array<{
+                type: string;
+                listType?: string;
+                listItemType?: string;
+            }>;
+
+            expect(affiliation.find(e => e.type === 'ol')?.listType).toBe('order');
+            // Bullet and ordered lists share the `list-item` block; the item's
+            // discriminator must come from the parent list.
+            expect(affiliation.find(e => e.type === 'li')?.listItemType).toBe('order');
+        },
+    );
+
+    it(
+        'PG1: loose lists report isLooseListItem true on both the list and the item',
+        () => {
+            // Blank lines between items make a loose list.
+            const muya = bootMuya('- one\n\n- two\n');
+            const leaf = muya.editor.scrollPage!.firstContentInDescendant()!;
+            const payload = emitSelectionFor(muya, leaf);
+            const affiliation = payload.affiliation as Array<{
+                type: string;
+                isLooseListItem?: boolean;
+            }>;
+
+            // Loose-ness lives on the list block; the `li` entry mirrors it.
+            expect(affiliation.find(e => e.type === 'ul')?.isLooseListItem).toBe(true);
+            expect(affiliation.find(e => e.type === 'li')?.isLooseListItem).toBe(true);
+        },
+    );
 });

--- a/packages/muya/src/selection/affiliation.ts
+++ b/packages/muya/src/selection/affiliation.ts
@@ -71,15 +71,16 @@ const FUNCTION_TYPE_BY_NAME: Readonly<Record<string, string>> = {
 };
 
 /**
- * Container `blockName` → list-block `listType` discriminator (matches
- * muyajs's `listType`/`listItemType`).
+ * List-block `blockName` → list discriminator (matches muyajs's
+ * `listType` / `listItemType`: `bullet` | `order` | `task`). Keyed only on the
+ * list container blocks — list-item blocks share the `list-item` block name for
+ * both bullet and ordered lists, so an item's discriminator is read from the
+ * parent list, never from the item itself.
  */
 const LIST_TYPE_BY_NAME: Readonly<Record<string, string>> = {
     'bullet-list': 'bullet',
     'order-list': 'order',
     'task-list': 'task',
-    'list-item': 'bullet',
-    'task-list-item': 'task',
 };
 
 /**
@@ -92,11 +93,19 @@ export interface IAffiliationEntry {
     type: string;
     /** Engine block name (`bullet-list`, `code-block`, …) for callers that want the precise block. */
     blockName: string;
-    /** Present on list / list-item ancestors: `bullet` | `order` | `task`. */
+    /** Present on list ancestors (`ul` / `ol`): `bullet` | `order` | `task`. */
     listType?: string;
-    /** Present on list-item ancestors: `bullet` | `task`. */
+    /**
+     * Present on list-item ancestors (`li`): the parent list's discriminator
+     * (`bullet` | `order` | `task`). Read from the parent list because both
+     * bullet and ordered lists share the `list-item` block.
+     */
     listItemType?: string;
-    /** Whether the list / list-item is rendered loose (blank-line separated). */
+    /**
+     * Whether the enclosing list is rendered loose (blank-line separated). For
+     * `li` entries this reflects the parent list's `meta.loose`, since the
+     * looseness flag lives on the list, not the item.
+     */
     isLooseListItem?: boolean;
 }
 
@@ -121,26 +130,51 @@ function _markdownTypeOf(block: TreeNode): string | undefined {
     return CONTAINER_TYPE_BY_NAME[block.blockName];
 }
 
-function _isLoose(block: Parent): boolean {
-    // Lists carry `meta.loose`; a loose list item is one inside a loose list.
-    const meta = (block as Parent & { meta?: { loose?: boolean } }).meta;
+const LIST_BLOCK_NAMES: ReadonlySet<string> = new Set([
+    'bullet-list',
+    'order-list',
+    'task-list',
+]);
+
+function _isLoose(block: Parent | null | undefined): boolean {
+    // Lists carry `meta.loose`; list *items* do not, so loose-ness for an `li`
+    // is read from its parent list block.
+    const meta = (block as (Parent & { meta?: { loose?: boolean } }) | null)?.meta;
 
     return Boolean(meta?.loose);
+}
+
+/**
+ * Walk up from a list-item block to its enclosing list block (`bullet-list` /
+ * `order-list` / `task-list`), which owns the list discriminator and the
+ * loose/tight flag.
+ */
+function _parentListOf(item: Parent): Parent | null {
+    let node: Nullable<Parent> = item.parent;
+    while (node) {
+        if (LIST_BLOCK_NAMES.has(node.blockName))
+            return node;
+
+        node = node.parent;
+    }
+
+    return null;
 }
 
 function _buildEntry(block: Parent, type: string): IAffiliationEntry {
     const entry: IAffiliationEntry = { type, blockName: block.blockName };
 
-    const listType = LIST_TYPE_BY_NAME[block.blockName];
-    if (listType) {
-        if (type === 'li')
-            entry.listItemType = listType;
-        else
-            entry.listType = listType;
-    }
-
-    if (type === 'ul' || type === 'ol' || type === 'li')
+    if (type === 'ul' || type === 'ol') {
+        entry.listType = LIST_TYPE_BY_NAME[block.blockName];
         entry.isLooseListItem = _isLoose(block);
+    }
+    else if (type === 'li') {
+        // Both bullet and ordered items share the `list-item` block, and the
+        // loose flag lives on the parent list — derive both from there.
+        const list = _parentListOf(block);
+        entry.listItemType = list ? LIST_TYPE_BY_NAME[list.blockName] : undefined;
+        entry.isLooseListItem = _isLoose(list);
+    }
 
     return entry;
 }

--- a/packages/muya/src/selection/affiliation.ts
+++ b/packages/muya/src/selection/affiliation.ts
@@ -1,0 +1,219 @@
+// Block-affiliation derivation for the `selection-change` payload.
+//
+// PARITY (gap PG1): legacy `packages/muyajs` emitted `selectionChange` with an
+// `affiliation` chain — the shared ancestor PARAGRAPH-type blocks of the
+// selection endpoints — plus per-endpoint `.type` (the markdown block type,
+// e.g. `span` for a content leaf) and `.functionType` (`codeContent`,
+// `cellContent`, …). The desktop store (`createApplicationMenuState`) consumed
+// those to light up the Paragraph-menu check marks, the Loose/Task-list
+// toggles, table/code-fence detection, and to disable the Format menu inside
+// code. `@muyajs/core` models the document as a block tree keyed by
+// `blockName`, so this module re-derives the same shape from that tree.
+
+import type Content from '../block/base/content';
+import type Parent from '../block/base/parent';
+import type TreeNode from '../block/base/treeNode';
+import type { Nullable } from '../types';
+
+/**
+ * The legacy "markdown block type" vocabulary the desktop menu vocabulary is
+ * keyed on (`MENU_ID_MAP` in `main/menu/actions/paragraph.ts`,
+ * `PARAGRAPH_TYPES` in the renderer config). Only ancestors whose mapped type
+ * is one of these belong in the affiliation chain.
+ */
+const PARAGRAPH_TYPES: ReadonlySet<string> = new Set([
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'blockquote',
+    'pre',
+    'ul',
+    'ol',
+    'li',
+    'figure',
+]);
+
+/**
+ * Container `blockName` → legacy markdown block `type`. Heading blocks resolve
+ * their level from `tagName` (`h1`…`h6`) so they are handled separately.
+ */
+const CONTAINER_TYPE_BY_NAME: Readonly<Record<string, string>> = {
+    'paragraph': 'p',
+    'block-quote': 'blockquote',
+    'bullet-list': 'ul',
+    'task-list': 'ul',
+    'order-list': 'ol',
+    'list-item': 'li',
+    'task-list-item': 'li',
+    'code-block': 'pre',
+    'frontmatter': 'pre',
+    'table': 'figure',
+    'html-block': 'figure',
+    'math-block': 'figure',
+    'diagram': 'figure',
+};
+
+/**
+ * Leaf-content `blockName` → legacy `functionType`. Mirrors the muyajs content
+ * blocks (`codeContent`, `cellContent`, `languageInput`, `paragraphContent`).
+ */
+const FUNCTION_TYPE_BY_NAME: Readonly<Record<string, string>> = {
+    'codeblock.content': 'codeContent',
+    'table.cell.content': 'cellContent',
+    'language-input': 'languageInput',
+    'paragraph.content': 'paragraphContent',
+    'atxheading.content': 'paragraphContent',
+    'setextheading.content': 'paragraphContent',
+};
+
+/**
+ * Container `blockName` → list-block `listType` discriminator (matches
+ * muyajs's `listType`/`listItemType`).
+ */
+const LIST_TYPE_BY_NAME: Readonly<Record<string, string>> = {
+    'bullet-list': 'bullet',
+    'order-list': 'order',
+    'task-list': 'task',
+    'list-item': 'bullet',
+    'task-list-item': 'task',
+};
+
+/**
+ * One ancestor block in the affiliation chain. `type` is the legacy markdown
+ * block type; the remaining fields carry the list-context the desktop menu
+ * needs. Shape parity with muyajs's affiliation entries.
+ */
+export interface IAffiliationEntry {
+    /** Legacy markdown block type: `p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`. */
+    type: string;
+    /** Engine block name (`bullet-list`, `code-block`, …) for callers that want the precise block. */
+    blockName: string;
+    /** Present on list / list-item ancestors: `bullet` | `order` | `task`. */
+    listType?: string;
+    /** Present on list-item ancestors: `bullet` | `task`. */
+    listItemType?: string;
+    /** Whether the list / list-item is rendered loose (blank-line separated). */
+    isLooseListItem?: boolean;
+}
+
+/**
+ * Per-endpoint block info for one selection end. `type` is always `span` for a
+ * content leaf (parity with muyajs's content-block `type`); `functionType`
+ * distinguishes code / table-cell / language-input content.
+ */
+export interface IEndpointBlockInfo {
+    /** Engine block name of the content leaf, e.g. `codeblock.content`. */
+    blockName: string;
+    /** Legacy content-block type — always `span` for a content leaf. */
+    type: string;
+    /** Legacy `functionType`: `codeContent` | `cellContent` | `languageInput` | `paragraphContent`. */
+    functionType?: string;
+}
+
+function _markdownTypeOf(block: TreeNode): string | undefined {
+    if (block.blockName === 'atx-heading' || block.blockName === 'setext-heading')
+        return block.tagName; // `h1`…`h6`
+
+    return CONTAINER_TYPE_BY_NAME[block.blockName];
+}
+
+function _isLoose(block: Parent): boolean {
+    // Lists carry `meta.loose`; a loose list item is one inside a loose list.
+    const meta = (block as Parent & { meta?: { loose?: boolean } }).meta;
+
+    return Boolean(meta?.loose);
+}
+
+function _buildEntry(block: Parent, type: string): IAffiliationEntry {
+    const entry: IAffiliationEntry = { type, blockName: block.blockName };
+
+    const listType = LIST_TYPE_BY_NAME[block.blockName];
+    if (listType) {
+        if (type === 'li')
+            entry.listItemType = listType;
+        else
+            entry.listType = listType;
+    }
+
+    if (type === 'ul' || type === 'ol' || type === 'li')
+        entry.isLooseListItem = _isLoose(block);
+
+    return entry;
+}
+
+/**
+ * Walk from a content leaf up to the outermost block, collecting the
+ * paragraph-type ancestor blocks. Ordered outermost-first (top block → … →
+ * leaf's container), matching muyajs where `affiliation[0]` is the enclosing
+ * list and deeper entries follow.
+ */
+function _ancestorBlocks(leaf: Content | null): Parent[] {
+    const blocks: Parent[] = [];
+    let node: Nullable<Parent> = leaf?.parent;
+
+    while (node) {
+        if (PARAGRAPH_TYPES.has(_markdownTypeOf(node) ?? ''))
+            blocks.unshift(node);
+
+        if (node.isOutMostBlock)
+            break;
+
+        node = node.parent;
+    }
+
+    return blocks;
+}
+
+/**
+ * Walk from a content leaf up to the outermost block, collecting the
+ * paragraph-type ancestors into an affiliation chain (outermost-first).
+ */
+export function buildAffiliation(leaf: Content | null): IAffiliationEntry[] {
+    return _ancestorBlocks(leaf).map(block =>
+        _buildEntry(block, _markdownTypeOf(block)!),
+    );
+}
+
+/**
+ * Compute the shared-ancestor affiliation for a selection. When both endpoints
+ * sit in the same block the anchor chain is returned; otherwise the chain is
+ * trimmed to the ancestor block instances shared by both endpoints (parity
+ * with muyajs's `startParents.filter(p => endParents.includes(p))`).
+ */
+export function buildSelectionAffiliation(
+    anchorLeaf: Content | null,
+    focusLeaf: Content | null,
+): IAffiliationEntry[] {
+    const anchorBlocks = _ancestorBlocks(anchorLeaf);
+    const shared
+        = anchorLeaf === focusLeaf
+            ? anchorBlocks
+            : _intersectBlocks(anchorBlocks, _ancestorBlocks(focusLeaf));
+
+    return shared.map(block => _buildEntry(block, _markdownTypeOf(block)!));
+}
+
+function _intersectBlocks(anchorBlocks: Parent[], focusBlocks: Parent[]): Parent[] {
+    const focusSet = new Set<Parent>(focusBlocks);
+
+    return anchorBlocks.filter(block => focusSet.has(block));
+}
+
+/**
+ * Describe one selection endpoint's content leaf in the legacy
+ * `{ type, functionType }` shape.
+ */
+export function endpointBlockInfo(leaf: Content | null): IEndpointBlockInfo | null {
+    if (!leaf)
+        return null;
+
+    return {
+        blockName: leaf.blockName,
+        type: leaf.tagName || 'span',
+        functionType: FUNCTION_TYPE_BY_NAME[leaf.blockName],
+    };
+}

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -10,6 +10,10 @@ import { BLOCK_DOM_PROPERTY, CLASS_NAMES } from '../config';
 import { isElement, isHTMLElement, isKeyboardEvent, isMouseEvent } from '../utils';
 import { getImageInfo, getImageSrc } from '../utils/image';
 import {
+    buildSelectionAffiliation,
+    endpointBlockInfo,
+} from './affiliation';
+import {
     compareParagraphsOrder,
     findContentDOM,
     getNodeAndOffset,
@@ -324,6 +328,18 @@ class Selection {
                 ? anchorBlockRef.getFormatsInRange().formats
                 : [];
 
+        // PARITY (gap PG1): re-derive the legacy `selectionChange` block-context
+        // the desktop Paragraph/Format menu state builder consumes —
+        // `affiliation` is the shared ancestor PARAGRAPH-type chain, and the
+        // per-endpoint `{ type, functionType }` describe the content leaves
+        // (`type: 'span'`, `functionType: 'codeContent' | 'cellContent' | …`).
+        const affiliation = buildSelectionAffiliation(
+            this.anchorBlock,
+            this.focusBlock,
+        );
+        const anchorBlockInfo = endpointBlockInfo(this.anchorBlock);
+        const focusBlockInfo = endpointBlockInfo(this.focusBlock);
+
         this.muya.eventCenter.emit('selection-change', {
             anchor,
             focus,
@@ -338,6 +354,9 @@ class Selection {
             selectedImage,
             cursorCoords,
             formats,
+            affiliation,
+            anchorBlockInfo,
+            focusBlockInfo,
         });
     }
 


### PR DESCRIPTION
## What

Parity follow-up to **#4406** (@muyajs/core migration). Flips parity scoreboard gap **PG1** from the failing `it.fails` scoreboard (**#4407**) to real passing tests.

The engine `selection-change` payload only carried flat caret/range info (`anchor`, `focus`, `anchorBlock`, `anchorPath`, …, `type`, `formats`). The desktop application-menu state builder (`createApplicationMenuState`) was written against muyajs's richer `selectionChange` shape and needs:

- an ancestor **`affiliation`** chain to light up the Paragraph-menu check marks and the Loose/Task-list toggles, and
- per-endpoint block **`type` + `functionType`** to set `isCodeFences` / `isCodeContent` / `isTable` and disable the Format menu inside code.

The new engine exposes `blockName` (`codeblock.content`, `bullet-list`, …), not muyajs's markdown `type` / `functionType`, so none of that downstream state could be reconstructed — Paragraph check marks never lit, Loose-list was always disabled, and the Format menu was never disabled in code.

## How

ENGINE-ONLY, in `packages/muya`. A focused `selection/affiliation.ts` helper re-derives the legacy block-context from the @muyajs/core block tree, and three fields are added to the `selection-change` payload (all existing fields untouched, new ones JSDoc'd):

- **`affiliation`** — shared ancestor PARAGRAPH-type chain (outermost-first), each entry: `{ type, blockName, listType?, listItemType?, isLooseListItem? }` where `type` is the markdown block type (`p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`). Cross-block selections are trimmed to the shared ancestor block instances (parity with muyajs's `startParents.filter(p => endParents.includes(p))`).
- **`anchorBlockInfo`** / **`focusBlockInfo`** — per-endpoint content-leaf info `{ blockName, type, functionType? }` where `type` is always `span` and `functionType` is `codeContent` / `cellContent` / `languageInput` / `paragraphContent`.

## Tests

The two PG1 `it.fails` scoreboard tests are now real `it()` tests, plus two new tests pin the per-endpoint code-content info and the list affiliation context. Verified locally: `lint` (0 errors), `lint:types`, `check-circular`, `test` (516 pass / 18 expected-fail remaining for other PGs), `test:spec` (1347 pass). `lint:css` has a pre-existing `no-descending-specificity` error on `develop` (no CSS touched here).

## Desktop adapter is wave 2

The desktop `editor.vue` `adaptSelectionChange` is intentionally **not** touched here. A separate wave-2 desktop PR will consume the new fields: map `affiliation` → `createApplicationMenuState`'s `affiliation`, and `anchorBlockInfo` / `focusBlockInfo` → `start.type` / `start.block.functionType` (and the same for `end`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)