### PR TITLE
fix(desktop): port print image-src resolution off muyajs (last muya/lib import)

### DIFF
--- a/packages/desktop/src/renderer/src/services/printService.ts
+++ b/packages/desktop/src/renderer/src/services/printService.ts
@@ -10,10 +10,14 @@ function resolveImageSrcForStaticPrint(src: string): string {
   if (!src) return src
   // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
   if (/^(?:https?:|file:|data:)/i.test(src)) return src
-  // Absolute local path (POSIX / UNC / Windows drive) → file://.
+  // Only rewrite recognised local image paths (mirrors muyajs's IMAGE_EXT_REG
+  // gate) — leave anything else untouched, e.g. an extensionless absolute
+  // server path `/api/image?id=…` must not become `file:///api/image…`.
+  if (!IMAGE_EXT_REG.test(src)) return src
+  // Absolute local image path (POSIX / UNC / Windows drive) → file://.
   if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
   // Relative local image path — resolve against the document directory.
-  if (IMAGE_EXT_REG.test(src) && window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
   return src
 }
 

--- a/packages/desktop/src/renderer/src/services/printService.ts
+++ b/packages/desktop/src/renderer/src/services/printService.ts
@@ -1,14 +1,21 @@
-// NOTE: still sourced from the legacy muyajs engine. The desktop calls
-// `getImageInfo(rawSrc: string)` to normalise an <img>'s src attribute into a
-// displayable URL before printing/PDF export (GH#678). @muyajs/core has no
-// behaviour-equivalent string helper:
-//   - its `getImageInfo(image: HTMLElement)` takes a DOM element, not a string;
-//   - its `getImageSrc(src: string)` double-prefixes already-resolved `file://`
-//     URLs (`file://file://…`) and blanks data: URLs — and the muyajs export
-//     renderer already emits absolute `file://` srcs here, so that would
-//     regress every image. This import migrates once the export render path
-//     (editor.vue / Muya#exportStyledHTML) moves to @muyajs/core.
-import { getImageInfo } from 'muya/lib/utils'
+// Resolve an <img>'s src for static (PDF) print (GH#678): a relative local
+// path is resolved to an absolute `file://` URL against the current document
+// directory; URLs, `data:` URIs, and already-absolute / `file://` srcs are
+// left untouched. Ported from the legacy muyajs `getImageInfo(src)` so the
+// desktop no longer depends on the muyajs engine (@muyajs/core's `getImageInfo`
+// takes a DOM element, and its `getImageSrc` would double-prefix `file://`).
+const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
+
+function resolveImageSrcForStaticPrint(src: string): string {
+  if (!src) return src
+  // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
+  if (/^(?:https?:|file:|data:)/i.test(src)) return src
+  // Absolute local path (POSIX / UNC / Windows drive) → file://.
+  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
+  // Relative local image path — resolve against the document directory.
+  if (IMAGE_EXT_REG.test(src) && window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  return src
+}
 
 class MarkdownPrint {
   private container: HTMLElement | null = null
@@ -33,7 +40,7 @@ class MarkdownPrint {
       const images = printContainer.getElementsByTagName('img')
       for (const image of Array.from(images)) {
         const rawSrc = image.getAttribute('src') ?? ''
-        image.src = getImageInfo(rawSrc).src
+        image.src = resolveImageSrcForStaticPrint(rawSrc)
       }
     }
 


### PR DESCRIPTION
## What
`services/printService.ts` was the **last desktop *source* file importing the legacy `muya/lib` (muyajs) engine** — it used muyajs `getImageInfo(src: string)` to resolve a relative `<img>` src into an absolute `file://` URL for static (PDF) print (GH#678).

`@muyajs/core` has no drop-in replacement (its `getImageInfo` takes a DOM element; `getImageSrc` would double-prefix `file://`). So the resolution is ported inline as a small, self-contained desktop helper using `window.path.resolve` + `window.DIRNAME`:
- relative local image path → `file://${resolve(DIRNAME, src)}`
- absolute local path → `file://${src}`
- URLs / `data:` / already-`file://` → unchanged (no `file://file://` double-prefix)

Behaviour-preserving (uses the same `path.resolve` semantics + muyajs's `IMAGE_EXT_REG`). `typecheck` clean.

## Why it matters
This removes the final `muya/lib` import from desktop **source** — the remaining references are comments + the `muya.d.ts` type shim, both removed in Phase H. **This unblocks deleting `packages/muyajs`.** PDF/print image rendering is manual-QA (headless can't verify visual print output).

Part of the muyajs → @muyajs/core migration.