### PR TITLE
fix(muya): inline export CSS + heading ids for offline export & TOC anchors (PG7/PG8)

### DIFF
--- a/packages/muya/package.json
+++ b/packages/muya/package.json
@@ -64,6 +64,7 @@
         "fast-diff": "^1.3.0",
         "flowchart.js": "^1.18.0",
         "fuse.js": "^7.3.0",
+        "github-markdown-css": "^5.9.0",
         "html-tags": "^5.1.0",
         "joplin-turndown-plugin-gfm": "^1.0.12",
         "katex": "0.16.47",

--- a/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
@@ -79,4 +79,23 @@ describe('parity PG8: exported headings carry slug ids (live TOC anchors)', () =
             expect(out).toMatch(/<h2[^>]*\sid="installation"/);
         },
     );
+
+    it(
+        'PG8: duplicate / chained-collision headings get unique ids',
+        async () => {
+            // `heading`, `heading`, then a heading literally titled `heading-1`
+            // exercises the chained-collision case: naive per-base dedup would
+            // emit `heading-1` twice. Every id must be unique so anchors point
+            // at exactly one target (matching the legacy Slugger).
+            const out = await generateExport(
+                '# heading\n\n## heading\n\n## heading-1\n',
+            );
+            const ids = [...out.matchAll(/<h[1-6][^>]*\sid="([^"]+)"/g)].map(
+                m => m[1],
+            );
+
+            expect(ids).toEqual(['heading', 'heading-1', 'heading-1-1']);
+            expect(new Set(ids).size).toBe(ids.length);
+        },
+    );
 });

--- a/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
@@ -18,9 +18,8 @@ import { MarkdownToHtml } from '../markdownToHtml';
 // worked. `@muyajs/core` renders via stock `marked` with no heading-id
 // renderer, so exported `<h1>..<h6>` carry NO id and every TOC anchor is dead.
 //
-// These assert the DESIRED export output. The engine now inlines base CSS
-// (PG7), so those pass. PG8 (heading ids) is implemented in a follow-up commit
-// — its specs remain `it.fails` until then.
+// These assert the export output: the engine now inlines base CSS (PG7) and
+// injects github-compatible heading ids (PG8), so they pass.
 
 const SAMPLE = '# Getting Started\n\n## Installation\n\nSome **body** text.\n';
 
@@ -56,19 +55,19 @@ describe('parity PG7: export inlines base stylesheets (offline-safe)', () => {
 });
 
 describe('parity PG8: exported headings carry slug ids (live TOC anchors)', () => {
-    it.fails(
+    it(
         'PG8: exported <h1>..<hN> carry an id attribute',
         async () => {
             const out = await generateExport(SAMPLE);
 
-            // Desired: headings are emitted with ids so TOC `href="#slug"`
-            // anchors resolve. Today headings have no id at all.
+            // Headings are emitted with ids so TOC `href="#slug"` anchors
+            // resolve.
             expect(out).toMatch(/<h1[^>]*\sid="[^"]+"/);
             expect(out).toMatch(/<h2[^>]*\sid="[^"]+"/);
         },
     );
 
-    it.fails(
+    it(
         'PG8: the heading id matches the marktext slug of the heading text',
         async () => {
             const out = await generateExport(SAMPLE);

--- a/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
@@ -18,9 +18,9 @@ import { MarkdownToHtml } from '../markdownToHtml';
 // worked. `@muyajs/core` renders via stock `marked` with no heading-id
 // renderer, so exported `<h1>..<h6>` carry NO id and every TOC anchor is dead.
 //
-// These assert the DESIRED export output and are expected to FAIL today. When
-// the engine inlines base CSS (PG7) / injects heading ids (PG8), drop the
-// `.fails`.
+// These assert the DESIRED export output. The engine now inlines base CSS
+// (PG7), so those pass. PG8 (heading ids) is implemented in a follow-up commit
+// — its specs remain `it.fails` until then.
 
 const SAMPLE = '# Getting Started\n\n## Installation\n\nSome **body** text.\n';
 
@@ -31,13 +31,12 @@ async function generateExport(markdown: string): Promise<string> {
 }
 
 describe('parity PG7: export inlines base stylesheets (offline-safe)', () => {
-    it.fails(
+    it(
         'PG7: generated HTML inlines github-markdown-css as a <style> block, not a CDN <link>',
         async () => {
             const out = await generateExport(SAMPLE);
 
-            // Desired: the markdown-body CSS is inlined so the file renders
-            // offline. Today it is a CDN <link> only.
+            // The markdown-body CSS is inlined so the file renders offline.
             expect(out).toContain('.markdown-body');
             expect(out).not.toMatch(
                 /<link[^>]+href="https:\/\/cdnjs\.cloudflare\.com[^>]+github-markdown-css/,
@@ -45,12 +44,12 @@ describe('parity PG7: export inlines base stylesheets (offline-safe)', () => {
         },
     );
 
-    it.fails(
+    it(
         'PG7: generated HTML does not depend on any external CDN stylesheet',
         async () => {
             const out = await generateExport(SAMPLE);
 
-            // Desired: zero external stylesheet links — fully self-contained.
+            // Zero external stylesheet links — fully self-contained.
             expect(out).not.toMatch(/<link[^>]+rel="stylesheet"[^>]+href="https:\/\//);
         },
     );

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -8,6 +8,7 @@ import { isHTMLElement, sanitize, unescapeHTML } from '../utils';
 import loadRenderer from '../utils/diagram';
 
 import { getHighlightHtml } from '../utils/marked';
+import { generateGithubSlug } from '../utils/slug';
 
 // Core stylesheets inlined into the exported document so the output is fully
 // self-contained and renders offline / behind CSP / air-gapped — matching the
@@ -126,6 +127,26 @@ export class MarkdownToHtml {
         }
     }
 
+    // Assign a github-compatible slug `id` to every `<h1>..<h6>` in the
+    // export container. Headings that already carry an explicit id (none today,
+    // but defensive) are left as-is. Duplicate slugs are deduplicated with a
+    // `-N` suffix so each anchor target is unique, matching github / the legacy
+    // muyajs Slugger.
+    private _injectHeadingIds(container: HTMLElement) {
+        const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        const seen = new Map<string, number>();
+
+        for (const heading of headings) {
+            if (heading.id)
+                continue;
+
+            const base = generateGithubSlug(heading.textContent ?? '') || 'heading';
+            const count = seen.get(base) ?? 0;
+            seen.set(base, count + 1);
+            heading.id = count === 0 ? base : `${base}-${count}`;
+        }
+    }
+
     // render pure html by marked
     async renderHtml() {
         let html = getHighlightHtml(this.markdown, {
@@ -147,6 +168,13 @@ export class MarkdownToHtml {
         // render only render the light theme of mermaid and diagram...
         await this.renderMermaid();
         await this.renderDiagram();
+
+        // Inject github-compatible slug ids onto exported headings so the
+        // exported document's [TOC] / `getHtmlToc` `href="#slug"` anchors
+        // resolve (PG8). Scoped to this export DOM path — the conformance
+        // renderer (`renderToStaticHTML`) is deliberately left untouched.
+        this._injectHeadingIds(exportContainer);
+
         let result = exportContainer.innerHTML;
         exportContainer.remove();
 

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -129,21 +129,34 @@ export class MarkdownToHtml {
 
     // Assign a github-compatible slug `id` to every `<h1>..<h6>` in the
     // export container. Headings that already carry an explicit id (none today,
-    // but defensive) are left as-is. Duplicate slugs are deduplicated with a
-    // `-N` suffix so each anchor target is unique, matching github / the legacy
-    // muyajs Slugger.
+    // but defensive) are left as-is and reserve that id. Duplicates are
+    // deduplicated by incrementing a `-N` suffix until the *full* candidate id
+    // is unused — so a later heading whose text already looks like an earlier
+    // `-N` slug (e.g. `heading`, `heading`, `heading-1`) still resolves to a
+    // unique anchor, matching github / the legacy muyajs Slugger.
     private _injectHeadingIds(container: HTMLElement) {
         const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6');
-        const seen = new Map<string, number>();
+        const seen = new Set<string>();
+
+        // Reserve any pre-existing ids first so generated slugs never collide
+        // with them.
+        for (const heading of headings) {
+            if (heading.id)
+                seen.add(heading.id);
+        }
 
         for (const heading of headings) {
             if (heading.id)
                 continue;
 
             const base = generateGithubSlug(heading.textContent ?? '') || 'heading';
-            const count = seen.get(base) ?? 0;
-            seen.set(base, count + 1);
-            heading.id = count === 0 ? base : `${base}-${count}`;
+            let slug = base;
+            let n = 1;
+            while (seen.has(slug))
+                slug = `${base}-${n++}`;
+
+            seen.add(slug);
+            heading.id = slug;
         }
     }
 

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -1,10 +1,30 @@
 import type { Muya } from '../muya';
+import githubMarkdownCss from 'github-markdown-css/github-markdown-light.css?inline';
+import katexCss from 'katex/dist/katex.css?inline';
+import prismCss from 'prismjs/themes/prism.css?inline';
 import exportStyle from '../assets/styles/exportStyle.css?inline';
 import { EXPORT_DOMPURIFY_CONFIG } from '../config';
 import { isHTMLElement, sanitize, unescapeHTML } from '../utils';
 import loadRenderer from '../utils/diagram';
 
 import { getHighlightHtml } from '../utils/marked';
+
+// Core stylesheets inlined into the exported document so the output is fully
+// self-contained and renders offline / behind CSP / air-gapped — matching the
+// legacy `packages/muyajs` `ExportHtml` behavior (PG7). Linking these from a
+// CDN left a saved `.html` file unstyled with no network access, a regression
+// for an offline desktop editor. Callers that explicitly want the lighter
+// CDN-linked shell can opt in via `generate({ inlineStyles: false })`.
+const BASE_STYLESHEETS = [githubMarkdownCss, katexCss, prismCss];
+
+// CDN `<link>` tags used when `inlineStyles` is disabled. Kept verbatim from
+// the previous default so the opt-out path is byte-identical to the old output.
+const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown-css -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown-light.css" integrity="sha512-n5zPz6LZB0QV1eraRj4OOxRbsV7a12eAGfFcrJ4bBFxxAwwYDp542z5M0w24tKPEhKk2QzjjIpR5hpOjJtGGoA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <!-- https://katex.org/docs/browser -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
+  <!-- https://cdnjs.com/libraries/prism -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css" integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />`;
 
 export class MarkdownToHtml {
     private _exportContainer: HTMLDivElement | null = null;
@@ -148,27 +168,34 @@ export class MarkdownToHtml {
     }
 
     /**
-     * Get HTML with style
+     * Get HTML with style.
      *
-     * @param {*} options Document options
+     * @param options Document options.
+     * @param options.title Document `<title>`.
+     * @param options.extraCSS Extra CSS appended after the base stylesheets.
+     * @param options.inlineStyles Inline the core stylesheets so the output is
+     * self-contained and renders offline (default `true`); pass `false` to fall
+     * back to CDN `<link>` tags.
      */
-    async generate(options: { title?: string; extraCSS?: string } = {}) {
+    async generate(
+        options: { title?: string; extraCSS?: string; inlineStyles?: boolean } = {},
+    ) {
         const html = await this.renderHtml();
 
         // `extraCSS` may changed in the mean time.
-        const { title = '', extraCSS = '' } = options;
+        const { title = '', extraCSS = '', inlineStyles = true } = options;
+
+        const baseStyles = inlineStyles
+            ? BASE_STYLESHEETS.map(css => `  <style>${css}</style>`).join('\n')
+            : CDN_STYLESHEET_LINKS;
+
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${sanitize(title, EXPORT_DOMPURIFY_CONFIG, true)}</title>
-  <!-- https://cdnjs.com/libraries/github-markdown-css -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown-light.css" integrity="sha512-n5zPz6LZB0QV1eraRj4OOxRbsV7a12eAGfFcrJ4bBFxxAwwYDp542z5M0w24tKPEhKk2QzjjIpR5hpOjJtGGoA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <!-- https://katex.org/docs/browser -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
-  <!-- https://cdnjs.com/libraries/prism -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css" integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+${baseStyles}
   <style>${exportStyle}</style>
   <style>${extraCSS}</style>
 </head>

--- a/packages/muya/vite.config.ts
+++ b/packages/muya/vite.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
         },
     },
     test: {
+        // Process CSS imports (including `?inline`) so the export path's
+        // inlined base stylesheets resolve to real content under Vitest.
+        // Without this Vitest defaults to `css: { include: [] }` and every
+        // CSS import returns an empty string, which would silently mask the
+        // PG7 offline-export regression in `parityExportHtml.spec.ts`.
+        css: true,
         coverage: {
             include: ['src/**/*.ts'],
             reporter: ['html', 'text', 'json'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       fuse.js:
         specifier: ^7.3.0
         version: 7.3.0
+      github-markdown-css:
+        specifier: ^5.9.0
+        version: 5.9.0
       html-tags:
         specifier: ^5.1.0
         version: 5.1.0


### PR DESCRIPTION
Follow-up to #4406 (`@muyajs/core` migration), closing two export-fidelity parity gaps tracked on the #4407 scoreboard. Engine-only (`packages/muya`); no desktop changes.

## PG7 — inline export CSS (offline-safe output)
`MarkdownToHtml.generate` linked github-markdown-css, katex, and prism from external CDNs via `<link>` tags, so a saved standalone `.html` (and any offline / CSP-restricted / air-gapped viewer) rendered unstyled. The legacy muyajs `ExportHtml` inlined those three core stylesheets as `<style>` blocks.

- Inline the three base stylesheets by default (`?inline` imports), matching legacy behavior.
- Keep the CDN shell behind an opt-in `generate({ inlineStyles: false })` for callers that want a lighter document.
- Add `github-markdown-css` to muya deps (katex / prismjs already present).
- Enable Vitest CSS processing (`css: true`) so `?inline` imports resolve to real content under test — without it Vitest stubs every CSS import to an empty string and silently masks this regression.

## PG8 — heading ids for live TOC anchors
`@muyajs/core` rendered exported headings via stock marked with no `id`, so in-document `[TOC]` / `getHtmlToc` `<a href="#slug">` anchors pointed at nonexistent targets (dead TOC links in exported HTML/PDF).

- Inject a github-compatible slug `id` (reusing the engine's existing `generateGithubSlug`) onto every `h1..h6` in the export DOM, deduplicating collisions with a `-N` suffix.
- Scoped to `MarkdownToHtml`'s export path only — `renderToStaticHTML` (the CommonMark/GFM conformance renderer) is untouched, so spec conformance output does not change.

## Tests
Flips the four `parityExportHtml.spec.ts` markers (`it.fails` → `it`) for PG7 (×2) + PG8 (×2). Verified locally:

- `lint` — 0 errors
- `lint:types` — pass
- `check-circular` — no circular deps
- `test` — 516 passed, 16 expected-fail (other gaps), 0 unexpected
- `test:spec` — 1347 passed (conformance **unchanged**)
- `build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)