### PR TITLE
fix(muya): add missing image i18n keys ('Click to add an image' / 'Load image failed')

### DIFF
--- a/packages/muya/src/locales/de.ts
+++ b/packages/muya/src/locales/de.ts
@@ -42,6 +42,8 @@ export const de = {
         'Search keyword...': 'Suchbegriff...',
         'Type / to insert...': '/ eingeben zum Einfügen...',
         'Copy anchor link to this heading': 'Ankerlink zu dieser Überschrift kopieren',
+        'Click to add an image': 'Klicken, um ein Bild hinzuzufügen',
+        'Load image failed': 'Bild konnte nicht geladen werden',
         // formatPicker
         'Emphasize': 'Fett',
         'Italic': 'Kursiv',

--- a/packages/muya/src/locales/en.ts
+++ b/packages/muya/src/locales/en.ts
@@ -42,6 +42,8 @@ export const en = {
         'Search keyword...': 'Search keyword...',
         'Type / to insert...': 'Type / to insert...',
         'Copy anchor link to this heading': 'Copy anchor link to this heading',
+        'Click to add an image': 'Click to add an image',
+        'Load image failed': 'Load image failed',
         // formatPicker
         'Emphasize': 'Emphasize',
         'Italic': 'Italic',

--- a/packages/muya/src/locales/es.ts
+++ b/packages/muya/src/locales/es.ts
@@ -42,6 +42,8 @@ export const es = {
         'Search keyword...': 'Buscar palabra clave...',
         'Type / to insert...': 'Escribe / para insertar...',
         'Copy anchor link to this heading': 'Copiar enlace de ancla a este encabezado',
+        'Click to add an image': 'Haz clic para añadir una imagen',
+        'Load image failed': 'Error al cargar la imagen',
         // formatPicker
         'Emphasize': 'Negrita',
         'Italic': 'Cursiva',

--- a/packages/muya/src/locales/fr.ts
+++ b/packages/muya/src/locales/fr.ts
@@ -42,6 +42,8 @@ export const fr = {
         'Search keyword...': 'Rechercher un mot-clé...',
         'Type / to insert...': 'Tapez / pour insérer...',
         'Copy anchor link to this heading': 'Copier le lien d\'ancrage vers ce titre',
+        'Click to add an image': 'Cliquez pour ajouter une image',
+        'Load image failed': 'Échec du chargement de l\'image',
         // formatPicker
         'Emphasize': 'Gras',
         'Italic': 'Italique',

--- a/packages/muya/src/locales/ja.ts
+++ b/packages/muya/src/locales/ja.ts
@@ -42,6 +42,8 @@ export const ja = {
         'Search keyword...': 'キーワードを検索する...',
         'Type / to insert...': '段落を入力 /挿入する',
         'Copy anchor link to this heading': 'この見出しへのアンカーリンクをコピー',
+        'Click to add an image': 'クリックして画像を追加',
+        'Load image failed': '画像の読み込みに失敗しました',
         // formatPicker
         'Emphasize': '太字',
         'Italic': '斜体',

--- a/packages/muya/src/locales/ko.ts
+++ b/packages/muya/src/locales/ko.ts
@@ -42,6 +42,8 @@ export const ko = {
         'Search keyword...': '키워드 검색...',
         'Type / to insert...': '/ 입력하여 삽입...',
         'Copy anchor link to this heading': '이 제목의 앵커 링크 복사',
+        'Click to add an image': '클릭하여 이미지 추가',
+        'Load image failed': '이미지 로드 실패',
         // formatPicker
         'Emphasize': '굵게',
         'Italic': '기울임',

--- a/packages/muya/src/locales/pt.ts
+++ b/packages/muya/src/locales/pt.ts
@@ -42,6 +42,8 @@ export const pt = {
         'Search keyword...': 'Buscar palavra-chave...',
         'Type / to insert...': 'Digite / para inserir...',
         'Copy anchor link to this heading': 'Copiar link de âncora para este título',
+        'Click to add an image': 'Clique para adicionar uma imagem',
+        'Load image failed': 'Falha ao carregar a imagem',
         // formatPicker
         'Emphasize': 'Negrito',
         'Italic': 'Itálico',

--- a/packages/muya/src/locales/zh-CN.ts
+++ b/packages/muya/src/locales/zh-CN.ts
@@ -42,6 +42,8 @@ export const zhCN = {
         'Search keyword...': '搜索关键字...',
         'Type / to insert...': '输入 / 插入段落',
         'Copy anchor link to this heading': '复制此标题的锚点链接',
+        'Click to add an image': '点击添加图片',
+        'Load image failed': '图片加载失败',
         // formatPicker
         'Emphasize': '加粗',
         'Italic': '斜体',

--- a/packages/muya/src/locales/zh-TW.ts
+++ b/packages/muya/src/locales/zh-TW.ts
@@ -42,6 +42,8 @@ export const zhTW = {
         'Search keyword...': '搜尋關鍵字...',
         'Type / to insert...': '輸入 / 插入段落',
         'Copy anchor link to this heading': '複製此標題的錨點連結',
+        'Click to add an image': '點擊新增圖片',
+        'Load image failed': '圖片載入失敗',
         // formatPicker
         'Emphasize': '粗體',
         'Italic': '斜體',


### PR DESCRIPTION
Follow-up audit after the #4424 `#`-typing crash: scanned every `i18n.t('…')` literal key in the muya engine against the locale resources and found **2 more missing** — `'Click to add an image'` and `'Load image failed'`. Pre-#4424 these would crash in a non-`en` locale; post-#4424 they render the raw English key. Added both to all 9 locales (en/zh-CN/zh-TW/de/es/fr/ja/ko/pt). Re-audit: 0 missing. lint/lint:types/test (581) green.