### PR TITLE
fix(muya): resolve pre-existing lint:css no-descending-specificity

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -383,6 +383,27 @@ ol.mu-order-list:last-child {
     margin-bottom: 0;
 }
 
+/* Focus mode (mirrors marktext muyajs `.ag-focus-mode`): when the editor
+   container carries `mu-focus-mode`, dim every top-level block and restore full
+   opacity on the active one. `mu-active` is applied to the whole ancestor chain
+   of the focused content block, so the top-level block containing the cursor
+   keeps `opacity: 1`. The class is toggled by `Muya#setFocusMode`.
+
+   Placed ahead of the task-list rules so the low-specificity
+   `.mu-focus-mode .mu-container > *` selector precedes the higher-specificity
+   `li.mu-task-list-item > … ~ *` rule below (stylelint no-descending-specificity).
+   The two target disjoint elements and set different properties, so order has
+   no visual effect. */
+.mu-focus-mode .mu-container > * {
+    opacity: 0.25;
+
+    transition: opacity 0.2s ease-in-out;
+}
+
+.mu-focus-mode .mu-container > .mu-active {
+    opacity: 1;
+}
+
 /* task list */
 ul.mu-task-list {
     padding-left: 1em;
@@ -901,19 +922,4 @@ pre.mu-active.mu-fenced-code::after {
 
 .mu-container figure.mu-footnote > i.mu-footnote-backlink:hover {
     color: var(--theme-color);
-}
-
-/* Focus mode (mirrors marktext muyajs `.ag-focus-mode`): when the editor
-   container carries `mu-focus-mode`, dim every top-level block and restore full
-   opacity on the active one. `mu-active` is applied to the whole ancestor chain
-   of the focused content block, so the top-level block containing the cursor
-   keeps `opacity: 1`. The class is toggled by `Muya#setFocusMode`. */
-.mu-focus-mode .mu-container > * {
-    opacity: 0.25;
-
-    transition: opacity 0.2s ease-in-out;
-}
-
-.mu-focus-mode .mu-container > .mu-active {
-    opacity: 1;
 }

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -392,7 +392,7 @@ ol.mu-order-list:last-child {
    Placed ahead of the task-list rules so the low-specificity
    `.mu-focus-mode .mu-container > *` selector precedes the higher-specificity
    `li.mu-task-list-item > … ~ *` rule below (stylelint no-descending-specificity).
-   The two target disjoint elements and set different properties, so order has
+   They target disjoint elements and set different properties, so order has
    no visual effect. */
 .mu-focus-mode .mu-container > * {
     opacity: 0.25;


### PR DESCRIPTION
## What

`pnpm -C packages/muya lint:css` failed with a `no-descending-specificity` error in `packages/muya/src/assets/styles/blockSyntax.css`:

> Expected selector `.mu-focus-mode .mu-container > *` to come before selector `li.mu-task-list-item > input.mu-checkbox-checked ~ *`

Both rules share the universal `*` key selector, but the higher-specificity task-list rule (0,2,2) preceded the lower-specificity focus-mode rule (0,2,0).

## Fix

Pure reorder — stylelint's standard fix. The self-contained focus-mode block (both rules plus its explanatory comment) is moved from the end of the file to ahead of the task-list section, so the lower-specificity selector now precedes the higher one.

This is a **pure reordering with no visual change**:
- No declarations or selectors were modified.
- The two rules match disjoint elements (focus-mode top-level blocks vs. siblings of a checked task-list checkbox) and set different properties (`opacity`/`transition` vs `color`), so their relative order cannot affect rendering.

No blanket `stylelint-disable` was used.

## Verification

- `pnpm -C packages/muya lint:css` → exits 0 (the two remaining `order/properties-order` items are pre-existing warnings, not errors, and out of scope here).
- `pnpm -C packages/muya lint` → 0 errors.
- `pnpm -C packages/muya test` → 72 files, 554 tests pass.

`lint:css` is not a CI gate today; this just keeps it clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)