### PR TITLE
fix(muya): crash typing '#' — guard I18n.t + add heading-copy-link locale key

### DIFF
--- a/packages/muya/src/i18n/index.ts
+++ b/packages/muya/src/i18n/index.ts
@@ -18,7 +18,7 @@ class I18n {
     t(key: string): string {
         const { lang, resources } = this;
 
-        return resources?.[lang]?.[key] || resources.en[key] || key;
+        return resources?.[lang]?.[key] || resources.en?.[key] || key;
     }
 
     locale(object: ILocale) {

--- a/packages/muya/src/i18n/index.ts
+++ b/packages/muya/src/i18n/index.ts
@@ -18,7 +18,7 @@ class I18n {
     t(key: string): string {
         const { lang, resources } = this;
 
-        return resources?.[lang]?.[key] || resources.en?.[key] || key;
+        return resources?.[lang]?.[key] || resources?.en?.[key] || key;
     }
 
     locale(object: ILocale) {

--- a/packages/muya/src/locales/de.ts
+++ b/packages/muya/src/locales/de.ts
@@ -41,6 +41,7 @@ export const de = {
         'No result': 'Kein Ergebnis',
         'Search keyword...': 'Suchbegriff...',
         'Type / to insert...': '/ eingeben zum Einfügen...',
+        'Copy anchor link to this heading': 'Ankerlink zu dieser Überschrift kopieren',
         // formatPicker
         'Emphasize': 'Fett',
         'Italic': 'Kursiv',

--- a/packages/muya/src/locales/en.ts
+++ b/packages/muya/src/locales/en.ts
@@ -41,6 +41,7 @@ export const en = {
         'No result': 'No result',
         'Search keyword...': 'Search keyword...',
         'Type / to insert...': 'Type / to insert...',
+        'Copy anchor link to this heading': 'Copy anchor link to this heading',
         // formatPicker
         'Emphasize': 'Emphasize',
         'Italic': 'Italic',

--- a/packages/muya/src/locales/es.ts
+++ b/packages/muya/src/locales/es.ts
@@ -41,6 +41,7 @@ export const es = {
         'No result': 'Sin resultados',
         'Search keyword...': 'Buscar palabra clave...',
         'Type / to insert...': 'Escribe / para insertar...',
+        'Copy anchor link to this heading': 'Copiar enlace de ancla a este encabezado',
         // formatPicker
         'Emphasize': 'Negrita',
         'Italic': 'Cursiva',

--- a/packages/muya/src/locales/fr.ts
+++ b/packages/muya/src/locales/fr.ts
@@ -41,6 +41,7 @@ export const fr = {
         'No result': 'Aucun résultat',
         'Search keyword...': 'Rechercher un mot-clé...',
         'Type / to insert...': 'Tapez / pour insérer...',
+        'Copy anchor link to this heading': 'Copier le lien d\'ancrage vers ce titre',
         // formatPicker
         'Emphasize': 'Gras',
         'Italic': 'Italique',

--- a/packages/muya/src/locales/ja.ts
+++ b/packages/muya/src/locales/ja.ts
@@ -41,6 +41,7 @@ export const ja = {
         'No result': '結果がありません',
         'Search keyword...': 'キーワードを検索する...',
         'Type / to insert...': '段落を入力 /挿入する',
+        'Copy anchor link to this heading': 'この見出しへのアンカーリンクをコピー',
         // formatPicker
         'Emphasize': '太字',
         'Italic': '斜体',

--- a/packages/muya/src/locales/ko.ts
+++ b/packages/muya/src/locales/ko.ts
@@ -41,6 +41,7 @@ export const ko = {
         'No result': '결과 없음',
         'Search keyword...': '키워드 검색...',
         'Type / to insert...': '/ 입력하여 삽입...',
+        'Copy anchor link to this heading': '이 제목의 앵커 링크 복사',
         // formatPicker
         'Emphasize': '굵게',
         'Italic': '기울임',

--- a/packages/muya/src/locales/pt.ts
+++ b/packages/muya/src/locales/pt.ts
@@ -41,6 +41,7 @@ export const pt = {
         'No result': 'Sem resultados',
         'Search keyword...': 'Buscar palavra-chave...',
         'Type / to insert...': 'Digite / para inserir...',
+        'Copy anchor link to this heading': 'Copiar link de âncora para este título',
         // formatPicker
         'Emphasize': 'Negrito',
         'Italic': 'Itálico',

--- a/packages/muya/src/locales/zh-CN.ts
+++ b/packages/muya/src/locales/zh-CN.ts
@@ -41,6 +41,7 @@ export const zhCN = {
         'No result': '无结果',
         'Search keyword...': '搜索关键字...',
         'Type / to insert...': '输入 / 插入段落',
+        'Copy anchor link to this heading': '复制此标题的锚点链接',
         // formatPicker
         'Emphasize': '加粗',
         'Italic': '斜体',

--- a/packages/muya/src/locales/zh-TW.ts
+++ b/packages/muya/src/locales/zh-TW.ts
@@ -41,6 +41,7 @@ export const zhTW = {
         'No result': '無結果',
         'Search keyword...': '搜尋關鍵字...',
         'Type / to insert...': '輸入 / 插入段落',
+        'Copy anchor link to this heading': '複製此標題的錨點連結',
         // formatPicker
         'Emphasize': '粗體',
         'Italic': '斜體',


### PR DESCRIPTION
## Crash
Typing `#` to create a heading throws in the renderer:
```
TypeError: Cannot read properties of undefined (reading 'Copy anchor link to this heading')
  at I18n.t (muya/src/i18n/index.ts)
  at new HeadingCopyLink (muya/src/block/commonMark/headingCopyLink/index.ts)
```

## Root cause (two bugs)
1. **`I18n.t` is not crash-safe.** `return resources?.[lang]?.[key] || resources.en[key] || key` — `resources.en` is **undefined whenever the loaded locale isn't named `en`** (the constructor stores only `{ [name]: resource }`). A key missing from the current locale fell through to `resources.en[key]` → throw.
2. **The key was never added to the locales.** `HeadingCopyLink` (PG11, #4414) calls `i18n.t('Copy anchor link to this heading')`, but that key isn't in any locale resource — so it always hit the unguarded fallback.

## Fix
- `resources.en[key]` → `resources.en?.[key]` (any missing key is now safe, every locale).
- Added `'Copy anchor link to this heading'` to all 9 locales (en/zh-CN/zh-TW/de/es/fr/ja/ko/pt).

Verified: `lint`, `lint:types`, full `test` green. This is a real-app regression the headless tests missed (the spec/e2e ran under the `en` default where `resources.en` exists) — exactly the Phase G class.