### PR TITLE
fix(desktop): pass imageAction + getPathForFile to Muya constructor (re-activate PG4/5/6)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1500,7 +1500,13 @@ onMounted(() => {
     sequenceTheme: sequenceTheme.value,
     spellcheckEnabled: spellcheckerEnabled.value,
     // Resolve the OS clipboard to a local file path on paste (image-from-file).
-    clipboardFilePath: guessClipboardFilePath
+    clipboardFilePath: guessClipboardFilePath,
+    // Image-persist callbacks read by the engine's clipboard + drag-drop handlers
+    // from `muya.options.*` (distinct from the ImageEditTool plugin option above).
+    // Without these, local-file drag-drop, screenshot/binary clipboard paste, and
+    // copy-to-assets on a pasted image file silently no-op or insert raw paths.
+    imageAction: muyaImageAction,
+    getPathForFile: (file: File) => window.electron.webUtils.getPathForFile(file)
   }
 
   if (/dark/i.test(theme.value)) {


### PR DESCRIPTION
## What
The `#4406` editor.vue rewrite dropped the constructor-level `imageAction` (and the new `getPathForFile`) options from the `new Muya(ele, options)` call. The engine reads these from `muya.options.*`:
- `packages/muya/src/clipboard/index.ts:825` — `const { imageAction } = this.muya.options` (PG5 binary paste, PG6 file paste)
- `packages/muya/src/editor/dragDropImage.ts:168/215/221` — `muya.options.imageAction` + `muya.options.getPathForFile` (PG4)

These are **distinct** from the `ImageEditTool` plugin's `imageAction` option (which was kept). Without the constructor options, three already-merged engine fixes were **silently inert on the desktop**:
- **PG4** local-file drag-drop image insertion (#4413)
- **PG5** screenshot / binary clipboard paste persistence (#4411)
- **PG6** copy-to-assets / upload on a pasted image file → raw absolute path was inserted (#4411)

## Fix
Add `imageAction: muyaImageAction` + `getPathForFile: (file) => window.electron.webUtils.getPathForFile(file)` to the constructor `options`. The `muyaImageAction` adapter and the `webUtils.getPathForFile` preload bridge already exist.

## Why it slipped
The PG4/PG5/PG6 e2e are manual-QA (headless can't drive real drag/clipboard-bitmap gestures), so the missing wiring wasn't caught by the automated scoreboard — a concrete data point for the Phase G real-app verification.

Verified: `typecheck` clean, no new lint errors. Gesture paths to be manual-QA'd. Part of the muyajs → @muyajs/core migration.