### PR TITLE
fix: #4356 support custom protocol links

### DIFF
--- a/packages/desktop/src/main/menu/actions/file.ts
+++ b/packages/desktop/src/main/menu/actions/file.ts
@@ -575,6 +575,21 @@ interface FormatLinkPayload {
   dirname?: string
 }
 
+const UNSAFE_EXTERNAL_PROTOCOLS = new Set(['file:', 'javascript:', 'data:', 'vbscript:'])
+
+const isExternalProtocolUrl = (value: string): boolean => {
+  if (/^[a-z]:[\\/]/i.test(value)) {
+    return false
+  }
+
+  try {
+    const url = new URL(value)
+    return !!url.protocol && !UNSAFE_EXTERNAL_PROTOCOLS.has(url.protocol.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
 ipcMain.on('mt::format-link-click', (e, { data, dirname }: FormatLinkPayload) => {
   if (!data || (!data.href && !data.text)) {
     return
@@ -602,8 +617,8 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }: FormatLinkPayload) =>
   if (URL_REG.test(urlCandidate)) {
     shell.openExternal(urlCandidate)
     return
-  } else if (/^[a-z0-9]+:\/\//i.test(urlCandidate)) {
-    // Prevent other URLs.
+  } else if (isExternalProtocolUrl(urlCandidate)) {
+    shell.openExternal(urlCandidate)
     return
   }
 

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -75,7 +75,7 @@ interface FileChangePayload {
 }
 
 interface FormatLinkClickPayload {
-  data: { href: string; [key: string]: unknown }
+  data: { href?: string | null; text?: string | null; [key: string]: unknown }
   dirname: string
 }
 
@@ -389,8 +389,9 @@ export const useEditorStore = defineStore('editor', {
     FORMAT_LINK_CLICK({ data, dirname }: FormatLinkClickPayload): void {
       // Check if the link starts with a #, that is a local anchor link.
 
-      if (data.href.length > 0 && data.href[0] === '#') {
-        const anchorSlug = data.href.substring(1)
+      const href = typeof data.href === 'string' ? data.href : ''
+      if (href.length > 0 && href[0] === '#') {
+        const anchorSlug = href.substring(1)
         if (!anchorSlug) return
 
         // Find the block with the anchor slug from the TOC

--- a/packages/desktop/test/e2e/issue-4356.spec.ts
+++ b/packages/desktop/test/e2e/issue-4356.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
+
+test.describe('issue #4356 custom protocol links', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchElectron()
+    app = launched.app
+    page = launched.page
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('opens custom protocol links through the external shell handler', async() => {
+    await app.evaluate(({ shell }) => {
+      const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+      g.__mt_opened_external_urls__ = []
+      shell.openExternal = async(url: string) => {
+        const urls = g.__mt_opened_external_urls__
+        if (urls) urls.push(url)
+      }
+    })
+
+    await page.evaluate(() => {
+      window.electron.ipcRenderer.send('mt::format-link-click', {
+        data: { href: null, text: 'sambesi://localhost/node/11164' },
+        dirname: ''
+      })
+    })
+
+    await expect
+      .poll(async() => {
+        return await app.evaluate(() => {
+          const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+          return g.__mt_opened_external_urls__ || []
+        })
+      })
+      .toContain('sambesi://localhost/node/11164')
+  })
+
+  test('does not pass file URLs to the external shell handler', async() => {
+    await app.evaluate(() => {
+      const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+      g.__mt_opened_external_urls__ = []
+    })
+
+    await page.evaluate(() => {
+      window.electron.ipcRenderer.send('mt::format-link-click', {
+        data: { href: 'file:///tmp/secret.md' },
+        dirname: ''
+      })
+    })
+
+    await page.waitForTimeout(250)
+    const opened = await app.evaluate(() => {
+      const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+      return g.__mt_opened_external_urls__ || []
+    })
+    expect(opened).toEqual([])
+  })
+
+  test('does not treat Windows drive paths as external protocols', async() => {
+    await app.evaluate(() => {
+      const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+      g.__mt_opened_external_urls__ = []
+    })
+
+    await page.evaluate(() => {
+      window.electron.ipcRenderer.send('mt::format-link-click', {
+        data: { href: 'C:/Users/example/note.md' },
+        dirname: ''
+      })
+    })
+
+    await page.waitForTimeout(250)
+    const opened = await app.evaluate(() => {
+      const g = global as unknown as { __mt_opened_external_urls__?: string[] }
+      return g.__mt_opened_external_urls__ || []
+    })
+    expect(opened).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #4356

## Summary

- Allow non-web custom protocol links such as `sambesi://...` to open through Electron's external shell path.
- Keep unsafe protocols (`file:`, `javascript:`, `data:`, `vbscript:`) out of `openExternal`.
- Avoid treating Windows drive paths such as `C:/Users/example/note.md` as external protocols.
- Make the renderer link-click payload tolerate `href: null` and fall back to `text` for links reported by the editor.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on: macOS

Validation run:

```sh
pnpm --filter marktext typecheck
pnpm --filter marktext build
pnpm --filter marktext exec eslint src/main/menu/actions/file.ts src/renderer/src/store/editor.ts test/e2e/issue-4356.spec.ts
pnpm --filter marktext exec playwright test test/e2e/issue-4356.spec.ts --config test/e2e/playwright.config.ts
```

Notes:

- Targeted ESLint completed with warning-only existing non-null assertion warnings in the touched files; no lint errors were reported.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.