### PR TITLE
fix(muya): record source-mode bulk edit as a single undo boundary (PG14)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1334,6 +1334,7 @@ const handleFileChange = (payload: unknown) => {
     markdown: newMarkdown,
     cursor: newCursor,
     muyaIndexCursor,
+    history: payloadHistory,
     scrollTop
   } = (payload ?? {}) as FileChangePayload
   if (!editor.value) return
@@ -1341,37 +1342,56 @@ const handleFileChange = (payload: unknown) => {
   if (!container) return
 
   if (typeof newMarkdown === 'string') {
-    // `setContent` replaces the document and clears history, so restore the
-    // real engine history (kept per-tab) afterwards — preserves undo/redo on
-    // in-session tab switch. The `history` in the payload is the synthetic
-    // desktop-shaped history used for save tracking, not the engine history.
-    editor.value.setContent(newMarkdown)
-    if (newCursor) {
-      editor.value.setCursor(newCursor)
-    } else if (isIndexCursor(muyaIndexCursor)) {
-      // Coming back from source-code mode the tab only has a CodeMirror
-      // `{ line, ch }` index cursor; map it onto a block-key cursor so the
-      // WYSIWYG caret lands where the source-mode cursor was (PG2). The engine
-      // runs its own setContent dance internally, so restore the history after.
+    // Returning from source-code mode: the WYSIWYG engine is never unmounted
+    // while source mode is up (index.vue overlays it via `v-if`), so it still
+    // holds the PRE-source-mode document and undo history. Record the bulk
+    // source-mode edit as a SINGLE engine undo boundary via `replaceContent`
+    // (PG14 parity): the first Ctrl+Z after the handoff reverts the entire
+    // source-mode change in one step, matching legacy muyajs' full-state
+    // snapshot history. `replaceContent` builds a fully-invertible whole-document
+    // ot-json1 op and applies undo/redo via a full block-tree rebuild (never the
+    // incremental pick/drop walker), so arbitrary block-type changes round-trip
+    // safely.
+    //
+    // Detection: only sourceCode.vue's onBeforeUnmount emits `file-changed` with
+    // a source-mode index cursor AND no block-key `cursor` AND no `history`
+    // (see sourceCode.vue ~L368). Every tab-switch / file-reload emitter in
+    // editor.ts carries both `cursor` and `history` alongside, so requiring
+    // those absent reliably isolates the WYSIWYG<-source handoff from a tab
+    // activation that merely replays a tab's persisted `muyaIndexCursor`.
+    const isSourceModeHandoff =
+      isIndexCursor(muyaIndexCursor) && !newCursor && payloadHistory == null
+
+    if (isSourceModeHandoff) {
+      // Record the bulk source-mode edit as a single undo boundary. When the
+      // document is unchanged this is a no-op (returns false) and the existing
+      // history/content already match — either way the caret still needs
+      // remapping below.
+      editor.value.replaceContent(newMarkdown)
+      // Map the CodeMirror `{ line, ch }` cursor onto a block-key cursor so the
+      // WYSIWYG caret lands where the source-mode cursor was (PG2).
       editor.value.setCursorByOffset(muyaIndexCursor)
+    } else {
+      // Tab switch / programmatic content swap: `setContent` replaces the
+      // document and clears history, so restore the real engine history (kept
+      // per-tab) afterwards — preserves undo/redo on in-session tab switch. The
+      // `history` in the payload is the synthetic desktop-shaped history used
+      // for save tracking, not the engine history.
+      editor.value.setContent(newMarkdown)
+      if (newCursor) {
+        editor.value.setCursor(newCursor)
+      } else if (isIndexCursor(muyaIndexCursor)) {
+        // Source-mode handoff for a tab the engine has no history for (e.g.
+        // first interaction after load): fall back to a caret-only remap. The
+        // engine runs its own setContent dance internally, so restore the
+        // history after.
+        editor.value.setCursorByOffset(muyaIndexCursor)
+      }
+      const savedEngineHistory = id ? engineHistoryByTab.get(id) : undefined
+      if (savedEngineHistory) {
+        editor.value.setHistory(savedEngineHistory)
+      }
     }
-    const savedEngineHistory = id ? engineHistoryByTab.get(id) : undefined
-    if (savedEngineHistory) {
-      editor.value.setHistory(savedEngineHistory)
-    }
-    // PARITY (gap PG14 — accept-defer): the bulk source-mode change is rebuilt
-    // via `setContent` and is NOT recorded as an engine undo op, so the first
-    // Ctrl+Z after exiting source mode replays the last pre-source WYSIWYG op
-    // instead of reverting the source-mode edit in one step (legacy muyajs
-    // pushed a full-state snapshot that made it a single undo boundary).
-    // Recording it as one boundary would mean computing a json1 op from the
-    // pre-source state to the post-source state and feeding it through
-    // `Editor.updateContents`' pick/drop walker — but that walker only handles
-    // specific op shapes (block insert at index, text edit, checked/meta), so a
-    // general whole-document diff (arbitrary add/remove/move/nested-replace)
-    // risks corrupting the document. Deferred rather than ship a fragile fix;
-    // the prior op stack is intact and undo still works, only the first-undo
-    // granularity across the boundary differs.
   } else if (newCursor) {
     editor.value.setCursor(newCursor)
   }

--- a/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
+++ b/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
@@ -22,6 +22,10 @@ const undo = async(app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> 
   await sendIpcToRenderer(app, 'mt::editor-edit-action', 'undo')
 }
 
+const redo = async(app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> => {
+  await sendIpcToRenderer(app, 'mt::editor-edit-action', 'redo')
+}
+
 test.describe('Parity PG2 — WYSIWYG caret restored after a source-mode edit', () => {
   // handleFileChange now maps the saved `muyaIndexCursor` ({line, ch}) onto a
   // block-key cursor via the engine's `setCursorByOffset`, so the source-mode
@@ -67,15 +71,13 @@ test.describe('Parity PG2 — WYSIWYG caret restored after a source-mode edit', 
 })
 
 test.describe('Parity PG14 — first undo after source mode reverts the edit in one step', () => {
-  // ACCEPT-DEFER: on source-mode exit the engine rebuilds the document via
-  // setContent (which does NOT record an undo op) then restores the pre-source
-  // op stack, so the bulk source-mode change is not a single undo boundary.
-  // Recording it as one boundary would require feeding a general
-  // whole-document json1 diff through Editor.updateContents' pick/drop walker,
-  // which only handles specific op shapes (block insert / text edit /
-  // checked|meta) and would risk corrupting the document on arbitrary diffs.
-  // Left as `test.fail()` — see the matching note in editor.vue handleFileChange.
-  test.fail()
+  // FIXED: on source-mode exit, handleFileChange records the bulk change as a
+  // SINGLE engine undo boundary via `Muya.replaceContent` (a fully-invertible
+  // whole-document ot-json1 op applied through a full block-tree rebuild, never
+  // the incremental pick/drop walker), so the first undo reverts the entire
+  // source-mode edit in one step — matching legacy muyajs' full-state-snapshot
+  // history. See the matching note in editor.vue handleFileChange and the
+  // engine unit coverage in packages/muya/src/__tests__/replaceContent.spec.ts.
   test('PG14: one undo after exiting source mode reverts the source-mode change', async() => {
     const { app, page } = await launchWithMarkdown('base\n')
     await waitForMenuReady(app)
@@ -92,6 +94,41 @@ test.describe('Parity PG14 — first undo after source mode reverts the edit in 
     // Desired: the document reverts to the exact pre-source-mode content in a
     // single undo step.
     expect((await getMarkdownContent(page, app)).trim()).toBe('base')
+    await app.close()
+  })
+
+  test('PG14: redo re-applies the source-mode change in one step', async() => {
+    const { app, page } = await launchWithMarkdown('base\n')
+    await waitForMenuReady(app)
+
+    await setSourceMarkdown(page, app, 'base\n\nSOURCE ADDED LINE\n')
+    await page.waitForTimeout(500)
+
+    await undo(app)
+    await page.waitForTimeout(600)
+    expect((await getMarkdownContent(page, app)).trim()).toBe('base')
+
+    // Redo restores the entire bulk change in one step.
+    await redo(app)
+    await page.waitForTimeout(600)
+    expect((await getMarkdownContent(page, app)).trim()).toContain('SOURCE ADDED LINE')
+    await app.close()
+  })
+
+  test('PG14: a block-type bulk change reverts in one undo step', async() => {
+    const { app, page } = await launchWithMarkdown('hello\n')
+    await waitForMenuReady(app)
+
+    // Convert a paragraph into a heading + add a list — an arbitrary
+    // whole-document change (the corruption-risk surface the incremental walker
+    // could not handle). The single undo must restore the exact paragraph.
+    await setSourceMarkdown(page, app, '# hello\n\n- new item\n')
+    await page.waitForTimeout(500)
+    expect((await getMarkdownContent(page, app)).trim()).toContain('# hello')
+
+    await undo(app)
+    await page.waitForTimeout(600)
+    expect((await getMarkdownContent(page, app)).trim()).toBe('hello')
     await app.close()
   })
 })

--- a/packages/muya/src/__tests__/replaceContent.spec.ts
+++ b/packages/muya/src/__tests__/replaceContent.spec.ts
@@ -1,0 +1,315 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// Coverage for `Muya.replaceContent` — the single-undo-boundary whole-document
+// replacement used when the desktop shell hands a tab back from source-code
+// mode (parity gap PG14). The first `undo()` after a bulk replacement must
+// revert the ENTIRE change in one step, and `redo()` must re-apply it; both
+// directions rebuild the block tree wholesale (ScrollPage.updateState) rather
+// than walking it incrementally, so arbitrary block-type changes round-trip
+// without desyncing the live DOM from the authoritative json state.
+//
+// Each case asserts on `getMarkdown()` (the authoritative json state) AND on a
+// fresh `setContent` of the same target (the ground-truth DOM) so a walker that
+// silently desynced the tree would be caught: `domHtml()` of the rebuilt tree
+// must equal the ground truth.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function placeCursorOnFirstBlock(muya: Muya): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    first.setCursor(0, 0, true);
+    return first;
+}
+
+// Normalize the editor DOM for structural comparison: drop the volatile
+// attributes (ids, keys, classes, contenteditable flags) and zero-width
+// markers so two trees built from the same state compare equal.
+function domHtml(muya: Muya): string {
+    const clone = muya.domNode.cloneNode(true) as HTMLElement;
+    clone.querySelectorAll('*').forEach((el) => {
+        el.removeAttribute('id');
+        el.removeAttribute('data-key');
+        el.removeAttribute('class');
+        el.removeAttribute('contenteditable');
+        el.removeAttribute('spellcheck');
+        el.removeAttribute('style');
+    });
+    return clone.innerHTML.replace(/\u200B/g, '').replace(/\s+/g, ' ').trim();
+}
+
+// Build a detached ground-truth tree for `markdown` and return both its
+// canonical (engine-rendered) markdown and its normalized DOM — what the live
+// tree MUST look like after a replaceContent / undo / redo settles on the same
+// content. The engine re-renders some constructs canonically (e.g. table cell
+// padding), so the target is compared against the engine's own output, not the
+// raw source string.
+function groundTruth(markdown: string): { md: string; dom: string } {
+    const muya = bootMuya(markdown);
+    return { md: muya.getMarkdown(), dom: domHtml(muya) };
+}
+
+function undoDepth(muya: Muya): number {
+    // @ts-expect-error — reach into the private stack for test assertions.
+    return muya.editor.history._stack.undo.length;
+}
+
+function redoDepth(muya: Muya): number {
+    // @ts-expect-error — reach into the private stack for test assertions.
+    return muya.editor.history._stack.redo.length;
+}
+
+const cases: Array<[string, string, string]> = [
+    ['paragraph add block', 'base\n', 'base\n\nSOURCE ADDED LINE\n'],
+    ['paragraph -> heading', 'hello\n', '# hello\n'],
+    ['heading -> paragraph', '# hello\n', 'hello\n'],
+    ['paragraph -> bullet list', 'item\n', '- item\n'],
+    ['list add item', '- a\n- b\n', '- a\n- b\n- c\n'],
+    ['list remove item', '- a\n- b\n- c\n', '- a\n- c\n'],
+    ['list nest', '- a\n- b\n', '- a\n  - b\n'],
+    ['bullet -> ordered list', '- a\n- b\n', '1. a\n2. b\n'],
+    ['paragraph -> table', 'x\n', '| a | b |\n| --- | --- |\n| 1 | 2 |\n'],
+    ['paragraph -> code block', 'x\n', '```js\nconst a = 1\n```\n'],
+    ['code block -> paragraph', '```js\nconst a = 1\n```\n', 'plain\n'],
+    ['add frontmatter', 'body\n', '---\ntitle: x\n---\n\nbody\n'],
+    ['remove frontmatter', '---\ntitle: x\n---\n\nbody\n', 'body\n'],
+    ['inline edit', 'hello world\n', 'hello WORLD\n'],
+    ['inline emphasis added', 'plain text\n', 'plain **bold** text\n'],
+    ['multi-block reorder', 'A\n\nB\n\nC\n', 'C\n\nA\n\nB\n'],
+    ['delete middle block', 'A\n\nB\n\nC\n', 'A\n\nC\n'],
+    ['blockquote', 'quote me\n', '> quote me\n'],
+    [
+        'mixed bulk replacement',
+        '# Title\n\npara\n\n- l1\n- l2\n',
+        '## Changed\n\nnew para\n\n1. ol1\n2. ol2\n\n```\ncode\n```\n',
+    ],
+    ['clear to single empty paragraph', 'A\n\nB\n', '\n'],
+];
+
+describe('muya replaceContent — single undo boundary', () => {
+    it.each(cases)(
+        'records ONE boundary and round-trips: %s',
+        async (_name, before, after) => {
+            const muya = bootMuya(before);
+            await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe(before.trim()));
+            placeCursorOnFirstBlock(muya);
+
+            const beforeMd = muya.getMarkdown();
+            const beforeDom = groundTruth(before).dom;
+            const truth = groundTruth(after);
+
+            // Forward replacement records exactly ONE undo boundary.
+            const depthBefore = undoDepth(muya);
+            const changed = muya.replaceContent(after);
+            expect(changed).toBe(true);
+            expect(undoDepth(muya)).toBe(depthBefore + 1);
+
+            // Json state AND live DOM both reflect the new content.
+            expect(muya.getMarkdown()).toBe(truth.md);
+            expect(domHtml(muya)).toBe(truth.dom);
+
+            // FIRST undo reverts the entire bulk change in one step.
+            placeCursorOnFirstBlock(muya);
+            muya.undo();
+            await vi.waitFor(() => {
+                expect(muya.getMarkdown()).toBe(beforeMd);
+            });
+            // Live DOM is restored too (catches a desynced incremental walker).
+            expect(domHtml(muya)).toBe(beforeDom);
+            expect(redoDepth(muya)).toBe(1);
+
+            // redo re-applies the entire change in one step.
+            placeCursorOnFirstBlock(muya);
+            muya.redo();
+            await vi.waitFor(() => {
+                expect(muya.getMarkdown()).toBe(truth.md);
+            });
+            expect(domHtml(muya)).toBe(truth.dom);
+        },
+    );
+
+    it('returns false and records nothing when content is unchanged', async () => {
+        const muya = bootMuya('same\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('same'));
+        const depth = undoDepth(muya);
+        expect(muya.replaceContent('same\n')).toBe(false);
+        expect(undoDepth(muya)).toBe(depth);
+        expect(muya.getMarkdown().trim()).toBe('same');
+    });
+
+    it('remains lossless across repeated undo/redo toggles (remove-heavy op)', async () => {
+        // A replacement that DELETES blocks exercises the `invert`-without-doc
+        // path `_change` uses to repopulate the redo stack: the recorded undo op
+        // must carry the removed block values so each toggle reproduces the exact
+        // state. Toggle several times to catch any drift.
+        const muya = bootMuya('A\n\nB\n\nC\n\nD\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('A\n\nB\n\nC\n\nD'));
+        placeCursorOnFirstBlock(muya);
+
+        const before = muya.getMarkdown();
+        muya.replaceContent('A\n\nD\n'); // delete B and C
+        const after = muya.getMarkdown();
+        expect(after.trim()).toBe('A\n\nD');
+
+        for (let i = 0; i < 3; i++) {
+            placeCursorOnFirstBlock(muya);
+            muya.undo();
+            await vi.waitFor(() => expect(muya.getMarkdown()).toBe(before));
+
+            placeCursorOnFirstBlock(muya);
+            muya.redo();
+            await vi.waitFor(() => expect(muya.getMarkdown()).toBe(after));
+        }
+    });
+
+    it('does not coalesce a later edit into the replacement boundary', async () => {
+        const muya = bootMuya('base\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('base'));
+        placeCursorOnFirstBlock(muya);
+
+        muya.replaceContent('base\n\nADDED\n');
+        expect(undoDepth(muya)).toBe(1);
+        expect(muya.getMarkdown().trim()).toContain('ADDED');
+
+        // A normal edit immediately afterwards must be its OWN boundary, even
+        // within the History coalescing window (recordRebuild reset lastRecorded).
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.editor.activeContentBlock = first;
+        first.setCursor(4, 4, true);
+        muya.insertParagraph('after', 'typed');
+        await vi.waitFor(() => {
+            expect(undoDepth(muya)).toBe(2);
+            expect(muya.getMarkdown()).toContain('typed');
+        });
+
+        // Undo only the typed edit — the replacement stays applied.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).not.toContain('typed');
+            expect(muya.getMarkdown()).toContain('ADDED');
+        });
+
+        // Second undo reverts the bulk replacement.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('base');
+        });
+    });
+
+    it('preserves the pre-existing undo stack beneath the boundary', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.insertParagraph('after', 'edit-one');
+        await vi.waitFor(() => {
+            expect(undoDepth(muya)).toBe(1);
+            expect(muya.getMarkdown()).toContain('edit-one');
+        });
+        muya.editor.history.cutoff();
+
+        // Bulk replacement on top of an existing 1-deep stack.
+        placeCursorOnFirstBlock(muya);
+        muya.replaceContent('completely different\n');
+        expect(undoDepth(muya)).toBe(2);
+        expect(muya.getMarkdown().trim()).toBe('completely different');
+
+        // Undo the replacement: back to the post-edit-one document.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('edit-one');
+            expect(muya.getMarkdown()).not.toContain('completely different');
+        });
+
+        // The earlier op is still undoable — back to the original title.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('# Title');
+        });
+        expect(muya.editor.history.canUndo()).toBe(false);
+    });
+
+    it('replacement boundary survives getHistory / setHistory round-trip', async () => {
+        const muya = bootMuya('start\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('start'));
+        placeCursorOnFirstBlock(muya);
+
+        muya.replaceContent('start\n\n## section\n\nrebuilt body\n');
+        expect(undoDepth(muya)).toBe(1);
+        const targetMd = muya.getMarkdown();
+
+        // Persist through JSON exactly as the desktop shell does on tab switch.
+        const snapshot = JSON.parse(JSON.stringify(muya.getHistory()));
+        expect(snapshot.stack.undo[0].rebuild).toBe(true);
+
+        muya.clearHistory();
+        muya.setHistory(snapshot);
+        expect(undoDepth(muya)).toBe(1);
+
+        // Undo the restored rebuild boundary — reverts to the pre-replacement doc.
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('start');
+        });
+
+        // redo reproduces the exact replacement target.
+        placeCursorOnFirstBlock(muya);
+        muya.redo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toBe(targetMd);
+        });
+    });
+
+    it('accepts a state array as well as markdown', async () => {
+        const muya = bootMuya('one\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('one'));
+        placeCursorOnFirstBlock(muya);
+
+        const target = muya.editor.jsonState.markdownToState('# heading\n\ntwo\n');
+        muya.replaceContent(target);
+        expect(undoDepth(muya)).toBe(1);
+        expect(muya.getMarkdown()).toContain('# heading');
+        expect(muya.getMarkdown()).toContain('two');
+
+        placeCursorOnFirstBlock(muya);
+        muya.undo();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('one');
+        });
+    });
+});

--- a/packages/muya/src/__tests__/replaceContent.spec.ts
+++ b/packages/muya/src/__tests__/replaceContent.spec.ts
@@ -194,6 +194,52 @@ describe('muya replaceContent — single undo boundary', () => {
         }
     });
 
+    it('does not mutate the stored undo-stack selection paths across replays', async () => {
+        // Regression: applying a rebuild entry restores the caret via
+        // Selection.setSelection -> _setCursor -> scrollPage.queryBlock(path),
+        // and queryBlock drains the path array with shift(). The stored undo
+        // entry's selection paths must survive repeated undo/redo replays (we
+        // clone them before resolving), otherwise the second replay would query
+        // an emptied path and lose the caret.
+        const muya = bootMuya('first\n\nsecond\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('first\n\nsecond'));
+        // Seat the caret in the SECOND block so the recorded selection has a
+        // non-trivial path ([1, ...]) that would be visibly corrupted if drained.
+        const second = muya.editor.scrollPage!.lastContentInDescendant()!;
+        muya.editor.activeContentBlock = second;
+        second.setCursor(0, 0, true);
+
+        muya.replaceContent('first\n\nsecond\n\nthird\n');
+        expect(undoDepth(muya)).toBe(1);
+
+        // @ts-expect-error — reach into the private stack for assertions.
+        const storedSel = muya.editor.history._stack.undo[0].selection;
+        const pathLenBefore = storedSel?.anchorPath?.length ?? 0;
+        expect(pathLenBefore).toBeGreaterThan(0);
+
+        // Two full undo/redo cycles — each replay resolves the caret from paths.
+        // Re-fetch a live block each iteration: the prior `second` ref is
+        // detached after the rebuild and would crash on `.path` reads.
+        for (let i = 0; i < 2; i++) {
+            const live = muya.editor.scrollPage!.firstContentInDescendant()!;
+            muya.editor.activeContentBlock = live;
+            live.setCursor(0, 0, true);
+            muya.undo();
+            await vi.waitFor(() => expect(muya.getMarkdown()).not.toContain('third'));
+            const live2 = muya.editor.scrollPage!.firstContentInDescendant()!;
+            muya.editor.activeContentBlock = live2;
+            live2.setCursor(0, 0, true);
+            muya.redo();
+            await vi.waitFor(() => expect(muya.getMarkdown()).toContain('third'));
+        }
+
+        // The stored selection's paths are untouched (not drained to []).
+        // @ts-expect-error — private stack read.
+        const after = muya.editor.history._stack;
+        const finalSel = after.redo[0]?.selection ?? after.undo[0]?.selection;
+        expect(finalSel?.anchorPath?.length ?? 0).toBeGreaterThan(0);
+    });
+
     it('does not coalesce a later edit into the replacement boundary', async () => {
         const muya = bootMuya('base\n');
         await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('base'));

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -361,18 +361,43 @@ export class Editor {
 
         drop(snapshot, operations);
 
-        if (selection) {
-            const { anchorPath, anchor, focus, isSelectionInSameBlock } = selection;
-            const cursorBlock = this.scrollPage?.queryBlock(anchorPath);
+        this._restoreSelection(selection);
+    }
 
-            const begin = Math.min(anchor.offset, focus.offset);
-            const end = Math.max(anchor.offset, focus.offset);
+    private _restoreSelection(selection: Nullable<IHistorySelection>) {
+        if (!selection)
+            return;
 
-            if (isSelectionInSameBlock && cursorBlock && cursorBlock.isContent())
-                cursorBlock.setCursor(begin, end, true);
-            else
-                this.selection.setSelection(selection);
-        }
+        const { anchorPath, anchor, focus, isSelectionInSameBlock } = selection;
+        // `ScrollPage.queryBlock` consumes the path array in place (`path.shift`),
+        // so query against a copy and leave the caller's selection untouched.
+        const cursorBlock = this.scrollPage?.queryBlock([...anchorPath]);
+
+        const begin = Math.min(anchor.offset, focus.offset);
+        const end = Math.max(anchor.offset, focus.offset);
+
+        if (isSelectionInSameBlock && cursorBlock && cursorBlock.isContent())
+            cursorBlock.setCursor(begin, end, true);
+        else
+            this.selection.setSelection(selection);
+    }
+
+    /**
+     * Apply a history op by rebuilding the live block tree wholesale instead of
+     * walking it incrementally (`updateContents`). The op is dispatched to the
+     * authoritative json state, then `ScrollPage.updateState` re-creates the DOM
+     * from that state — the same safe path `setContent` uses. Used for undo/redo
+     * of whole-document boundaries (e.g. exiting source-code mode) whose op
+     * shapes the incremental pick/drop walker cannot apply without desyncing the
+     * DOM from the json state.
+     */
+    rebuildContents(operations: JSONOp, selection: Nullable<IHistorySelection>, source: string) {
+        this.jsonState.dispatch(operations, source);
+
+        const state = this.jsonState.getState();
+        this.scrollPage!.updateState(state);
+
+        this._restoreSelection(selection);
     }
 
     setContent(content: TState[] | string, autoFocus = false) {

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -364,7 +364,7 @@ export class Editor {
         this._restoreSelection(selection);
     }
 
-    private _restoreSelection(selection: Nullable<IHistorySelection>) {
+    private _restoreSelection(selection: Nullable<IHistorySelection>, treeRebuilt = false) {
         if (!selection)
             return;
 
@@ -376,10 +376,35 @@ export class Editor {
         const begin = Math.min(anchor.offset, focus.offset);
         const end = Math.max(anchor.offset, focus.offset);
 
-        if (isSelectionInSameBlock && cursorBlock && cursorBlock.isContent())
+        if (isSelectionInSameBlock && cursorBlock && cursorBlock.isContent()) {
             cursorBlock.setCursor(begin, end, true);
-        else
-            this.selection.setSelection(selection);
+            return;
+        }
+
+        // When the tree was rebuilt wholesale (rebuildContents), the saved
+        // selection's cached `anchorBlock` / `focusBlock` reference DETACHED
+        // nodes from the previous tree — resolving them would set the native DOM
+        // range onto a detached node and crash the next `getSelection()` read.
+        // Re-resolve the caret from the (cloned) path against the fresh tree;
+        // fall back to focusing the first content block when the saved path no
+        // longer points at a content leaf (e.g. a paragraph became a table).
+        if (treeRebuilt) {
+            if (cursorBlock && cursorBlock.isContent())
+                cursorBlock.setCursor(begin, end, true);
+            else
+                this.focus();
+
+            return;
+        }
+
+        // Incremental (updateContents) path: blocks are still attached. Clone the
+        // paths so `_setCursor`'s `queryBlock(path)` fallback can't drain the
+        // caller's arrays — notably the selection object stored in the undo stack.
+        this.selection.setSelection({
+            ...selection,
+            anchorPath: [...selection.anchorPath],
+            focusPath: [...selection.focusPath],
+        });
     }
 
     /**
@@ -397,7 +422,9 @@ export class Editor {
         const state = this.jsonState.getState();
         this.scrollPage!.updateState(state);
 
-        this._restoreSelection(selection);
+        // The tree was rebuilt wholesale, so the selection's cached block
+        // references are stale — resolve the caret from paths instead.
+        this._restoreSelection(selection, true);
     }
 
     setContent(content: TState[] | string, autoFocus = false) {

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -16,6 +16,16 @@ interface IOptions {
 interface IOperation {
     operation: JSONOpList;
     selection: Nullable<IHistorySelection>;
+    // A `rebuild` entry is applied on undo/redo by dispatching its op to the
+    // authoritative json state and rebuilding the live block tree wholesale
+    // (ScrollPage.updateState) — NOT through `Editor.updateContents`'
+    // incremental pick/drop DOM walker. The walker only handles a few op shapes
+    // (single block insert at an index, text edit, checked/meta) and desyncs the
+    // DOM from the json state for whole-document ops, so bulk replacements
+    // (e.g. exiting source-code mode) are recorded as rebuild entries. The op
+    // itself is a normal, fully-invertible ot-json1 op, so compose / transform /
+    // invert continue to work unchanged.
+    rebuild?: boolean;
 }
 
 interface IStack {
@@ -42,6 +52,7 @@ interface ISerializableSelection {
 interface ISerializableOperation {
     operation: JSONOpList;
     selection: Nullable<ISerializableSelection>;
+    rebuild?: boolean;
 }
 
 // The public, JSON-serializable shape returned by `getHistory` and accepted by
@@ -112,17 +123,21 @@ class History {
         if (this._stack[source].length === 0)
             return;
 
-        const { operation, selection } = this._stack[source].pop()!;
+        const { operation, selection, rebuild } = this._stack[source].pop()!;
         const inverseOperation = json1.type.invert(operation);
 
         this._stack[dest].push({
             operation: inverseOperation as JSONOpList,
             selection: this.selection.getSelection(),
+            rebuild,
         });
 
         this._lastRecorded = 0;
         this._ignoreChange = true;
-        this.muya.editor.updateContents(operation, selection, 'user');
+        if (rebuild)
+            this.muya.editor.rebuildContents(operation, selection, 'user');
+        else
+            this.muya.editor.updateContents(operation, selection, 'user');
         this._ignoreChange = false;
 
         this.getLastSelection();
@@ -180,6 +195,7 @@ class History {
         return {
             operation: deepClone(op.operation),
             selection: this._toSerializableSelection(op.selection),
+            ...(op.rebuild ? { rebuild: true } : {}),
         };
     }
 
@@ -187,6 +203,7 @@ class History {
         return {
             operation: deepClone(op.operation),
             selection: this._fromSerializableSelection(op.selection),
+            ...(op.rebuild ? { rebuild: true } : {}),
         };
     }
 
@@ -277,6 +294,52 @@ class History {
 
         if (this._stack.undo.length > this.options.maxStack)
             this._stack.undo.shift();
+    }
+
+    /**
+     * Record a whole-document replacement (e.g. exiting source-code mode) as a
+     * single, standalone undo boundary that is applied via a full block-tree
+     * rebuild rather than the incremental DOM walker.
+     *
+     * The forward op (`prevDoc` -> current state) is dispatched to the json
+     * state by the caller; here we only record its lossless inverse so the first
+     * undo reverts the entire bulk change in one step. The entry never coalesces
+     * with neighbouring edits: `_lastRecorded` is reset so the next ordinary
+     * edit also starts its own boundary, and the redo stack is cleared.
+     */
+    recordRebuild(op: JSONOpList, prevDoc: TState[], selection: Nullable<IHistorySelection>) {
+        if (op.length === 0)
+            return;
+
+        const undoOperation = json1.type.invertWithDoc(op, asDoc(prevDoc));
+
+        if (!undoOperation || undoOperation.length === 0)
+            return;
+
+        this._stack.redo = [];
+        this._stack.undo.push({ operation: undoOperation, selection, rebuild: true });
+        // Force the next ordinary edit into its own undo entry — the bulk
+        // replacement must not absorb a later keystroke (or vice versa).
+        this._lastRecorded = 0;
+
+        if (this._stack.undo.length > this.options.maxStack)
+            this._stack.undo.shift();
+    }
+
+    /**
+     * Run `fn` (which dispatches a json-change) WITHOUT recording it on the undo
+     * stack. The caller has already recorded the corresponding boundary itself
+     * (see `recordRebuild`), so the forward apply must not be double-recorded.
+     */
+    suppressRecording(fn: () => void) {
+        const previous = this._ignoreChange;
+        this._ignoreChange = true;
+        try {
+            fn();
+        }
+        finally {
+            this._ignoreChange = previous;
+        }
     }
 
     canRedo() {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -239,6 +239,43 @@ export class Muya {
     }
 
     /**
+     * Replace the whole document with `content` (markdown or a state array) as a
+     * SINGLE undo boundary — the first subsequent `undo()` reverts the entire
+     * replacement in one step. Unlike `setContent`, the existing undo/redo
+     * history is preserved and a new boundary is pushed on top of it.
+     *
+     * Used by the desktop shell when handing a tab back from source-code mode:
+     * the bulk source-mode edit becomes one undo step (legacy muyajs parity,
+     * gap PG14). The change is recorded as a `rebuild` history entry, so undo /
+     * redo re-create the block tree wholesale (`ScrollPage.updateState`) rather
+     * than walking it incrementally — making arbitrary block-type changes
+     * (paragraph<->heading, list/table/code/frontmatter, multi-block reorder…)
+     * safe to round-trip. No-op when `content` is identical to the current
+     * document.
+     *
+     * @returns `true` if a boundary was recorded, `false` if nothing changed.
+     */
+    replaceContent(content: TState[] | string): boolean {
+        const { jsonState, history } = this.editor;
+        const { op, prevState } = jsonState.buildReplaceOp(content);
+
+        if (op.length === 0)
+            return false;
+
+        const selection = this.editor.selection.getSelection();
+        // Record the lossless inverse as a standalone rebuild boundary BEFORE
+        // applying the forward op, so the recorded `prevState` matches the doc
+        // the inverse must restore. The forward apply dispatches a json-change,
+        // so suppress History's own recording of it to avoid a duplicate entry.
+        history.recordRebuild(op, prevState, selection);
+        history.suppressRecording(() => {
+            this.editor.rebuildContents(op, selection, 'api');
+        });
+
+        return true;
+    }
+
+    /**
      * Update editor options at runtime (mirrors marktext muyajs `setOptions`):
      * merges `options` into `muya.options`, reflects the container-level ones
      * (spellcheck, quick-insert hint), and — when `forceRender` is set — fully

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -72,6 +72,13 @@ class JSONState {
     }
 
     setMarkdown(markdown: string) {
+        this._state = this.markdownToState(markdown);
+    }
+
+    // Parse markdown into a block-state array with the editor's current
+    // render-affecting options, WITHOUT mutating `this._state`. Used by
+    // `buildReplaceOp` to compute the target state for a bulk replacement.
+    markdownToState(markdown: string): TState[] {
         const {
             footnote,
             isGitlabCompatibilityEnabled,
@@ -80,13 +87,75 @@ class JSONState {
             math,
         } = this.muya.options;
 
-        this._state = new MarkdownToState({
+        return new MarkdownToState({
             footnote,
             isGitlabCompatibilityEnabled,
             trimUnnecessaryCodeBlockEmptyLines,
             frontMatter,
             math,
         }).generate(markdown);
+    }
+
+    /**
+     * Build a single, fully-invertible ot-json1 op that turns the CURRENT
+     * document state into `content` (markdown or a state array), and return it
+     * together with the before/after states.
+     *
+     * The op is deliberately MOVE-FREE: it replaces each overlapping top-level
+     * block, inserts the tail, and removes the surplus (highest index first).
+     * It never emits a pick/drop `move`, so `json1.type.apply` reproduces the
+     * target state exactly and `invertWithDoc` yields a lossless inverse. The op
+     * is applied to the live tree via `ScrollPage.updateState` (a full rebuild),
+     * never the incremental DOM walker, so arbitrary block-type changes are safe.
+     */
+    buildReplaceOp(content: TState[] | string): {
+        op: JSONOpList;
+        prevState: TState[];
+        nextState: TState[];
+    } {
+        const prevState = this.getState();
+        const nextState
+            = typeof content === 'string' ? this.markdownToState(content) : deepClone(content);
+
+        const components: JSONOpList[] = [];
+        const max = Math.max(prevState.length, nextState.length);
+
+        for (let i = 0; i < max; i++) {
+            if (i < prevState.length && i < nextState.length) {
+                if (
+                    JSON.stringify(prevState[i]) !== JSON.stringify(nextState[i])
+                ) {
+                    components.push(
+                        json1.replaceOp(
+                            [i],
+                            asDoc(prevState[i]),
+                            asDoc(nextState[i]),
+                        )!,
+                    );
+                }
+            }
+            else if (i < nextState.length) {
+                components.push(json1.insertOp([i], asDoc(nextState[i]))!);
+            }
+        }
+
+        // Remove surplus trailing blocks from the end so earlier indices stay
+        // stable while composing.
+        for (let i = prevState.length - 1; i >= nextState.length; i--)
+            components.push(json1.removeOp([i])!);
+
+        // Compose the components into one op. `json1.type.compose` returns
+        // `JSONOp` (= null | JSONOpList) and its identity element is `null`
+        // (composing onto `[]` throws "Empty descent"). Start from `null`, then
+        // normalize the final result to the empty op `[]` when nothing changed
+        // (the documents were identical) so callers can rely on `op.length`.
+        let composed: JSONOp = null;
+        for (const component of components)
+            composed = json1.type.compose(composed, component);
+
+        const op: JSONOpList = composed ?? [];
+
+        return { op, prevState, nextState };
     }
 
     insertOperation(path: Path, state: TState) {


### PR DESCRIPTION
## Summary

Closes the last open parity gap **PG14**: after editing in source-code mode and switching back to WYSIWYG, the **first Ctrl+Z now reverts the entire source-mode bulk edit as ONE undo step** (matching legacy muyajs' full-state-snapshot history). Previously the first undo replayed the last pre-source WYSIWYG op instead.

## The problem

On source-mode exit, `editor.vue::handleFileChange` rebuilt the document via `setContent` (which `history.clear()`s the engine undo stack) then restored only the PRE-source-mode op stack via `setHistory`, so the source-mode bulk change was never recorded as an engine undo boundary.

## Why a general json1 diff is NOT safe (the Wave-2 concern, empirically confirmed)

The engine applies undo/redo through `Editor.updateContents`' incremental pick/drop DOM walker, which only handles a few op shapes (single block insert at an index, text edit, checked/meta). I empirically tested feeding move-free whole-document json1 ops through that walker across 14 diverse transforms: the **json state was always correct** (`json1.type.apply` is sound) but the **live block tree desynced in every case** — usually left completely empty. A general-diff approach through the existing walker corrupts the document.

## The safe fix (approach b — checkpoint applied via full rebuild)

New engine API `Muya.replaceContent(content)` records the change as a **`rebuild` history entry** whose undo/redo are applied via a **full block-tree rebuild** (`Editor.rebuildContents` → `ScrollPage.updateState`) — the same safe path `setContent` already uses everywhere — **never** the incremental walker.

The op itself is a normal, **fully-invertible** ot-json1 op:
- `JSONState.buildReplaceOp` builds a **move-free** replace/insert/remove composition (no `p:`/`d:` moves), so `json1.type.apply` reproduces the target exactly.
- `invertWithDoc` yields a lossless undo op carrying removed block values, and `invert` (no doc) correctly recovers the forward op — so `_change`'s redo-push round-trips losslessly.
- compose / transform / invert and the `getHistory`/`setHistory` serialization keep working unchanged (the `rebuild` flag is just propagated).

The existing undo machinery for ordinary edits is untouched.

## Corruption-safety argument

The authoritative json state is always updated by `json1.type.apply` (sound for any valid op). The DOM is then rebuilt **wholesale from that state** via `ScrollPage.updateState`, identical to a fresh `setContent`. Tests assert the rebuilt DOM equals a fresh-`setContent` ground truth across every transform, so a desync would fail the suite.

## Test coverage

**Engine unit (`packages/muya/src/__tests__/replaceContent.spec.ts`, 26 tests):** every case asserts BOTH the json state AND the live DOM (vs fresh-`setContent` ground truth) round-trip through replace → undo → redo across: paragraph↔heading, list add/remove/nest, bullet↔ordered, table, code block, frontmatter add/remove, inline edits + emphasis, blockquote, multi-block reorder, delete-middle, mixed bulk, clear-to-empty; plus no-op detection, non-coalescing with later edits, preserving the prior undo stack, `getHistory`/`setHistory` round-trip of the rebuild boundary, state-array input, and a remove-heavy **repeated** undo/redo toggle (the `invert`-without-doc path).

**Desktop e2e (`parity-source-undo-saved.spec.ts`):** PG14 flipped `test.fail()` → passing, plus added a redo round-trip and a block-type bulk-change (paragraph → heading + list) scenario.

## Verification (all green locally)

- muya: `lint` · `lint:types` · `check-circular` · `test` (579) · `test:spec` (1347)
- desktop: `typecheck` · `lint` · `test:unit` (560) · `build:unpack` · parity e2e (5/5) + source-mode/tab/crash/find-replace e2e regression set

Refs the muyajs→@muyajs/core migration parity scoreboard (PG14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)