### PR TITLE
test(e2e): add image rendering and TOC sidebar smoke tests

### DIFF
--- a/packages/desktop/test/e2e/data/headings.md
+++ b/packages/desktop/test/e2e/data/headings.md
@@ -1,0 +1,19 @@
+# Introduction
+
+Some introductory text here.
+
+## Getting Started
+
+Steps to get started with the project.
+
+### Prerequisites
+
+Things you need before starting.
+
+## Usage
+
+How to use the application.
+
+## Conclusion
+
+Final thoughts.

--- a/packages/desktop/test/e2e/image-toc-render.spec.ts
+++ b/packages/desktop/test/e2e/image-toc-render.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithDoc } from './helpers'
+
+test.describe('Image rendering', () => {
+  let app: ElectronApplication | null = null
+  let page: Page
+
+  test.beforeAll(async () => {
+    const launched = await launchWithDoc('test/e2e/data/link-image.md')
+    app = launched.app
+    page = launched.page
+    await page.waitForTimeout(800)
+  })
+
+  test.afterAll(async () => {
+    if (app) await app.close()
+  })
+
+  test('renders image element in editor', async () => {
+    const img = page.locator('.editor-component img')
+    await expect(img.first()).toBeVisible({ timeout: 10000 })
+  })
+})
+
+test.describe('TOC sidebar', () => {
+  let app: ElectronApplication | null = null
+  let page: Page
+
+  test.beforeAll(async () => {
+    const launched = await launchWithDoc('test/e2e/data/headings.md')
+    app = launched.app
+    page = launched.page
+    await page.waitForTimeout(800)
+  })
+
+  test.afterAll(async () => {
+    if (app) await app.close()
+  })
+
+  test('TOC sidebar shows heading entries', async () => {
+    // Click the TOC icon in the sidebar to open TOC view
+    const tocIcon = page.locator('[title*="Table"], [title*="TOC"], .side-bar-toc').first()
+    if (await tocIcon.isVisible()) {
+      await tocIcon.click()
+    }
+    // Wait for el-tree nodes to appear
+    const treeNodes = page.locator('.side-bar-toc .el-tree-node')
+    await expect(treeNodes.first()).toBeVisible({ timeout: 10000 })
+    // Should have at least 2 heading entries
+    const count = await treeNodes.count()
+    expect(count).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary

Adds two e2e smoke tests that verify core rendering still works after engine changes:

1. **Image rendering** — opens `link-image.md`, asserts `<img>` is visible in the editor
2. **TOC sidebar** — opens `headings.md`, opens TOC sidebar, asserts heading entries appear

### Why

The `@muyajs/core` migration (`efcaf0c2`) broke image loading and TOC generation. These tests would have caught the regression.

### Status

These tests are expected to **fail on current develop** until the image/TOC regression is fixed. They serve as a regression gate for future engine changes.

### Files

| File | Purpose |
|------|---------|
| `test/e2e/image-toc-render.spec.ts` | Two test suites (image + TOC) |
| `test/e2e/data/headings.md` | Fixture with 5 headings at different levels |
