### PR TITLE
fix(desktop): retarget theme.ts editor CSS at muya mu-* classes (E4)

### DIFF
--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -52,7 +52,7 @@ const patchTheme = (css: string): string => {
 
 const getEmojiPickerPatch = (): string => {
   return isLinux
-    ? '.ag-emoji-picker section .emoji-wrapper .item span { font-family: sans-serif, "Noto Color Emoji"; }'
+    ? '.mu-emoji-picker section .emoji-wrapper .item span { font-family: sans-serif, "Noto Color Emoji"; }'
     : ''
 }
 
@@ -200,10 +200,10 @@ export const setWrapCodeBlocks = (value: boolean): void => {
   let result = ''
   if (value) {
     result =
-      '.ag-code-content { display: block; white-space: pre-wrap; word-break: break-word; overflow: hidden; }'
+      '.mu-code { display: block; white-space: pre-wrap; word-break: break-word; overflow: hidden; }'
   } else {
     result =
-      '.ag-code-content { display: block; white-space: pre; word-break: break-word; overflow: auto; }'
+      '.mu-code { display: block; white-space: pre; word-break: break-word; overflow: auto; }'
   }
   let styleEle = document.querySelector(`#${CODE_WRAP_STYLE_ID}`) as HTMLStyleElement | null
   if (!styleEle) {
@@ -260,7 +260,7 @@ th code,
 code,
 code[class*="language-"],
 .CodeMirror,
-pre.ag-paragraph {
+.mu-code-block {
 font-family: ${codeFontFamily}, ${DEFAULT_CODE_FONT_FAMILY};
 font-size: ${codeFontSize}px;
 }

--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -200,10 +200,10 @@ export const setWrapCodeBlocks = (value: boolean): void => {
   let result = ''
   if (value) {
     result =
-      '.mu-code { display: block; white-space: pre-wrap; word-break: break-word; overflow: hidden; }'
+      '.mu-code-block .mu-code { display: block; white-space: pre-wrap; word-break: break-word; overflow: hidden; }'
   } else {
     result =
-      '.mu-code { display: block; white-space: pre; word-break: break-word; overflow: auto; }'
+      '.mu-code-block .mu-code { display: block; white-space: pre; word-break: break-word; overflow: auto; }'
   }
   let styleEle = document.querySelector(`#${CODE_WRAP_STYLE_ID}`) as HTMLStyleElement | null
   if (!styleEle) {


### PR DESCRIPTION
## What (Phase E4)
The @muyajs/core migration changed the editor DOM from muyajs `ag-*` classes to `mu-*`. `util/theme.ts` still injected three **editor-targeting** rules at the old `ag-*` selectors, which silently stopped applying after the swap:
- **wrapCodeBlocks** preference white-space: `.ag-code-content` → `.mu-code` (the `code.mu-code` element)
- emoji-picker font fallback: `.ag-emoji-picker` → `.mu-emoji-picker` (inner `section .emoji-wrapper .item span` is identical)
- code-block font: `pre.ag-paragraph` → `.mu-code-block`

Same class of silent-failure as #4417 — visual-only, but `wrapCodeBlocks` is a real setting.

## Notes
- `themeColor.ts` has no `ag-*` selectors. The `.CodeMirror` (source-mode) and generic `code` / `code[class*="language-"]` (Prism tokens) selectors are correct and untouched → **E2 (prism/CodeMirror) needs no change**.
- `ag-code-wrap` (the injected `<style>` element's id) is internal, not a selector — left as-is.
- String-content-only change; typecheck/lint unaffected.

Part of the muyajs → @muyajs/core migration (Phase E).