### PR TITLE
fix: restore editor visual parity after @muyajs/core migration

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1861,6 +1861,11 @@ onBeforeUnmount(() => {
   overflow-anchor: none !important;
 }
 
+.editor-component .mu-container {
+  padding-top: 20px;
+  padding-bottom: 100vh;
+}
+
 .typewriter .editor-component {
   padding-top: calc(50vh - 136px);
   padding-bottom: calc(50vh - 54px);

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -19,8 +19,8 @@
 .mu-container dl,
 .mu-container table,
 .mu-container figure:not(.mu-table) {
-    margin: 0;
-    padding: 0.5em 0;
+    margin: 0.5em 0;
+    padding: 0;
 }
 
 .mu-container h1,
@@ -31,9 +31,8 @@
 .mu-container h6 {
     position: relative;
 
-    margin-top: 0;
-    margin-bottom: 0;
-    padding: 0.5em 0;
+    margin: 1rem 0;
+    padding: 0;
 
     color: var(--editor-color-80);
     font-weight: bold;
@@ -127,7 +126,7 @@
 
     margin-right: 0;
     margin-left: 0;
-    padding: 0 1em;
+    padding: 0 30px;
 
     color: var(--blockquote-text-color, var(--editor-color-50));
 
@@ -136,12 +135,12 @@
 
 .mu-container blockquote::before {
     position: absolute;
-    top: 0.5em;
-    left: 0;
+    top: 0;
+    left: 15px;
 
     display: block;
-    width: 3px;
-    height: calc(100% - 1em);
+    width: 2px;
+    height: 100%;
 
     background: var(--blockquote-border-color, var(--editor-color-30));
 
@@ -159,14 +158,16 @@
 
 .mu-thematic-break:not(.mu-active)::before {
     position: absolute;
-    top: 1.3em;
+    top: 50%;
     left: 0;
 
     display: block;
     width: 100%;
-    height: 1px;
+    height: 2px;
 
-    background: var(--hr-color, var(--editor-color-10));
+    background: none;
+    border-top: 2px dashed var(--hr-color, var(--editor-color-10));
+    transform: translateY(-50%);
 
     content: '';
 }
@@ -355,7 +356,7 @@ span.mu-language-input {
 /* order list and bullet list */
 ol.mu-order-list,
 ul.mu-bullet-list {
-    padding-left: 1em;
+    padding-left: 30px;
 }
 
 ol.mu-order-list {
@@ -406,13 +407,11 @@ ol.mu-order-list:last-child {
 
 /* task list */
 ul.mu-task-list {
-    padding-left: 1em;
+    padding-left: 30px;
 }
 
 li.mu-task-list-item {
     position: relative;
-
-    padding-left: 0.3em;
 
     list-style-type: none;
 }
@@ -420,7 +419,7 @@ li.mu-task-list-item {
 li.mu-task-list-item > input[type='checkbox'],
 li.mu-task-list-item > span.mu-task-list-checkbox {
     position: absolute;
-    top: 0.9em;
+    top: 0.3em;
     left: -23px;
 
     width: 12px;
@@ -493,8 +492,9 @@ li.mu-task-list-item > span.mu-checkbox-checked::after {
 
 li.mu-task-list-item > input.mu-checkbox-checked::before,
 li.mu-task-list-item > span.mu-checkbox-checked::before {
-    background: var(--icon-color);
-    border-color: var(--icon-color);
+    background: var(--theme-color);
+    border-color: var(--theme-color);
+    box-shadow: 0 3px 12px 0 var(--selection-color);
 }
 
 /* table */

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -235,7 +235,7 @@ code.mu-code .mu-code-copy:hover {
 
     width: 16px;
     height: 16px;
-    overflow: auto;
+    overflow: hidden;
 }
 
 .mu-code-copy i.icon > i[class^='icon-'] {

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -342,7 +342,7 @@ blockquote .mu-hide.mu-math > .mu-math-render {
     display: inline-block;
     width: 20px;
     height: 20px;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 }

--- a/packages/muya/src/ui/footnoteTool/index.css
+++ b/packages/muya/src/ui/footnoteTool/index.css
@@ -52,7 +52,7 @@
     display: inline-block;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 

--- a/packages/muya/src/ui/linkTools/index.css
+++ b/packages/muya/src/ui/linkTools/index.css
@@ -74,7 +74,7 @@
     display: inline-block;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 

--- a/packages/muya/src/ui/paragraphFrontButton/index.css
+++ b/packages/muya/src/ui/paragraphFrontButton/index.css
@@ -43,7 +43,7 @@
     display: inline-block;
     width: 14px;
     height: 14px;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 

--- a/packages/muya/src/ui/paragraphFrontMenu/index.css
+++ b/packages/muya/src/ui/paragraphFrontMenu/index.css
@@ -55,7 +55,7 @@
     display: flex;
     width: 18px;
     height: 18px;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 }

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.css
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.css
@@ -69,7 +69,7 @@
     display: inline-block;
     width: 16px;
     height: 16px;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 

--- a/packages/muya/src/ui/previewToolBar/index.css
+++ b/packages/muya/src/ui/previewToolBar/index.css
@@ -69,7 +69,7 @@
     display: inline-block;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 

--- a/packages/muya/src/ui/tableColumnToolbar/index.css
+++ b/packages/muya/src/ui/tableColumnToolbar/index.css
@@ -66,7 +66,7 @@
     display: inline-block;
     width: 100%;
     height: 100%;
-    overflow: auto;
+    overflow: hidden;
 
     color: var(--icon-color);
 


### PR DESCRIPTION
After the `@muyajs/core` engine migration (#4406) the desktop editor picked up the new engine's `.mu-*` design language, which diverged from the legacy marktext look in several places. This restores parity. Three self-contained commits:

### 1. `fix(desktop)` — first-paragraph top spacing + bottom scroll buffer
The legacy `#ag-editor-id` padding no longer matched the new `.mu-container`, so the first block sat ~20px too close to the top and the doc lost its 100vh bottom scroll buffer. Restored on `.editor-component .mu-container`.

### 2. `fix(muya)` — render toolbar/copy icons (overflow:auto → hidden)
The drop-shadow icon trick shifts the source PNG off-screen. `overflow: auto` on the tiny icon box let the desktop's global `::-webkit-scrollbar` styling force a classic, space-taking scrollbar that filled the ~14px box (a gray square), hiding the **table-column toolbar**, **code/math copy** and other icons. The muya examples were unaffected (no scrollbar styling → macOS overlay scrollbars). All icon `i.icon` boxes now use `overflow: hidden`, matching the already-correct inline-format toolbar.

### 3. `fix(muya)` — block-level content styling parity across themes
Match the legacy muyajs look on the new `.mu-*` DOM:
- paragraph/block spacing → collapsing `margin: 0.5em 0` (was non-collapsing `padding`, which doubled the gap)
- headings → `margin: 1rem 0`
- divider → 2px dashed, vertically centred
- list indent → 30px
- blockquote → `0 30px` padding + 2px bar at `left:15px`, full height
- task-list checked marker → `--theme-color` + selection glow; loose checkbox `top: 0.3em`

Colours flow through the existing per-theme camelCase→kebab variable bridge, so this applies uniformly across all 32 themes.

### Verification
- `stylelint` clean on the changed muya CSS (0 errors).
- Side-by-side old-engine vs new-engine render (Electron 42, solarized-light): paragraph/heading spacing, list indent, blue checked checkbox, dashed divider and blockquote bar all match.

### Open question (not addressed here)
The new engine colours bullet `::marker`s with `--list-marker-color` (theme accent), whereas the old engine left them text-coloured. Left as-is since it's a deliberate themable feature, not clearly a regression — happy to revert to text-coloured bullets if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)