### PR TITLE
fix(desktop): Edit▸Replace action + saved-indicator false-clean (Phase G)

### DIFF
--- a/packages/desktop/src/main/menu/actions/edit.ts
+++ b/packages/desktop/src/main/menu/actions/edit.ts
@@ -90,7 +90,7 @@ export const editorFindPrevious = (win: Win): void => {
 }
 
 export const editorReplace = (win: Win): void => {
-  edit(win, 'undo')
+  edit(win, 'replace')
 }
 
 export const findInFolder = (win: Win): void => {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -135,6 +135,7 @@ import { useEditorStore } from '@/store/editor'
 import { useProjectStore } from '@/store/project'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
+import { SyntheticHistory, type IFileHistoryLike } from './syntheticHistory'
 
 // Importing the engine entrypoint auto-injects its editor CSS (the muya.ts
 // module imports its stylesheets at load time). Desktop themes still target the
@@ -237,7 +238,7 @@ const {
 } = storeToRefs(preferencesStore)
 
 // Editor store refs
-const { currentFile } = storeToRefs(editorStore)
+const { currentFile, tabs } = storeToRefs(editorStore)
 
 // Project store refs
 const { projectTree } = storeToRefs(projectStore)
@@ -272,34 +273,44 @@ let scrollHandler: ((e: Event) => void) | null = null
 // is migrated separately). We therefore keep the real engine history in a
 // per-tab map here for restoration across in-session tab switches, and feed the
 // store a SYNTHETIC desktop-shaped history.
-//
-// The synthetic entry id is the engine undo-stack DEPTH — a stable position
-// marker, NOT an ever-incrementing counter. The store records the save-time id
-// as `lastSavedHistoryId` and clears the dirty indicator whenever the current
-// id matches it again. Using the undo-stack depth means undoing back to the
-// on-disk content returns the id to its saved value, so the saved/clean
-// indicator is restored (parity with the legacy history-index behaviour). An
-// ever-incrementing counter never matched again after an undo, leaving the tab
-// permanently dirty even when its content matched disk.
 const engineHistoryByTab = new Map<string, unknown>()
-const engineUndoDepth = (history: unknown): number => {
-  const stack = (history as { stack?: { undo?: unknown[] } } | null)?.stack
-  return Array.isArray(stack?.undo) ? stack.undo.length : 0
-}
-const makeSyntheticHistory = (engineHistory: unknown): IFileHistoryLike => {
-  return {
-    stack: [{ id: engineUndoDepth(engineHistory) }],
-    index: 0,
-    lastEditIndex: 0,
-    lastInitIndex: -1
-  }
-}
 
-interface IFileHistoryLike {
-  stack: Array<{ id: number | string; [key: string]: unknown }>
-  index: number
-  lastEditIndex: number
-  lastInitIndex: number
+// Per-tab monotonic save-tracking id allocator. The synthetic history entry id
+// is a MONOTONIC, never-reused id keyed on the live document content (see
+// `syntheticHistory.ts`), NOT the engine undo-stack depth: depth is reused
+// across distinct documents at the same stack height, which falsely showed a
+// divergently re-edited tab as clean (Phase G — G6). Reset whenever the engine
+// reloads the document via `setContent` (which clears the engine history), so
+// the reloaded content is the id-0 baseline matching the store's seeded
+// `lastSavedHistoryId: 0`.
+const syntheticHistoryByTab = new Map<string, SyntheticHistory>()
+const getSyntheticHistory = (id: string, baselineContent: string): SyntheticHistory => {
+  let tracker = syntheticHistoryByTab.get(id)
+  if (!tracker) {
+    tracker = new SyntheticHistory(baselineContent)
+    syntheticHistoryByTab.set(id, tracker)
+  }
+  return tracker
+}
+// Re-baseline a tab's id allocator to the given content (id 0). Called after
+// `setContent` reloads the document so the freshly loaded content is clean.
+const resetSyntheticHistory = (id: string, baselineContent: string): void => {
+  syntheticHistoryByTab.set(id, new SyntheticHistory(baselineContent))
+}
+const makeSyntheticHistory = (id: string, content: string): IFileHistoryLike => {
+  return getSyntheticHistory(id, content).build(content)
+}
+// Drop per-tab bookkeeping for tabs that no longer exist. Tab ids are unique
+// over the session, so without pruning these maps (and the content -> id map
+// each `SyntheticHistory` holds) would grow unbounded as tabs are opened and
+// closed. Driven by a watcher on the store's live tab id set.
+const pruneClosedTabState = (liveTabIds: Set<string>): void => {
+  for (const id of engineHistoryByTab.keys()) {
+    if (!liveTabIds.has(id)) engineHistoryByTab.delete(id)
+  }
+  for (const id of syntheticHistoryByTab.keys()) {
+    if (!liveTabIds.has(id)) syntheticHistoryByTab.delete(id)
+  }
 }
 
 interface SelectionFormatLike {
@@ -488,6 +499,16 @@ class SimpleImageViewer {
 }
 
 // Watchers
+// Prune per-tab engine/synthetic history bookkeeping when tabs close, so the
+// maps don't accumulate stale entries (and their content -> id maps) over a long
+// session. Watching the id set keeps this cheap — it only fires on tab add/close.
+watch(
+  () => tabs.value.map((t) => t.id),
+  (ids) => {
+    pruneClosedTabState(new Set(ids))
+  }
+)
+
 watch(typewriter, (value) => {
   if (value) {
     scrollToCursor()
@@ -1283,17 +1304,27 @@ const handleDialogTableConfirm = () => {
 }
 
 interface FileLoadedPayload {
+  id?: string
   markdown?: string
   cursor?: unknown
 }
 
 // listen for `open-single-file` event, it will call this method only when open a new file.
 const setMarkdownToEditor = (payload: unknown) => {
-  const { markdown: newMarkdown, cursor: newCursor } = (payload ?? {}) as FileLoadedPayload
+  const { id, markdown: newMarkdown, cursor: newCursor } = (payload ?? {}) as FileLoadedPayload
   if (editor.value) {
     // `setContent` resets the document and clears the undo history; only set a
     // cursor afterwards (a freshly-opened file has no history to restore).
     editor.value.setContent(newMarkdown ?? '')
+    // The freshly loaded content is this tab's clean baseline (id 0). Re-seed
+    // the monotonic save-tracking allocator so undoing an edit back to this
+    // content reads as clean again (matches the store's `lastSavedHistoryId: 0`).
+    // Seed from the engine's OWN serialization of the loaded document (not the
+    // raw payload) so it matches the markdown later emitted on `json-change`
+    // — the engine may normalize trailing newlines / whitespace on round-trip.
+    if (id) {
+      resetSyntheticHistory(id, editor.value.getMarkdown())
+    }
     if (newCursor) {
       editor.value.setCursor(newCursor)
     }
@@ -1611,8 +1642,11 @@ onMounted(() => {
     const { id } = currentFile.value
     if (!id) return
     const markdown = editor.value.getMarkdown()
-    // Stash the real engine history for in-session tab-switch restoration, and
-    // derive the synthetic save-tracking id from its undo-stack depth.
+    // Stash the real engine history for in-session tab-switch restoration. The
+    // synthetic save-tracking id is derived from the live document content (a
+    // monotonic, never-reused id — see `syntheticHistory.ts`), NOT the engine
+    // undo-stack depth, which is reused and falsely showed a divergently
+    // re-edited tab as clean (Phase G — G6).
     const engineHistory = editor.value.getHistory()
     engineHistoryByTab.set(id, engineHistory)
     editorStore.LISTEN_FOR_CONTENT_CHANGE({
@@ -1622,7 +1656,7 @@ onMounted(() => {
       cursor: serializeCursor(editor.value.getSelection()),
       // Synthetic, desktop-shaped history so the store's save/dirty tracking
       // keeps working (the engine history shape is incompatible).
-      history: makeSyntheticHistory(engineHistory),
+      history: makeSyntheticHistory(id, markdown),
       toc: editor.value.getTOC(),
       blocks: editor.value.getState()
     })

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/syntheticHistory.ts
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/syntheticHistory.ts
@@ -1,0 +1,108 @@
+// Synthetic save-tracking history for the WYSIWYG engine.
+//
+// The `@muyajs/core` engine's undo/redo history (`getHistory()`) has a
+// different shape than the desktop store's `tab.history` (which drives the
+// save/dirty indicator). The renderer therefore feeds the store a SYNTHETIC,
+// desktop-shaped history whose single stack entry carries an `id` the store
+// compares against `tab.lastSavedHistoryId`: when the current id equals the
+// saved id the tab is shown as clean, otherwise dirty.
+//
+// The id MUST satisfy two properties:
+//   1. clean  <=> the live document content matches the saved-on-disk content.
+//   2. monotonic & never-reused: a divergent edit can never collide with the
+//      saved id, even when it returns the engine undo-stack to the same DEPTH.
+//
+// An earlier implementation used the undo-stack DEPTH as the id. Depth is
+// REUSED across distinct documents at the same stack height, so the sequence
+//   type A, type B, save, undo B, type C  (a NEW divergent edit)
+// returned the depth — and therefore the id — to the saved value while the
+// document was actually A+C, falsely showing the tab as clean and risking
+// data loss on close-without-save (Phase G — G6).
+//
+// Legacy muyajs avoided this by assigning every pushed history entry a
+// MONOTONIC, never-reused id and splicing the redo tail on a new edit. We
+// reproduce the exact semantics here, but keyed on the live document content
+// rather than on the engine's internal stack objects (the engine regenerates
+// its undo operations via invert on every undo/redo, so object identity is not
+// stable). Each DISTINCT content snapshot is assigned a fresh monotonic id the
+// first time it is seen; revisiting an earlier snapshot (undo/redo back to it)
+// reuses that snapshot's original id. Undoing back to the saved content
+// therefore restores the saved id (clean); a divergent re-edit produces brand
+// new content and hence a brand new id (dirty) — never the saved one.
+
+// Trailing newlines are NOT meaningful content for save/dirty tracking — the
+// store itself normalizes them via `adjustTrailingNewlines`/`trimTrailingNewline`
+// before saving. The engine's markdown serialization is also unstable across a
+// `setContent` -> edit -> undo round-trip purely in trailing newlines (loading
+// `'x\n'` may serialize to `'x\n\n\n'`, while undoing an edit lands on `'x\n'`),
+// so the content signature must ignore them or undo-to-saved would never match.
+const stripTrailingNewlines = (content: string): string =>
+  content.replace(/[\r\n]+$/, '')
+
+// A fast, stable 64-bit string hash (FNV-1a) over the trailing-newline-normalized
+// content. Used so the content -> id map stores short keys instead of whole
+// documents; a collision would map two genuinely different documents to the same
+// id and could reintroduce the false-clean it guards against. 64 bits keeps the
+// collision probability negligible even for a long editing session with many
+// thousands of distinct snapshots (a 32-bit hash hits ~50% collision odds near
+// ~77k snapshots via the birthday bound — realistic over a long session — so the
+// extra width is worth the BigInt key).
+const FNV64_OFFSET = 0xcbf29ce484222325n
+const FNV64_PRIME = 0x100000001b3n
+const MASK64 = 0xffffffffffffffffn
+const hashContent = (content: string): bigint => {
+  const normalized = stripTrailingNewlines(content)
+  let hash = FNV64_OFFSET
+  for (let i = 0; i < normalized.length; i++) {
+    hash ^= BigInt(normalized.charCodeAt(i))
+    hash = (hash * FNV64_PRIME) & MASK64
+  }
+  return hash
+}
+
+export interface IFileHistoryLike {
+  stack: Array<{ id: number | string; [key: string]: unknown }>
+  index: number
+  lastEditIndex: number
+  lastInitIndex: number
+}
+
+// Per-tab monotonic id allocator. Created once when a tab's content baseline is
+// established and reset whenever the engine reloads the document (`setContent`
+// clears the engine history), so the baseline id is always 0 — matching the
+// store's seeded `lastSavedHistoryId: 0` for a freshly loaded/clean document.
+export class SyntheticHistory {
+  private counter = 0
+  private readonly idByContent = new Map<bigint, number>()
+
+  constructor(baselineContent: string = '') {
+    // The freshly-loaded document is its own clean baseline; the store seeds
+    // `lastSavedHistoryId` to 0, so the baseline content must map to id 0.
+    this.idByContent.set(hashContent(baselineContent), 0)
+  }
+
+  // Return the monotonic id for the given content snapshot, assigning a fresh,
+  // never-reused id the first time a snapshot is seen and reusing the original
+  // id on every subsequent revisit (undo/redo back to it).
+  idFor(content: string): number {
+    const key = hashContent(content)
+    let id = this.idByContent.get(key)
+    if (id === undefined) {
+      id = ++this.counter
+      this.idByContent.set(key, id)
+    }
+    return id
+  }
+
+  // Build the desktop-shaped synthetic history the store consumes. The store
+  // only reads `stack[lastEditIndex].id`; the remaining fields keep its
+  // bookkeeping happy (a single committed edit at index 0).
+  build(content: string): IFileHistoryLike {
+    return {
+      stack: [{ id: this.idFor(content) }],
+      index: 0,
+      lastEditIndex: 0,
+      lastInitIndex: -1
+    }
+  }
+}

--- a/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
+++ b/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
@@ -134,10 +134,11 @@ test.describe('Parity PG14 — first undo after source mode reverts the edit in 
 })
 
 test.describe('Parity PG15 — undo back to on-disk content restores the saved indicator', () => {
-  // The synthetic save-tracking id is now the engine undo-stack depth (a stable
-  // position marker), and a freshly-loaded tab seeds `lastSavedHistoryId` to the
-  // baseline depth (0). Undoing an edit back to disk content returns the id to
-  // its saved value, so the saved/clean indicator is restored.
+  // The synthetic save-tracking id is a MONOTONIC, never-reused id keyed on the
+  // live document content (see `syntheticHistory.ts`). A freshly-loaded tab seeds
+  // `lastSavedHistoryId` to the baseline (id 0); undoing an edit back to disk
+  // content reproduces the baseline content and hence the saved id, restoring the
+  // saved/clean indicator.
   test('PG15: undoing an edit back to disk content clears the unsaved indicator', async() => {
     const { app, page } = await launchWithMarkdown('hello world\n')
     await waitForMenuReady(app)
@@ -156,12 +157,53 @@ test.describe('Parity PG15 — undo back to on-disk content restores the saved i
     // Content is restored to disk...
     expect((await getMarkdownContent(page, app)).trim()).toBe('hello world')
 
-    // Desired: ...and the saved/clean indicator comes back (tab no longer
-    // marked unsaved). Today the tab stays dirty.
-    const stillUnsaved = await page.evaluate(
+    // ...and the saved/clean indicator comes back (tab no longer marked
+    // unsaved). Poll: the indicator clears on the undo's async json-change.
+    await expect
+      .poll(() => page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved')))
+      .toBe(false)
+    await app.close()
+  })
+
+  // G6: the saved/clean indicator must NOT falsely show clean after
+  // undo + a divergent re-edit returns the engine undo-stack to the saved DEPTH.
+  // With the old depth-as-id scheme the id collided with the saved id and the
+  // dirty tab read as clean (risking data loss on close-without-save). The
+  // monotonic content-keyed id keeps the divergent document dirty.
+  test('G6: a divergent re-edit at the saved undo depth stays dirty', async() => {
+    const { app, page } = await launchWithMarkdown('A\n')
+    await waitForMenuReady(app)
+
+    // Edit to A + B, then mark the tab saved at this state (same IPC channel the
+    // main process sends after a real save: records the current synthetic id as
+    // `lastSavedHistoryId` and clears the dirty flag).
+    await placeCaretInEditor(page)
+    await typeIntoEditor(page, ' B')
+    await page.waitForTimeout(500)
+    const tabId = await page.evaluate(
+      () => document.querySelector('.editor-tabs li.active')?.getAttribute('data-id') ?? null
+    )
+    expect(tabId).toBeTruthy()
+    await sendIpcToRenderer(app, 'mt::tab-saved', tabId)
+    await expect
+      .poll(() => page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved')))
+      .toBe(false)
+
+    // Undo B (back to 'A', dirty), then make a DIFFERENT edit C. The engine undo
+    // depth returns to the saved depth, but the document is A + C != saved A + B.
+    await undo(app)
+    await page.waitForTimeout(400)
+    await typeIntoEditor(page, ' C')
+    await page.waitForTimeout(500)
+
+    // The divergent document must stay dirty (the G6 false-clean regression).
+    const content = (await getMarkdownContent(page, app)).trim()
+    expect(content).toContain('C')
+    expect(content).not.toContain('B')
+    const dirty = await page.evaluate(
       () => !!document.querySelector('.editor-tabs li.unsaved')
     )
-    expect(stillUnsaved).toBe(false)
+    expect(dirty).toBe(true)
     await app.close()
   })
 })

--- a/packages/desktop/test/unit/specs/synthetic-history.spec.ts
+++ b/packages/desktop/test/unit/specs/synthetic-history.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { SyntheticHistory } from '@/components/editorWithTabs/syntheticHistory'
+
+// Mirror of the store's PG15 dirty/clean decision (store/editor.ts): a tab is
+// clean iff the current synthetic history entry id equals the saved id. We feed
+// it ids produced by `SyntheticHistory` for a sequence of document contents to
+// prove the saved/clean indicator is correct.
+const isClean = (entryId: number, lastSavedHistoryId: number): boolean =>
+  entryId === lastSavedHistoryId
+
+describe('SyntheticHistory (saved/clean indicator id allocator)', () => {
+  it('seeds the loaded/baseline content to id 0', () => {
+    const h = new SyntheticHistory('A\n')
+    expect(h.idFor('A\n')).toBe(0)
+    expect(h.build('A\n').stack[0].id).toBe(0)
+  })
+
+  it('assigns a fresh, never-reused id to each distinct content snapshot', () => {
+    const h = new SyntheticHistory('')
+    const a = h.idFor('A')
+    const b = h.idFor('AB')
+    const c = h.idFor('ABC')
+    expect(new Set([a, b, c]).size).toBe(3)
+    expect(a).toBeLessThan(b)
+    expect(b).toBeLessThan(c)
+  })
+
+  it('reuses the original id when an earlier snapshot is revisited (undo/redo)', () => {
+    const h = new SyntheticHistory('')
+    const a = h.idFor('A')
+    h.idFor('AB')
+    // Undo back to 'A' must reproduce 'A's original id.
+    expect(h.idFor('A')).toBe(a)
+  })
+
+  // The G6 regression: type A, type B, SAVE, undo B, then a NEW divergent edit C
+  // that returns the engine undo-stack to the SAVED depth. With the old
+  // depth-as-id scheme the id collided with the saved id and the dirty tab
+  // falsely showed clean. With content-keyed monotonic ids it stays dirty.
+  it('stays dirty after undo + divergent re-edit returns to the saved depth (G6)', () => {
+    const h = new SyntheticHistory('') // baseline (empty) == id 0
+
+    h.idFor('A') // type A   -> depth 1
+    const idAB = h.idFor('A\nB') // type B -> depth 2
+
+    // SAVE at A+B: the store records this entry's id as the saved id.
+    const lastSavedHistoryId = idAB
+
+    // Undo B -> back to 'A' (depth 1): different content -> dirty.
+    const idAfterUndo = h.idFor('A')
+    expect(isClean(idAfterUndo, lastSavedHistoryId)).toBe(false)
+
+    // Divergent re-edit C: the engine undo-stack returns to depth 2, but the
+    // document is now A+C, NOT the saved A+B. Must be DIRTY.
+    const idAfterDivergent = h.idFor('A\nC')
+    expect(idAfterDivergent).not.toBe(lastSavedHistoryId)
+    expect(isClean(idAfterDivergent, lastSavedHistoryId)).toBe(false)
+  })
+
+  it('undo back to the SAVED content shows clean again', () => {
+    const h = new SyntheticHistory('')
+
+    h.idFor('A')
+    const idAB = h.idFor('A\nB')
+    const lastSavedHistoryId = idAB
+
+    // Undo to 'A' (dirty), then redo back to the saved A+B content (clean).
+    expect(isClean(h.idFor('A'), lastSavedHistoryId)).toBe(false)
+    expect(isClean(h.idFor('A\nB'), lastSavedHistoryId)).toBe(true)
+  })
+
+  it('undo back to the unsaved baseline shows clean (lastSavedHistoryId 0)', () => {
+    // A freshly loaded document is its own clean baseline: the store seeds
+    // `lastSavedHistoryId: 0`, and the baseline content maps to id 0.
+    const h = new SyntheticHistory('hello\n')
+    const lastSavedHistoryId = 0
+
+    const idAfterEdit = h.idFor('hello world\n')
+    expect(isClean(idAfterEdit, lastSavedHistoryId)).toBe(false)
+
+    // Undo the edit back to the loaded baseline -> clean.
+    expect(isClean(h.idFor('hello\n'), lastSavedHistoryId)).toBe(true)
+  })
+
+  it('tracks the saved id across save-here -> edit -> undo-to-saved', () => {
+    // Save at a NON-baseline state, then verify undo-to-saved is clean and any
+    // divergent content is dirty.
+    const h = new SyntheticHistory('')
+    h.idFor('one')
+    const idSaved = h.idFor('one\ntwo') // saved here
+    const lastSavedHistoryId = idSaved
+
+    // Edit further, then undo back exactly to the saved content.
+    expect(isClean(h.idFor('one\ntwo\nthree'), lastSavedHistoryId)).toBe(false)
+    expect(isClean(h.idFor('one\ntwo'), lastSavedHistoryId)).toBe(true)
+
+    // A different document that happens to reach the same undo depth is dirty.
+    expect(isClean(h.idFor('one\nTWO'), lastSavedHistoryId)).toBe(false)
+  })
+
+  // The engine's markdown serialization is unstable across a setContent -> edit
+  // -> undo round-trip purely in trailing newlines (loading 'x\n' may serialize
+  // to 'x\n\n\n', while undoing an edit lands on 'x\n'). The id must ignore
+  // trailing newlines so undo-to-saved still reads as clean.
+  it('treats trailing-newline-only differences as the same content', () => {
+    const h = new SyntheticHistory('hello world\n')
+    const lastSavedHistoryId = 0
+
+    // Same visible content, different trailing newlines -> still id 0 (clean).
+    expect(h.idFor('hello world\n\n\n')).toBe(0)
+    expect(h.idFor('hello world')).toBe(0)
+
+    // A real content change is a fresh id (dirty)...
+    expect(isClean(h.idFor('hello world EXTRA\n'), lastSavedHistoryId)).toBe(false)
+    // ...and undoing it (engine lands on a different trailing-newline form of
+    // the baseline) is clean again.
+    expect(isClean(h.idFor('hello world\n'), lastSavedHistoryId)).toBe(true)
+  })
+
+  it('assigns distinct ids to many distinct snapshots (wide hash key)', () => {
+    const h = new SyntheticHistory('')
+    const ids = new Set<number>()
+    for (let i = 0; i < 5000; i++) {
+      ids.add(h.idFor(`line ${i}\ncontent body ${i}`))
+    }
+    // No collisions: every distinct content snapshot got its own id.
+    expect(ids.size).toBe(5000)
+  })
+
+  it('build() emits a desktop-shaped single-entry history', () => {
+    const h = new SyntheticHistory('')
+    const hist = h.build('X')
+    expect(hist).toMatchObject({
+      index: 0,
+      lastEditIndex: 0,
+      lastInitIndex: -1
+    })
+    expect(hist.stack).toHaveLength(1)
+    expect(typeof hist.stack[0].id).toBe('number')
+  })
+})


### PR DESCRIPTION
Fixes two desktop-only bugs found by the Phase G audit (`packages/desktop`). Two single-responsibility commits.

## G3 (major) — Edit▸Replace performed an UNDO

`editorReplace` (`src/main/menu/actions/edit.ts`) emitted `edit(win, 'undo')`, so the **Edit▸Replace** menu item and its accelerator (Cmd+Opt+F / Ctrl+R) performed an UNDO instead of opening the replace bar. The renderer re-emits the IPC action verbatim on the bus, so `'undo'` invoked `handleUndo` and `listenReplace` (bound to the `'replace'` bus event) was never reached from the menu/shortcut path.

**Fix:** send `'replace'` so the search component opens in replace mode (`showSearch=true`, `type='replace'`), matching the command-palette `edit.replace` entry. Verified end-to-end: IPC `'replace'` → `EDITOR_EDIT_ACTION` → `bus.emit('replace','replace')` → `listenReplace()`. Covered by the existing `find-replace.spec.ts` "Replace action shows the search bar in replace mode".

## G6 (major, data-loss risk) — saved indicator false-clean

The renderer fed the store a synthetic, desktop-shaped history whose entry id was the engine **undo-stack DEPTH**. Depth is reused across distinct documents at the same stack height, so:

```
type A, type B, save, undo B, type C   (a NEW divergent edit)
```

returned the depth — and therefore the id — to the saved value while the document was actually A+C, not the saved A+B. The store's PG15 check is `editEntry.id !== lastSavedHistoryId`, so the tab read as **clean** and could be closed without a save prompt → silent data loss.

**Fix:** replace the depth-as-id scheme with a **monotonic, never-reused id keyed on the live document content** (new `SyntheticHistory` allocator). Each distinct content snapshot gets a fresh id the first time it is seen and reuses that id on every revisit. Undoing back to the saved content restores the saved id (clean); a divergent re-edit produces brand-new content and hence a brand-new id (dirty) — never the saved one. This matches legacy muyajs' monotonic, never-reused history ids while preserving the undo-to-saved clean case. The allocator is re-baselined to the loaded content (id 0) on `file-loaded`, matching the store's seeded `lastSavedHistoryId: 0`.

The content signature ignores trailing newlines, because the engine's markdown serialization is unstable across a `setContent → edit → undo` round-trip purely in trailing newlines (loading `'x\n'` may serialize to `'x\n\n\n'` while undoing an edit lands on `'x\n'`), and the store already normalizes trailing newlines via `adjustTrailingNewlines`.

## Tests
- New unit spec `test/unit/specs/synthetic-history.spec.ts` (9 cases): the exact G6 scenario, undo-to-saved, redo-to-saved, unsaved-baseline, trailing-newline insensitivity.
- New e2e `G6: a divergent re-edit at the saved undo depth stays dirty` in `parity-source-undo-saved.spec.ts`, driving the full undo + divergent-re-edit-at-saved-depth flow and asserting the tab stays dirty. **Verified to fail against the old depth-as-id scheme** and pass with the fix.
- Updated the existing PG15 e2e + stale comment; hardened the saved-indicator checks with `expect.poll`.

## Verification
`pnpm run typecheck`, `pnpm run lint` (0 errors), `pnpm run test` (464 pass), `pnpm run build:unpack`, and the relevant e2e (`find-replace`, `parity-source-undo-saved`) all green.

Refs: Phase G audit G3, G6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)