### PR TITLE
test: cover @muyajs/core migration regression gaps (Phase G)

### DIFF
--- a/packages/muya/src/__tests__/headingLocaleCrash.spec.ts
+++ b/packages/muya/src/__tests__/headingLocaleCrash.spec.ts
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { en, zhCN } from '../locales';
+import { Muya } from '../muya';
+
+// REGRESSION GUARD — #4424 / #4427 (Phase-G migration crash).
+//
+// Typing `#` (then a space) to create an ATX heading converts the paragraph to
+// an AtxHeading block, which appends a `HeadingCopyLink` attachment. That
+// attachment's constructor calls
+// `muya.i18n.t('Copy anchor link to this heading')`.
+//
+// Two independent migration bugs converged on that single call:
+//   1. `I18n.t` fell through to `resources.en[key]`, but the constructor only
+//      stores `{ [name]: resource }`. Under a NON-`en` locale `resources.en`
+//      is `undefined`, so a missing key threw `Cannot read properties of
+//      undefined` instead of falling back to the raw key.
+//   2. The `'Copy anchor link to this heading'` key was never added to the
+//      locale resources, so every locale (en included) hit that fall-through —
+//      crashing under a non-en locale and showing the raw key under en.
+//
+// Both were fixed in #4424 (optional-chain the fallback + add the key to all
+// locales) but NO automated test booted Muya under a non-en locale and hit the
+// HeadingCopyLink `i18n.t` path. These tests pin both halves: (a) creating a
+// heading under zh-CN via the real input path must not throw and must render
+// the affordance with the translated label, and (b) `I18n.t` must stay
+// crash-safe for a key missing from a non-en locale — guarding the
+// optional-chaining fix directly, so a regression there is caught even if the
+// locale key were re-supplied.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, locale: typeof en): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {
+        markdown,
+        locale,
+    } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+const COPY_LINK_SELECTOR
+    = '.ag-copy-header-link, .mu-copy-header-link, [class*="copy-header-link"]';
+
+// Drive the real "type `# x`" input path: write the text into the active
+// content block's contenteditable node, place the caret, and run the block's
+// `inputHandler` the way a keystroke does. `inputHandler` reads the DOM text
+// and runs `_convertIfNeeded`, which converts the paragraph to an ATX heading —
+// the exact path that builds HeadingCopyLink and calls `i18n.t`. (We invoke
+// `inputHandler` directly because happy-dom does not deliver a dispatched
+// `input` event to the engine's listener.) The conversion's state flush lands
+// on the next animation frame, so callers await `flush()` before asserting on
+// `getState()`.
+function typeHeading(muya: Muya, raw: string): void {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as Content;
+    muya.editor.activeContentBlock = content;
+    content.domNode!.textContent = raw;
+    content.setCursor(raw.length, raw.length);
+    content.inputHandler(
+        new InputEvent('input', { bubbles: true, inputType: 'insertText' }),
+    );
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+function copyLinkAffordance(muya: Muya): HTMLElement | null {
+    return muya.domNode.querySelector<HTMLElement>(COPY_LINK_SELECTOR);
+}
+
+describe('typing `#` to create a heading under a non-en locale (#4424 / #4427)', () => {
+    it('does not throw when converting a paragraph to an ATX heading under zh-CN', async () => {
+        const muya = bootMuya('\n', zhCN);
+
+        expect(() => typeHeading(muya, '# Heading')).not.toThrow();
+
+        // The conversion actually happened — otherwise the i18n path that used
+        // to crash would never have run.
+        await flush();
+        expect(muya.getState()[0].name).toBe('atx-heading');
+    });
+
+    it('renders the copy-anchor affordance with the zh-CN translated label', () => {
+        const muya = bootMuya('\n', zhCN);
+        typeHeading(muya, '# Heading');
+
+        const affordance = copyLinkAffordance(muya);
+        expect(affordance).toBeTruthy();
+
+        const expected = zhCN.resource['Copy anchor link to this heading'];
+        // The label is a real translation — not the raw-key fall-through that
+        // the pre-#4424 missing locale key would have produced.
+        expect(expected).not.toBe('Copy anchor link to this heading');
+        expect(affordance!.getAttribute('aria-label')).toBe(expected);
+        expect(affordance!.getAttribute('title')).toBe(expected);
+    });
+
+    it('resolves the affordance label per-locale (en vs zh-CN) for the same heading', () => {
+        const enMuya = bootMuya('\n', en);
+        typeHeading(enMuya, '# Heading');
+        const enLabel = copyLinkAffordance(enMuya)!.getAttribute('aria-label');
+
+        const zhMuya = bootMuya('\n', zhCN);
+        typeHeading(zhMuya, '# Heading');
+        const zhLabel = copyLinkAffordance(zhMuya)!.getAttribute('aria-label');
+
+        expect(enLabel).toBe(en.resource['Copy anchor link to this heading']);
+        expect(zhLabel).toBe(zhCN.resource['Copy anchor link to this heading']);
+        expect(enLabel).not.toBe(zhLabel);
+    });
+
+    it('still emits heading-copy-link when the zh-CN affordance is activated', () => {
+        const muya = bootMuya('\n', zhCN);
+        typeHeading(muya, '# Heading');
+
+        const handler = vi.fn();
+        muya.on('heading-copy-link', handler);
+        copyLinkAffordance(muya)!.dispatchEvent(
+            new MouseEvent('click', { bubbles: true, cancelable: true }),
+        );
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler.mock.calls[0]?.[0]?.key).toBeTruthy();
+    });
+
+    it('i18n.t stays crash-safe and falls back to the raw key for a key missing from a non-en locale', () => {
+        // Guards the optional-chaining fix in I18n.t directly: under a non-en
+        // locale `resources.en` is undefined, so a missing key must fall back
+        // to the raw key instead of throwing.
+        const muya = bootMuya('\n', zhCN);
+        const missingKey = '__definitely_not_a_real_i18n_key__';
+        expect(() => muya.i18n.t(missingKey)).not.toThrow();
+        expect(muya.i18n.t(missingKey)).toBe(missingKey);
+    });
+
+    it('every shipped locale defines the heading copy-anchor key (no raw-key fall-through)', () => {
+        // The crash's second half was the missing locale key. Lock it in for
+        // every shipped locale so a future locale addition can't silently
+        // reintroduce the raw-key fall-through (and, under a non-en locale, the
+        // crash before the optional-chaining guard).
+        for (const locale of [en, zhCN]) {
+            const muya = bootMuya('\n', locale);
+            typeHeading(muya, '# Heading');
+            const label = copyLinkAffordance(muya)!.getAttribute('aria-label');
+            expect(label).toBe(locale.resource['Copy anchor link to this heading']);
+        }
+    });
+});

--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+// Coverage for the PUBLIC `Format.format()` toggle-OFF and `clear` paths over a
+// real engine boot. `formatCursor.spec.ts` pins the apply-side `_addFormat`
+// text rewriter at the function level, but the migration audit flagged that
+// removing an existing inline format (toggle-off) and the `clear`-all path had
+// NO direct coverage — both are the text surgery that, if it miscounts offsets,
+// silently corrupts user content. These tests drive `format()` on a booted
+// block whose run already carries the format, with the caret resting INSIDE the
+// run (the way Ctrl+B-to-un-bold works), and assert the markers are stripped
+// while the run's text survives.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    // The DOM selection is document-global; a range left pointing into the
+    // just-removed host would corrupt the next test's `setCursor`. Clear it so
+    // each test starts from a clean selection.
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Rest a collapsed caret at `offset` (in RENDERED-text coordinates — markdown
+// markers are hidden) inside the first content block and mark it active, the
+// way a click lands the caret inside a formatted run before a Format command.
+function caretInFirstBlock(muya: Muya, offset: number): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(offset, offset, true);
+    return content;
+}
+
+describe('format.format() toggle-off with the caret inside the formatted run', () => {
+    it('strong: `**word**` un-bolds to plain `word`', () => {
+        const content = caretInFirstBlock(bootMuya('**word**\n'), 2);
+        content.format('strong');
+        expect(content.text).toBe('word');
+    });
+
+    it('un-bolding also drops the markers from the serialized markdown', async () => {
+        const muya = bootMuya('**word**\n');
+        caretInFirstBlock(muya, 2).format('strong');
+        // getMarkdown() reads the JSON state, which flushes on the next frame.
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('word');
+        });
+    });
+
+    it('em: `*word*` un-italics to plain `word`', () => {
+        const content = caretInFirstBlock(bootMuya('*word*\n'), 2);
+        content.format('em');
+        expect(content.text).toBe('word');
+    });
+
+    it('del: `~~word~~` un-strikes to plain `word`', () => {
+        const content = caretInFirstBlock(bootMuya('~~word~~\n'), 2);
+        content.format('del');
+        expect(content.text).toBe('word');
+    });
+
+    it('u (html_tag): `<u>word</u>` removes the underline tags', () => {
+        // `format('u')` matches the html_tag token whose tag === 'u'.
+        const content = caretInFirstBlock(bootMuya('<u>word</u>\n'), 2);
+        content.format('u');
+        expect(content.text).toBe('word');
+    });
+
+    it('mark (html_tag): `<mark>word</mark>` removes the highlight tags', () => {
+        const content = caretInFirstBlock(bootMuya('<mark>word</mark>\n'), 2);
+        content.format('mark');
+        expect(content.text).toBe('word');
+    });
+});
+
+describe('format.format(\'clear\') with the caret inside the run', () => {
+    it('strips a strong run to plain text', () => {
+        const content = caretInFirstBlock(bootMuya('**word**\n'), 2);
+        content.format('clear');
+        expect(content.text).toBe('word');
+    });
+
+    it('unwraps an inline-code run to its raw content', () => {
+        const content = caretInFirstBlock(bootMuya('`code`\n'), 2);
+        content.format('clear');
+        expect(content.text).toBe('code');
+        expect(content.text).not.toContain('`');
+    });
+
+    it('unwraps a link to its anchor text', () => {
+        // Caret rests inside the anchor text `Anthropic`.
+        const content = caretInFirstBlock(bootMuya('[Anthropic](https://example.com)\n'), 4);
+        content.format('clear');
+        expect(content.text).toBe('Anthropic');
+        expect(content.text).not.toContain('](');
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/backspaceUnwrap.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/backspaceUnwrap.spec.ts
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// DATA-LOSS GUARD — backspace-at-offset-0 block surgery.
+//
+// Pressing Backspace at the very start of a paragraph either MERGES it onto the
+// previous block or UNWRAPS it out of its container (block-quote / list). The
+// migration audit flagged these cross-block paths as untested even though a
+// miscount here drops or duplicates user content. `ParagraphContent`'s four
+// branches are driven directly here (the handler reads the caret offset and the
+// active block, the way a real Backspace keystroke routes through it), with the
+// resulting document state asserted after the json1 op flushes on the next
+// frame.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Find the leaf `.content` block whose rendered text matches `text`, the way a
+// click resolves the active content block.
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+// Land the caret at offset 0 of the given content block (active block + cursor),
+// then route a Backspace through its handler the way the keydown listener does.
+function backspaceAtStart(muya: Muya, content: Content): void {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(0, 0, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Backspace',
+    } as unknown as KeyboardEvent;
+    content.backspaceHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// `getState()` returns a discriminated `TState` union; only some variants carry
+// `text`. The blocks asserted here are paragraphs, so narrow to read it.
+function blockText(state: ReturnType<Muya['getState']>, index: number): string {
+    return (state[index] as { text: string }).text;
+}
+
+describe('backspace at start-of-paragraph — merge with previous block', () => {
+    it('merges `beta` onto the end of `alpha` into a single paragraph', async () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const beta = contentByText(muya, 'beta');
+
+        backspaceAtStart(muya, beta);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('alphabeta');
+    });
+
+    it('lands the caret at the join point (end of the former first paragraph)', () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const beta = contentByText(muya, 'beta');
+
+        backspaceAtStart(muya, beta);
+
+        // After the merge the active block is `alpha`'s content; the caret sits
+        // at offset 5 (the original `alpha` length), where the two joined.
+        const merged = contentByText(muya, 'alphabeta');
+        const cursor = merged.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(5);
+    });
+
+    it('is a no-op for the first paragraph in the document (no previous block)', async () => {
+        const muya = bootMuya('only\n');
+        const only = contentByText(muya, 'only');
+
+        backspaceAtStart(muya, only);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(blockText(state, 0)).toBe('only');
+    });
+});
+
+describe('backspace at start-of-paragraph — unwrap block-quote / list', () => {
+    it('unwraps an only-child quote paragraph out of the block-quote', async () => {
+        const muya = bootMuya('> quoted\n');
+        const quoted = contentByText(muya, 'quoted');
+
+        backspaceAtStart(muya, quoted);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('quoted');
+    });
+
+    it('unwraps an only/first list item out of the list to a paragraph', async () => {
+        const muya = bootMuya('- item one\n');
+        const item = contentByText(muya, 'item one');
+
+        backspaceAtStart(muya, item);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('item one');
+    });
+
+    it('keeps the remaining items when the FIRST of several list items is unwrapped', async () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const first = contentByText(muya, 'one');
+
+        backspaceAtStart(muya, first);
+
+        await flush();
+        const md = muya.getMarkdown();
+        // `one` lifts out to a leading paragraph; `two` and `three` stay in the
+        // list — nothing is dropped.
+        expect(md).toContain('one');
+        expect(md).toContain('two');
+        expect(md).toContain('three');
+        const state = muya.getState();
+        expect(state[0].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('one');
+        expect(state[1].name).toBe('bullet-list');
+    });
+
+    it('merges a MIDDLE list item into the previous item, preserving all text', async () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const two = contentByText(muya, 'two');
+
+        backspaceAtStart(muya, two);
+
+        await flush();
+        const md = muya.getMarkdown();
+        // The whole document stays a single bullet list; `two` is absorbed into
+        // the previous item rather than dropped.
+        expect(md).toContain('one');
+        expect(md).toContain('two');
+        expect(md).toContain('three');
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('bullet-list');
+    });
+});

--- a/packages/muya/src/block/content/tableCell/__tests__/backspaceSafety.spec.ts
+++ b/packages/muya/src/block/content/tableCell/__tests__/backspaceSafety.spec.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// DATA-LOSS GUARD — `TableCellContent.backspaceHandler` deletion safety.
+//
+// Backspace at the start of a table cell has two branches the migration audit
+// flagged as untested:
+//   1. Whole table empty AND no previous content cell → the table is replaced
+//      with an empty paragraph and the caret lands there (so the user can keep
+//      typing) rather than the keystroke being swallowed or the table left in a
+//      broken state.
+//   2. A previous cell exists → the caret jumps to the END of the previous
+//      cell; the table is NOT destructively merged and no content is lost.
+// Both branches are driven here through a real boot so the cell-resolution and
+// caret-placement run exactly as a Backspace keystroke would.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Collect the table cell content blocks in document order.
+function tableCells(muya: Muya): Content[] {
+    const out: Content[] = [];
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'table.cell.content')
+            out.push(block as unknown as Content);
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return out;
+}
+
+function backspaceAtStart(muya: Muya, cell: Content): void {
+    muya.editor.activeContentBlock = cell;
+    cell.setCursor(0, 0, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Backspace',
+    } as unknown as KeyboardEvent;
+    cell.backspaceHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('tableCellContent backspace deletion safety', () => {
+    it('replaces a wholly-empty table with an empty paragraph when there is no previous content', async () => {
+        // 2x2 table with every cell empty, nothing before it in the document.
+        const muya = bootMuya('|  |  |\n| --- | --- |\n|  |  |\n');
+        const cells = tableCells(muya);
+        expect(cells.length).toBe(4);
+
+        backspaceAtStart(muya, cells[0]);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('paragraph');
+        // The replacement is a paragraph state, which carries `text`.
+        expect((state[0] as { text: string }).text).toBe('');
+    });
+
+    it('jumps the caret to the end of the previous cell without destroying the table', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        const secondCell = cells[1]; // header cell `cd`
+
+        backspaceAtStart(muya, secondCell);
+
+        await flush();
+        // The table is intact — no destructive merge.
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('table');
+
+        // The caret moved to the END of the previous cell (`ab`, length 2).
+        const previousCell = cells[0];
+        const cursor = previousCell.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(previousCell.text.length);
+        expect(previousCell.text).toBe('ab');
+    });
+
+    it('preserves all cell text when backspacing at the start of a non-first cell', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+
+        backspaceAtStart(muya, cells[1]);
+
+        await flush();
+        const md = muya.getMarkdown();
+        for (const text of ['ab', 'cd', 'ef', 'gh'])
+            expect(md).toContain(text);
+    });
+});

--- a/packages/muya/src/block/gfm/table/__tests__/insertRowColumn.spec.ts
+++ b/packages/muya/src/block/gfm/table/__tests__/insertRowColumn.spec.ts
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// Coverage for `Table.insertRow` / `Table.insertColumn`. The migration audit
+// noted only the REMOVAL paths are unit-tested (removeRowColumn.spec.ts) — the
+// insertion paths, which the floating table toolbar / row-column menu drive,
+// had no direct test. A miscount here silently mis-shapes the table or drops
+// per-column alignment. These tests boot a real table and assert the resulting
+// shape, alignment inheritance, and the returned caret cell so the toolbar can
+// place the cursor in the new cell.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// eslint-disable-next-line ts/no-explicit-any
+function findTable(muya: Muya): any {
+    // eslint-disable-next-line ts/no-explicit-any
+    let table: any = null;
+    // eslint-disable-next-line ts/no-explicit-any
+    const visit = (block: any) => {
+        if (block.constructor?.blockName === 'table')
+            table = block;
+        // eslint-disable-next-line ts/no-explicit-any
+        block.children?.forEach((c: any) => visit(c));
+    };
+    visit(muya.editor.scrollPage);
+    if (!table)
+        throw new Error('no table found');
+    return table;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// A 1-header + 1-body table whose two columns are left- and right-aligned.
+const ALIGNED_TABLE = '| a | b |\n| :--- | ---: |\n| 1 | 2 |\n';
+
+describe('table.insertRow', () => {
+    it('inserts an empty body row and grows the row count', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+        expect(table.rowCount).toBe(2);
+
+        table.insertRow(1);
+
+        await flush();
+        expect(table.rowCount).toBe(3);
+        // The new row carries the same column count, all cells empty.
+        const state = table.getState();
+        const newRow = state.children[1];
+        expect(newRow.children.length).toBe(2);
+        expect(newRow.children.every((c: { text: string }) => c.text === '')).toBe(true);
+    });
+
+    it('inherits the header row\'s per-column alignment in the new row', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+
+        table.insertRow(1);
+
+        await flush();
+        const state = table.getState();
+        const newRow = state.children[1];
+        // Column 0 is left-aligned, column 1 right-aligned in the header — the
+        // inserted row's cells copy that.
+        expect(newRow.children[0].meta.align).toBe('left');
+        expect(newRow.children[1].meta.align).toBe('right');
+    });
+
+    it('returns the first cell content of the new row for caret placement', () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+
+        const caretCell = table.insertRow(1);
+
+        expect(caretCell).toBeTruthy();
+        expect(caretCell.constructor.blockName).toBe('table.cell.content');
+        expect(caretCell.text).toBe('');
+    });
+
+    it('round-trips the alignment delimiter row after the insert', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        findTable(muya).insertRow(1);
+
+        await flush();
+        const md = muya.getMarkdown();
+        // The :--- (left) / ---: (right) delimiter survives the row insert.
+        expect(md).toContain(':---');
+        expect(md).toContain('---:');
+    });
+});
+
+describe('table.insertColumn', () => {
+    it('inserts an empty column and grows the column count', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+        expect(table.columnCount).toBe(2);
+
+        table.insertColumn(1, 'center');
+
+        await flush();
+        expect(table.columnCount).toBe(3);
+        // Every row gained one empty cell.
+        const state = table.getState();
+        for (const row of state.children)
+            expect(row.children.length).toBe(3);
+    });
+
+    it('applies the requested alignment to the whole new column', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+
+        table.insertColumn(1, 'center');
+
+        await flush();
+        const state = table.getState();
+        // The inserted column (index 1) is center-aligned in every row.
+        for (const row of state.children)
+            expect(row.children[1].meta.align).toBe('center');
+    });
+
+    it('returns the new column\'s first cell content for caret placement', () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        const table = findTable(muya);
+
+        const caretCell = table.insertColumn(1, 'center');
+
+        expect(caretCell).toBeTruthy();
+        expect(caretCell.constructor.blockName).toBe('table.cell.content');
+        expect(caretCell.text).toBe('');
+    });
+
+    it('serializes the new center column as a :---: delimiter between the existing ones', async () => {
+        const muya = bootMuya(ALIGNED_TABLE);
+        findTable(muya).insertColumn(1, 'center');
+
+        await flush();
+        const md = muya.getMarkdown();
+        // Delimiter row now reads left | center | right.
+        expect(md).toContain(':---:');
+    });
+});


### PR DESCRIPTION
## What

Fills the highest-value **missing** automated tests identified by the @muyajs/core migration regression audit — the recently-fixed bugs and data-loss-adjacent paths that had no engine coverage. All tests assert already-correct behavior (coverage gaps, not failing-first) and pass on current `develop`.

## Gaps covered

| Spec | Gap | Priority |
|---|---|---|
| `headingLocaleCrash.spec.ts` | **#4424 / #4427** — typing `#` to create a heading under a non-`en` locale used to crash on the `HeadingCopyLink` `i18n.t` path. No test booted Muya with a non-en locale and hit it. | **TOP** (recently-fixed migration bug) |
| `formatToggle.spec.ts` | `Format.format()` toggle-OFF + `clear` over a real selection (only the apply-side `_addFormat` was covered) | data-loss-adjacent |
| `paragraphContent/backspaceUnwrap.spec.ts` | Backspace-at-offset-0 cross-block merge + block-quote / list unwrap (all four branches) | data-loss |
| `tableCell/backspaceSafety.spec.ts` | empty-table Backspace → paragraph; previous-cell caret jump | data-loss |
| `table/insertRowColumn.spec.ts` | `insertRow` / `insertColumn` shape, align inheritance, caret cell (only removal was tested) | heavily-rewritten core |

### TOP-priority detail (#4424/#4427)
The new spec boots Muya with the bundled **zh-CN** locale, drives the real `# ` → heading conversion input path (the path that builds `HeadingCopyLink` and calls `muya.i18n.t('Copy anchor link to this heading')`), and asserts:
- no throw + the heading actually converts,
- the copy-anchor affordance renders with the **translated** label (resolves per-locale: en vs zh-CN),
- `heading-copy-link` still emits on activation,
- `I18n.t` stays crash-safe and falls back to the raw key for a key missing from a non-en locale (guards the optional-chaining fix directly).

## Scope

Engine-only (`packages/muya`). 5 new spec files, 33 test cases. No production code changed.

## Verification

`pnpm -C packages/muya lint && lint:types && check-circular && test && test:spec` all green (656 unit + 1347 conformance + the 33 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)