### PR TITLE
fix(muya): render relative image paths anchored to the document dir (Phase G blocker)

### DIFF
--- a/packages/muya/src/types/global.d.ts
+++ b/packages/muya/src/types/global.d.ts
@@ -5,6 +5,12 @@ declare global {
     interface Window {
         Prism: unknown;
         MUYA_VERSION: string;
+        // Absolute directory of the document currently open in the host
+        // (desktop) app. `getImageSrc` reads it to anchor relative local
+        // image paths, mirroring legacy muyajs `getImageInfo`. Undefined in
+        // non-desktop / headless contexts (the resolver then leaves relative
+        // paths untouched rather than producing a broken `file://`).
+        DIRNAME?: string;
     }
 
     interface Element {

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { getImageSrc } from '../image';
+
+// Regression tests for the Phase G "G1" blocker: relative-path images stopped
+// rendering after the @muyajs/core migration because `getImageSrc` returned a
+// non-anchored `file://assets/foo.png` instead of resolving the relative path
+// against the document directory. Legacy muyajs `getImageInfo(src, baseUrl =
+// window.DIRNAME)` did `'file://' + path.resolve(baseUrl, src)`; this suite
+// pins the ported behaviour.
+
+const DIRNAME = '/home/user/docs';
+
+function withDirname(dirname: string | undefined, fn: () => void) {
+    const previous = window.DIRNAME;
+    window.DIRNAME = dirname;
+    try {
+        fn();
+    }
+    finally {
+        window.DIRNAME = previous;
+    }
+}
+
+afterEach(() => {
+    window.DIRNAME = undefined;
+});
+
+describe('getImageSrc — relative local image paths anchored to window.DIRNAME', () => {
+    it('resolves a relative path against the document directory', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('assets/foo.png')).toEqual({
+                isUnknownType: false,
+                src: 'file:///home/user/docs/assets/foo.png',
+            });
+        });
+    });
+
+    it('resolves a `./` relative path', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('./img/cat.jpg').src).toBe(
+                'file:///home/user/docs/img/cat.jpg',
+            );
+        });
+    });
+
+    it('collapses `../` parent segments', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('../shared/logo.svg').src).toBe(
+                'file:///home/user/shared/logo.svg',
+            );
+        });
+    });
+
+    it('does not produce a double `file://` prefix', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('assets/foo.png').src).not.toContain(
+                'file://file://',
+            );
+        });
+    });
+
+    it('falls back to bare `file://` when window.DIRNAME is absent', () => {
+        withDirname(undefined, () => {
+            expect(getImageSrc('assets/foo.png')).toEqual({
+                isUnknownType: false,
+                src: 'file://assets/foo.png',
+            });
+        });
+    });
+
+    it('resolves Windows-drive base dirs with forward slashes', () => {
+        withDirname('C:\\Users\\me\\docs', () => {
+            expect(getImageSrc('assets\\foo.png').src).toBe(
+                'file://C:/Users/me/docs/assets/foo.png',
+            );
+        });
+    });
+});
+
+describe('getImageSrc — non-relative sources are left unchanged', () => {
+    it('leaves an absolute POSIX local path as a single `file://`', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('/var/img/pic.png')).toEqual({
+                isUnknownType: false,
+                src: 'file:///var/img/pic.png',
+            });
+        });
+    });
+
+    it('leaves an absolute Windows-drive path as a single `file://`', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('C:/img/pic.png').src).toBe('file://C:/img/pic.png');
+        });
+    });
+
+    it('leaves an http(s) URL untouched', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('https://example.com/x.png')).toEqual({
+                isUnknownType: false,
+                src: 'https://example.com/x.png',
+            });
+        });
+    });
+
+    it('leaves an already-`file://` src untouched (no double prefix)', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('file:///already/abs.png')).toEqual({
+                isUnknownType: false,
+                src: 'file:///already/abs.png',
+            });
+        });
+    });
+
+    it('leaves a data: URL untouched', () => {
+        const dataUrl
+            = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc(dataUrl)).toEqual({
+                isUnknownType: false,
+                src: dataUrl,
+            });
+        });
+    });
+
+    it('flags an extensionless http URL as unknown type', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('https://example.com/image')).toEqual({
+                isUnknownType: true,
+                src: 'https://example.com/image',
+            });
+        });
+    });
+});

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -25,6 +25,41 @@ export function getImageInfo(image: HTMLElement): IImageInfo {
     };
 }
 
+// A local image path that is already anchored to a filesystem root:
+// POSIX (`/foo`), Windows UNC (`\\host\share`), or a drive letter
+// (`C:\foo` / `C:/foo`). Mirrors legacy muyajs `getImageInfo`'s
+// `isAbsoluteLocal` check so absolute paths are NOT resolved against the
+// document directory.
+const ABSOLUTE_LOCAL_REG = /^(?:\/|\\\\|[a-z]:\\|[a-z]:\/).+/i;
+
+/**
+ * Resolve a relative POSIX path against an absolute base directory, mirroring
+ * Node's `path.resolve(base, rel)` for the cases `getImageSrc` cares about.
+ * Kept self-contained so the engine does not depend on the desktop host's
+ * `window.path` polyfill. Windows-style backslashes in `base` are normalised
+ * to `/` first (Chromium loads `file://` URLs with forward slashes regardless
+ * of platform). `.` and `..` segments are collapsed.
+ */
+function resolveRelativePath(base: string, relative: string): string {
+    const normalizedBase = base.replace(/\\/g, '/').replace(/\/+$/, '');
+    const combined = `${normalizedBase}/${relative.replace(/\\/g, '/')}`;
+    const isWinDrive = /^[a-z]:/i.test(combined);
+    const segments = combined.split('/');
+    const resolved: string[] = [];
+    for (const segment of segments) {
+        if (segment === '' || segment === '.')
+            continue;
+
+        if (segment === '..')
+            resolved.pop();
+        else
+            resolved.push(segment);
+    }
+    // POSIX absolute paths keep their leading slash; Windows drive paths
+    // (`C:/...`) do not get one.
+    return isWinDrive ? resolved.join('/') : `/${resolved.join('/')}`;
+}
+
 export function getImageSrc(src: string) {
     const EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
     // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
@@ -33,12 +68,28 @@ export function getImageSrc(src: string) {
     const DATA_URL_REG
         = /^data:image\/[\w+-]+(?:;[\w-]+=[\w-]+|;base64)*,[a-zA-Z0-9+/]+={0,2}$/;
     const imageExtension = EXT_REG.test(src);
-    const isUrl = URL_REG.test(src);
+    // An already-`file://` src must not be re-prefixed (avoids `file://file://`).
+    const isFileUrl = /^file:\/\//i.test(src);
+    const isUrl = URL_REG.test(src) || (imageExtension && isFileUrl);
     if (imageExtension) {
+        const isAbsoluteLocal = ABSOLUTE_LOCAL_REG.test(src);
+        // Anchor a relative local path to the document directory, mirroring
+        // legacy muyajs `getImageInfo(src, baseUrl = window.DIRNAME)`. The
+        // engine runs in the host renderer where `window.DIRNAME` tracks the
+        // current document's directory; when it is absent (headless / no open
+        // file) we fall back to the legacy `file://${src}` form.
+        const baseUrl
+            = typeof window !== 'undefined' ? window.DIRNAME : undefined;
         if (isUrl) {
             return {
                 isUnknownType: false,
                 src,
+            };
+        }
+        else if (!isAbsoluteLocal && baseUrl) {
+            return {
+                isUnknownType: false,
+                src: `file://${resolveRelativePath(baseUrl, src)}`,
             };
         }
         else {


### PR DESCRIPTION
## The bug (Phase G — G1, BLOCKER)

Relative-path images stopped rendering in the live editor after the `@muyajs/core` migration.

Legacy muyajs rendered relative image paths anchored to the document directory: the inline renderer called `getImageInfo(src, baseUrl = window.DIRNAME)` which did `'file://' + path.resolve(baseUrl, src)`, yielding a loadable absolute `file://` URL. So `![](assets/foo.png)` in a document opened from disk rendered correctly.

The migrated engine's `getImageSrc` (`packages/muya/src/utils/image.ts`) had **no baseUrl resolution** — for a relative path it returned `{ src: 'file://' + src }` (e.g. `file://assets/foo.png`), a non-anchored, broken URL. The `<img>` then failed to load and rendered the fail icon. This affected every pre-existing relative image in opened documents, plus paste and programmatic-insert flows; drag-drop was only transiently masked by a `urlMap` entry that died on reload.

The desktop already maintains `window.DIRNAME` on every open / tab-switch / rename, but the engine never read it (the legacy string resolver's `baseUrl`/`path.resolve` relative-path resolution was dropped, not ported).

## The fix (engine-only — `packages/muya`)

`getImageSrc` now mirrors legacy `getImageInfo`:

- Resolves a relative local image path against `window.DIRNAME` → `file://<resolved-absolute>`.
- Leaves URLs, `data:` URIs, absolute local paths, and already-`file://` srcs untouched (no `file://file://` double-prefix). `imageExtension && file://` is now classed as a URL, matching legacy.
- Uses a small self-contained POSIX-style resolver (collapses `.`/`..`, normalises Windows backslashes) so the engine does **not** depend on the desktop's `window.path` polyfill.
- Falls back to the legacy bare `file://` form when `window.DIRNAME` is absent (headless / no open file).
- `Window.DIRNAME` declared on the engine's global types.

Also covers the reference-image render path (`referenceImage.ts`), which shares `getImageSrc`.

## Tests

This path was previously untested. Adds `packages/muya/src/utils/__tests__/image.spec.ts` (12 cases) asserting:
- relative path → anchored `file://` absolute
- `./` and `../` resolution; Windows-drive base dirs
- absolute / URL / `data:` / already-`file://` left unchanged
- no double `file://` prefix
- no-`DIRNAME` fallback to bare `file://`

Local CI gates all green: `lint` (0 errors), `lint:types`, `lint:css` (0 errors), `check-circular`, `test` (593), `test:spec` (1347).

## Desktop change required

**None.** This is an engine-only fix. The desktop already keeps `window.DIRNAME` current, which the engine now consumes directly — no `editor.vue` / constructor wiring change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)