### PR TITLE
fix(muya): preserve drive/UNC roots in relative image path resolution (#4428 review follow-up)

### DIFF
--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -133,3 +133,41 @@ describe('getImageSrc — non-relative sources are left unchanged', () => {
         });
     });
 });
+
+describe('getImageSrc — Windows drive + UNC base directories (Phase G review)', () => {
+    it('preserves the drive when resolving `..`', () => {
+        withDirname('C:/Users/me/docs', () => {
+            expect(getImageSrc('../img/a.png').src).toBe('file://C:/Users/me/img/a.png');
+        });
+    });
+
+    it('clamps `..` at the drive root so the drive is never lost', () => {
+        withDirname('C:/docs', () => {
+            expect(getImageSrc('../../../a.png').src).toBe('file://C:/a.png');
+        });
+    });
+
+    it('normalises a Windows-backslash base dir', () => {
+        withDirname('C:\\docs', () => {
+            expect(getImageSrc('a.png').src).toBe('file://C:/docs/a.png');
+        });
+    });
+
+    it('resolves against a UNC share base directory', () => {
+        withDirname('//server/share/docs', () => {
+            expect(getImageSrc('a.png').src).toBe('file:////server/share/docs/a.png');
+        });
+    });
+
+    it('normalises a backslash UNC base', () => {
+        withDirname('\\\\server\\share', () => {
+            expect(getImageSrc('sub/a.png').src).toBe('file:////server/share/sub/a.png');
+        });
+    });
+
+    it('clamps `..` at the UNC share root', () => {
+        withDirname('//server/share/docs', () => {
+            expect(getImageSrc('../../../a.png').src).toBe('file:////server/share/a.png');
+        });
+    });
+});

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -43,10 +43,15 @@ const ABSOLUTE_LOCAL_REG = /^(?:\/|\\\\|[a-z]:\\|[a-z]:\/).+/i;
 function resolveRelativePath(base: string, relative: string): string {
     const normalizedBase = base.replace(/\\/g, '/').replace(/\/+$/, '');
     const combined = `${normalizedBase}/${relative.replace(/\\/g, '/')}`;
-    const isWinDrive = /^[a-z]:/i.test(combined);
-    const segments = combined.split('/');
+    // Isolate the root that `..` must never collapse past (mirroring
+    // `path.resolve`): a UNC share (`//server/share`), a Windows drive (`C:`),
+    // or the POSIX root. The root prefix is preserved; `..` beyond it is a no-op.
+    const root = combined.match(/^\/\/[^/]+\/[^/]+/)?.[0]
+        ?? combined.match(/^[a-z]:/i)?.[0]
+        ?? '';
+    const body = root ? combined.slice(root.length) : combined;
     const resolved: string[] = [];
-    for (const segment of segments) {
+    for (const segment of body.split('/')) {
         if (segment === '' || segment === '.')
             continue;
 
@@ -55,9 +60,12 @@ function resolveRelativePath(base: string, relative: string): string {
         else
             resolved.push(segment);
     }
-    // POSIX absolute paths keep their leading slash; Windows drive paths
-    // (`C:/...`) do not get one.
-    return isWinDrive ? resolved.join('/') : `/${resolved.join('/')}`;
+    const tail = resolved.join('/');
+    // POSIX root keeps a leading slash; a drive/UNC root prefixes its tail.
+    if (root === '')
+        return `/${tail}`;
+
+    return tail ? `${root}/${tail}` : root;
 }
 
 export function getImageSrc(src: string) {


### PR DESCRIPTION
Fix-forward for a Copilot comment that landed on #4428 after merge. The new `resolveRelativePath` collapsed `..` past the root: a Windows drive (`C:/a/../../b` lost the `C:` segment) and UNC `//server/share` roots got mangled. Now the root (UNC share / drive / POSIX) is isolated and never collapsed past, mirroring `path.resolve`. +6 regression cases (drive preservation, drive-root clamp, backslash normalisation, UNC share, backslash-UNC, UNC-root clamp). lint/lint:types/test green.