### PR TITLE
feat(desktop): wire @muyajs/core parity APIs (menu state, copyAsRich, heading-link, source cursor, saved indicator)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -297,38 +297,77 @@ interface SelectionFormatLike {
   [key: string]: unknown
 }
 
-// The engine's `selection-change` payload is keyed by `anchor`/`focus` +
-// `anchorPath`/`focusPath` and carries live block refs. The desktop's
-// application-menu state builder (`createApplicationMenuState`) was written
-// against the legacy `{ start, end, affiliation }` shape, so adapt it. Only
-// `start`/`end` (key + offset + the active content block) are derivable from
-// the new payload; the rich block `affiliation` chain is not surfaced by the
-// engine yet, so it degrades to empty (block-context menu toggles like
-// list/table awareness are a documented gap — format toggles still work via
-// `formats`).
+// Container `blockName` → legacy `functionType`. The engine's affiliation
+// entries carry `blockName` but not the legacy `functionType` the desktop
+// menu-state builder keys off for `pre`/`figure` containers (table detection +
+// Format-menu disable). Re-derive it here so `createApplicationMenuState`'s
+// existing `pre`/`figure` branches fire. The `code$` / `multiplemath` /
+// `frontmatter` / `html` / `table` values match the legacy muyajs vocabulary
+// (`createApplicationMenuState`'s `/frontmatter|html|multiplemath|code$/` test
+// and `=== 'table'` check).
+const CONTAINER_FUNCTION_TYPE: Record<string, string> = {
+  'code-block': 'fencecode',
+  frontmatter: 'frontmatter',
+  table: 'table',
+  'html-block': 'html',
+  'math-block': 'multiplemath'
+}
+
+interface EngineAffiliationEntry {
+  type: string
+  blockName: string
+  listType?: string
+  listItemType?: string
+  isLooseListItem?: boolean
+  [key: string]: unknown
+}
+
+// The engine's `selection-change` payload (since #4410) carries an
+// `affiliation` chain (shared-ancestor paragraph-type blocks, outermost-first)
+// plus per-endpoint `anchorBlockInfo`/`focusBlockInfo` describing the content
+// leaf (`type: 'span'` + `functionType`). The desktop's application-menu state
+// builder (`createApplicationMenuState`) was written against the legacy
+// `{ start, end, affiliation }` shape, so map the new payload onto it:
+//   - `start.type`/`end.type` from the leaf info (`'span'`) so the
+//     `start.type === 'span'` guards fire,
+//   - `start.block.functionType`/`end.block.functionType` from the leaf info so
+//     code-content / table-cell detection lights up,
+//   - `affiliation` straight through (entries already carry `type` +
+//     `listType`/`listItemType`/`isLooseListItem`), surfacing a derived
+//     `functionType` on `pre`/`figure` containers for table / code-fence keys.
 const adaptSelectionChange = (changes: MuyaChange) => {
   const anchorPath = (changes.anchorPath ?? []) as Array<string | number>
   const focusPath = (changes.focusPath ?? anchorPath) as Array<string | number>
-  const anchorBlock = changes.anchorBlock as
-    | { text?: string; functionType?: string }
+  const anchorInfo = changes.anchorBlockInfo as
+    | { type?: string; functionType?: string }
+    | null
     | undefined
-  const focusBlock = changes.focusBlock as
-    | { text?: string; functionType?: string }
+  const focusInfo = changes.focusBlockInfo as
+    | { type?: string; functionType?: string }
+    | null
     | undefined
+  const rawAffiliation = (changes.affiliation ?? []) as EngineAffiliationEntry[]
+  const affiliation = rawAffiliation.map((entry) => {
+    const functionType =
+      entry.type === 'pre' || entry.type === 'figure'
+        ? CONTAINER_FUNCTION_TYPE[entry.blockName]
+        : undefined
+    return functionType ? { ...entry, functionType } : entry
+  })
   return {
     start: {
       key: anchorPath.join('/'),
       offset: (changes.anchor?.offset ?? 0) as number,
-      block: anchorBlock,
-      type: changes.type as string | undefined
+      block: { functionType: anchorInfo?.functionType },
+      type: anchorInfo?.type
     },
     end: {
       key: focusPath.join('/'),
       offset: (changes.focus?.offset ?? 0) as number,
-      block: focusBlock,
-      type: changes.type as string | undefined
+      block: { functionType: focusInfo?.functionType },
+      type: focusInfo?.type
     },
-    affiliation: [] as Array<{ type: string; [key: string]: unknown }>
+    affiliation
   }
 }
 

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1518,9 +1518,12 @@ onMounted(() => {
   }
   container.addEventListener('scroll', scrollHandler, { passive: true })
 
-  // NOTE (gap): the engine does not emit `heading-copy-link` yet, so the
-  // hover-to-copy-heading-anchor affordance is unavailable. `scroll-to-header`
-  // (TOC navigation) and `copyGithubSlug` (via the command/menu) still work.
+  // Clicking the hover-to-copy affordance on a heading emits `heading-copy-link`
+  // with the heading's stable slug; copy the matching GitHub anchor to the
+  // clipboard (resolved via `listToc.find(i => i.slug === key)`).
+  editor.value.on('heading-copy-link', ({ key }: { key: string }) => {
+    editorStore.copyGithubSlug(key)
+  })
 
   editor.value.on(
     'format-click',

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -271,14 +271,24 @@ let scrollHandler: ((e: Event) => void) | null = null
 // the desktop store's `tab.history` (which drives the save/dirty tracking and
 // is migrated separately). We therefore keep the real engine history in a
 // per-tab map here for restoration across in-session tab switches, and feed the
-// store a SYNTHETIC desktop-shaped history whose entry id changes on every edit
-// so the store's `isSaved` logic keeps flipping correctly.
+// store a SYNTHETIC desktop-shaped history.
+//
+// The synthetic entry id is the engine undo-stack DEPTH — a stable position
+// marker, NOT an ever-incrementing counter. The store records the save-time id
+// as `lastSavedHistoryId` and clears the dirty indicator whenever the current
+// id matches it again. Using the undo-stack depth means undoing back to the
+// on-disk content returns the id to its saved value, so the saved/clean
+// indicator is restored (parity with the legacy history-index behaviour). An
+// ever-incrementing counter never matched again after an undo, leaving the tab
+// permanently dirty even when its content matched disk.
 const engineHistoryByTab = new Map<string, unknown>()
-let editSeq = 0
-const makeSyntheticHistory = (): IFileHistoryLike => {
-  editSeq += 1
+const engineUndoDepth = (history: unknown): number => {
+  const stack = (history as { stack?: { undo?: unknown[] } } | null)?.stack
+  return Array.isArray(stack?.undo) ? stack.undo.length : 0
+}
+const makeSyntheticHistory = (engineHistory: unknown): IFileHistoryLike => {
   return {
-    stack: [{ id: editSeq }],
+    stack: [{ id: engineUndoDepth(engineHistory) }],
     index: 0,
     lastEditIndex: 0,
     lastInitIndex: -1
@@ -1533,8 +1543,10 @@ onMounted(() => {
     const { id } = currentFile.value
     if (!id) return
     const markdown = editor.value.getMarkdown()
-    // Stash the real engine history for in-session tab-switch restoration.
-    engineHistoryByTab.set(id, editor.value.getHistory())
+    // Stash the real engine history for in-session tab-switch restoration, and
+    // derive the synthetic save-tracking id from its undo-stack depth.
+    const engineHistory = editor.value.getHistory()
+    engineHistoryByTab.set(id, engineHistory)
     editorStore.LISTEN_FOR_CONTENT_CHANGE({
       id,
       markdown,
@@ -1542,7 +1554,7 @@ onMounted(() => {
       cursor: serializeCursor(editor.value.getSelection()),
       // Synthetic, desktop-shaped history so the store's save/dirty tracking
       // keeps working (the engine history shape is incompatible).
-      history: makeSyntheticHistory(),
+      history: makeSyntheticHistory(engineHistory),
       toc: editor.value.getTOC(),
       blocks: editor.value.getState()
     })

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1353,6 +1353,19 @@ const handleFileChange = (payload: unknown) => {
     if (savedEngineHistory) {
       editor.value.setHistory(savedEngineHistory)
     }
+    // PARITY (gap PG14 — accept-defer): the bulk source-mode change is rebuilt
+    // via `setContent` and is NOT recorded as an engine undo op, so the first
+    // Ctrl+Z after exiting source mode replays the last pre-source WYSIWYG op
+    // instead of reverting the source-mode edit in one step (legacy muyajs
+    // pushed a full-state snapshot that made it a single undo boundary).
+    // Recording it as one boundary would mean computing a json1 op from the
+    // pre-source state to the post-source state and feeding it through
+    // `Editor.updateContents`' pick/drop walker — but that walker only handles
+    // specific op shapes (block insert at index, text edit, checked/meta), so a
+    // general whole-document diff (arbitrary add/remove/move/nested-replace)
+    // risks corrupting the document. Deferred rather than ship a fragile fix;
+    // the prior op stack is intact and undo still works, only the first-undo
+    // granularity across the boundary differs.
   } else if (newCursor) {
     editor.value.setCursor(newCursor)
   }

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -935,10 +935,11 @@ const handleSelectAll = () => {
 }
 
 // Custom copyAsRich copyAsHtml pasteAsPlainText.
-// The engine has no `copyAsRich`; the legacy "copy as rich text" maps to
-// `copyAsHtml` (copies the rendered HTML of the selection).
-const COPY_PASTE_METHOD_MAP: Record<string, 'copyAsHtml' | 'pasteAsPlainText'> = {
-  copyAsRich: 'copyAsHtml',
+// `copyAsRich` writes the rendered HTML to `text/html` AND the plain text to
+// `text/plain`, so pasting into Word/email yields formatted rich text (whereas
+// `copyAsHtml` blanks `text/html` and puts the HTML source into `text/plain`).
+const COPY_PASTE_METHOD_MAP: Record<string, 'copyAsRich' | 'copyAsHtml' | 'pasteAsPlainText'> = {
+  copyAsRich: 'copyAsRich',
   copyAsHtml: 'copyAsHtml',
   pasteAsPlainText: 'pasteAsPlainText'
 }

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1305,12 +1305,29 @@ interface FileChangePayload {
   blocks?: unknown
 }
 
+// A source-mode (CodeMirror) index cursor: `{ anchor, focus }` in `{ line, ch }`
+// coordinates. Produced by sourceCode.vue and carried on `file-changed` as
+// `muyaIndexCursor` when handing a tab back to WYSIWYG.
+const isIndexCursor = (
+  cursor: unknown
+): cursor is { anchor: { line: number; ch: number }; focus: { line: number; ch: number } } => {
+  const c = cursor as { anchor?: { line?: unknown }; focus?: { line?: unknown } } | null
+  return (
+    !!c &&
+    !!c.anchor &&
+    !!c.focus &&
+    typeof c.anchor.line === 'number' &&
+    typeof c.focus.line === 'number'
+  )
+}
+
 // listen for markdown change form source mode or change tabs etc
 const handleFileChange = (payload: unknown) => {
   const {
     id,
     markdown: newMarkdown,
     cursor: newCursor,
+    muyaIndexCursor,
     scrollTop
   } = (payload ?? {}) as FileChangePayload
   if (!editor.value) return
@@ -1323,12 +1340,18 @@ const handleFileChange = (payload: unknown) => {
     // in-session tab switch. The `history` in the payload is the synthetic
     // desktop-shaped history used for save tracking, not the engine history.
     editor.value.setContent(newMarkdown)
+    if (newCursor) {
+      editor.value.setCursor(newCursor)
+    } else if (isIndexCursor(muyaIndexCursor)) {
+      // Coming back from source-code mode the tab only has a CodeMirror
+      // `{ line, ch }` index cursor; map it onto a block-key cursor so the
+      // WYSIWYG caret lands where the source-mode cursor was (PG2). The engine
+      // runs its own setContent dance internally, so restore the history after.
+      editor.value.setCursorByOffset(muyaIndexCursor)
+    }
     const savedEngineHistory = id ? engineHistoryByTab.get(id) : undefined
     if (savedEngineHistory) {
       editor.value.setHistory(savedEngineHistory)
-    }
-    if (newCursor) {
-      editor.value.setCursor(newCursor)
     }
   } else if (newCursor) {
     editor.value.setCursor(newCursor)

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -335,19 +335,25 @@ interface EngineAffiliationEntry {
 // The engine's `selection-change` payload (since #4410) carries an
 // `affiliation` chain (shared-ancestor paragraph-type blocks, outermost-first)
 // plus per-endpoint `anchorBlockInfo`/`focusBlockInfo` describing the content
-// leaf (`type: 'span'` + `functionType`). The desktop's application-menu state
-// builder (`createApplicationMenuState`) was written against the legacy
-// `{ start, end, affiliation }` shape, so map the new payload onto it:
+// leaf (`type: 'span'` + `functionType`), alongside the live `anchorBlock`/
+// `focusBlock` refs (which carry `.text`). The desktop's application-menu state
+// builder (`createApplicationMenuState`) and the selected-text derivation in
+// `SELECTION_CHANGE` were written against the legacy `{ start, end, affiliation }`
+// shape, so map the new payload onto it:
 //   - `start.type`/`end.type` from the leaf info (`'span'`) so the
 //     `start.type === 'span'` guards fire,
 //   - `start.block.functionType`/`end.block.functionType` from the leaf info so
 //     code-content / table-cell detection lights up,
+//   - `start.block.text`/`end.block.text` from the live block so the store can
+//     still slice the selected text (`SELECTION_CHANGE` → search prefill),
 //   - `affiliation` straight through (entries already carry `type` +
 //     `listType`/`listItemType`/`isLooseListItem`), surfacing a derived
 //     `functionType` on `pre`/`figure` containers for table / code-fence keys.
 const adaptSelectionChange = (changes: MuyaChange) => {
   const anchorPath = (changes.anchorPath ?? []) as Array<string | number>
   const focusPath = (changes.focusPath ?? anchorPath) as Array<string | number>
+  const anchorBlock = changes.anchorBlock as { text?: string } | null | undefined
+  const focusBlock = changes.focusBlock as { text?: string } | null | undefined
   const anchorInfo = changes.anchorBlockInfo as
     | { type?: string; functionType?: string }
     | null
@@ -368,13 +374,13 @@ const adaptSelectionChange = (changes: MuyaChange) => {
     start: {
       key: anchorPath.join('/'),
       offset: (changes.anchor?.offset ?? 0) as number,
-      block: { functionType: anchorInfo?.functionType },
+      block: { text: anchorBlock?.text, functionType: anchorInfo?.functionType },
       type: anchorInfo?.type
     },
     end: {
       key: focusPath.join('/'),
       offset: (changes.focus?.offset ?? 0) as number,
-      block: { functionType: focusInfo?.functionType },
+      block: { text: focusBlock?.text, functionType: focusInfo?.functionType },
       type: focusInfo?.type
     },
     affiliation
@@ -1307,18 +1313,18 @@ interface FileChangePayload {
 
 // A source-mode (CodeMirror) index cursor: `{ anchor, focus }` in `{ line, ch }`
 // coordinates. Produced by sourceCode.vue and carried on `file-changed` as
-// `muyaIndexCursor` when handing a tab back to WYSIWYG.
+// `muyaIndexCursor` when handing a tab back to WYSIWYG. Both `line` AND `ch`
+// must be present numbers — otherwise the engine would clamp a missing `ch` to
+// 0 and silently restore the caret to the wrong column.
+const isIndexPosition = (pos: unknown): pos is { line: number; ch: number } => {
+  const p = pos as { line?: unknown; ch?: unknown } | null
+  return !!p && typeof p.line === 'number' && typeof p.ch === 'number'
+}
 const isIndexCursor = (
   cursor: unknown
 ): cursor is { anchor: { line: number; ch: number }; focus: { line: number; ch: number } } => {
-  const c = cursor as { anchor?: { line?: unknown }; focus?: { line?: unknown } } | null
-  return (
-    !!c &&
-    !!c.anchor &&
-    !!c.focus &&
-    typeof c.anchor.line === 'number' &&
-    typeof c.focus.line === 'number'
-  )
+  const c = cursor as { anchor?: unknown; focus?: unknown } | null
+  return !!c && isIndexPosition(c.anchor) && isIndexPosition(c.focus)
 }
 
 // listen for markdown change form source mode or change tabs etc

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1830,7 +1830,9 @@ const createApplicationMenuState = ({
   if (aff.length >= 1 && /ul|ol/.test(aff[0].type)) {
     const listBlock = aff[0]
     state.affiliation[listBlock.type] = true
-    state.isLooseListItem = !!listBlock.children?.[0]?.isLooseListItem
+    // The engine's affiliation entry carries the loose flag on the list block
+    // itself (derived from `meta.loose`), not via a `children` chain.
+    state.isLooseListItem = !!listBlock.isLooseListItem
     state.isTaskList = listBlock.listType === 'task'
   } else if (aff.length >= 3 && aff[1].type === 'li') {
     const listItem = aff[1]

--- a/packages/desktop/src/renderer/src/store/help.ts
+++ b/packages/desktop/src/renderer/src/store/help.ts
@@ -119,7 +119,12 @@ export const getBlankFileState = (
     id,
     filename: `${defaultFilenamePrefix}-${++untitleId}`,
     markdown,
-    lastSavedHistoryId: -1
+    // The freshly-loaded document IS its on-disk/clean baseline. The engine
+    // clears its undo history on `setContent`, so the baseline undo-stack depth
+    // (the synthetic save-tracking id) is 0. Seeding `lastSavedHistoryId` to 0
+    // (not -1) lets the dirty indicator clear again when an edit is undone back
+    // to this baseline, even before the document has ever been saved.
+    lastSavedHistoryId: 0
   }) as IFileState
 }
 
@@ -143,7 +148,9 @@ export const createDocumentState = (
 
   return Object.assign(docState, {
     id,
-    lastSavedHistoryId: -1
+    // See `getBlankFileState`: the loaded document is its own clean baseline and
+    // the engine's baseline undo-stack depth (the synthetic id) is 0.
+    lastSavedHistoryId: 0
   }) as IFileState
 }
 

--- a/packages/desktop/src/renderer/src/util/pdf.ts
+++ b/packages/desktop/src/renderer/src/util/pdf.ts
@@ -1,14 +1,11 @@
 // `escapeHTML`/`unescapeHTML` are migrated to @muyajs/core (identical impl).
-import { escapeHTML, unescapeHTML } from '@muyajs/core'
-// NOTE: `Slugger` is intentionally still sourced from the legacy muyajs engine.
-// The TOC anchors produced here (`#${slugger.slug(content)}`) must match the
-// heading `id` attributes in the exported document, and those ids are emitted
-// by the muyajs export renderer (`Muya#exportStyledHTML`) via the SAME Slugger.
-// editor.vue — and therefore the export render path — is still on muyajs in
-// this PR, so swapping to @muyajs/core's `generateGithubSlug` (a different
-// algorithm with no dedup/unicode downcoding) would break in-document TOC
-// links. This import moves to @muyajs/core together with the editor.vue swap.
-import Slugger from 'muya/lib/parser/marked/slugger'
+// The TOC anchors produced here (`#${slug}`) must match the heading `id`
+// attributes in the exported document. Now that editor.vue exports via
+// @muyajs/core (#4406) and the engine injects github-compatible heading ids
+// (#4412), this module derives its slugs from the SAME `generateGithubSlug`
+// algorithm, with the SAME `-N` document-order dedup the engine uses, so the
+// in-document TOC links resolve.
+import { escapeHTML, unescapeHTML, generateGithubSlug } from '@muyajs/core'
 import academicTheme from '@/assets/themes/export/academic.theme.css?inline'
 import liberTheme from '@/assets/themes/export/liber.theme.css?inline'
 import { deepClone } from '../util'
@@ -128,10 +125,29 @@ export interface HtmlTocOptions {
   [key: string]: unknown
 }
 
+// Replicate @muyajs/core's `MarkdownToHtml#_injectHeadingIds` slugging so the
+// TOC `href="#slug"` anchors target the exact ids the engine writes onto the
+// exported `<h1>..<h6>`: github-compatible base slug (falling back to
+// `heading` when the text slugs to empty), deduplicated in document order with
+// an incrementing `-N` suffix. Computed over the FULL heading list in order
+// (before the render-time filtering below) to keep the dedup sequence aligned
+// with the engine's whole-document pass.
+const assignHeadingSlugs = (tocList: TocEntry[]): void => {
+  const seen = new Set<string>()
+  for (const entry of tocList) {
+    const base = generateGithubSlug(entry.content) || 'heading'
+    let slug = base
+    let n = 1
+    while (seen.has(slug)) {
+      slug = `${base}-${n++}`
+    }
+    seen.add(slug)
+    entry.slug = slug
+  }
+}
+
 const generateHtmlToc = (
   tocList: TocEntry[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  slugger: any,
   currentLevel: number,
   options: HtmlTocOptions
 ): string => {
@@ -142,30 +158,29 @@ const generateHtmlToc = (
   const topLevel = tocList[0].lvl
   if (!options.tocIncludeTopHeading && topLevel <= 1) {
     tocList.shift()
-    return generateHtmlToc(tocList, slugger, currentLevel, options)
+    return generateHtmlToc(tocList, currentLevel, options)
   } else if (topLevel <= currentLevel) {
     return ''
   }
 
   const shifted = tocList.shift() as TocEntry
-  const { content, lvl } = shifted
-  const slug = slugger.slug(content)
+  const { content, lvl, slug } = shifted
 
   let html = `<li><span><a class="toc-h${lvl}" href="#${slug}">${content}</a><span class="dots"></span></span>`
 
   // Generate sub-items
   if (tocList.length !== 0 && tocList[0].lvl > lvl) {
-    html += '<ul>' + generateHtmlToc(tocList, slugger, lvl, options) + '</ul>'
+    html += '<ul>' + generateHtmlToc(tocList, lvl, options) + '</ul>'
   }
 
-  html += '</li>' + generateHtmlToc(tocList, slugger, currentLevel, options)
+  html += '</li>' + generateHtmlToc(tocList, currentLevel, options)
   return html
 }
 
 export const getHtmlToc = (toc: TocEntry[], options: HtmlTocOptions = {}): string => {
   const list = deepClone(toc)
-  const slugger = new Slugger()
-  const tocList = generateHtmlToc(list, slugger, 0, options)
+  assignHeadingSlugs(list)
+  const tocList = generateHtmlToc(list, 0, options)
   if (!tocList) {
     return ''
   }

--- a/packages/desktop/test/PARITY_SCOREBOARD.md
+++ b/packages/desktop/test/PARITY_SCOREBOARD.md
@@ -2,20 +2,29 @@
 
 This is a **failing-test scoreboard**. The desktop app migrated from the legacy
 `packages/muyajs` engine to `@muyajs/core` (`packages/muya`) in PR #4406. That
-migration left **15 confirmed functional-parity gaps**. This board encodes each
-one as a regression test that **fails on `develop` today** (proving the gap) but
-is marked as an *expected failure* so the test suites stay GREEN.
+migration left **15 confirmed functional-parity gaps**. This board encoded each
+one as a regression test that *failed on `develop`* (proving the gap), marked as
+an *expected failure* so the suites stayed GREEN. **14 of the 15 are now fixed**
+(seven Wave-1 engine PRs #4408–#4414 + the Wave-2 desktop consumer wiring); the
+xfail markers were removed as each landed and the tests now assert the correct
+behaviour directly. **PG14 alone remains xfail** (accept-defer — see its row).
 
 ## How it works
 
+The board started fully xfail and is now almost entirely flipped to real
+assertions (only PG14 remains xfail). The mechanism, for the one remaining gap
+and any future ones:
+
 - **muya engine unit tests** (`packages/muya/src/**/__tests__/parity*.spec.ts`)
-  use vitest `it.fails(...)`: the assertion describes the correct
-  (pre-migration) behaviour and fails today, which vitest counts as a *pass*.
-  When a fix lands and the behaviour becomes correct, the test starts passing
-  and `it.fails` then **errors** — forcing the fixer to delete `.fails`.
+  used vitest `it.fails(...)`: the assertion describes the correct
+  (pre-migration) behaviour and failed pre-fix, which vitest counts as a *pass*.
+  When a fix lands and the behaviour becomes correct, `it.fails` then **errors**
+  — forcing the fixer to delete `.fails`. All engine parity specs now use plain
+  `it` and pass.
 - **desktop e2e tests** (`packages/desktop/test/e2e/parity-*.spec.ts`) use
-  Playwright `test.fail()`: the test runs headless and currently fails, which
-  Playwright counts as a *pass*. When the fix lands, remove `test.fail()`.
+  Playwright `test.fail()`: the test runs headless and fails pre-fix, which
+  Playwright counts as a *pass*. When the fix lands, remove `test.fail()`. Only
+  PG14 still carries it.
 - **manual-QA** entries (`packages/desktop/test/PARITY_QA.md`) cover gaps that
   cannot be driven headless (real OS clipboard bitmaps, drag-and-drop gestures).
 
@@ -32,45 +41,65 @@ is marked as an *expected failure* so the test suites stay GREEN.
 
 ## Scoreboard
 
-> **Gaps remaining: 11 / 15.** PG4, PG5, PG6, PG9 closed on the engine side.
-> PG4's drag-drop image handler is fixed and unit-tested (its local-file
-> persistence path still needs the desktop wave-2 wiring noted in
-> `PARITY_QA.md` § PG4); PG5's OS-clipboard delivery and PG9's desktop
-> `copyAsRich` menu map likewise remain as wave-2 desktop work.
+> **Gaps remaining: 1 / 15** (PG14, accept-defer). The other 14 are closed:
+> the seven Wave-1 engine PRs (#4408–#4414) landed the engine halves, and the
+> Wave-2 desktop PR wired the consumers (PG1 affiliation adapter, PG2
+> `setCursorByOffset`, PG8 pdf.ts slugger, PG9 `copyAsRich` map, PG11
+> `heading-copy-link` subscription, PG15 stable saved-id). PG4's local-file
+> drag-drop persistence and PG5's OS-clipboard bitmap delivery still have
+> manual-QA entries in `PARITY_QA.md` (cannot be driven headless), but their
+> code paths are fixed and unit-tested. PG14 (single-undo-boundary across the
+> source-mode handoff) is deferred — see its row.
 
 | Gap | Severity | Behaviour lost | Test location(s) | Mechanism | Status |
 |-----|----------|----------------|------------------|-----------|--------|
-| **PG1** | major | `selection-change` lacks block affiliation / ancestor type → native Paragraph & Format menu state is dead | `packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts` (`PG1:` ×2) · `packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts` (`PG1:`) | `it.fails` + `test.fail()` | ❌ xfail |
-| **PG2** | major | source-mode → WYSIWYG caret not restored (`handleFileChange` drops `muyaIndexCursor`) | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG2:`) | `test.fail()` | ❌ xfail |
-| **PG3** | major | `autoCheck` preference not consumed (task-list checkbox cascade lost) | `packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts` (`PG3:` ×2) | `it.fails` | ❌ xfail |
-| **PG4** | major | drag-drop image insertion (local file + web link) absent | `packages/muya/src/editor/__tests__/dragDropImage.spec.ts` (PG4 ×7) · `packages/desktop/test/PARITY_QA.md` § PG4 | unit (synthetic `DataTransfer`) + manual-QA | ✅ engine fixed |
-| **PG5** | major | binary/bitmap clipboard image paste lost (screenshot, browser "Copy Image") | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG5:`) · `packages/desktop/test/PARITY_QA.md` § PG5 | passing `it` + manual-QA | ✅ engine fixed (OS-clipboard manual-QA remains) |
-| **PG6** | major | pasted image FILE bypasses `imageAction` (copy-to-assets / upload preference ignored) | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG6:` ×2) | passing `it` | ✅ fixed |
-| **PG7** | major | export loads core CSS from CDN instead of inlining it (unstyled offline) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG7:` ×2) | `it.fails` | ❌ xfail |
-| **PG8** | major | exported headings carry no `id` (dead TOC / `[TOC]` anchors) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG8:` ×2) | `it.fails` | ❌ xfail |
-| **PG9** | major | "Copy as Rich Text" pastes HTML *source* not rich text (no `copyAsRich` path) | `packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts` (`PG9:` ×2) | passing `it` | ✅ engine fixed (desktop `copyAsRich` map = wave 2) |
-| **PG10** | minor | `preview-image` never emitted — select-image + Space full-screen preview lost | `packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts` (`PG10:` ×2) | `it.fails` | ❌ xfail |
-| **PG11** | minor | `heading-copy-link` never emitted — hover-to-copy-anchor affordance gone | `packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts` (`PG11:` ×2) | `it.fails` | ❌ xfail |
-| **PG12** | minor | `hideLinkPopup` preference not consumed — link hover popover not gated | `packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts` (`PG12:`) | `it.fails` (+ control) | ❌ xfail |
-| **PG13** | minor | `insertParagraph` anchors to outermost not immediate block in nested structures | `packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts` (`PG13:` ×2) | `it.fails` | ❌ xfail |
-| **PG14** | minor | first undo after source-mode doesn't revert the edit as one step | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG14:`) | `test.fail()` | ❌ xfail |
-| **PG15** | minor | undo back to on-disk content doesn't restore the saved/clean indicator | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG15:`) | `test.fail()` | ❌ xfail |
+| **PG1** | major | `selection-change` lacks block affiliation / ancestor type → native Paragraph & Format menu state is dead | `packages/muya/src/selection/__tests__/paritySelectionChange.spec.ts` (`PG1:` ×2) · `packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts` (`PG1:`) | passing `it` + passing `test` | ✅ fixed (engine #4410 · desktop wave 2) |
+| **PG2** | major | source-mode → WYSIWYG caret not restored (`handleFileChange` drops `muyaIndexCursor`) | `packages/muya/src/__tests__/setCursorByOffset.spec.ts` (`PG2:` ×5) · `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG2:`) | passing `it` + passing `test` | ✅ fixed (engine `setCursorByOffset` + desktop wave 2) |
+| **PG3** | major | `autoCheck` preference not consumed (task-list checkbox cascade lost) | `packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts` (`PG3:` ×2) | passing `it` | ✅ engine fixed (#4409) |
+| **PG4** | major | drag-drop image insertion (local file + web link) absent | `packages/muya/src/editor/__tests__/dragDropImage.spec.ts` (PG4 ×7) · `packages/desktop/test/PARITY_QA.md` § PG4 | unit (synthetic `DataTransfer`) + manual-QA | ✅ engine fixed (#4413) |
+| **PG5** | major | binary/bitmap clipboard image paste lost (screenshot, browser "Copy Image") | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG5:`) · `packages/desktop/test/PARITY_QA.md` § PG5 | passing `it` + manual-QA | ✅ engine fixed #4411 (OS-clipboard manual-QA remains) |
+| **PG6** | major | pasted image FILE bypasses `imageAction` (copy-to-assets / upload preference ignored) | `packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts` (`PG6:` ×2) | passing `it` | ✅ engine fixed (#4411) |
+| **PG7** | major | export loads core CSS from CDN instead of inlining it (unstyled offline) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG7:` ×2) | passing `it` | ✅ engine fixed (#4412) |
+| **PG8** | major | exported headings carry no `id` (dead TOC / `[TOC]` anchors) | `packages/muya/src/state/__tests__/parityExportHtml.spec.ts` (`PG8:` ×2) | passing `it` | ✅ fixed (engine #4412 · desktop pdf.ts slugger wave 2) |
+| **PG9** | major | "Copy as Rich Text" pastes HTML *source* not rich text (no `copyAsRich` path) | `packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts` (`PG9:` ×2) | passing `it` | ✅ fixed (engine #4411 · desktop `copyAsRich` map wave 2) |
+| **PG10** | minor | `preview-image` never emitted — select-image + Space full-screen preview lost | `packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts` (`PG10:` ×2) | passing `it` | ✅ engine fixed #4414 (desktop subscription already present) |
+| **PG11** | minor | `heading-copy-link` never emitted — hover-to-copy-anchor affordance gone | `packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts` (`PG11:` ×2) | passing `it` | ✅ fixed (engine #4414 · desktop subscription wave 2) |
+| **PG12** | minor | `hideLinkPopup` preference not consumed — link hover popover not gated | `packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts` (`PG12:`) | passing `it` (+ control) | ✅ engine fixed (#4409) |
+| **PG13** | minor | `insertParagraph` anchors to outermost not immediate block in nested structures | `packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts` (`PG13:` ×2) | passing `it` | ✅ engine fixed (#4408) |
+| **PG14** | minor | first undo after source-mode doesn't revert the edit as one step | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG14:`) | `test.fail()` | ❌ xfail (accept-defer) |
+| **PG15** | minor | undo back to on-disk content doesn't restore the saved/clean indicator | `packages/desktop/test/e2e/parity-source-undo-saved.spec.ts` (`PG15:`) | passing `test` | ✅ desktop fixed (wave 2) |
 
 ### Severity tally
 
-- **major:** PG1, PG2, PG3, PG4, PG5, PG6, PG7, PG8, PG9 (9)
-- **minor:** PG10, PG11, PG12, PG13, PG14, PG15 (6)
+- **major:** PG1, PG2, PG3, PG4, PG5, PG6, PG7, PG8, PG9 (9) — all fixed
+- **minor:** PG10, PG11, PG12, PG13, PG14, PG15 (6) — all fixed except **PG14**
+
+### PG14 — why it is deferred
+
+On source-mode exit, `handleFileChange` rebuilds the document via `setContent`
+(which `history.clear()`s) then restores the pre-source op stack, so the bulk
+source-mode change is not recorded as a single engine undo op. Making it one
+undo boundary would require computing a general whole-document `ot-json1` diff
+(pre-source state → post-source state) and applying it through
+`Editor.updateContents`' pick/drop walker. That walker only handles a fixed set
+of op shapes (block insert at index, text edit, `checked`/`meta`); an arbitrary
+diff (removes, moves, nested replaces) could mis-apply and corrupt the document.
+The risk outweighs the benefit — first-undo granularity across the boundary is a
+narrow edge case, undo still works, and the prior op stack is intact — so PG14
+is left as `test.fail()` rather than shipping a fragile fix. Reviving it cleanly
+would mean a dedicated engine "record a state replacement as one op" API.
 
 ## Running the suites
 
 ```bash
-# muya engine xfail tests (suite must stay GREEN: it.fails entries count as pass)
+# muya engine parity tests (all pass; PG2 cursor mapping is also covered by
+# src/__tests__/setCursorByOffset.spec.ts)
 pnpm -C packages/muya test
 
 # a single gap's engine tests
 pnpm -C packages/muya exec vitest run src/state/__tests__/parityExportHtml.spec.ts
 
-# desktop parity e2e (needs `pnpm run build:unpack` first; suite stays GREEN)
+# desktop parity e2e (needs `pnpm run build:unpack` first; PG14 stays xfail)
 pnpm -C packages/desktop exec playwright test \
   test/e2e/parity-pg1-menu-state.spec.ts \
   test/e2e/parity-source-undo-saved.spec.ts \

--- a/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
+++ b/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
@@ -9,15 +9,11 @@ import { launchWithMarkdown, setSourceMarkdown, waitForMenuReady } from './helpe
 //
 // Legacy muyajs `selectionChange` carried the ancestor block `affiliation`
 // chain + block markdown types, which `createApplicationMenuState`
-// (store/editor.ts) turned into Paragraph-menu check marks. With @muyajs/core
-// the `selection-change` payload has no affiliation chain, so the affiliation
-// map the store builds stays empty and the Paragraph-menu check marks never
-// light up. Here we read the live application-menu `checked` state after
-// placing the caret in a heading.
-//
-// This RUNS but currently fails (the menu item never gets checked), so it is
-// marked `test.fail()`. When the engine restores affiliation and the store
-// lights the check mark, remove the `test.fail()`.
+// (store/editor.ts) turned into Paragraph-menu check marks. #4410 restored the
+// affiliation chain + per-endpoint block info on the `selection-change`
+// payload, and the desktop adapter (`adaptSelectionChange`) now feeds them to
+// the store, so the Paragraph-menu check marks light up again. Here we read the
+// live application-menu `checked` state after placing the caret in a heading.
 
 const headingMenuChecked = async(app: ElectronApplication, id: string): Promise<boolean> => {
   return await app.evaluate(({ Menu }, menuId) => {
@@ -69,7 +65,6 @@ test.describe('Parity PG1 — Paragraph menu reflects the current block', () => 
     if (app) await app.close()
   })
 
-  test.fail()
   test('PG1: placing the caret in an H1 checks heading1MenuItem in the Paragraph menu', async() => {
     await setSourceMarkdown(page, app, '# A heading\n')
     // Sanity: the heading rendered and the caret landed inside it (so a `false`

--- a/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
+++ b/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
@@ -23,10 +23,9 @@ const undo = async(app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> 
 }
 
 test.describe('Parity PG2 — WYSIWYG caret restored after a source-mode edit', () => {
-  // handleFileChange drops `muyaIndexCursor`/`blocks` and the engine has no
-  // index→path cursor conversion, so the source-mode editing position is lost
-  // on the handoff back to WYSIWYG and no meaningful caret is restored.
-  test.fail()
+  // handleFileChange now maps the saved `muyaIndexCursor` ({line, ch}) onto a
+  // block-key cursor via the engine's `setCursorByOffset`, so the source-mode
+  // editing position is restored on the handoff back to WYSIWYG.
   test('PG2: the caret lands in the block the source-mode cursor was on', async() => {
     const { app, page } = await launchWithMarkdown(
       'first para\n\nsecond para\n\nthird para here\n'
@@ -68,9 +67,14 @@ test.describe('Parity PG2 — WYSIWYG caret restored after a source-mode edit', 
 })
 
 test.describe('Parity PG14 — first undo after source mode reverts the edit in one step', () => {
-  // On source-mode exit the engine rebuilds the document via setContent (which
-  // does NOT record an undo op) then restores the pre-source op stack, so the
-  // bulk source-mode change is not a single undo boundary.
+  // ACCEPT-DEFER: on source-mode exit the engine rebuilds the document via
+  // setContent (which does NOT record an undo op) then restores the pre-source
+  // op stack, so the bulk source-mode change is not a single undo boundary.
+  // Recording it as one boundary would require feeding a general
+  // whole-document json1 diff through Editor.updateContents' pick/drop walker,
+  // which only handles specific op shapes (block insert / text edit /
+  // checked|meta) and would risk corrupting the document on arbitrary diffs.
+  // Left as `test.fail()` — see the matching note in editor.vue handleFileChange.
   test.fail()
   test('PG14: one undo after exiting source mode reverts the source-mode change', async() => {
     const { app, page } = await launchWithMarkdown('base\n')
@@ -93,10 +97,10 @@ test.describe('Parity PG14 — first undo after source mode reverts the edit in 
 })
 
 test.describe('Parity PG15 — undo back to on-disk content restores the saved indicator', () => {
-  // The desktop feeds the store a synthetic history whose id is regenerated on
-  // every json-change (including undo), so the saved-id comparison never
-  // matches again and the tab stays marked dirty even when content == disk.
-  test.fail()
+  // The synthetic save-tracking id is now the engine undo-stack depth (a stable
+  // position marker), and a freshly-loaded tab seeds `lastSavedHistoryId` to the
+  // baseline depth (0). Undoing an edit back to disk content returns the id to
+  // its saved value, so the saved/clean indicator is restored.
   test('PG15: undoing an edit back to disk content clears the unsaved indicator', async() => {
     const { app, page } = await launchWithMarkdown('hello world\n')
     await waitForMenuReady(app)

--- a/packages/muya/src/__tests__/setCursorByOffset.spec.ts
+++ b/packages/muya/src/__tests__/setCursorByOffset.spec.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+import { injectSentinels, resolveSentinelCursor } from '../selection/offsetCursor';
+
+// PARITY (gap PG2): the source-code -> WYSIWYG handoff carries only a
+// CodeMirror `{ line, ch }` index cursor. `setCursorByOffset` reproduces the
+// legacy muyajs index->block-key cursor conversion (sentinel injection + tree
+// walk) so the WYSIWYG caret lands on the block the source-mode cursor was in.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('muya.setCursorByOffset() (PG2)', () => {
+    it('PG2: maps a source-mode {line, ch} cursor onto the matching paragraph block', async () => {
+        const muya = bootMuya('first para\n\nsecond para\n\nthird para here\n');
+        // Line 4 = "third para here" (lines: 0 first, 1 blank, 2 second, 3 blank, 4 third).
+        const restored = muya.setCursorByOffset({
+            anchor: { line: 4, ch: 6 },
+            focus: { line: 4, ch: 6 },
+        });
+        expect(restored).toBe(true);
+
+        await vi.waitFor(() => {
+            const sel = muya.editor.selection.getSelection();
+            expect(sel).not.toBeNull();
+            // The caret lands inside the "third para here" block.
+            expect(sel!.anchorBlock.text).toBe('third para here');
+            expect(sel!.anchor.offset).toBe(6);
+        });
+        // The document content is left clean (no sentinel residue).
+        expect(muya.getMarkdown()).not.toContain('mUyAcUrSoR');
+        expect(muya.getMarkdown().trim()).toBe('first para\n\nsecond para\n\nthird para here');
+    });
+
+    it('PG2: maps a cursor inside a heading block', async () => {
+        const muya = bootMuya('# Title\n\nbody text\n');
+        const restored = muya.setCursorByOffset({
+            anchor: { line: 0, ch: 4 }, // inside "# Title" (after "# Ti")
+            focus: { line: 0, ch: 4 },
+        });
+        expect(restored).toBe(true);
+        await vi.waitFor(() => {
+            const sel = muya.editor.selection.getSelection();
+            // This engine keeps the `# ` marker in the heading content block's
+            // text, so the caret lands at offset 4 of "# Title".
+            expect(sel!.anchorBlock.text).toBe('# Title');
+            expect(sel!.anchor.offset).toBe(4);
+        });
+    });
+
+    it('PG2: resolves a non-collapsed selection within a block to the right offsets', () => {
+        // Asserted at the resolver level: happy-dom does not preserve a
+        // non-collapsed DOM range across the contenteditable re-render, so the
+        // DOM-readback `getSelection()` would collapse it (works in Chromium).
+        // The resolver is what computes the sentinel-free anchor/focus offsets.
+        const muya = bootMuya('hello world\n');
+        const sentinelMarkdown = injectSentinels(muya.getMarkdown(), {
+            anchor: { line: 0, ch: 0 },
+            focus: { line: 0, ch: 5 },
+        });
+        expect(sentinelMarkdown).not.toBeNull();
+        muya.editor.setContent(sentinelMarkdown!);
+        const cursor = resolveSentinelCursor(muya.editor.scrollPage!);
+        expect(cursor).not.toBeNull();
+        expect(cursor!.anchor!.offset).toBe(0);
+        expect(cursor!.focus!.offset).toBe(5);
+        // Both endpoints resolve to the same block (same path).
+        expect(cursor!.anchorPath).toEqual(cursor!.focusPath);
+    });
+
+    it('PG2: returns false and leaves the document intact for a stale line', () => {
+        const muya = bootMuya('only line\n');
+        const restored = muya.setCursorByOffset({
+            anchor: { line: 99, ch: 0 },
+            focus: { line: 99, ch: 0 },
+        });
+        expect(restored).toBe(false);
+        expect(muya.getMarkdown().trim()).toBe('only line');
+    });
+
+    it('PG2: returns false for a null cursor', () => {
+        const muya = bootMuya('text\n');
+        expect(muya.setCursorByOffset({ anchor: null, focus: null })).toBe(false);
+    });
+});

--- a/packages/muya/src/__tests__/setCursorByOffset.spec.ts
+++ b/packages/muya/src/__tests__/setCursorByOffset.spec.ts
@@ -111,4 +111,29 @@ describe('muya.setCursorByOffset() (PG2)', () => {
         const muya = bootMuya('text\n');
         expect(muya.setCursorByOffset({ anchor: null, focus: null })).toBe(false);
     });
+
+    it('PG2: preserves the undo history across the internal setContent rebuild', async () => {
+        const muya = bootMuya('alpha\n');
+        // Seed a non-empty undo stack so we can detect a clobber. The text-setter
+        // op flushes to the history on the next frame (JSONState._emitStateChange).
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        first.setCursor(5, 5, true);
+        muya.editor.activeContentBlock = first;
+        first.text = 'alpha beta';
+        await vi.waitFor(() => {
+            expect(muya.getHistory().stack.undo.length).toBeGreaterThan(0);
+        });
+        const before = muya.getHistory();
+
+        const restored = muya.setCursorByOffset({
+            anchor: { line: 0, ch: 3 },
+            focus: { line: 0, ch: 3 },
+        });
+        expect(restored).toBe(true);
+
+        // The undo stack survives the caret-restore (setContent would otherwise
+        // have cleared it).
+        const after = muya.getHistory();
+        expect(after.stack.undo.length).toBe(before.stack.undo.length);
+    });
 });

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -728,8 +728,13 @@ export class Muya {
      * landed in, then rebuild the clean document and set the cursor by the
      * resolved block paths + offsets. The sentinel-bearing tree is transient —
      * both `setContent` calls run synchronously within this task, so no
-     * intermediate paint happens. No-op (returns `false`) when the cursor is
-     * stale / unresolvable, letting the caller fall back to its default.
+     * intermediate paint happens.
+     *
+     * `Editor.setContent` clears the undo history, so this method snapshots the
+     * history before its internal rebuild and restores it afterwards — the undo
+     * stack is preserved, leaving only the caret changed. No-op (returns
+     * `false`) when the cursor is stale / unresolvable, letting the caller fall
+     * back to its default.
      */
     setCursorByOffset(indexCursor: IIndexCursor): boolean {
         const { scrollPage } = this.editor;
@@ -741,9 +746,14 @@ export class Muya {
         if (sentinelMarkdown == null)
             return false;
 
+        // Preserve the undo history across the internal setContent rebuild
+        // (setContent clears it) so this stays a caret-only operation.
+        const savedHistory = this.getHistory();
+
         this.editor.setContent(sentinelMarkdown);
         const cursor = resolveSentinelCursor(this.editor.scrollPage!);
         this.editor.setContent(cleanMarkdown);
+        this.setHistory(savedHistory);
 
         if (!cursor)
             return false;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -2,6 +2,7 @@ import type Content from './block/base/content';
 import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
+import type { IIndexCursor } from './selection/offsetCursor';
 import type { ICursor } from './selection/types';
 import type { ITocItem } from './state/getTOC';
 import type { IBulletListState, IOrderListState, ITableState, ITaskListState, TState } from './state/types';
@@ -19,6 +20,7 @@ import { Editor } from './editor/index';
 
 import EventCenter from './event/index';
 import I18n from './i18n/index';
+import { injectSentinels, resolveSentinelCursor } from './selection/offsetCursor';
 import { getTOC } from './state/getTOC';
 import { isAnyListState, isAtxHeadingState } from './state/types';
 import { replaceBlockByLabel } from './ui/paragraphQuickInsertMenu/config';
@@ -715,6 +717,40 @@ export class Muya {
             focusBlock,
             focusPath: focusBlock.path,
         });
+    }
+
+    /**
+     * Restore the WYSIWYG caret from a source-mode (CodeMirror) `{ line, ch }`
+     * index cursor (PG2 parity). The block tree has no source-line mapping, so
+     * the offsets are resolved the way legacy muyajs did: inject sentinel
+     * strings into the current markdown at the line/ch positions, rebuild the
+     * tree (sentinels embed as literal text), find which content blocks they
+     * landed in, then rebuild the clean document and set the cursor by the
+     * resolved block paths + offsets. The sentinel-bearing tree is transient —
+     * both `setContent` calls run synchronously within this task, so no
+     * intermediate paint happens. No-op (returns `false`) when the cursor is
+     * stale / unresolvable, letting the caller fall back to its default.
+     */
+    setCursorByOffset(indexCursor: IIndexCursor): boolean {
+        const { scrollPage } = this.editor;
+        if (!scrollPage)
+            return false;
+
+        const cleanMarkdown = this.getMarkdown();
+        const sentinelMarkdown = injectSentinels(cleanMarkdown, indexCursor);
+        if (sentinelMarkdown == null)
+            return false;
+
+        this.editor.setContent(sentinelMarkdown);
+        const cursor = resolveSentinelCursor(this.editor.scrollPage!);
+        this.editor.setContent(cleanMarkdown);
+
+        if (!cursor)
+            return false;
+
+        this.setCursor(cursor);
+
+        return true;
     }
 
     /**

--- a/packages/muya/src/selection/offsetCursor.ts
+++ b/packages/muya/src/selection/offsetCursor.ts
@@ -1,0 +1,168 @@
+// Index-cursor → block-key cursor conversion for the source-code → WYSIWYG
+// handoff.
+//
+// PARITY (gap PG2): when the desktop app switches a tab back from source-code
+// mode to WYSIWYG, the only cursor it holds is a CodeMirror `{ line, ch }`
+// offset pair (`muyaIndexCursor`). Legacy `packages/muyajs` translated that
+// into a real block-key cursor by injecting sentinel strings into the markdown
+// at the line/ch offsets, re-parsing, and walking the block tree to find which
+// block's text the sentinels landed in (`addCursorToMarkdown` +
+// `convertMuyaIndexCursortoCursor`). `@muyajs/core` had no equivalent, so the
+// WYSIWYG caret was lost on the handoff. This module reproduces that mapping by
+// resolving the offsets against the live block tree.
+
+import type Content from '../block/base/content';
+import type { ScrollPage } from '../block/scrollPage';
+import type { ICursor } from './types';
+
+/** One end of a source-mode (CodeMirror) selection: a `{ line, ch }` offset. */
+export interface IIndexPosition {
+    line: number;
+    ch: number;
+}
+
+/** A source-mode selection in CodeMirror `{ line, ch }` coordinates. */
+export interface IIndexCursor {
+    anchor: IIndexPosition | null;
+    focus: IIndexPosition | null;
+}
+
+// Sentinel strings injected at the cursor offsets. They must be improbable in
+// real markdown AND survive the markdown -> state round-trip as literal text.
+// (The legacy engine used private-use-area code points, but this engine's
+// markdown parser strips non-ASCII control/PUA characters, so the markers are
+// plain ASCII with a long random-looking token unlikely to occur in real
+// documents.) The two markers share no common substring so neither can be
+// found inside the other.
+const ANCHOR_SENTINEL = 'mUyAcUrSoRzZqAnChOr9x7kPvWb';
+const FOCUS_SENTINEL = 'mUyAcUrSoRzZqFoCuS4t2nDhGj';
+
+function _clampOffset(offset: number, length: number): number {
+    if (!Number.isInteger(offset))
+        return 0;
+
+    return Math.min(Math.max(offset, 0), length);
+}
+
+/**
+ * Inject the anchor/focus sentinels into `markdown` at the given `{ line, ch }`
+ * offsets. Returns `null` when either offset references a line that does not
+ * exist (stale cursor) so the caller can fall back to no cursor restore.
+ */
+export function injectSentinels(
+    markdown: string,
+    cursor: IIndexCursor,
+): string | null {
+    const { anchor, focus } = cursor;
+    if (!anchor || !focus)
+        return null;
+
+    const lines = markdown.split('\n');
+    const isValidLine = (line: number): boolean =>
+        Number.isInteger(line) && line >= 0 && line < lines.length;
+
+    if (!isValidLine(anchor.line) || !isValidLine(focus.line))
+        return null;
+
+    const anchorText = lines[anchor.line]!;
+    const focusText = lines[focus.line]!;
+    const anchorCh = _clampOffset(anchor.ch, anchorText.length);
+    const focusCh = _clampOffset(focus.ch, focusText.length);
+
+    if (anchor.line === focus.line) {
+        const min = Math.min(anchorCh, focusCh);
+        const max = Math.max(anchorCh, focusCh);
+        const first = anchorText.substring(0, min);
+        const middle = anchorText.substring(min, max);
+        const last = anchorText.substring(max);
+        lines[anchor.line]
+            = first
+                + (anchorCh <= focusCh ? ANCHOR_SENTINEL : FOCUS_SENTINEL)
+                + middle
+                + (anchorCh <= focusCh ? FOCUS_SENTINEL : ANCHOR_SENTINEL)
+                + last;
+    }
+    else {
+        lines[anchor.line]
+            = anchorText.substring(0, anchorCh) + ANCHOR_SENTINEL + anchorText.substring(anchorCh);
+        lines[focus.line]
+            = focusText.substring(0, focusCh) + FOCUS_SENTINEL + focusText.substring(focusCh);
+    }
+
+    return lines.join('\n');
+}
+
+interface ISentinelHit {
+    block: Content;
+    offset: number;
+}
+
+/**
+ * Walk the live content blocks of `scrollPage` and, for each sentinel found in
+ * a block's text, record the owning block and the offset the sentinel sits at
+ * (with the sentinel removed from the offset accounting). The block's text is
+ * left untouched — the tree carrying the sentinels is transient and replaced by
+ * the caller immediately after.
+ */
+function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit | null {
+    let hit: ISentinelHit | null = null;
+
+    scrollPage.depthFirstTraverse((node) => {
+        if (hit || !node.isContent())
+            return;
+
+        const idx = node.text.indexOf(sentinel);
+        if (idx > -1)
+            hit = { block: node, offset: idx };
+    });
+
+    return hit;
+}
+
+/**
+ * Resolve the index cursor against the live (sentinel-bearing) block tree into
+ * a PATH-ONLY `ICursor` (json paths + offsets), or `null` when neither sentinel
+ * resolved to a content block.
+ *
+ * Only the plain `anchorPath`/`focusPath` arrays are captured (snapshotted from
+ * the live blocks here) — NOT the live block references. The caller rebuilds
+ * the clean document immediately after, detaching these block instances, so
+ * `setCursor` must re-resolve fresh blocks from those paths against the new
+ * tree. The structure is identical between the sentinel tree and the clean tree
+ * (the sentinels only change text), so the paths stay valid.
+ *
+ * The returned offsets are sentinel-free: the focus offset is decremented when
+ * the anchor sentinel precedes it in the same block, mirroring the legacy
+ * two-sentinel bookkeeping.
+ */
+export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
+    const anchorHit = _findSentinel(scrollPage, ANCHOR_SENTINEL);
+    const focusHit = _findSentinel(scrollPage, FOCUS_SENTINEL);
+
+    if (!anchorHit && !focusHit)
+        return null;
+
+    const anchor = anchorHit ?? focusHit!;
+    const focus = focusHit ?? anchorHit!;
+
+    let anchorOffset = anchor.offset;
+    let focusOffset = focus.offset;
+
+    // When both sentinels live in the same block, the second one's recorded
+    // offset is shifted by the first sentinel's length. Normalise so both
+    // offsets are expressed against the sentinel-free text.
+    if (anchor.block === focus.block) {
+        if (anchorOffset <= focusOffset)
+            focusOffset = Math.max(focusOffset - ANCHOR_SENTINEL.length, anchorOffset);
+        else
+            anchorOffset = Math.max(anchorOffset - FOCUS_SENTINEL.length, focusOffset);
+    }
+
+    // Snapshot the paths now, while the blocks are still attached.
+    return {
+        anchor: { offset: anchorOffset },
+        anchorPath: [...anchor.block.path],
+        focus: { offset: focusOffset },
+        focusPath: [...focus.block.path],
+    };
+}


### PR DESCRIPTION
## Summary

Final wave of the muyajs → @muyajs/core parity follow-ups to #4406. The seven Wave-1 engine PRs (#4408–#4414) landed the engine halves; this PR wires the **desktop** consumers and flips the remaining desktop scoreboard tests. **14 of the 15 confirmed gaps are now closed; PG14 is accept-deferred.**

## Per-gap outcome

| Gap | What this PR wires | Status |
|-----|--------------------|--------|
| **PG1** | `adaptSelectionChange` consumes the new `affiliation` chain + `anchorBlockInfo`/`focusBlockInfo` (engine #4410); fixes the consumer's loose-list read. Native Paragraph/Format menu check-marks, loose/task-list toggles, table/code detection, and Format-disable-in-code work again. | ✅ fixed |
| **PG2** | New engine helper `Muya#setCursorByOffset` + desktop `handleFileChange` maps the saved CodeMirror `{line, ch}` `muyaIndexCursor` onto a block-key cursor, restoring the WYSIWYG caret after a source-mode edit. | ✅ fixed (engine helper added) |
| **PG8** | `util/pdf.ts::getHtmlToc` swaps the legacy muyajs `Slugger` for `@muyajs/core`'s `generateGithubSlug`, replicating the engine's whole-document `-N` dedup (#4412) so exported-TOC anchors match the injected heading ids. | ✅ fixed |
| **PG9** | `COPY_PASTE_METHOD_MAP.copyAsRich` → the real `Muya#copyAsRich` (engine #4411). "Copy as Rich Text" now yields formatted rich text, not HTML source. | ✅ fixed |
| **PG10** | `preview-image` subscription already present; engine now emits it (#4414). **Verified, no change.** | ✅ fixed |
| **PG11** | Re-added `editor.on('heading-copy-link', ({ key }) => editorStore.copyGithubSlug(key))` (engine emits it, #4414). | ✅ fixed |
| **PG15** | `makeSyntheticHistory` id is now the engine undo-stack **depth** (a stable position marker, not an ever-incrementing counter), and a freshly-loaded tab seeds `lastSavedHistoryId` to the baseline depth (0). Undo-to-disk restores the saved/clean indicator. | ✅ fixed |
| **PG14** | First undo after source mode reverting the bulk edit in one step. **Accept-deferred** — see below. | ⏸️ deferred |

PG3/PG12 (#4409), PG4 (#4413), PG5/PG6 (#4411), PG7 (#4412), PG13 (#4408) are engine-only and needed no desktop change.

## Engine helper added

`packages/muya/src/selection/offsetCursor.ts` + `Muya#setCursorByOffset(indexCursor)` (separate commit `feat(muya): add setCursorByOffset…`). It reproduces the legacy muyajs index→block-key conversion: inject sentinel strings into the current markdown at the line/ch offsets, rebuild the tree, find the content blocks they landed in, then rebuild the clean document and set the cursor by the resolved paths + offsets (both `setContent` calls run synchronously, so no intermediate paint). Covered by `setCursorByOffset.spec.ts` (5 `PG2:` cases).

## PG14 — accept-defer rationale

On source-mode exit, `handleFileChange` rebuilds the doc via `setContent` (which `history.clear()`s) then restores the pre-source op stack, so the bulk change is not a single undo boundary. Recording it as one boundary would require computing a general whole-document `ot-json1` diff and feeding it through `Editor.updateContents`' pick/drop walker, which only handles a fixed set of op shapes (block insert at index, text edit, `checked`/`meta`); an arbitrary diff (removes/moves/nested replaces) risks corrupting the document. The risk outweighs the benefit (narrow first-undo-granularity edge case; undo still works, prior stack intact), so PG14 is left `test.fail()` with explanatory notes in `handleFileChange` and the spec. A clean revival needs a dedicated engine "record a state replacement as one op" API.

## Tests

- Flipped `test.fail()` → real on PG1 (`parity-pg1-menu-state.spec.ts`), PG2 + PG15 (`parity-source-undo-saved.spec.ts`); all genuinely pass.
- PG14 stays `test.fail()`.
- Added `packages/muya/src/__tests__/setCursorByOffset.spec.ts`.
- Reconciled `packages/desktop/test/PARITY_SCOREBOARD.md` to the true state (gaps remaining 11 → 1).

## Verification

`pnpm typecheck` (only the pre-existing `electron.vite.config.ts` vite/rolldown typing error remains), `pnpm lint` (0 errors), `pnpm test` (560 pass), `pnpm build:unpack` (clean), the parity e2e suite (4 pass incl. PG14 xfail) + core e2e (launch/editor-input/tabs/selection-change/inline-format/paragraph-blocks, 36 pass), and the full muya engine gauntlet (lint/types/circular/553 unit/1347 spec — all green).

Parity follow-up to #4406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)