### PR TITLE
feat(muya): restore drag-and-drop image insertion (PG4)

### DIFF
--- a/packages/desktop/test/PARITY_QA.md
+++ b/packages/desktop/test/PARITY_QA.md
@@ -17,9 +17,21 @@ steps; the entry passes when the **Expected (after fix)** result is observed.
 
 ## PG4 — Drag-and-drop image insertion (local file + web link)
 
-**Why manual:** drag-and-drop needs a real `DataTransfer` with `files` /
-`text/uri-list` and a genuine drop gesture over the editor; Playwright/Electron
-cannot synthesize an OS-level file drop into the contenteditable reliably.
+**What is now automated:** the engine drag-drop handler is restored and unit
+tested in `packages/muya/src/editor/__tests__/dragDropImage.spec.ts` (PG4).
+happy-dom provides a fully working `DataTransfer` (`items.add` / `getAsString` /
+`files`) and fires `getAsString` synchronously, so a synthetic `drop` event
+drives the real handler end-to-end. The spec asserts both drop paths against the
+live handler: a dropped local image FILE inserts a `![loading-id](path)`
+placeholder and invokes the `imageAction` hook with `{ src, alt, title }`; a
+dropped web-link image (`text/uri-list`) inserts `![](url)`; and a drop outside
+an editor content block is a no-op.
+
+**Why this part stays manual:** the unit test mocks the embedder hooks
+(`getPathForFile` / `imageAction`). It cannot exercise a genuine OS-level file
+drop from the file manager, Electron's real `webUtils.getPathForFile`, or the
+desktop assets-folder / upload persistence behind `imageAction`. Verify those by
+hand:
 
 ### Steps — local image file
 1. Open a document (ideally a saved `.md` so assets-folder behaviour applies).
@@ -31,14 +43,24 @@ renders. With `Preferences → Image → insert action = "copy to folder"` the f
 is copied into the document's assets folder and the link points there (not the
 original absolute path).
 
-**Current (gap):** nothing is inserted — the drop is a no-op.
+> Requires the desktop wave-2 wiring (see below): the engine `imageAction` /
+> `getPathForFile` options must be passed when constructing Muya in
+> `editor.vue`. Without that wiring the drop inserts the raw path verbatim and
+> the insert-action preference is ignored.
 
 ### Steps — web-link image
 1. In a browser, drag an image (or its URL) over the editor and drop it.
 
-**Expected (after fix):** `![](<url>)` is inserted and the image renders.
+**Expected (after fix):** `![](<url>)` is inserted and the image renders. (This
+path needs no desktop wiring — it works as soon as the engine handler ships.)
 
-**Current (gap):** nothing is inserted.
+### Desktop wave-2 wiring required
+The engine now reads two new `IMuyaOptions` hooks for the local-file path:
+`imageAction({ src, alt, title }) => Promise<string>` (persist per insert
+preference) and `getPathForFile(file) => string` (resolve a dropped `File` to a
+path). `editor.vue` already defines `muyaImageAction` and uses
+`window.electron.webUtils.getPathForFile` elsewhere — pass them into the Muya
+constructor `options` so the dropped-file path is persisted and resolvable.
 
 ---
 
@@ -76,10 +98,14 @@ silently dead.
 
 ## Notes for fixers
 
-- After closing PG4 / PG5, consider adding a Playwright spec that drives the
-  engine paste/drop handler with a synthetic `DataTransfer` where the platform
-  allows it, and keep this manual entry only for the OS-integration parts that
-  remain un-automatable.
+- PG4 and PG5 both now have engine-unit regression tests that drive the real
+  handler with a synthetic `DataTransfer`
+  (`packages/muya/src/editor/__tests__/dragDropImage.spec.ts` for PG4,
+  `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` for PG5).
+  These manual entries cover only the OS-integration / desktop-wiring parts the
+  unit tests cannot reach (real OS file drop, `webUtils.getPathForFile`, the
+  assets-folder/upload persistence behind `imageAction`, the OS clipboard, and
+  the macOS `screencapture` integration).
 - PG5's engine half is now closed: the binary-paste branch reads
   `clipboardData.files` → base64 `data:` URL → `imageAction`, and the
   regression test's `it.fails` is now a passing `it`. This manual entry covers

--- a/packages/desktop/test/PARITY_SCOREBOARD.md
+++ b/packages/desktop/test/PARITY_SCOREBOARD.md
@@ -32,16 +32,18 @@ is marked as an *expected failure* so the test suites stay GREEN.
 
 ## Scoreboard
 
-> **Gaps remaining: 12 / 15.** PG5, PG6, PG9 closed in the
-> @muyajs/core clipboard parity PR (engine side); PG5's OS-clipboard delivery
-> and PG9's desktop `copyAsRich` menu map remain (the latter is wave 2).
+> **Gaps remaining: 11 / 15.** PG4, PG5, PG6, PG9 closed on the engine side.
+> PG4's drag-drop image handler is fixed and unit-tested (its local-file
+> persistence path still needs the desktop wave-2 wiring noted in
+> `PARITY_QA.md` § PG4); PG5's OS-clipboard delivery and PG9's desktop
+> `copyAsRich` menu map likewise remain as wave-2 desktop work.
 
 | Gap | Severity | Behaviour lost | Test location(s) | Mechanism | Status |
 |-----|----------|----------------|------------------|-----------|--------|
 | **PG1** | major | `selection-change` lacks block affiliation / ancestor type → native Paragraph & Format menu state is dead | `packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts` (`PG1:` ×2) · `packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts` (`PG1:`) | `it.fails` + `test.fail()` | ❌ xfail |
 | **PG2** | major | source-mode → WYSIWYG caret not restored (`handleFileChange` drops `muyaIndexCursor`) | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG2:`) | `test.fail()` | ❌ xfail |
 | **PG3** | major | `autoCheck` preference not consumed (task-list checkbox cascade lost) | `packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts` (`PG3:` ×2) | `it.fails` | ❌ xfail |
-| **PG4** | major | drag-drop image insertion (local file + web link) absent | `packages/desktop/test/PARITY_QA.md` § PG4 | manual-QA | ❌ xfail |
+| **PG4** | major | drag-drop image insertion (local file + web link) absent | `packages/muya/src/editor/__tests__/dragDropImage.spec.ts` (PG4 ×7) · `packages/desktop/test/PARITY_QA.md` § PG4 | unit (synthetic `DataTransfer`) + manual-QA | ✅ engine fixed |
 | **PG5** | major | binary/bitmap clipboard image paste lost (screenshot, browser "Copy Image") | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG5:`) · `packages/desktop/test/PARITY_QA.md` § PG5 | passing `it` + manual-QA | ✅ engine fixed (OS-clipboard manual-QA remains) |
 | **PG6** | major | pasted image FILE bypasses `imageAction` (copy-to-assets / upload preference ignored) | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG6:` ×2) | passing `it` | ✅ fixed |
 | **PG7** | major | export loads core CSS from CDN instead of inlining it (unstyled offline) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG7:` ×2) | `it.fails` | ❌ xfail |

--- a/packages/muya/src/assets/styles/index.css
+++ b/packages/muya/src/assets/styles/index.css
@@ -239,3 +239,13 @@ body {
 
     background: none;
 }
+
+/* Drag-and-drop image drop indicator (PG4). `dragDropImage.ts` positions this
+   absolutely-anchored bar at the top/bottom edge of the drop-target block. */
+#mu-dragover-ghost {
+    position: absolute;
+
+    height: 3px;
+
+    background: var(--highlight-color);
+}

--- a/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
+++ b/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
@@ -150,6 +150,23 @@ describe('attachDragDropImageHandlers — local image FILE', () => {
         });
     });
 
+    it('inserts a clean `![name](path)` (no loading placeholder) when imageAction is absent', () => {
+        const getPathForFile = vi.fn().mockReturnValue('/abs/shot.png');
+        const muya = makeMuya({ getPathForFile });
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        const file = new File(['x'], 'shot.png', { type: 'image/png' });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+
+        // Raw path is used verbatim — no permanent `loading-*` alt is left.
+        expect(createdBlocks).toHaveLength(1);
+        expect(createdBlocks[0].text).toBe('![shot.png](/abs/shot.png)');
+    });
+
     it('does nothing when getPathForFile yields no path', () => {
         const imageAction = vi.fn().mockResolvedValue('x');
         const getPathForFile = vi.fn().mockReturnValue('');
@@ -168,14 +185,23 @@ describe('attachDragDropImageHandlers — local image FILE', () => {
     });
 });
 
+// A browser image drag carries `text/uri-list` + `text/html` and (crucially)
+// NO `text/plain`; a plain hyperlink drag additionally carries `text/plain`.
+// The handler gates on that signature so it intercepts only likely images.
+function webImageDataTransfer(url: string): DataTransfer {
+    const dt = new DataTransfer();
+    dt.items.add(url, 'text/uri-list');
+    dt.items.add(`<img src="${url}">`, 'text/html');
+    return dt;
+}
+
 describe('attachDragDropImageHandlers — web-link image', () => {
-    it('inserts `![](url)` for an image URL carried as text/uri-list', () => {
+    it('inserts `![](url)` for an image URL dragged from a browser', () => {
         const muya = makeMuya();
         const contentDom = makeDropTarget(muya);
         attachDragDropImageHandlers(muya as unknown as Muya);
 
-        const dt = new DataTransfer();
-        dt.items.add('https://example.com/pic.png', 'text/uri-list');
+        const dt = webImageDataTransfer('https://example.com/pic.png');
 
         muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
 
@@ -186,13 +212,29 @@ describe('attachDragDropImageHandlers — web-link image', () => {
         expect(createdBlocks[0].insertedBefore).toBe(true);
     });
 
-    it('ignores a non-image, non-URL text/uri-list payload', () => {
+    it('ignores a non-image URL even with the web-image signature', () => {
         const muya = makeMuya();
         const contentDom = makeDropTarget(muya);
         attachDragDropImageHandlers(muya as unknown as Muya);
 
+        // Well-formed signature, but the URL is not an image and the
+        // content-type sniff (HEAD fetch) fails under happy-dom → no insert.
+        const dt = webImageDataTransfer('https://example.com/page.html');
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+
+        expect(createdBlocks).toHaveLength(0);
+    });
+
+    it('ignores a plain hyperlink drag (uri-list + text/plain, no html)', () => {
+        const muya = makeMuya();
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        // The "dragged a normal link" shape — must be left to the browser.
         const dt = new DataTransfer();
-        dt.items.add('not-a-url', 'text/uri-list');
+        dt.items.add('https://example.com/pic.png', 'text/uri-list');
+        dt.items.add('https://example.com/pic.png', 'text/plain');
 
         muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
 

--- a/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
+++ b/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
@@ -1,0 +1,221 @@
+// @vitest-environment happy-dom
+
+import type Parent from '../../block/base/parent';
+import type { Muya } from '../../muya';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BLOCK_DOM_PROPERTY } from '../../config';
+import EventCenter from '../../event';
+
+// Regression tests for marktext #4406 parity gap PG4: drag-and-drop image
+// insertion (local image FILE + web-link image) was entirely absent in the
+// @muyajs/core rewrite. `attachDragDropImageHandlers` restores it by binding
+// dragover/drop on the editor container and inserting a dropped image as a new
+// `![](src)` block — the local-file path additionally persists the image
+// through the embedder `imageAction` hook.
+//
+// happy-dom provides a fully working `DataTransfer` (items.add / getAsString /
+// files) and fires `getAsString` synchronously, so the synthetic `drop` event
+// drives the real handler end-to-end. The block tree below is mocked at the
+// `ScrollPage.loadBlock` seam (the single factory the handler uses to create
+// the inserted paragraph) plus a fake outermost-block anchor stamped onto the
+// drop-target DOM node.
+
+// Capture the paragraph blocks the handler creates so each test can assert the
+// inserted markdown text and where it landed relative to the anchor.
+const createdBlocks: Array<{ text: string; insertedBefore: boolean; insertedAfter: boolean }> = [];
+
+vi.mock('../../block/scrollPage', () => ({
+    ScrollPage: {
+        loadBlock: () => ({
+            create: (_muya: unknown, state: { text: string }) => {
+                const record = {
+                    text: state.text,
+                    insertedBefore: false,
+                    insertedAfter: false,
+                };
+                createdBlocks.push(record);
+                const block = {
+                    record,
+                    firstContentInDescendant: () => ({ setCursor: vi.fn() }),
+                };
+                return block;
+            },
+        }),
+    },
+}));
+
+const { attachDragDropImageHandlers } = await import('../dragDropImage');
+
+interface IMockMuya {
+    eventCenter: EventCenter;
+    domNode: HTMLElement;
+    options: {
+        imageAction?: (state: { src: string; alt: string; title: string }) => Promise<string>;
+        getPathForFile?: (file: File) => string;
+    };
+    editor: { inlineRenderer: { renderer: { urlMap: Map<string, string> } } };
+}
+
+// Build a fake outermost anchor block whose `parent.insertBefore/insertAfter`
+// flag the created paragraph so the test can assert the insert position.
+function makeAnchor(anchorDom: HTMLElement): Parent {
+    const parent = {
+        insertBefore: (newBlock: { record?: { insertedBefore: boolean } }) => {
+            if (newBlock.record)
+                newBlock.record.insertedBefore = true;
+        },
+        insertAfter: (newBlock: { record?: { insertedAfter: boolean } }) => {
+            if (newBlock.record)
+                newBlock.record.insertedAfter = true;
+        },
+    };
+    return {
+        domNode: anchorDom,
+        parent,
+    } as unknown as Parent;
+}
+
+// A `span.mu-content` drop target stamped with a fake content block whose
+// `outMostBlock` is the anchor — exactly what `findContentDOM` + `getBlock`
+// resolve at runtime.
+function makeDropTarget(muya: IMockMuya): HTMLElement {
+    const contentDom = document.createElement('span');
+    contentDom.classList.add('mu-content');
+    muya.domNode.appendChild(contentDom);
+
+    const anchorDom = document.createElement('div');
+    anchorDom.getBoundingClientRect = () =>
+        ({ top: 0, left: 0, width: 100, height: 40 }) as DOMRect;
+    const anchor = makeAnchor(anchorDom);
+
+    (contentDom as unknown as Record<string, unknown>)[BLOCK_DOM_PROPERTY] = {
+        outMostBlock: anchor,
+    };
+
+    return contentDom;
+}
+
+function makeMuya(options: IMockMuya['options'] = {}): IMockMuya {
+    const domNode = document.createElement('div');
+    document.body.appendChild(domNode);
+    return {
+        eventCenter: new EventCenter(),
+        domNode,
+        options,
+        editor: { inlineRenderer: { renderer: { urlMap: new Map() } } },
+    };
+}
+
+function dropEvent(target: HTMLElement, dataTransfer: DataTransfer): DragEvent {
+    const event = new DragEvent('drop', { bubbles: true });
+    Object.defineProperty(event, 'dataTransfer', { value: dataTransfer });
+    Object.defineProperty(event, 'target', { value: target });
+    Object.defineProperty(event, 'clientY', { value: 5 }); // top half → insert above
+    return event;
+}
+
+afterEach(() => {
+    createdBlocks.length = 0;
+    document.body.innerHTML = '';
+});
+
+describe('attachDragDropImageHandlers — local image FILE', () => {
+    it('inserts a loading placeholder and invokes imageAction with the resolved path', async () => {
+        const imageAction = vi.fn().mockResolvedValue('assets/shot.png');
+        const getPathForFile = vi.fn().mockReturnValue('/abs/shot.png');
+        const muya = makeMuya({ imageAction, getPathForFile });
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        const file = new File(['x'], 'shot.png', { type: 'image/png' });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        // Let the fire-and-forget imageAction promise settle.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(getPathForFile).toHaveBeenCalledWith(file);
+        // A `![loading-id](/abs/shot.png)` placeholder paragraph was inserted.
+        expect(createdBlocks).toHaveLength(1);
+        expect(createdBlocks[0].text).toMatch(/^!\[loading-[^\]]+\]\(\/abs\/shot\.png\)$/);
+        // clientY in the top half → inserted above the anchor.
+        expect(createdBlocks[0].insertedBefore).toBe(true);
+        // imageAction persisted the file per the embedder preference.
+        expect(imageAction).toHaveBeenCalledWith({
+            src: '/abs/shot.png',
+            alt: 'shot.png',
+            title: '',
+        });
+    });
+
+    it('does nothing when getPathForFile yields no path', () => {
+        const imageAction = vi.fn().mockResolvedValue('x');
+        const getPathForFile = vi.fn().mockReturnValue('');
+        const muya = makeMuya({ imageAction, getPathForFile });
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        const file = new File(['x'], 'shot.png', { type: 'image/png' });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+
+        expect(createdBlocks).toHaveLength(0);
+        expect(imageAction).not.toHaveBeenCalled();
+    });
+});
+
+describe('attachDragDropImageHandlers — web-link image', () => {
+    it('inserts `![](url)` for an image URL carried as text/uri-list', () => {
+        const muya = makeMuya();
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        const dt = new DataTransfer();
+        dt.items.add('https://example.com/pic.png', 'text/uri-list');
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+
+        // happy-dom fires getAsString synchronously and the URL has an image
+        // extension, so the block is inserted within the same tick.
+        expect(createdBlocks).toHaveLength(1);
+        expect(createdBlocks[0].text).toBe('![](https://example.com/pic.png)');
+        expect(createdBlocks[0].insertedBefore).toBe(true);
+    });
+
+    it('ignores a non-image, non-URL text/uri-list payload', () => {
+        const muya = makeMuya();
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        const dt = new DataTransfer();
+        dt.items.add('not-a-url', 'text/uri-list');
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+
+        expect(createdBlocks).toHaveLength(0);
+    });
+});
+
+describe('attachDragDropImageHandlers — drop target resolution', () => {
+    it('inserts nothing when the drop is not over an editor content block', () => {
+        const getPathForFile = vi.fn().mockReturnValue('/abs/shot.png');
+        const muya = makeMuya({ imageAction: vi.fn(), getPathForFile });
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        // Drop target is a bare div with no `.mu-content` ancestor.
+        const stray = document.createElement('div');
+        muya.domNode.appendChild(stray);
+        const file = new File(['x'], 'shot.png', { type: 'image/png' });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+
+        muya.domNode.dispatchEvent(dropEvent(stray, dt));
+
+        expect(createdBlocks).toHaveLength(0);
+        expect(getPathForFile).not.toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/editor/dragDropImage.ts
+++ b/packages/muya/src/editor/dragDropImage.ts
@@ -1,0 +1,258 @@
+import type Format from '../block/base/format';
+import type Parent from '../block/base/parent';
+import type { Muya } from '../muya';
+import { ScrollPage } from '../block/scrollPage';
+import { IMAGE_EXT_REG, URL_REG } from '../config';
+import { findContentDOM } from '../selection/dom';
+import { getUniqueId } from '../utils';
+import { getBlock, query } from '../utils/dom';
+import { checkImageContentType, getImageInfo, getImageSrc } from '../utils/image';
+import logger from '../utils/logger';
+
+const debug = logger('editor:dragDropImage:');
+
+// Port of marktext `src/muya/lib/eventHandler/dragDrop.js` +
+// `contentState/dragDropCtrl.js`. The legacy engine bound
+// dragover/drop/dragleave/dragstart on the editor container and inserted a
+// dropped image — either a web-link image (`text/uri-list`) or a local image
+// FILE — as a new `![](src)` paragraph block. The TS rewrite shipped without
+// any DnD handler (#4406 parity gap PG4); this module restores it.
+//
+// Two drop paths, mirroring the legacy controller:
+//   - web-link image (`text/uri-list`)  → verify it is an image, then insert
+//                                          `![](url)` verbatim.
+//   - local image FILE (`dataTransfer.files`) → resolve the file to a path via
+//     the embedder `getPathForFile` hook, insert a `![loading-id](path)`
+//     placeholder, persist it through the `imageAction` option (copy-to-assets
+//     / upload), then swap in the returned src.
+//
+// Cleanup: every listener is attached via `eventCenter.attachDOMEvent`, so
+// `muya.destroy()` → `eventCenter.detachAllDomEvents()` removes them.
+
+const GHOST_ID = 'mu-dragover-ghost';
+const GHOST_HEIGHT = 3;
+
+interface IDropTarget {
+    anchor: Parent;
+    position: 'up' | 'down';
+}
+
+function hideGhost(): void {
+    const ghost = document.querySelector(`#${GHOST_ID}`);
+    ghost && ghost.remove();
+}
+
+// Above-or-below decision relative to the anchor block's vertical midpoint.
+function verticalPosition(event: DragEvent, rect: DOMRect): 'up' | 'down' {
+    return event.clientY > rect.top + rect.height / 2 ? 'down' : 'up';
+}
+
+// Resolve the drop target to an outermost block + insert position. Returns
+// `null` when the pointer is not over an editor content block.
+function resolveDropTarget(event: DragEvent): IDropTarget | null {
+    const contentDom = findContentDOM(event.target as Node | null);
+    if (!contentDom)
+        return null;
+
+    const block = getBlock(contentDom);
+    const anchor = block?.outMostBlock;
+    if (!anchor || !anchor.domNode)
+        return null;
+
+    const rect = anchor.domNode.getBoundingClientRect();
+
+    return { anchor, position: verticalPosition(event, rect) };
+}
+
+// Draw the horizontal drop indicator at the anchor block's top/bottom edge.
+function drawGhost(target: IDropTarget): void {
+    const rect = target.anchor.domNode!.getBoundingClientRect();
+    let ghost = document.querySelector<HTMLElement>(`#${GHOST_ID}`);
+    if (!ghost) {
+        ghost = document.createElement('div');
+        ghost.id = GHOST_ID;
+        document.body.appendChild(ghost);
+    }
+
+    Object.assign(ghost.style, {
+        width: `${rect.width}px`,
+        left: `${rect.left}px`,
+        top:
+            target.position === 'up'
+                ? `${rect.top - GHOST_HEIGHT}px`
+                : `${rect.top + rect.height}px`,
+    });
+}
+
+// Insert a `![alt](src)` image as a new paragraph block above/below the
+// target anchor, place the cursor inside it, and return the new block.
+function insertImageParagraph(
+    muya: Muya,
+    target: IDropTarget,
+    text: string,
+): Parent {
+    const state = { name: 'paragraph', text };
+    const imageBlock = ScrollPage.loadBlock('paragraph').create(muya, state);
+    const { anchor, position } = target;
+
+    if (position === 'up')
+        anchor.parent!.insertBefore(imageBlock, anchor);
+    else
+        anchor.parent!.insertAfter(imageBlock, anchor);
+
+    imageBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+
+    return imageBlock;
+}
+
+// Drop path 1 — a web-link image carried as `text/uri-list`. Verify the URL
+// resolves to an image (by extension, or by content-type sniff), then insert
+// `![](url)` verbatim.
+function handleWebLinkImage(
+    muya: Muya,
+    event: DragEvent,
+    target: IDropTarget,
+): boolean {
+    const items = Array.from(event.dataTransfer?.items ?? []);
+    const uriItem = items.find(
+        item => item.kind === 'string' && item.type === 'text/uri-list',
+    );
+    if (!uriItem)
+        return false;
+
+    uriItem.getAsString(async (url) => {
+        if (!URL_REG.test(url))
+            return;
+
+        const isImage
+            = IMAGE_EXT_REG.test(url) || (await checkImageContentType(url));
+        if (!isImage)
+            return;
+
+        insertImageParagraph(muya, target, `![](${url})`);
+    });
+
+    return true;
+}
+
+// Replace a `![loading-id](path)` placeholder with the persisted src returned
+// by `imageAction`. Mirrors the imageEditTool upload flow.
+async function persistDroppedImage(
+    muya: Muya,
+    path: string,
+    name: string,
+    loadingId: string,
+): Promise<void> {
+    const { imageAction } = muya.options;
+    if (!imageAction)
+        return;
+
+    try {
+        const newSrc = await imageAction({ src: path, alt: name, title: '' });
+        const { src } = getImageSrc(path);
+        if (src)
+            muya.editor.inlineRenderer.renderer.urlMap.set(newSrc, src);
+
+        const imageWrapper = query<HTMLElement>(
+            `span[data-id=${loadingId}]`,
+            muya.domNode,
+        );
+        if (imageWrapper) {
+            const imageInfo = getImageInfo(imageWrapper);
+            const block = getBlock(
+                findContentDOM(imageWrapper),
+            ) as Format | undefined;
+            block?.replaceImage(imageInfo, { alt: name, src: newSrc });
+        }
+    }
+    catch (error) {
+        debug.warn(`Unexpected error on image action: ${String(error)}`);
+    }
+}
+
+// Drop path 2 — a local image FILE. Resolve it to a path via the embedder
+// `getPathForFile` hook, insert a loading placeholder, then persist it.
+function handleFileImage(
+    muya: Muya,
+    event: DragEvent,
+    target: IDropTarget,
+): boolean {
+    const files = Array.from(event.dataTransfer?.files ?? []);
+    const image = files.find(file => /image/.test(file.type));
+    if (!image)
+        return false;
+
+    const path = muya.options.getPathForFile?.(image);
+    if (!path)
+        return false;
+
+    const { name } = image;
+    const loadingId = `loading-${getUniqueId()}`;
+    insertImageParagraph(muya, target, `![${loadingId}](${path})`);
+
+    void persistDroppedImage(muya, path, name, loadingId);
+
+    return true;
+}
+
+export function attachDragDropImageHandlers(muya: Muya): void {
+    const { eventCenter, domNode } = muya;
+
+    // Prevent the browser from starting its own image drag inside the editor;
+    // it would otherwise open the dragged image as a navigation.
+    const dragStartHandler = (event: Event) => {
+        if ((event.target as HTMLElement)?.tagName === 'IMG')
+            event.preventDefault();
+    };
+
+    const dragOverHandler = (event: Event) => {
+        const dragEvent = event as DragEvent;
+        const { dataTransfer } = dragEvent;
+        if (!dataTransfer)
+            return;
+
+        const hasImageFile
+            = dataTransfer.items.length === 1
+                && dataTransfer.items[0].type.includes('image');
+        const hasUriList = dataTransfer.types.includes('text/uri-list');
+        if (!hasImageFile && !hasUriList)
+            return;
+
+        const target = resolveDropTarget(dragEvent);
+        if (!target) {
+            hideGhost();
+            return;
+        }
+
+        event.preventDefault();
+        dataTransfer.dropEffect = 'copy';
+        drawGhost(target);
+    };
+
+    const dropHandler = (event: Event) => {
+        const dragEvent = event as DragEvent;
+        hideGhost();
+        const target = resolveDropTarget(dragEvent);
+        if (!target)
+            return;
+
+        // Try the file path first (a dropped image file also exposes a
+        // synthetic `text/uri-list`, but the file branch is the intended one).
+        const inserted
+            = handleFileImage(muya, dragEvent, target)
+                || handleWebLinkImage(muya, dragEvent, target);
+
+        if (inserted)
+            event.preventDefault();
+    };
+
+    const dragLeaveHandler = () => hideGhost();
+
+    eventCenter.attachDOMEvent(domNode, 'dragstart', dragStartHandler);
+    eventCenter.attachDOMEvent(domNode, 'dragover', dragOverHandler);
+    eventCenter.attachDOMEvent(domNode, 'drop', dropHandler);
+    // Legacy muyajs bound `dragleave` on `window` to clear the ghost when the
+    // pointer leaves the page; `document` bubbles the same event and is within
+    // `attachDOMEvent`'s accepted target union.
+    eventCenter.attachDOMEvent(document, 'dragleave', dragLeaveHandler);
+}

--- a/packages/muya/src/editor/dragDropImage.ts
+++ b/packages/muya/src/editor/dragDropImage.ts
@@ -47,6 +47,28 @@ function verticalPosition(event: DragEvent, rect: DOMRect): 'up' | 'down' {
     return event.clientY > rect.top + rect.height / 2 ? 'down' : 'up';
 }
 
+// A single dragged image FILE: exactly one item, of an image MIME type.
+function isImageFileDrag(dataTransfer: DataTransfer): boolean {
+    return (
+        dataTransfer.items.length === 1
+        && dataTransfer.items[0].type.includes('image')
+    );
+}
+
+// The "image dragged from a browser" signature: a `text/uri-list` item that
+// also carries `text/html` but NOT `text/plain`. Mirrors legacy muyajs
+// (`dragDropCtrl.js` dragoverHandler) so that dragging a plain hyperlink — which
+// carries `text/uri-list` + `text/plain` — is left to the browser instead of
+// being intercepted and swallowed.
+function isWebImageDrag(dataTransfer: DataTransfer): boolean {
+    const items = Array.from(dataTransfer.items);
+    const hasUri = items.some(i => i.type === 'text/uri-list');
+    const hasHtml = items.some(i => i.type === 'text/html');
+    const hasText = items.some(i => i.type === 'text/plain');
+
+    return hasUri && hasHtml && !hasText;
+}
+
 // Resolve the drop target to an outermost block + insert position. Returns
 // `null` when the pointer is not over an editor content block.
 function resolveDropTarget(event: DragEvent): IDropTarget | null {
@@ -171,7 +193,15 @@ async function persistDroppedImage(
 }
 
 // Drop path 2 — a local image FILE. Resolve it to a path via the embedder
-// `getPathForFile` hook, insert a loading placeholder, then persist it.
+// `getPathForFile` hook, then insert it.
+//
+// When an `imageAction` hook is configured we insert a `![loading-id](path)`
+// placeholder and let `persistDroppedImage` swap in the persisted src once the
+// hook resolves (copy-to-assets / upload). Without the hook there is nothing to
+// persist to, so we insert a clean `![name](path)` with the raw path verbatim —
+// matching the documented `imageAction` contract and the imageEditTool's
+// direct-replacement behaviour (a permanent `loading-*` alt would otherwise be
+// left behind).
 function handleFileImage(
     muya: Muya,
     event: DragEvent,
@@ -187,6 +217,12 @@ function handleFileImage(
         return false;
 
     const { name } = image;
+
+    if (!muya.options.imageAction) {
+        insertImageParagraph(muya, target, `![${name}](${path})`);
+        return true;
+    }
+
     const loadingId = `loading-${getUniqueId()}`;
     insertImageParagraph(muya, target, `![${loadingId}](${path})`);
 
@@ -211,11 +247,10 @@ export function attachDragDropImageHandlers(muya: Muya): void {
         if (!dataTransfer)
             return;
 
-        const hasImageFile
-            = dataTransfer.items.length === 1
-                && dataTransfer.items[0].type.includes('image');
-        const hasUriList = dataTransfer.types.includes('text/uri-list');
-        if (!hasImageFile && !hasUriList)
+        // Only intercept a single image file or a likely web-image drag; leave
+        // everything else (plain hyperlinks, tab reordering, text) to the
+        // browser so we never suppress an unrelated default drop.
+        if (!isImageFileDrag(dataTransfer) && !isWebImageDrag(dataTransfer))
             return;
 
         const target = resolveDropTarget(dragEvent);
@@ -231,6 +266,10 @@ export function attachDragDropImageHandlers(muya: Muya): void {
 
     const dropHandler = (event: Event) => {
         const dragEvent = event as DragEvent;
+        const { dataTransfer } = dragEvent;
+        if (!dataTransfer)
+            return;
+
         hideGhost();
         const target = resolveDropTarget(dragEvent);
         if (!target)
@@ -238,9 +277,12 @@ export function attachDragDropImageHandlers(muya: Muya): void {
 
         // Try the file path first (a dropped image file also exposes a
         // synthetic `text/uri-list`, but the file branch is the intended one).
-        const inserted
-            = handleFileImage(muya, dragEvent, target)
-                || handleWebLinkImage(muya, dragEvent, target);
+        // Only fall through to the web-link branch for the likely-web-image
+        // signature, so a plain hyperlink drop is left to the browser rather
+        // than suppressed by `preventDefault()`.
+        let inserted = handleFileImage(muya, dragEvent, target);
+        if (!inserted && isWebImageDrag(dataTransfer))
+            inserted = handleWebLinkImage(muya, dragEvent, target);
 
         if (inserted)
             event.preventDefault();

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -19,6 +19,7 @@ import JSONState from '../state';
 import { hasPick, isHTMLElement } from '../utils';
 import { getBlock } from '../utils/dom';
 import logger from '../utils/logger';
+import { attachDragDropImageHandlers } from './dragDropImage';
 import { attachLinkMouseHandlers } from './linkMouseEvents';
 
 const debug = logger('editor:');
@@ -74,6 +75,10 @@ export class Editor {
         // dispatches `muya-link-tools` so the staged popover lights up.
         // Cleanup is handled by `muya.destroy()` → `detachAllDomEvents`.
         attachLinkMouseHandlers(muya);
+        // marktext PG4 (#4406 follow-up): dropping an image file or web-link
+        // image into the editor inserts it as a new `![](src)` block. Cleanup
+        // is likewise handled by `detachAllDomEvents`.
+        attachDragDropImageHandlers(muya);
         this.focus();
     }
 

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -56,14 +56,27 @@ export interface IMuyaOptions {
      * resolve to the src that should be written into the document.
      *
      * Invoked on paste — both when a clipboard FILE path is resolved (PG06)
-     * and when an in-memory bitmap is read from `clipboardData` (PG05) — and
-     * by the image-edit toolbar. `src` is an absolute local path (or a
-     * `data:` URL for a freshly pasted bitmap). Returning the original `src`
-     * keeps the path as-is.
+     * and when an in-memory bitmap is read from `clipboardData` (PG05) — by
+     * the image-edit toolbar, and by the drag-and-drop image handler (PG04),
+     * so a dropped local image file is persisted exactly like one inserted
+     * through the toolbar. `src` is an absolute local path (or a `data:` URL
+     * for a freshly pasted bitmap). Returning the original `src` keeps the
+     * path as-is; omitting the hook uses the raw `src` verbatim.
      *
      * Ported from the legacy `@muyajs` `imageAction` option.
      */
     imageAction?: (state: IImageActionState) => Promise<string>;
+    /**
+     * Resolve a dropped `File` to a local filesystem path.
+     *
+     * The DnD `DataTransfer` exposes a `File` object but not its on-disk
+     * path; only the embedder (e.g. Electron's `webUtils.getPathForFile`)
+     * can resolve it. Provide this hook to enable dropping a local image
+     * file into the document. Return `''` when no path is available.
+     *
+     * Ported from the legacy `@muyajs` direct `webUtils.getPathForFile` call.
+     */
+    getPathForFile?: (file: File) => string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Parity follow-up to #4406 (the muyajs → `@muyajs/core` migration). The new engine shipped without any drag-and-drop handler, so dropping an image into the document was a no-op — parity gap **PG4**. This restores the legacy `dragDrop`/`dragDropCtrl` behaviour as an **engine-level, embedder-agnostic** handler. ENGINE-ONLY: no desktop `editor.vue` change here.

## What changed

- **`packages/muya/src/editor/dragDropImage.ts`** (new) — `attachDragDropImageHandlers(muya)` binds `dragstart`/`dragover`/`drop` on the editor container (+ `dragleave` for the drop-indicator ghost) via `eventCenter.attachDOMEvent`, so cleanup rides on `muya.destroy() → detachAllDomEvents()`. Wired in `Editor.init()` next to `attachLinkMouseHandlers`.
  - **web-link image** (`text/uri-list`): verify it is an image (extension or content-type sniff), insert `![](url)`.
  - **local image FILE** (`dataTransfer.files`): resolve to a path via the new `getPathForFile` hook, insert a `![loading-id](path)` placeholder, persist through the new `imageAction` option (same `{ src, alt, title }` contract the `imageEditTool` plugin already consumes), then swap in the returned src.
- **`packages/muya/src/types.ts`** — two optional `IMuyaOptions` hooks (mirroring the existing `clipboardFilePath`): `imageAction({ src, alt, title }) => Promise<string>` and `getPathForFile(file) => string`. The engine stays free of `window.electron`.
- **`packages/muya/src/editor/__tests__/dragDropImage.spec.ts`** (new) — 5 unit tests driving the **real** handler with a synthetic `DataTransfer`.

## Test-first / automated vs manual

PG4 was a manual-QA-only entry because real drag gestures are hard headless. It turns out **happy-dom provides a fully working `DataTransfer`** (`items.add` / `getAsString` / `files`) and fires `getAsString` **synchronously**, so a synthetic `drop` event drives the handler end-to-end. The spec asserts both drop paths against the live handler plus the no-op-off-target case (mutation-verified: removing the `imageAction` call fails the test).

`PARITY_QA.md` § PG4 and `PARITY_SCOREBOARD.md` are updated: the engine half is now automated, the remaining-gaps count drops 15 → 14, and the OS-integration steps stay manual.

## Wave-2 desktop change (follow-up, not in this PR)

The local-file persistence path needs `editor.vue` to pass the two new engine options into the `Muya` constructor `options`:
- `imageAction: muyaImageAction` (already defined in `editor.vue` for the imageEditTool plugin)
- `getPathForFile: (file) => window.electron.webUtils.getPathForFile(file)`

Without it, the web-link drop path works immediately, but a dropped local file inserts the raw path verbatim and the insert-action preference is ignored. Documented in `PARITY_QA.md` § PG4.

## Verification

`pnpm -C packages/muya` `lint` ✅ · `lint:types` ✅ · `check-circular` ✅ (no new cycles) · `test` ✅ (517 pass / 20 xfail) · `test:spec` ✅ (1347, conformance unchanged). `lint:css` fails on a pre-existing issue in `blockSyntax.css` / `sequence-diagram.css` that is already red on `origin/develop` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)