### PR TITLE
test(muya): de-flake heading-locale + backspace regression specs (#4434 review)

### DIFF
--- a/packages/muya/src/__tests__/headingLocaleCrash.spec.ts
+++ b/packages/muya/src/__tests__/headingLocaleCrash.spec.ts
@@ -2,7 +2,7 @@
 
 import type Content from '../block/base/content';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { en, zhCN } from '../locales';
+import { de, en, es, fr, ja, ko, pt, zhCN, zhTW } from '../locales';
 import { Muya } from '../muya';
 
 // REGRESSION GUARD — #4424 / #4427 (Phase-G migration crash).
@@ -45,6 +45,9 @@ afterEach(() => {
         const host = bootedHosts.pop()!;
         host.remove();
     }
+    // Drop any document-global Selection so a stale Range can't point into a
+    // removed host node and break a later test's setCursor.
+    window.getSelection()?.removeAllRanges();
     if (hadVersion)
         window.MUYA_VERSION = originalVersion as string;
     else
@@ -105,9 +108,12 @@ describe('typing `#` to create a heading under a non-en locale (#4424 / #4427)',
         expect(muya.getState()[0].name).toBe('atx-heading');
     });
 
-    it('renders the copy-anchor affordance with the zh-CN translated label', () => {
+    it('renders the copy-anchor affordance with the zh-CN translated label', async () => {
         const muya = bootMuya('\n', zhCN);
         typeHeading(muya, '# Heading');
+        // The conversion (and its HeadingCopyLink attachment render) flushes on
+        // the next animation frame; await it before querying the affordance.
+        await flush();
 
         const affordance = copyLinkAffordance(muya);
         expect(affordance).toBeTruthy();
@@ -120,13 +126,15 @@ describe('typing `#` to create a heading under a non-en locale (#4424 / #4427)',
         expect(affordance!.getAttribute('title')).toBe(expected);
     });
 
-    it('resolves the affordance label per-locale (en vs zh-CN) for the same heading', () => {
+    it('resolves the affordance label per-locale (en vs zh-CN) for the same heading', async () => {
         const enMuya = bootMuya('\n', en);
         typeHeading(enMuya, '# Heading');
+        await flush();
         const enLabel = copyLinkAffordance(enMuya)!.getAttribute('aria-label');
 
         const zhMuya = bootMuya('\n', zhCN);
         typeHeading(zhMuya, '# Heading');
+        await flush();
         const zhLabel = copyLinkAffordance(zhMuya)!.getAttribute('aria-label');
 
         expect(enLabel).toBe(en.resource['Copy anchor link to this heading']);
@@ -134,9 +142,12 @@ describe('typing `#` to create a heading under a non-en locale (#4424 / #4427)',
         expect(enLabel).not.toBe(zhLabel);
     });
 
-    it('still emits heading-copy-link when the zh-CN affordance is activated', () => {
+    it('still emits heading-copy-link when the zh-CN affordance is activated', async () => {
         const muya = bootMuya('\n', zhCN);
         typeHeading(muya, '# Heading');
+        // The affordance only exists after the conversion flush; await it before
+        // dispatching the click.
+        await flush();
 
         const handler = vi.fn();
         muya.on('heading-copy-link', handler);
@@ -158,14 +169,19 @@ describe('typing `#` to create a heading under a non-en locale (#4424 / #4427)',
         expect(muya.i18n.t(missingKey)).toBe(missingKey);
     });
 
-    it('every shipped locale defines the heading copy-anchor key (no raw-key fall-through)', () => {
+    it('every shipped locale defines the heading copy-anchor key (no raw-key fall-through)', async () => {
         // The crash's second half was the missing locale key. Lock it in for
         // every shipped locale so a future locale addition can't silently
         // reintroduce the raw-key fall-through (and, under a non-en locale, the
-        // crash before the optional-chaining guard).
-        for (const locale of [en, zhCN]) {
+        // crash before the optional-chaining guard). This is the whole point of
+        // the guard — typing `#` must not crash under ANY shipped locale — so
+        // exercise the real conversion path for every one of them.
+        const shippedLocales = [de, en, es, fr, ja, ko, pt, zhCN, zhTW];
+        for (const locale of shippedLocales) {
             const muya = bootMuya('\n', locale);
             typeHeading(muya, '# Heading');
+            // The HeadingCopyLink attachment renders on the next frame.
+            await flush();
             const label = copyLinkAffordance(muya)!.getAttribute('aria-label');
             expect(label).toBe(locale.resource['Copy anchor link to this heading']);
         }

--- a/packages/muya/src/block/content/paragraphContent/__tests__/backspaceUnwrap.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/backspaceUnwrap.spec.ts
@@ -102,12 +102,16 @@ describe('backspace at start-of-paragraph — merge with previous block', () => 
         expect(blockText(state, 0)).toBe('alphabeta');
     });
 
-    it('lands the caret at the join point (end of the former first paragraph)', () => {
+    it('lands the caret at the join point (end of the former first paragraph)', async () => {
         const muya = bootMuya('alpha\n\nbeta\n');
         const beta = contentByText(muya, 'beta');
 
         backspaceAtStart(muya, beta);
 
+        // The merge flushes on the next animation frame; await it before reading
+        // the merged tree, otherwise contentByText/getCursor observe the
+        // pre-merge state.
+        await flush();
         // After the merge the active block is `alpha`'s content; the caret sits
         // at offset 5 (the original `alpha` length), where the two joined.
         const merged = contentByText(muya, 'alphabeta');


### PR DESCRIPTION
## Summary

Fix-forward for **#4434**. After that PR merged, Copilot posted 6 review comments flagging genuine timing-flakiness in the two regression specs it added (now on `develop`). This PR hardens both so they deterministically exercise their bug guards rather than racing the engine's next-animation-frame flush.

## What changed

### `packages/muya/src/__tests__/headingLocaleCrash.spec.ts`
- **`afterEach` now clears the document-global Selection** (`window.getSelection()?.removeAllRanges()`) — matching several other Muya specs — so a stale `Range` can't point into a removed host node and break a later test's `setCursor`.
- **Every affordance assertion now `await flush()`** after `typeHeading()`. The paragraph→atx-heading conversion and the `HeadingCopyLink` attachment render flush on the next animation frame, so querying the affordance / reading its `aria-label` / dispatching its click immediately after `typeHeading()` could see `null`. Affected: the zh-CN render test, the per-locale (en vs zh-CN) test, the click test, and the all-locale test.
- **The "every shipped locale" test now actually covers all shipped locales** — it loops `de, en, es, fr, ja, ko, pt, zh-CN, zh-TW` (9) instead of just `[en, zhCN]`. Typing `#` must not crash under *any* locale, which is the whole point of the guard.

### `packages/muya/src/block/content/paragraphContent/__tests__/backspaceUnwrap.spec.ts`
- **The caret/join-point assertion now `await flush()`** before reading the merged tree. The merge op flushes on the next frame; without awaiting it, `contentByText('alphabeta')` / `getCursor()` could observe the pre-merge state.

Test **intent is preserved** — each spec still genuinely exercises its original bug guard (the `#`-crash-under-non-en-locale guard especially, now broadened to all 9 shipped locales).

## Verification
- Target specs: 13 passed; **stable across 5 consecutive runs** (no longer timing-dependent).
- `pnpm -C packages/muya lint` — 0 errors (only pre-existing warnings in untouched files); the two changed files lint clean.
- `pnpm -C packages/muya lint:types` — clean.
- `pnpm -C packages/muya test` — 671 passed.
- `pnpm -C packages/muya test:spec` — 1347 passed.
- `madge` circular check — no circular deps.

Related: #4434

🤖 Generated with [Claude Code](https://claude.com/claude-code)