### PR TITLE
fix(muya): align Cmd+A / copy / cut / paste with legacy muyajs

### DIFF
--- a/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
@@ -1,6 +1,8 @@
+/* eslint-disable ts/no-explicit-any */
 import type Content from '../../block/base/content';
 import type { Muya } from '../../muya';
 import { describe, expect, it, vi } from 'vitest';
+import { ScrollPage } from '../../block/scrollPage';
 
 // The clipboard module pulls in CodeBlockContent → utils/prism which touches
 // `window` at import time. Stub the prism shim so the test can run under Node
@@ -147,8 +149,37 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
         // snapshot of `event.clipboardData` must be taken synchronously BEFORE
         // that await — otherwise the detached DataTransfer would yield '' here
         // and the paste would silently insert nothing.
+        //
+        // A plain-text paste into a non-literal anchor now always parses
+        // through `MarkdownToState` (Track D / sub-item 1), so the captured text
+        // lands in a created paragraph block rather than being spliced into the
+        // anchor verbatim. Mock `loadBlock` to capture the created block's state.
+        const created: any[] = [];
+        const spy = vi
+            .spyOn(ScrollPage, 'loadBlock')
+            .mockImplementation(() => ({
+                create: (_muya: unknown, state: any) => {
+                    created.push(state);
+                    return {
+                        firstContentInDescendant: () => ({
+                            text: state.text ?? '',
+                            setCursor: vi.fn(),
+                        }),
+                    };
+                },
+            }) as any);
+
         const clipboardFilePath = vi.fn().mockResolvedValue('');
         const anchorBlock = makeAnchorBlock('', 0);
+        // The anchor's wrapper records the created block so the empty origin
+        // paragraph cleanup can run without crashing.
+        const wrapper = {
+            blockName: 'paragraph',
+            getState: () => ({ name: 'paragraph', text: '' }),
+            remove: vi.fn(),
+            parent: { insertAfter: vi.fn() },
+        };
+        (anchorBlock as any).getAnchor = () => wrapper;
         const clipboard = makeClipboard({ clipboardFilePath }, anchorBlock);
         const { event, getData } = makePasteEvent({ 'text/plain': 'hello world' });
 
@@ -156,9 +187,10 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
 
         expect(clipboardFilePath).toHaveBeenCalledOnce();
         expect(getData).toHaveBeenCalledWith('text/plain');
-        // The captured text survived the async hook and was pasted in.
-        expect(anchorBlock.text).toBe('hello world');
-        expect(anchorBlock.setCursor).toHaveBeenCalledWith(11, 11, true);
+        // The captured text survived the async hook and reached the paste path.
+        expect(created).toEqual([{ name: 'paragraph', text: 'hello world' }]);
+
+        spy.mockRestore();
     });
 
     it('falls through to the normal paste when the resolved path is not an image', async () => {

--- a/packages/muya/src/clipboard/__tests__/copyHandler.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyHandler.spec.ts
@@ -49,13 +49,17 @@ describe('clipboard.copyHandler — skip empty clipboard writes', () => {
         expect(setData).not.toHaveBeenCalled();
     });
 
-    it('normal copy: writes both formats when text is non-empty', () => {
+    it('normal copy: writes markdown source to text/plain and blanks text/html', () => {
+        // Track B / D1: a `normal` copy writes ONLY the markdown source to
+        // text/plain and blanks text/html (legacy `copyCutCtrl.copyHandler`),
+        // so an external paste lands as markdown and an internal copy → paste
+        // round-trips through the markdown branch losslessly.
         const clipboard = makeClipboard('<p>hi</p>', 'hi');
         const { event, setData } = makeEvent();
 
         clipboard.copyHandler(event);
 
-        expect(setData).toHaveBeenCalledWith('text/html', '<p>hi</p>');
+        expect(setData).toHaveBeenCalledWith('text/html', '');
         expect(setData).toHaveBeenCalledWith('text/plain', 'hi');
     });
 

--- a/packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/parityCopyAsRich.spec.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import type { Muya } from '../../muya';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
@@ -1,0 +1,309 @@
+// @vitest-environment happy-dom
+
+/* eslint-disable ts/no-explicit-any */
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+import { ScrollPage } from '../../block/scrollPage';
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as the sibling specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+// Keep the real markdown/HTML conversion logic, but neuter `normalizePastedHTML`
+// (its DOMPurify call needs a richer DOM than the test gives) — return the html
+// unchanged so the converter sees what we pasted.
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return {
+        ...actual,
+        normalizePastedHTML: async (html: string) => html,
+    };
+});
+
+const Clipboard = (await import('../index')).default;
+
+// ---------------------------------------------------------------------------
+// Fakes. The pasteHandler block-creation path calls
+// `ScrollPage.loadBlock(name).create(muya, state)` and
+// `wrapperBlock.parent.insertAfter(newBlock, ref)`. We record every created
+// block's state and the wrapper's children so a test can assert that single
+// line markdown produced REAL block states (heading / list / table / quote)
+// rather than a literal text insert.
+// ---------------------------------------------------------------------------
+
+interface IRecordedBlock {
+    name: string;
+    state: any;
+    _contentText: string;
+}
+
+function makeCreatedBlock(state: any): IRecordedBlock & {
+    firstContentInDescendant: () => any;
+    lastContentInDescendant: () => any;
+} {
+    const content = {
+        text: state.text ?? '',
+        setCursor: vi.fn(),
+    };
+    return {
+        name: state.name,
+        state,
+        _contentText: state.text ?? '',
+        firstContentInDescendant: () => content,
+        lastContentInDescendant: () => content,
+    };
+}
+
+function installLoadBlockSpy(created: IRecordedBlock[]) {
+    return vi.spyOn(ScrollPage, 'loadBlock').mockImplementation((_name: string) => {
+        return {
+            create: (_muya: Muya, state: any) => {
+                const block = makeCreatedBlock(state);
+                created.push(block);
+                return block;
+            },
+        } as any;
+    });
+}
+
+function makeWrapper(blockName: string) {
+    const children: any[] = [];
+    const wrapper: any = {
+        blockName,
+        firstContentInDescendant: () => null,
+        getState: () => ({ name: blockName, text: '' }),
+        remove: vi.fn(),
+    };
+    wrapper.parent = {
+        insertAfter: vi.fn((newBlock: any, _ref: any) => {
+            children.push(newBlock);
+        }),
+        children,
+    };
+    return wrapper;
+}
+
+function makeAnchorBlock(
+    blockName: string,
+    text: string,
+    wrapper: any,
+    cursor = text.length,
+) {
+    const block: any = {
+        blockName,
+        text,
+        getCursor: () => ({ start: { offset: cursor }, end: { offset: cursor } }),
+        setCursor: vi.fn(),
+        getAnchor: () => wrapper,
+        firstContentInDescendant: () => block,
+        getState: () => ({ name: blockName, text: block.text }),
+        update: vi.fn(),
+    };
+    return block;
+}
+
+function makeClipboard(anchorBlock: any, options: Record<string, unknown> = {}) {
+    const clipboard = new Clipboard({
+        options: { bulletListMarker: '-', frontMatter: true, ...options },
+        editor: {},
+    } as unknown as Muya);
+    Object.defineProperty(clipboard, 'selection', {
+        get: () => ({
+            getSelection: () => ({ isSelectionInSameBlock: true, anchorBlock }),
+        }),
+    });
+    return clipboard;
+}
+
+function makePasteEvent(data: Record<string, string> = {}) {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: {
+            getData: (type: string) => data[type] ?? '',
+            files: [],
+            items: [],
+        },
+    } as unknown as ClipboardEvent;
+}
+
+describe('pasteHandler — single-line markdown parses into real blocks (sub-item 1)', () => {
+    it('pastes `# Title` into an empty paragraph as an atx-heading block', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '# Title' }));
+
+        const names = created.map(b => b.name);
+        expect(names).toContain('atx-heading');
+        expect(anchor.text).toBe('');
+    });
+
+    it('pastes `- item` into an empty paragraph as a bullet-list block', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '- item' }));
+
+        expect(created.map(b => b.name)).toContain('bullet-list');
+    });
+
+    it('pastes `1. one` into an empty paragraph as an order-list block', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '1. one' }));
+
+        expect(created.map(b => b.name)).toContain('order-list');
+    });
+
+    it('pastes `> quote` into an empty paragraph as a block-quote block', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '> quote' }));
+
+        expect(created.map(b => b.name)).toContain('block-quote');
+    });
+
+    it('pastes a single-line GFM table into an empty paragraph as a table block', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        const md = '| a | b |\n| - | - |\n| 1 | 2 |';
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': md }));
+
+        expect(created.map(b => b.name)).toContain('table');
+    });
+});
+
+describe('pasteHandler — single-line paste keeps literal insert for code-like anchors', () => {
+    it('language-input anchor inserts the text literally, no block creation', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('code-block');
+        const anchor = makeAnchorBlock('language-input', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '# Title' }));
+
+        expect(created).toHaveLength(0);
+        expect(anchor.text).toBe('# Title');
+    });
+
+    it('table.cell.content anchor inserts literally with \\n → <br/>', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('table');
+        const anchor = makeAnchorBlock('table.cell.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '- item' }));
+
+        expect(created).toHaveLength(0);
+        expect(anchor.text).toBe('- item');
+    });
+
+    it('codeblock.content anchor inserts the text literally', async () => {
+        const created: IRecordedBlock[] = [];
+        installLoadBlockSpy(created);
+        const wrapper = makeWrapper('code-block');
+        const anchor = makeAnchorBlock('codeblock.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        await clipboard.pasteHandler(makePasteEvent({ 'text/plain': '# Title' }));
+
+        expect(created).toHaveLength(0);
+        expect(anchor.text).toBe('# Title');
+    });
+});
+
+describe('pasteHandler — block-level HTML becomes a live html-block (sub-item 2)', () => {
+    it('pastes `<ul>...</ul>` (block HTML in text/plain) as an html-block, not a ```html code block', async () => {
+        const created: IRecordedBlock[] = [];
+        const spy = installLoadBlockSpy(created);
+        const wrapper = makeWrapper('paragraph');
+        const anchor = makeAnchorBlock('paragraph.content', '', wrapper, 0);
+        const clipboard = makeClipboard(anchor);
+
+        // A block-level tag arrives in text/plain only (no text/html flavour) →
+        // getCopyTextType returns 'code' (legacy `copyAsHtml`).
+        await clipboard.pasteHandler(
+            makePasteEvent({ 'text/plain': '<ul><li>a</li><li>b</li></ul>' }),
+        );
+
+        const requested = spy.mock.calls.map(c => c[0]);
+        expect(requested).toContain('html-block');
+        expect(created.some(b => b.name === 'html-block')).toBe(true);
+        expect(created.some(b => b.state?.meta?.lang === 'html')).toBe(false);
+    });
+});
+
+describe('pasteHandler — table-cell paste guards (sub-item 4)', () => {
+    function makeClipboardWithTableSelection(
+        anchorBlock: any,
+        hasSelection: boolean,
+        isSingleCell: boolean,
+    ) {
+        const clipboard = makeClipboard(anchorBlock);
+        const rows = isSingleCell
+            ? [{ children: [{ text: '' }] }]
+            : [{ children: [{ text: '' }, { text: '' }] }];
+        Object.defineProperty(clipboard, 'tableSelection', {
+            get: () => ({
+                hasSelection,
+                getStateForCopy: () => ({ name: 'table', children: rows }),
+                clear: vi.fn(),
+            }),
+        });
+        return clipboard;
+    }
+
+    it('single-cell selection replaces the cell text (\\n → <br/>)', async () => {
+        installLoadBlockSpy([]);
+        const wrapper = makeWrapper('table');
+        const anchor = makeAnchorBlock('table.cell.content', 'old', wrapper, 3);
+        const clipboard = makeClipboardWithTableSelection(anchor, true, true);
+
+        await clipboard.pasteHandler(
+            makePasteEvent({ 'text/plain': 'line1\nline2' }),
+        );
+
+        expect(anchor.text).toBe('line1<br/>line2');
+    });
+
+    it('multi-cell selection is a no-op — the cell text is left unchanged', async () => {
+        installLoadBlockSpy([]);
+        const wrapper = makeWrapper('table');
+        const anchor = makeAnchorBlock('table.cell.content', 'keep', wrapper, 4);
+        const clipboard = makeClipboardWithTableSelection(anchor, true, false);
+
+        await clipboard.pasteHandler(
+            makePasteEvent({ 'text/plain': 'pasted' }),
+        );
+
+        expect(anchor.text).toBe('keep');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
@@ -1,0 +1,104 @@
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as the sibling specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return {
+        ...actual,
+        normalizePastedHTML: async (html: string) => html,
+    };
+});
+
+const Clipboard = (await import('../index')).default;
+
+// Track D / sub-item 5 (D3): pasting an image should insert a LOADING
+// placeholder image immediately, then await `imageAction`, and only then
+// replace the placeholder with the final src. Mirrors legacy
+// `pasteCtrl.pasteImage`'s `loading-<id>` insert → imageAction → replace flow.
+
+function makeAnchorBlock(initialText = '', cursor = 0) {
+    const block = {
+        text: initialText,
+        blockName: 'paragraph.content',
+        getCursor: () => ({
+            start: { offset: cursor },
+            end: { offset: cursor },
+        }),
+        setCursor: vi.fn(),
+        getAnchor: () => null,
+    };
+    return block as unknown as Content;
+}
+
+function makeClipboard(options: Record<string, unknown>, anchorBlock: Content) {
+    const clipboard = new Clipboard({ options } as unknown as Muya);
+    Object.defineProperty(clipboard, 'selection', {
+        get: () => ({
+            getSelection: () => ({
+                isSelectionInSameBlock: true,
+                anchorBlock,
+            }),
+        }),
+    });
+    return clipboard;
+}
+
+function makePasteEvent() {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        clipboardData: { getData: () => '', files: [], items: [] },
+    } as unknown as ClipboardEvent;
+}
+
+describe('pasteHandler image paste — loading placeholder then replace (sub-item 5)', () => {
+    it('inserts a placeholder image BEFORE imageAction resolves, then swaps in the final src', async () => {
+        let resolveAction: (src: string) => void = () => {};
+        const actionPromise = new Promise<string>((resolve) => {
+            resolveAction = resolve;
+        });
+        const anchorBlock = makeAnchorBlock('', 0);
+        // While imageAction is in flight, the anchor must already carry a
+        // placeholder image (non-empty) so the user sees a loading state.
+        let textWhileLoading: string | null = null;
+        const imageAction = vi.fn().mockImplementation(() => {
+            textWhileLoading = anchorBlock.text;
+            return actionPromise;
+        });
+        const clipboardFilePath = vi.fn().mockResolvedValue('/abs/photo.png');
+
+        const clipboard = makeClipboard(
+            { clipboardFilePath, imageAction },
+            anchorBlock,
+        );
+
+        const done = clipboard.pasteHandler(makePasteEvent());
+
+        // Give the microtasks up to the `await imageAction` a chance to run.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // A placeholder image markdown must already be present in the anchor.
+        expect(anchorBlock.text).toMatch(/!\[[^\]]*\]\([^)]+\)/);
+
+        resolveAction('assets/photo.png');
+        await done;
+
+        // The placeholder was captured while imageAction was pending.
+        expect(textWhileLoading).toMatch(/!\[[^\]]*\]\([^)]+\)/);
+        // And the final anchor text carries the resolved src, exactly once.
+        expect(anchorBlock.text).toBe('![](assets/photo.png)');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/trackBCopy.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackBCopy.spec.ts
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+
+import type { ImageToken } from '../../inlineRenderer/types';
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// Track B — Copy (clipboard chain step 1). Ports `packages/muyajs`
+// `copyCutCtrl.copyHandler` behaviour into `@muyajs/core`:
+//   1. `normal` copy writes ONLY text/plain (markdown source); text/html is
+//      blanked so an internal copy → paste round-trips through the markdown
+//      branch losslessly and external pastes land as markdown source.
+//   2. `copyAsHtml` writes the DOMPurify-sanitized rendered HTML into
+//      text/plain and blanks text/html, with the empty-guard keyed on `text`.
+//   3. A selected inline image copies its raw `![alt](src)` markdown.
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as the sibling
+// clipboard specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const Clipboard = (await import('../index')).default;
+
+function makeEvent() {
+    const setData = vi.fn();
+    return {
+        event: {
+            clipboardData: { setData },
+        } as unknown as ClipboardEvent,
+        setData,
+    };
+}
+
+function dataFor(setData: ReturnType<typeof vi.fn>, format: string) {
+    const call = setData.mock.calls.find(([f]) => f === format);
+    return call ? call[1] : undefined;
+}
+
+function fakeMuya(overrides: Partial<Muya> = {}) {
+    return {
+        options: { frontMatter: true },
+        editor: { selection: { selectedImage: null } },
+        ...overrides,
+    } as unknown as Muya;
+}
+
+function clipboardWithData(html: string, text: string, muya: Muya = fakeMuya()) {
+    const clipboard = new Clipboard(muya);
+    clipboard.getClipboardData = () => ({ html, text });
+    return clipboard;
+}
+
+describe('track B — normal copy writes only text/plain', () => {
+    it('blanks text/html and writes markdown source to text/plain', () => {
+        const clipboard = clipboardWithData('<p>hi</p>', 'hi');
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(dataFor(setData, 'text/html')).toBe('');
+        expect(dataFor(setData, 'text/plain')).toBe('hi');
+    });
+
+    it('skips setData entirely when the selection is empty', () => {
+        const clipboard = clipboardWithData('', '');
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+
+    it('round-trips: a normal copy produces markdown that pastes losslessly', () => {
+        // text/html empty means `getCopyTextType` classifies the paste as
+        // `onlyMarkdown`, so the markdown source is re-inserted verbatim.
+        const markdown = '**bold** and `code`';
+        const clipboard = clipboardWithData('<p><strong>bold</strong></p>', markdown);
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(dataFor(setData, 'text/html')).toBe('');
+        expect(dataFor(setData, 'text/plain')).toBe(markdown);
+    });
+});
+
+describe('track B — copyAsRich still writes both slots', () => {
+    it('keeps rendered html in text/html and markdown in text/plain', () => {
+        const clipboard = clipboardWithData('<p>hi</p>', 'hi');
+        clipboard.copyType = 'copyAsRich';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(dataFor(setData, 'text/html')).toBe('<p>hi</p>');
+        expect(dataFor(setData, 'text/plain')).toBe('hi');
+    });
+});
+
+describe('track B — copyAsHtml is sanitized and text-guarded', () => {
+    it('writes sanitized rendered HTML to text/plain, blanks text/html', () => {
+        const clipboard = clipboardWithData('', '# Heading\n\nhello');
+        clipboard.copyType = 'copyAsHtml';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(dataFor(setData, 'text/html')).toBe('');
+        const plain = dataFor(setData, 'text/plain') as string;
+        expect(plain).toContain('<h1');
+        expect(plain).toContain('hello');
+    });
+
+    it('neutralises XSS payloads in the exported html (DOMPurify)', () => {
+        // muyajs `getSanitizeHtml` runs `sanitize(html, EXPORT_DOMPURIFY_CONFIG,
+        // false)`, which escapes raw in-block HTML rather than dropping it. The
+        // guarantee is no LIVE `<script>` element survives — the markup is
+        // escaped to inert text.
+        const clipboard = clipboardWithData('', 'before\n\n<script>alert(1)</script>\n\nafter');
+        clipboard.copyType = 'copyAsHtml';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        const plain = dataFor(setData, 'text/plain') as string;
+        expect(plain).not.toContain('<script>');
+        expect(plain).toContain('&lt;script&gt;');
+    });
+
+    it('guards on `text` being empty, not html', () => {
+        // html empty but text non-empty: legacy guarded on text, so it MUST
+        // still copy. (muya previously returned early on empty html.)
+        const clipboard = clipboardWithData('', 'plain text');
+        clipboard.copyType = 'copyAsHtml';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).toHaveBeenCalled();
+        expect(dataFor(setData, 'text/plain')).toBeTruthy();
+    });
+
+    it('skips when text is empty', () => {
+        const clipboard = clipboardWithData('', '');
+        clipboard.copyType = 'copyAsHtml';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+});
+
+describe('track B — selected inline image copies its raw markdown', () => {
+    function imageToken(raw: string): ImageToken {
+        return { type: 'image', raw } as unknown as ImageToken;
+    }
+
+    it('writes `![alt](src)` to both slots and short-circuits', () => {
+        const raw = '![alt](https://e.com/x.png)';
+        const muya = fakeMuya({
+            editor: {
+                selection: { selectedImage: { token: imageToken(raw) } },
+            },
+        } as unknown as Partial<Muya>);
+        const clipboard = new Clipboard(muya);
+        const getData = vi.fn(() => ({ html: 'SHOULD_NOT_RUN', text: 'SHOULD_NOT_RUN' }));
+        clipboard.getClipboardData = getData;
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(dataFor(setData, 'text/html')).toBe(raw);
+        expect(dataFor(setData, 'text/plain')).toBe(raw);
+        expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for an image with empty raw', () => {
+        const muya = fakeMuya({
+            editor: {
+                selection: { selectedImage: { token: imageToken('') } },
+            },
+        } as unknown as Partial<Muya>);
+        const clipboard = new Clipboard(muya);
+        clipboard.getClipboardData = () => ({ html: '', text: '' });
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -1,0 +1,367 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type TableBlock from '../../block/gfm/table';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+
+// Track C — Cut (clipboard chain step 2). Ports `packages/muyajs`
+// `copyCutCtrl.cutHandler` + `removeBlocks` semantics into `@muyajs/core`:
+//   1. A cross-block cut merges at the LEAF level —
+//      `startBlock.text = start.head + end.tail` — keeping BOTH endpoint tails
+//      and removing only the structure strictly between. The start block keeps
+//      its container (list item stays a list item, blockquote stays a quote).
+//   2. A whole-document selection collapses to a single empty paragraph
+//      (muyajs `isSelectAll` reset).
+//   3. An empty whole-row / whole-column / whole-table table-cell cut removes
+//      that row / column / table structurally.
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as sibling specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Document-order list of every content leaf.
+function contentBlocks(muya: Muya): Content[] {
+    const out: Content[] = [];
+    let c: Content | null = muya.editor.scrollPage!.firstContentInDescendant();
+    while (c) {
+        out.push(c);
+        c = c.nextContentInContext() ?? null;
+    }
+    return out;
+}
+
+// Replace the live (happy-dom-unreliable) cross-block DOM selection with a
+// constructed `ISelection` that the real `cutHandler` consumes. The block tree
+// and every mutation remain real; only the selection read is stubbed.
+function stubSelection(
+    muya: Muya,
+    a: Content,
+    aOff: number,
+    f: Content,
+    fOff: number,
+    direction = 'forward',
+) {
+    const aPath = a.path;
+    const fPath = f.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: aOff },
+        focus: { offset: fOff },
+        anchorBlock: a,
+        anchorPath: aPath,
+        focusBlock: f,
+        focusPath: fPath,
+        isCollapsed: false,
+        isSelectionInSameBlock: a === f,
+        direction,
+        type: 'Range',
+    });
+}
+
+// json state applies composed ops on a requestAnimationFrame; wait for the
+// authoritative markdown to settle.
+async function cutAndRead(muya: Muya): Promise<string> {
+    // eslint-disable-next-line ts/no-explicit-any
+    (muya.editor as any).clipboard.cutHandler();
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('track C — cross-block cut keeps both endpoint tails (leaf merge)', () => {
+    it('paragraph -> list item: tail of the list item survives', async () => {
+        const muya = bootMuya('hello\n\n- world item\n');
+        const blocks = contentBlocks(muya);
+        // 'hello'@2 -> 'he' merged with 'world item'@3 -> 'ld item'.
+        stubSelection(muya, blocks[0], 2, blocks[blocks.length - 1], 3);
+        expect(await cutAndRead(muya)).toBe('held item\n');
+    });
+
+    it('list item -> paragraph: start stays a list item, both tails kept', async () => {
+        const muya = bootMuya('- list one\n\nparagraph two\n');
+        const blocks = contentBlocks(muya);
+        stubSelection(muya, blocks[0], 2, blocks[blocks.length - 1], 4);
+        expect(await cutAndRead(muya)).toBe('- ligraph two\n');
+    });
+
+    it('paragraph -> block quote: quote tail survives', async () => {
+        const muya = bootMuya('hello\n\n> quoted text\n');
+        const blocks = contentBlocks(muya);
+        stubSelection(muya, blocks[0], 2, blocks[blocks.length - 1], 3);
+        expect(await cutAndRead(muya)).toBe('heted text\n');
+    });
+
+    it('block quote -> paragraph: start stays a quote, both tails kept', async () => {
+        const muya = bootMuya('> quoted text\n\nhello\n');
+        const blocks = contentBlocks(muya);
+        stubSelection(muya, blocks[0], 2, blocks[blocks.length - 1], 3);
+        expect(await cutAndRead(muya)).toBe('> qulo\n');
+    });
+
+    it('paragraph -> code block: code tail merges into the paragraph', async () => {
+        const muya = bootMuya('hello\n\n```\ncodeline\n```\n');
+        const blocks = contentBlocks(muya);
+        // The code body content leaf is the LAST content leaf (the
+        // language-input leaf comes before it).
+        const codeContent = blocks[blocks.length - 1];
+        // 'hello'@2 -> 'he' merged with 'codeline'@4 -> 'line'.
+        stubSelection(muya, blocks[0], 2, codeContent, 4);
+        expect(await cutAndRead(muya)).toBe('heline\n');
+    });
+
+    it('code block -> paragraph: start stays a code block, both tails kept', async () => {
+        const muya = bootMuya('```\ncodeline\n```\n\nhello\n');
+        const blocks = contentBlocks(muya);
+        // blocks: [language-input '', codeblock.content 'codeline', paragraph 'hello'].
+        const codeContent = blocks.find(b => b.blockName === 'codeblock.content')!;
+        const para = blocks[blocks.length - 1];
+        // 'codeline'@2 -> 'co' merged with 'hello'@3 -> 'lo'.
+        stubSelection(muya, codeContent, 2, para, 3);
+        expect(await cutAndRead(muya)).toBe('```\ncolo\n```\n');
+    });
+
+    it('list item -> list item: middle item gone, tails merged', async () => {
+        const muya = bootMuya('- one item\n- two item\n- three item\n');
+        const blocks = contentBlocks(muya);
+        // 'one item'@2 -> 'on' merged with 'three item'@3 -> 'ee item'.
+        stubSelection(muya, blocks[0], 2, blocks[2], 3);
+        expect(await cutAndRead(muya)).toBe('- onee item\n');
+    });
+
+    it('list item -> sibling list item (adjacent): tails merged into one item', async () => {
+        const muya = bootMuya('- one item\n- two item\n');
+        const blocks = contentBlocks(muya);
+        // 'one item'@2 -> 'on' merged with 'two item'@3 -> ' item'.
+        stubSelection(muya, blocks[0], 2, blocks[1], 3);
+        expect(await cutAndRead(muya)).toBe('- on item\n');
+    });
+
+    it('paragraph -> paragraph across an intervening block: middle removed', async () => {
+        const muya = bootMuya('alpha\n\nbeta\n\ngamma\n');
+        const blocks = contentBlocks(muya);
+        stubSelection(muya, blocks[0], 2, blocks[2], 2);
+        expect(await cutAndRead(muya)).toBe('almma\n');
+    });
+
+    it('cut is the engine behind typing-replace on a cross-block selection', async () => {
+        // The paste/typing path calls cutHandler first to collapse the range;
+        // the result must be the merged single block ready to receive input.
+        const muya = bootMuya('foo\n\nbar\n');
+        const blocks = contentBlocks(muya);
+        stubSelection(muya, blocks[0], 1, blocks[1], 2);
+        expect(await cutAndRead(muya)).toBe('fr\n');
+    });
+
+    it('paragraph -> table cell: grid is preserved, spanned cells emptied', async () => {
+        const muya = bootMuya('hello\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n');
+        const blocks = contentBlocks(muya);
+        const firstCell = blocks.find(
+            b => b.blockName === 'table.cell.content' && b.text === 'a',
+        )!;
+        // 'hello'@2 -> 'he'; the table survives with cell 'a' emptied.
+        stubSelection(muya, blocks[0], 2, firstCell, 1);
+        const md = await cutAndRead(muya);
+        expect(md).toContain('he\n');
+        expect(md).toContain('| b'); // the rest of the grid survives
+        expect(md).toContain('| 1'); // body row untouched
+        expect(md).not.toMatch(/\|\s*a\s*\|/); // cell 'a' is now empty
+    });
+
+    it('table cell -> paragraph: start cell keeps the merge, grid preserved', async () => {
+        const muya = bootMuya('| a | b |\n| --- | --- |\n| 1 | 2 |\n\nhello\n');
+        const blocks = contentBlocks(muya);
+        const firstCell = blocks.find(
+            b => b.blockName === 'table.cell.content' && b.text === 'a',
+        )!;
+        const para = blocks[blocks.length - 1];
+        // cell 'a'@0 -> '' merged with 'hello'@3 -> 'lo'.
+        stubSelection(muya, firstCell, 0, para, 3);
+        const md = await cutAndRead(muya);
+        expect(md).toMatch(/\|\s*lo\s*\|/); // merged into the start cell
+        expect(md).toContain('| b'); // grid intact
+        expect(md).not.toContain('hello');
+    });
+
+    it('paragraph -> first list item keeps the later items', async () => {
+        const muya = bootMuya('hello\n\n- x item\n- y item\n- z item\n');
+        const blocks = contentBlocks(muya);
+        // end = first list item 'x item'@2 -> 'item'; items y/z survive.
+        stubSelection(muya, blocks[0], 2, blocks[1], 2);
+        expect(await cutAndRead(muya)).toBe('heitem\n\n- y item\n- z item\n');
+    });
+
+    it('cell -> cell in the same table: grid kept, spanned cells emptied', async () => {
+        const muya = bootMuya('| a | b |\n| --- | --- |\n| 1 | 2 |\n');
+        const blocks = contentBlocks(muya);
+        const cellA = blocks.find(b => b.text === 'a')!;
+        const cell2 = blocks.find(b => b.text === '2')!;
+        // 'a'@1 -> 'a' merged with '2'@0 -> '2'; cells between emptied.
+        stubSelection(muya, cellA, 1, cell2, 0);
+        const md = await cutAndRead(muya);
+        // Two-column, two-row grid survives.
+        expect(md.match(/\| --- \| --- \|/g)?.length).toBe(1);
+        expect(md).toMatch(/\|\s*a2\s*\|/);
+        expect(md).not.toMatch(/\|\s*b\s*\|/); // 'b' emptied
+        expect(md).not.toMatch(/\|\s*1\s*\|/); // '1' emptied
+    });
+
+    it('places the caret at the start block / start offset after the cut', async () => {
+        const muya = bootMuya('hello\n\n- world item\n');
+        const blocks = contentBlocks(muya);
+        const start = blocks[0];
+        stubSelection(muya, start, 2, blocks[blocks.length - 1], 3);
+        // eslint-disable-next-line ts/no-explicit-any
+        (muya.editor as any).clipboard.cutHandler();
+        await new Promise(r => setTimeout(r, 40));
+        // The caret is seated on the merged start block at the cut offset. The
+        // happy-dom native selection does not round-trip, so assert on the
+        // engine selection state that `setCursor` writes directly.
+        const { selection } = muya.editor;
+        expect(muya.editor.activeContentBlock).toBe(start);
+        expect(muya.editor.activeContentBlock?.text).toBe('held item');
+        expect(selection.anchor?.offset).toBe(2);
+        expect(selection.focus?.offset).toBe(2);
+    });
+});
+
+describe('track C — whole-document selection collapses to one empty paragraph', () => {
+    it('select-all then cut leaves a single empty paragraph', async () => {
+        const muya = bootMuya('# Title\n\nbody text\n\n- a\n- b\n');
+        const blocks = contentBlocks(muya);
+        const first = blocks[0];
+        const last = blocks[blocks.length - 1];
+        stubSelection(muya, first, 0, last, last.text.length);
+        expect(await cutAndRead(muya)).toBe('\n');
+    });
+
+    it('select-all over a single paragraph collapses to empty', async () => {
+        const muya = bootMuya('just one line\n');
+        const blocks = contentBlocks(muya);
+        // Single block, but the whole text is selected (anchor !== focus block
+        // is false here) — exercise via the cross-block-style whole selection.
+        const only = blocks[0];
+        stubSelection(muya, only, 0, only, only.text.length);
+        expect(await cutAndRead(muya)).toBe('\n');
+    });
+});
+
+// Drive a real frozen table selection through DOM mouse events (same pattern
+// as editor/__tests__/tableCellSelection.spec.ts) so `cutHandler`'s table
+// branch reads a genuine selection.
+function firstTable(muya: Muya): TableBlock {
+    return muya.editor.scrollPage!.firstContentInDescendant()!.closestBlock('table') as TableBlock;
+}
+
+function cellDom(table: TableBlock, row: number, column: number): HTMLElement {
+    const cell = table.cellAt(row, column)!;
+    return (cell.firstChild as { domNode: HTMLElement }).domNode;
+}
+
+function fireMouse(node: HTMLElement, type: string): void {
+    const event = new MouseEvent(type, { bubbles: true, button: 0 });
+    if (!('x' in event))
+        Object.defineProperty(event, 'x', { value: 0, configurable: true });
+    node.dispatchEvent(event);
+}
+
+function dragSelect(table: TableBlock, r1: number, c1: number, r2: number, c2: number): void {
+    fireMouse(cellDom(table, r1, c1), 'mousedown');
+    fireMouse(cellDom(table, r2, c2), 'mousemove');
+    fireMouse(cellDom(table, r2, c2), 'mouseup');
+}
+
+async function cutSelectionAndRead(muya: Muya): Promise<string> {
+    // eslint-disable-next-line ts/no-explicit-any
+    (muya.editor as any).clipboard.cutHandler();
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('track C — empty table row/column/whole-table cut is structural', () => {
+    it('cutting an already-empty whole column removes that column', async () => {
+        // 3-column table whose middle column is entirely empty.
+        const muya = bootMuya(
+            '| a1 |  | c1 |\n| --- | --- | --- |\n| a2 |  | c2 |\n| a3 |  | c3 |\n',
+        );
+        const table = firstTable(muya);
+        dragSelect(table, 0, 1, 2, 1); // whole middle column (all 3 rows)
+        const md = await cutSelectionAndRead(muya);
+        // The empty middle column is gone; the table now has 2 columns.
+        expect(md).toContain('a1');
+        expect(md).toContain('c1');
+        expect(table.columnCount).toBe(2);
+    });
+
+    it('cutting an already-empty whole row removes that row', async () => {
+        // 4 body rows; the LAST body row is entirely empty.
+        const muya = bootMuya(
+            '| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n|  |  |\n',
+        );
+        const table = firstTable(muya);
+        const before = table.rowCount;
+        dragSelect(table, before - 1, 0, before - 1, 1); // whole empty last row
+        await cutSelectionAndRead(muya);
+        expect(table.rowCount).toBe(before - 1);
+    });
+
+    it('cutting an empty whole table removes the table block', async () => {
+        const muya = bootMuya(
+            '|  |  |\n| --- | --- |\n|  |  |\n',
+        );
+        const table = firstTable(muya);
+        dragSelect(table, 0, 0, table.rowCount - 1, table.columnCount - 1);
+        const md = await cutSelectionAndRead(muya);
+        expect(md).not.toContain('|');
+    });
+
+    it('cutting a selection that still has content only empties in place', async () => {
+        const muya = bootMuya(
+            '| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n',
+        );
+        const table = firstTable(muya);
+        const beforeRows = table.rowCount;
+        const beforeCols = table.columnCount;
+        dragSelect(table, 0, 0, 1, 1); // has content
+        const md = await cutSelectionAndRead(muya);
+        // Structure unchanged; only the cells were emptied.
+        expect(table.rowCount).toBe(beforeRows);
+        expect(table.columnCount).toBe(beforeCols);
+        expect(md).not.toMatch(/\ba1\b/);
+        expect(md).not.toMatch(/\bb2\b/);
+    });
+});

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -1,6 +1,8 @@
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
 import type TreeNode from '../block/base/treeNode';
+import type Table from '../block/gfm/table';
+import type TableBodyCell from '../block/gfm/table/cell';
 import type TableCellSelection from '../editor/tableCellSelection';
 import type { Muya } from '../muya';
 import type { TState } from '../state/types';
@@ -9,13 +11,13 @@ import { fromEvent, merge } from 'rxjs';
 import CodeBlockContent from '../block/content/codeBlockContent';
 import { ScrollPage } from '../block/scrollPage';
 import { URL_REG } from '../config';
-import emptyStates from '../config/emptyStates';
 import HtmlToMarkdown from '../state/htmlToMarkdown';
 import { MarkdownToState } from '../state/markdownToState';
 import StateToMarkdown from '../state/stateToMarkdown';
 import { isAnyListState, isParagraphState } from '../state/types';
-import { deepClone, isClipboardEvent, isKeyboardEvent } from '../utils';
-import { getClipBoardHtml } from '../utils/marked';
+import { getUniqueId, isClipboardEvent, isKeyboardEvent } from '../utils';
+import { getBlock } from '../utils/dom';
+import { getClipBoardHtml, getSanitizeClipboardHtml } from '../utils/marked';
 import { getClipboardImageFile, getCopyTextType, isStandaloneTableHtml, normalizePastedHTML, readFileAsDataURL, resolveClipboardImagePath } from '../utils/paste';
 import { mergePasteIntoHeading } from './mergePasteIntoHeading';
 
@@ -370,12 +372,25 @@ class Clipboard {
     }
 
     copyHandler(event: ClipboardEvent): void {
-        const { html, text } = this.getClipboardData();
+        if (!event.clipboardData)
+            return;
+
+        // A selected inline image copies its raw `![alt](src)` markdown
+        // verbatim (legacy `copyCutCtrl.copyHandler`), short-circuiting the
+        // text-selection clipboard data.
+        const selectedImage = this.muya.editor?.selection?.selectedImage;
+        if (selectedImage) {
+            const { raw } = selectedImage.token;
+            if (raw.length > 0) {
+                event.clipboardData.setData('text/html', raw);
+                event.clipboardData.setData('text/plain', raw);
+            }
+            return;
+        }
 
         const { copyType } = this;
 
-        if (!event.clipboardData)
-            return;
+        const { html, text } = this.getClipboardData();
 
         // Mirror native copy behaviour: leave the system clipboard untouched
         // when the selection has nothing to contribute, so a previous copy
@@ -384,16 +399,30 @@ class Clipboard {
             case 'normal': {
                 if (text.length === 0)
                     return;
-                event.clipboardData.setData('text/html', html);
+                event.clipboardData.setData('text/html', '');
                 event.clipboardData.setData('text/plain', text);
                 break;
             }
 
             case 'copyAsHtml': {
-                if (html.length === 0)
+                if (text.length === 0)
                     return;
+                const {
+                    frontMatter = true,
+                    math,
+                    isGitlabCompatibilityEnabled,
+                    superSubScript,
+                } = this.muya.options ?? {};
                 event.clipboardData.setData('text/html', '');
-                event.clipboardData.setData('text/plain', html);
+                event.clipboardData.setData(
+                    'text/plain',
+                    getSanitizeClipboardHtml(text, {
+                        frontMatter,
+                        math,
+                        isGitlabCompatibilityEnabled,
+                        superSubScript,
+                    }),
+                );
                 break;
             }
 
@@ -429,11 +458,15 @@ class Clipboard {
     }
 
     cutHandler() {
-        // A frozen cross-cell table selection: empty just those cells in place
-        // (legacy `deleteSelectedTableCells`). The copy half already captured
-        // the rectangle's markdown via `getClipboardData`.
+        // A frozen cross-cell table selection. When every selected cell is
+        // already empty and the rectangle covers a whole row / column / table,
+        // delete that structure (legacy `deleteSelectedTableCells`); otherwise
+        // empty the cells in place. The copy half already captured the
+        // rectangle's markdown via `getClipboardData`.
         if (this.tableSelection?.hasSelection) {
-            this.tableSelection.clearSelectedCells();
+            if (!this._cutEmptyTableStructure())
+                this.tableSelection.clearSelectedCells();
+
             return;
         }
 
@@ -463,190 +496,324 @@ class Clipboard {
             return anchorBlock.setCursor(startOffset, startOffset, true);
         }
 
-        const anchorOutMostBlock = anchorBlock.outMostBlock;
-        const focusOutMostBlock = focusBlock.outMostBlock;
-
-        const startOutBlock
-            = direction === 'forward' ? anchorOutMostBlock : focusOutMostBlock;
-        const endOutBlock
-            = direction === 'forward' ? focusOutMostBlock : anchorOutMostBlock;
-
-        if (startOutBlock == null || endOutBlock == null)
-            return;
-
         const startBlock = direction === 'forward' ? anchorBlock : focusBlock;
         const endBlock = direction === 'forward' ? focusBlock : anchorBlock;
         const startOffset = direction === 'forward' ? anchor.offset : focus.offset;
         const endOffset = direction === 'forward' ? focus.offset : anchor.offset;
-        let cursorBlock: Nullable<Content> = null;
-        let cursorOffset;
 
-        const removePartial = (position: 'start' | 'end') => {
-            const outBlock = position === 'start' ? startOutBlock : endOutBlock;
-            const block = position === 'start' ? startBlock : endBlock;
-            // Handle anchor and focus in different blocks
-            if (
-                /block-quote|code-block|html-block|table|math-block|frontmatter|diagram/.test(
-                    outBlock.blockName,
-                )
-            ) {
-                if (position === 'start') {
-                    const state
-                        = outBlock.blockName === 'block-quote'
-                            ? deepClone(emptyStates['block-quote'])
-                            : deepClone(emptyStates.paragraph);
-                    const newBlock = ScrollPage.loadBlock(state.name).create(this.muya, state);
-                    outBlock.replaceWith(newBlock);
-                    cursorBlock = newBlock.firstContentInDescendant();
-                    cursorOffset = 0;
-                }
-                else {
-                    outBlock.remove();
-                }
-            }
-            else if (/bullet-list|order-list|task-list/.test(outBlock.blockName)) {
-                const listItemBlockName
-                    = outBlock.blockName === 'task-list' ? 'task-list-item' : 'list-item';
-                const listItem = block.farthestBlock(listItemBlockName)!;
-                const offset = outBlock.offset(listItem);
-                outBlock.forEach((item, index) => {
-                    if (position === 'start' && index === offset) {
-                        const state = {
-                            name: listItemBlockName,
-                            children: [
-                                {
-                                    name: 'paragraph',
-                                    text: '',
-                                },
-                            ],
-                        };
-                        const newListItem = ScrollPage.loadBlock(state.name).create(
-                            this.muya,
-                            state,
-                        );
-                        (item as Parent).replaceWith(newListItem);
-                        cursorBlock = newListItem.firstContentInDescendant();
-                        cursorOffset = 0;
-                    }
-                    else if (
-                        (position === 'start' && index > offset)
-                        || (position === 'end' && index <= offset)
-                    ) {
-                        if (item.isOnlyChild())
-                            outBlock.remove();
-                        else item.remove();
-                    }
-                });
-            }
-            else {
-                if (position === 'start') {
-                    startBlock.text = startBlock.text.substring(0, startOffset);
-                    cursorBlock = startBlock;
-                    cursorOffset = startOffset;
-                }
-                else if (position === 'end') {
-                    if (cursorBlock) {
-                        cursorBlock.text += endBlock.text.substring(endOffset);
-                        endOutBlock.remove();
-                    }
-                }
-            }
-        };
+        // Whole-document selection collapses to a single empty paragraph
+        // (legacy `backspaceCtrl` `isSelectAll` reset).
+        if (this._isSelectAll(startBlock, startOffset, endBlock, endOffset)) {
+            this._resetToEmptyParagraph();
 
-        if (anchorOutMostBlock === focusOutMostBlock) {
-            // Handle anchor and focus in same list\quote block
-            if (anchorOutMostBlock?.blockName === 'block-quote') {
-                const state = deepClone(emptyStates['block-quote']);
-                const newQuoteBlock = ScrollPage.loadBlock(state.name).create(this.muya, state);
-                anchorOutMostBlock.replaceWith(newQuoteBlock);
-                cursorBlock = newQuoteBlock.firstContentInDescendant();
-                cursorOffset = 0;
-            }
-            else if (anchorOutMostBlock?.blockName === 'table') {
-                const state = {
-                    name: 'paragraph',
-                    text: '',
-                };
-                const newBlock = ScrollPage.loadBlock(state.name).create(
-                    this.muya,
-                    state,
-                );
-                anchorOutMostBlock.replaceWith(newBlock);
-                cursorBlock = newBlock.firstContentInDescendant();
-                cursorOffset = 0;
-            }
-            else {
-                const listItemBlockName
-                    = anchorOutMostBlock?.blockName === 'task-list'
-                        ? 'task-list-item'
-                        : 'list-item';
-                const anchorFarthestListItem
-                    = anchorBlock.farthestBlock(listItemBlockName)!;
-                const focusFarthestListItem
-                    = focusBlock.farthestBlock(listItemBlockName)!;
-                const anchorOffset = anchorOutMostBlock?.offset(anchorFarthestListItem);
-                const focusOffset = anchorOutMostBlock?.offset(focusFarthestListItem);
-
-                if (anchorOffset == null || focusOffset == null)
-                    return;
-
-                const minOffset = Math.min(anchorOffset, focusOffset);
-                const maxOffset = Math.max(anchorOffset, focusOffset);
-                anchorOutMostBlock?.forEach((item, index) => {
-                    if (index === minOffset) {
-                        const state = {
-                            name: listItemBlockName,
-                            children: [
-                                {
-                                    name: 'paragraph',
-                                    text: '',
-                                },
-                            ],
-                        };
-                        const newListItem = ScrollPage.loadBlock(state.name).create(
-                            this.muya,
-                            state,
-                        );
-                        (item as Parent).replaceWith(newListItem);
-                        cursorBlock = newListItem.firstContentInDescendant();
-                        cursorOffset = 0;
-                    }
-                    else if (index > minOffset && index <= maxOffset) {
-                        item.remove();
-                    }
-                });
-            }
-        }
-        else {
-            removePartial('start');
-            // Get State between the start outmost block and the end outmost block.
-            let node = startOutBlock.next;
-            while (node && node !== endOutBlock) {
-                const temp = node.next;
-                node.remove();
-                node = temp;
-            }
-            removePartial('end');
+            return;
         }
 
-        if (cursorBlock && cursorOffset != null)
-            cursorBlock.setCursor(cursorOffset, cursorOffset, true);
+        // Leaf-level merge (legacy `cutHandler` + `removeBlocks`): keep the
+        // start head and the end tail in the start content block, then remove
+        // only the structure strictly between the two leaves (and the emptied
+        // end-side containers). The start block keeps its container — a list
+        // item stays a list item, a quote stays a quote.
+        startBlock.text
+            = startBlock.text.substring(0, startOffset)
+                + endBlock.text.substring(endOffset);
+
+        this._removeBlocks(startBlock, endBlock);
+
+        startBlock.setCursor(startOffset, startOffset, true);
 
         if (this.scrollPage?.length() === 0) {
-            const state = {
-                name: 'paragraph',
-                text: '',
-            };
-
-            const newParagraphBlock = ScrollPage.loadBlock('paragraph').create(
-                this.muya,
-                state,
-            );
-            this.scrollPage.append(newParagraphBlock, 'user');
-            cursorBlock = newParagraphBlock.firstContentInDescendant();
-
-            cursorBlock && cursorBlock.setCursor(0, 0, true);
+            this._resetToEmptyParagraph();
         }
+    }
+
+    /**
+     * Whole-document selection predicate, ported from legacy
+     * `paragraphCtrl.isSelectAll`: the selection spans from the very first
+     * content leaf at offset 0 to the very last content leaf at its end.
+     */
+    private _isSelectAll(
+        startBlock: Content,
+        startOffset: number,
+        endBlock: Content,
+        endOffset: number,
+    ): boolean {
+        const firstContent = this.scrollPage?.firstContentInDescendant();
+        const lastContent = this.scrollPage?.lastContentInDescendant();
+
+        return (
+            firstContent === startBlock
+            && startOffset === 0
+            && lastContent === endBlock
+            && endOffset === endBlock.text.length
+        );
+    }
+
+    /**
+     * Replace the whole document with a single empty paragraph and seat the
+     * caret in it (legacy `backspaceCtrl` `isSelectAll` reset / empty-document
+     * guard).
+     */
+    private _resetToEmptyParagraph(): void {
+        const { scrollPage } = this;
+        if (scrollPage == null)
+            return;
+
+        scrollPage.forEach((child) => {
+            (child as Parent).remove();
+        });
+
+        const newParagraphBlock = ScrollPage.loadBlock('paragraph').create(
+            this.muya,
+            { name: 'paragraph', text: '' },
+        );
+        scrollPage.append(newParagraphBlock, 'user');
+
+        const cursorBlock = newParagraphBlock.firstContentInDescendant();
+        cursorBlock?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Remove the document-order span between the `before` content leaf and the
+     * `after` content leaf — every block strictly between them, plus `after`
+     * and any container `after` leaves empty — while preserving `before`'s
+     * container chain and any block that follows `after`. Equivalent to legacy
+     * `contentState.removeBlocks(before, after)` (`before`'s head + `after`'s
+     * tail already live in `before.text`).
+     *
+     * Nodes are removed children-before-parents so each dispatched json removal
+     * targets a still-attached path.
+     */
+    private _removeBlocks(before: TreeNode, after: TreeNode): void {
+        // A table is exempt from structural removal (legacy `removeBlocks`
+        // `exemption` for `td`/`th`): empty the spanned cells in place and keep
+        // the grid rather than deleting cells/rows.
+        const beforeTable = before.closestBlock('table');
+        const afterTable = after.closestBlock('table');
+
+        // Both endpoints inside the same table — empty every cell strictly
+        // between them and keep the grid.
+        if (beforeTable != null && beforeTable === afterTable) {
+            let cellContent = before.nextContentInContext();
+            while (cellContent) {
+                if (cellContent.text !== '')
+                    cellContent.text = '';
+
+                if (cellContent === after)
+                    break;
+
+                cellContent = cellContent.nextContentInContext();
+            }
+
+            return;
+        }
+
+        // `after` lands inside a table that does not also contain `before`:
+        // remove only the blocks between `before` and the table, then empty the
+        // spanned cells.
+        if (afterTable != null) {
+            this._removeBlocksIntoTable(before, after, afterTable as Parent);
+
+            return;
+        }
+
+        const beforeAncestors = new Set<TreeNode>();
+        for (let node: Nullable<TreeNode> = before; node; node = node.parent)
+            beforeAncestors.add(node);
+
+        // The shared container: the lowest ancestor of `after` that also
+        // contains `before`.
+        let afterBranch: TreeNode = after;
+        while (
+            afterBranch.parent
+            && !afterBranch.parent.isScrollPage
+            && !beforeAncestors.has(afterBranch.parent)
+        ) {
+            afterBranch = afterBranch.parent;
+        }
+
+        const commonParent = afterBranch.parent;
+        const beforeBranch = commonParent
+            ? [...beforeAncestors].find(node => node.parent === commonParent)
+            : null;
+
+        // Remove every sibling strictly between `beforeBranch` and
+        // `afterBranch` inside the shared container.
+        let between = beforeBranch ? beforeBranch.next : afterBranch.prev;
+        while (between && between !== afterBranch) {
+            const temp = between.next;
+            between.remove();
+            between = temp;
+        }
+
+        // Does any content leaf after `after` survive inside `afterBranch`? If
+        // not, `afterBranch` is fully consumed — remove it once (this also keeps
+        // atomic blocks like code/math/html/diagram/frontmatter, whose inner
+        // tree collapses to a single json node, from being double-removed).
+        const nextContent = after.nextContentInContext();
+        const afterHasSurvivors
+            = nextContent != null && nextContent.isInBlock(afterBranch as Parent);
+
+        if (!afterHasSurvivors) {
+            if (afterBranch.parent)
+                afterBranch.remove();
+
+            return;
+        }
+
+        // `after`'s branch is removed but later siblings inside `afterBranch`
+        // survive. Walk up from `after` to the direct child of `afterBranch`,
+        // removing each on-path node's preceding siblings and any ancestor it
+        // leaves empty, stopping below `afterBranch`.
+        let onPath: TreeNode = after;
+        while (onPath.parent && onPath.parent !== afterBranch) {
+            let prev = onPath.prev;
+            while (prev) {
+                const temp = prev.prev;
+                prev.remove();
+                prev = temp;
+            }
+            const parent = onPath.parent;
+            onPath.remove();
+            if (parent.children.length > 0)
+                return;
+
+            onPath = parent;
+        }
+
+        // `onPath` is now the direct child of `afterBranch` on `after`'s path —
+        // remove its preceding siblings and itself; later siblings survive.
+        let prev = onPath.prev;
+        while (prev) {
+            const temp = prev.prev;
+            prev.remove();
+            prev = temp;
+        }
+        onPath.remove();
+    }
+
+    /**
+     * Handle a cross-block cut whose end lands inside a table. The table grid is
+     * exempt from structural removal (legacy `removeBlocks` `exemption`): remove
+     * the outmost blocks strictly between `before` and the table, then empty —
+     * not remove — every cell from the table's first cell up to and including
+     * `after`'s cell.
+     */
+    private _removeBlocksIntoTable(
+        before: TreeNode,
+        after: TreeNode,
+        table: Parent,
+    ): void {
+        const beforeOutMost = before.outMostBlock;
+
+        // Remove every outmost block strictly between `before`'s outmost block
+        // and the table.
+        if (beforeOutMost != null) {
+            let between = beforeOutMost.next;
+            while (between && between !== table) {
+                const temp = between.next;
+                between.remove();
+                between = temp;
+            }
+        }
+
+        // Empty the cell content leaves from the table start through `after`'s
+        // cell, keeping the grid intact.
+        let cellContent: Nullable<Content> = table.firstContentInDescendant();
+        while (cellContent) {
+            if (cellContent.text !== '')
+                cellContent.text = '';
+
+            if (cellContent === after)
+                break;
+
+            cellContent = cellContent.nextContentInContext();
+        }
+    }
+
+    /**
+     * Structurally delete an empty whole row / column / table when cutting a
+     * frozen table-cell selection. Returns `true` when it handled the cut (the
+     * caller then skips the in-place clear), `false` to fall through to the
+     * in-place clear. Mirrors legacy `deleteSelectedTableCells` (152-211).
+     */
+    private _cutEmptyTableStructure(): boolean {
+        const selectedCells = this._selectedTableCells();
+        if (selectedCells == null)
+            return false;
+
+        const { table, cells } = selectedCells;
+        const hasContent = cells.some(cell => (cell.firstChild as Content)?.text);
+        if (hasContent)
+            return false;
+
+        const rows = new Set(cells.map(cell => cell.rowOffset));
+        const columns = new Set(cells.map(cell => cell.columnOffset));
+        const { rowCount, columnCount } = table;
+
+        const isWholeColumn = columns.size === 1 && rows.size === rowCount;
+        const isWholeRow = rows.size === 1 && columns.size === columnCount;
+        const isWholeTable
+            = rows.size === rowCount
+                && columns.size === columnCount
+                && cells.length === rowCount * columnCount;
+
+        if (!isWholeColumn && !isWholeRow && !isWholeTable)
+            return false;
+
+        const cursorOffsetRow = [...rows][0];
+        const cursorOffsetColumn = [...columns][0];
+
+        this.tableSelection?.clear();
+
+        if (isWholeTable) {
+            const outsideContent
+                = table.nextContentInContext() ?? table.previousContentInContext();
+            table.remove();
+            if (this.scrollPage?.length() === 0) {
+                this._resetToEmptyParagraph();
+            }
+            else {
+                outsideContent?.setCursor(0, 0, true);
+            }
+        }
+        else if (isWholeColumn) {
+            const cursorBlock = table.removeColumn(cursorOffsetColumn);
+            cursorBlock?.setCursor(0, 0, true);
+        }
+        else {
+            const cursorBlock = table.removeRow(cursorOffsetRow);
+            cursorBlock?.setCursor(0, 0, true);
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve the frozen table selection to its table and the list of selected
+     * body cells, reading the highlighted cell DOM nodes. Returns `null` when
+     * there is no resolvable selection.
+     */
+    private _selectedTableCells(): Nullable<{ table: Table; cells: TableBodyCell[] }> {
+        const { domNode } = this.muya;
+        const selectedDoms = domNode.querySelectorAll('.mu-table-cell-selected');
+        const cells: TableBodyCell[] = [];
+        let table: Nullable<Table> = null;
+
+        for (const dom of selectedDoms) {
+            const block = getBlock(dom);
+            if (block == null || block.blockName !== 'table.cell')
+                continue;
+
+            const cell = block as TableBodyCell;
+            cells.push(cell);
+            table ??= cell.table;
+        }
+
+        if (table == null || cells.length === 0)
+            return null;
+
+        return { table, cells };
     }
 
     // eslint-disable-next-line complexity
@@ -735,11 +902,24 @@ class Clipboard {
                     ? new HtmlToMarkdown({ bulletListMarker }).generate(html)
                     : text;
 
-            if (
-                /\n\n/.test(markdown)
-                && anchorBlock.blockName !== 'codeblock.content'
-            ) {
-                // Has multiple paragraphs.
+            // `language-input`, `table.cell.content` and `codeblock.content`
+            // never parse a paste into blocks — they take the text literally
+            // (legacy `pasteCtrl.pasteHandler` `languageInput` / `cellContent` /
+            // `codeContent` branches). Every other anchor always parses through
+            // `MarkdownToState`, regardless of line count, so a single line of
+            // `# heading` / `- list` / a one-row table becomes real structure.
+            const isLiteralAnchor
+                = anchorBlock.blockName === 'language-input'
+                    || anchorBlock.blockName === 'table.cell.content'
+                    || anchorBlock.blockName === 'codeblock.content';
+
+            if (!isLiteralAnchor) {
+                // An empty / whitespace-only paste is a no-op (legacy
+                // `pasteCtrl` bails on `stateFragments.length <= 0`); the parser
+                // would otherwise emit a lone empty paragraph and churn blocks.
+                if (markdown.trim().length === 0)
+                    return;
+
                 const states = new MarkdownToState({
                     footnote,
                     math,
@@ -785,6 +965,25 @@ class Clipboard {
                     cursorBlock?.setCursor(offset, offset, true);
             }
             else {
+                // A frozen table-cell selection scopes the paste: a single cell
+                // gets its text replaced (with `\n` → `<br/>`); a multi-cell
+                // rectangle cancels the paste (legacy `pasteCtrl.pasteHandler`
+                // `cellContent` branch).
+                if (
+                    anchorBlock.blockName === 'table.cell.content'
+                    && this.tableSelection?.hasSelection
+                ) {
+                    if (!this._isSingleCellSelected())
+                        return;
+
+                    anchorBlock.text = markdown.trim().replace(/\n/g, '<br/>');
+                    const offset = anchorBlock.text.length;
+                    anchorBlock.setCursor(offset, offset, true);
+                    this.tableSelection.clear();
+
+                    return;
+                }
+
                 if (anchorBlock.blockName === 'language-input')
                     markdown = markdown.replace(/\n/g, '');
                 else if (anchorBlock.blockName === 'table.cell.content')
@@ -817,20 +1016,41 @@ class Clipboard {
             }
         }
         else {
+            // Block-level HTML (`<ul>`/`<ol>`/`<pre>`/`<blockquote>` … — tags in
+            // `PARAGRAPH_TYPES`) lands as a live html-block (legacy
+            // `pasteCtrl` `copyAsHtml` → `insertHtmlBlock`), not a fenced ```html
+            // code block, so the markup renders in place.
             const state = {
-                name: 'code-block',
-                meta: {
-                    type: 'fenced',
-                    lang: 'html',
-                },
-                text,
+                name: 'html-block',
+                text: text.trim(),
             };
             const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
             wrapperBlock?.parent?.insertAfter(newBlock, wrapperBlock);
-            const offset = text.length;
 
+            // Drop the empty paragraph the html-block replaced.
+            if (originWrapperBlock?.blockName === 'paragraph') {
+                const originState = originWrapperBlock.getState();
+                if (isParagraphState(originState) && originState.text === '')
+                    originWrapperBlock.remove();
+            }
+
+            const offset = state.text.length;
             newBlock.lastContentInDescendant().setCursor(offset, offset, true);
         }
+    }
+
+    /**
+     * Whether the frozen table-cell selection covers exactly one cell. Mirrors
+     * the single-cell shape check used by `_getTableSelectionClipboardData`:
+     * one row containing one cell. Used by `pasteHandler` to decide between
+     * replacing a single cell's text and cancelling a multi-cell paste.
+     */
+    private _isSingleCellSelected(): boolean {
+        const state = this.tableSelection?.getStateForCopy();
+        if (state == null)
+            return false;
+
+        return state.children.length === 1 && state.children[0].children.length === 1;
     }
 
     /**
@@ -866,26 +1086,43 @@ class Clipboard {
 
     /**
      * Insert a pasted image at the cursor, routing it through the embedder's
-     * `imageAction` first so the user's insert preference (copy-to-assets /
-     * upload / keep-path) applies and a portable src is written. `src` is
-     * either a resolved clipboard file path (PG06) or a `data:` URL for an
-     * in-memory bitmap (PG05). When no `imageAction` is configured the src is
-     * inserted as-is, preserving the legacy file-path behaviour.
+     * `imageAction` so the user's insert preference (copy-to-assets / upload /
+     * keep-path) applies and a portable src is written. `src` is either a
+     * resolved clipboard file path (PG06) or a `data:` URL for an in-memory
+     * bitmap (PG05).
+     *
+     * A `loading-<id>` placeholder image is spliced in synchronously (with the
+     * incoming `src` as a temporary preview) BEFORE awaiting `imageAction`, then
+     * replaced with the resolved src once it settles — mirroring legacy
+     * `pasteCtrl.pasteImage`'s loading-id insert → imageAction → replace flow,
+     * so the user sees a placeholder while the upload/copy runs. When no
+     * `imageAction` is configured the placeholder's src is the final one.
      */
     private async insertImageSrc(anchorBlock: Content, src: string): Promise<void> {
-        let finalSrc = src;
         const { imageAction } = this.muya.options;
-        if (imageAction) {
-            const resolved = await imageAction({ src, alt: '', title: '' });
-            if (resolved)
-                finalSrc = resolved;
+
+        // No async insert preference: write the final image directly, no
+        // placeholder (there is nothing to wait for).
+        if (!imageAction) {
+            this.insertImageText(anchorBlock, src);
+
+            return;
         }
 
-        this.insertImageText(anchorBlock, finalSrc);
+        const id = `loading-${getUniqueId()}`;
+        const placeholderText = this.insertImageText(anchorBlock, src, id);
+
+        let finalSrc = src;
+        const resolved = await imageAction({ src, alt: '', title: '' });
+        if (resolved)
+            finalSrc = resolved;
+
+        this._replacePlaceholderImage(anchorBlock, placeholderText, finalSrc);
     }
 
     /**
-     * Splice `![](src)` into the anchor block at the current selection.
+     * Splice `![alt](src)` into the anchor block at the current selection and
+     * return the exact text inserted.
      *
      * Inline images in muya are plain markdown text (`![](src)`) on a content
      * block; rendering turns the token into an image. We replace any
@@ -893,17 +1130,17 @@ class Clipboard {
      * escaped the same way as {@link Format.replaceImage} so spaces and `#`
      * survive in the path.
      */
-    private insertImageText(anchorBlock: Content, src: string): void {
+    private insertImageText(anchorBlock: Content, src: string, alt = ''): string {
         const cursor = anchorBlock.getCursor();
         if (!cursor)
-            return;
+            return '';
 
         const { start, end } = cursor;
         const { text: content } = anchorBlock;
         const escapedSrc = src
             .replace(/ /g, encodeURI(' '))
             .replace(/#/g, encodeURIComponent('#'));
-        const imageText = `![](${escapedSrc})`;
+        const imageText = `![${alt}](${escapedSrc})`;
 
         anchorBlock.text
             = content.substring(0, start.offset)
@@ -911,6 +1148,36 @@ class Clipboard {
                 + content.substring(end.offset);
 
         const offset = start.offset + imageText.length;
+        anchorBlock.setCursor(offset, offset, true);
+
+        return imageText;
+    }
+
+    /**
+     * Replace the `loading-<id>` placeholder image previously inserted by
+     * {@link insertImageText} with the final `![](src)`, once `imageAction`
+     * resolved. The cursor is seated right after the swapped image.
+     */
+    private _replacePlaceholderImage(
+        anchorBlock: Content,
+        placeholderText: string,
+        src: string,
+    ): void {
+        const index = anchorBlock.text.indexOf(placeholderText);
+        if (index === -1)
+            return;
+
+        const escapedSrc = src
+            .replace(/ /g, encodeURI(' '))
+            .replace(/#/g, encodeURIComponent('#'));
+        const imageText = `![](${escapedSrc})`;
+
+        anchorBlock.text
+            = anchorBlock.text.substring(0, index)
+                + imageText
+                + anchorBlock.text.substring(index + placeholderText.length);
+
+        const offset = index + imageText.length;
         anchorBlock.setCursor(offset, offset, true);
     }
 

--- a/packages/muya/src/editor/tableCellSelection.ts
+++ b/packages/muya/src/editor/tableCellSelection.ts
@@ -57,6 +57,85 @@ class TableCellSelection {
         return this._table != null && this._anchor != null && this._focus != null;
     }
 
+    /**
+     * Whether the frozen selection covers exactly one cell. Mirrors legacy
+     * `tableSelectCellsCtrl.isSingleCellSelected` (cells.length === 1).
+     */
+    isSingleCellSelected(): boolean {
+        return this.hasSelection && this._anchor!.cell === this._focus!.cell;
+    }
+
+    /**
+     * Whether the frozen selection covers every cell in the table. Mirrors
+     * legacy `tableSelectCellsCtrl.isWholeTableSelected` (cells.length ===
+     * (row + 1) * (column + 1)).
+     */
+    isWholeTableSelected(): boolean {
+        if (!this.hasSelection)
+            return false;
+
+        const minRow = Math.min(this._anchor!.row, this._focus!.row);
+        const maxRow = Math.max(this._anchor!.row, this._focus!.row);
+        const minColumn = Math.min(this._anchor!.column, this._focus!.column);
+        const maxColumn = Math.max(this._anchor!.column, this._focus!.column);
+
+        return (
+            minRow === 0
+            && minColumn === 0
+            && maxRow === this._table!.rowCount - 1
+            && maxColumn === this._table!.columnCount - 1
+        );
+    }
+
+    /**
+     * Freeze a whole-table selection (anchor at the top-left cell, focus at the
+     * bottom-right cell) and highlight every cell. Mirrors legacy
+     * `tableSelectCellsCtrl.selectTable`.
+     */
+    selectTable(table: Table): void {
+        this.clear();
+
+        const anchorCell = table.cellAt(0, 0);
+        const focusCell = table.cellAt(table.rowCount - 1, table.columnCount - 1);
+        if (anchorCell == null || focusCell == null)
+            return;
+
+        this._table = table;
+        this._anchor = {
+            cell: anchorCell,
+            row: anchorCell.rowOffset,
+            column: anchorCell.columnOffset,
+        };
+        this._focus = {
+            cell: focusCell,
+            row: focusCell.rowOffset,
+            column: focusCell.columnOffset,
+        };
+        this._isSelecting = true;
+        this._collapseCaretToAnchor();
+        this._renderHighlight();
+    }
+
+    /**
+     * Freeze a single 1x1 cell selection on the given cell. Mirrors the legacy
+     * `selectAll` single-cell branch (`selectedTableCells` of length 1).
+     */
+    selectSingleCell(cell: TableBodyCell): void {
+        this.clear();
+
+        this._table = cell.table;
+        const position: ICellPosition = {
+            cell,
+            row: cell.rowOffset,
+            column: cell.columnOffset,
+        };
+        this._anchor = position;
+        this._focus = position;
+        this._isSelecting = true;
+        this._collapseCaretToAnchor();
+        this._renderHighlight();
+    }
+
     attach(): void {
         const { eventCenter, domNode } = this.muya;
         eventCenter.attachDOMEvent(domNode, 'mousedown', this._onMouseDown);

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -1,0 +1,241 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type Table from '../../block/gfm/table';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// Port of the legacy `packages/muyajs` `selectAll` behavior
+// (`contentState/paragraphCtrl.js`). Cmd+A escalates level-by-level:
+//   - cursor inside a single table cell      → freeze that 1x1 cell
+//   - one cell already frozen                → select the whole table
+//   - whole table already frozen             → clear + select whole document
+//   - selection spanning two cells (same)    → select the whole table
+//   - selection spanning two DIFFERENT tables → no-op (don't select document)
+// Code / language-input content blocks clamp inside their own block and stay
+// idempotent on repeated Cmd+A (never escalate to the whole document).
+
+const bootedMuyas: Muya[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedMuyas.push(muya);
+    return muya;
+}
+
+const TABLE_MD = '| a | b |\n| --- | --- |\n| c | d |\n';
+
+function getTable(muya: Muya): Table {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    return first.closestBlock('table') as Table;
+}
+
+function cellContent(table: Table, row: number, column: number): Content {
+    return table.cellAt(row, column)!.firstChild as unknown as Content;
+}
+
+describe('selection.selectAll table escalation', () => {
+    it('cursor inside a single cell freezes that 1x1 cell (no document selection)', () => {
+        const muya = bootMuya(TABLE_MD);
+        const table = getTable(muya);
+        const { selection, tableSelection } = muya.editor;
+
+        // Caret inside the (0,0) cell content.
+        cellContent(table, 0, 0).setCursor(0, 0, false);
+
+        selection.selectAll();
+
+        expect(tableSelection.hasSelection).toBe(true);
+        expect(tableSelection.isSingleCellSelected()).toBe(true);
+        expect(tableSelection.isWholeTableSelected()).toBe(false);
+    });
+
+    it('escalates a frozen single cell to the whole table on the next Cmd+A', () => {
+        const muya = bootMuya(TABLE_MD);
+        const table = getTable(muya);
+        const { selection, tableSelection } = muya.editor;
+
+        cellContent(table, 0, 0).setCursor(0, 0, false);
+        selection.selectAll();
+        expect(tableSelection.isSingleCellSelected()).toBe(true);
+
+        // Second Cmd+A: single cell → whole table.
+        selection.selectAll();
+
+        expect(tableSelection.hasSelection).toBe(true);
+        expect(tableSelection.isWholeTableSelected()).toBe(true);
+        expect(tableSelection.isSingleCellSelected()).toBe(false);
+    });
+
+    it('escalates a frozen whole table to the whole document and clears the table selection', () => {
+        const muya = bootMuya(`${TABLE_MD}\nbelow\n`);
+        const table = getTable(muya);
+        const { selection, tableSelection } = muya.editor;
+        const sp = muya.editor.scrollPage!;
+
+        tableSelection.selectTable(table);
+        expect(tableSelection.isWholeTableSelected()).toBe(true);
+
+        // Third Cmd+A: whole table → whole document.
+        selection.selectAll();
+
+        expect(tableSelection.hasSelection).toBe(false);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
+    });
+
+    it('escalates cell → whole table → whole document across three sequential Cmd+A presses', () => {
+        const muya = bootMuya(`${TABLE_MD}\nbelow\n`);
+        const table = getTable(muya);
+        const { selection, tableSelection } = muya.editor;
+        const sp = muya.editor.scrollPage!;
+
+        cellContent(table, 0, 0).setCursor(0, 0, false);
+
+        selection.selectAll();
+        expect(tableSelection.isSingleCellSelected()).toBe(true);
+
+        selection.selectAll();
+        expect(tableSelection.isWholeTableSelected()).toBe(true);
+
+        selection.selectAll();
+        expect(tableSelection.hasSelection).toBe(false);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
+    });
+
+    it('selecting two cells of the SAME table escalates to the whole table', () => {
+        const muya = bootMuya(TABLE_MD);
+        const table = getTable(muya);
+        const { selection, tableSelection } = muya.editor;
+
+        const a = cellContent(table, 0, 0);
+        const b = cellContent(table, 1, 1);
+        selection.setSelection({
+            anchor: { offset: 0 },
+            focus: { offset: b.text.length },
+            anchorBlock: a,
+            anchorPath: a.path,
+            focusBlock: b,
+            focusPath: b.path,
+        });
+
+        selection.selectAll();
+
+        expect(tableSelection.hasSelection).toBe(true);
+        expect(tableSelection.isWholeTableSelected()).toBe(true);
+    });
+
+    it('selecting cells across TWO different tables is a no-op (no document selection)', () => {
+        const muya = bootMuya(`${TABLE_MD}\n${TABLE_MD}`);
+        const sp = muya.editor.scrollPage!;
+        const { selection, tableSelection } = muya.editor;
+
+        // Two distinct tables in the document.
+        const firstContent = sp.firstContentInDescendant()!;
+        const firstTable = firstContent.closestBlock('table') as Table;
+        const lastContent = sp.lastContentInDescendant()!;
+        const secondTable = lastContent.closestBlock('table') as Table;
+        expect(firstTable).not.toBe(secondTable);
+
+        const a = cellContent(firstTable, 0, 0);
+        const b = cellContent(secondTable, 0, 0);
+        selection.setSelection({
+            anchor: { offset: 0 },
+            focus: { offset: b.text.length },
+            anchorBlock: a,
+            anchorPath: a.path,
+            focusBlock: b,
+            focusPath: b.path,
+        });
+
+        selection.selectAll();
+
+        // No table selection frozen and no whole-document escalation.
+        expect(tableSelection.hasSelection).toBe(false);
+        expect(selection.anchorBlock).toBe(a);
+        expect(selection.focusBlock).toBe(b);
+    });
+});
+
+describe('selection.selectAll code / language clamp', () => {
+    it('clamps inside a code block and stays idempotent on repeated Cmd+A', () => {
+        const muya = bootMuya('```js\nconst a = 1\nconst b = 2\n```\n');
+        const sp = muya.editor.scrollPage!;
+        const codeLeaf = sp.lastContentInDescendant()!;
+        const { selection } = muya.editor;
+
+        codeLeaf.setCursor(0, 3, false);
+
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(codeLeaf);
+        expect(selection.focusBlock).toBe(codeLeaf);
+        expect(selection.anchor!.offset).toBe(0);
+        expect(selection.focus!.offset).toBe(codeLeaf.text.length);
+
+        // Second Cmd+A: stays clamped inside the code block (no document).
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(codeLeaf);
+        expect(selection.focusBlock).toBe(codeLeaf);
+        expect(selection.focus!.offset).toBe(codeLeaf.text.length);
+    });
+
+    it('clamps inside the language-input and stays idempotent on repeated Cmd+A', () => {
+        const muya = bootMuya('```js\nconst a = 1\n```\n');
+        const sp = muya.editor.scrollPage!;
+        const langInput = sp.firstContentInDescendant()!;
+        expect(langInput.blockName).toBe('language-input');
+        const { selection } = muya.editor;
+
+        langInput.setCursor(0, 0, false);
+
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(langInput);
+        expect(selection.focusBlock).toBe(langInput);
+        expect(selection.anchor!.offset).toBe(0);
+        expect(selection.focus!.offset).toBe(langInput.text.length);
+
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(langInput);
+        expect(selection.focusBlock).toBe(langInput);
+        expect(selection.focus!.offset).toBe(langInput.text.length);
+    });
+
+    it('plain paragraph still escalates to the whole document', () => {
+        const muya = bootMuya('hello world\n\nsecond line\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const { selection } = muya.editor;
+
+        // First Cmd+A selects the line; assert it selects the whole block.
+        first.setCursor(0, 0, false);
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(first);
+        expect(selection.focusBlock).toBe(first);
+
+        // Second Cmd+A escalates to the whole document.
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
+    });
+});

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -2,6 +2,8 @@ import type Content from '../block/base/content';
 import type Format from '../block/base/format';
 import type Parent from '../block/base/parent';
 import type ListItem from '../block/commonMark/listItem';
+import type Table from '../block/gfm/table';
+import type TableBodyCell from '../block/gfm/table/cell';
 import type TaskListItem from '../block/gfm/taskListItem';
 import type { ImageToken } from '../inlineRenderer/types';
 import type { Muya } from '../muya';
@@ -168,9 +170,71 @@ class Selection {
             focus,
             isSelectionInSameBlock,
             anchorBlock,
+            focusBlock,
             anchorPath,
-            scrollPage,
         } = this;
+        const { tableSelection } = this.muya.editor;
+
+        // Table escalation, mirroring legacy `selectAll`:
+        //   whole table frozen → clear + select the whole document.
+        //   single cell frozen → select the whole table.
+        if (tableSelection.isWholeTableSelected()) {
+            tableSelection.clear();
+            return this._selectAllContent();
+        }
+        if (tableSelection.isSingleCellSelected()) {
+            const cellBlock = anchorBlock?.closestBlock('table.cell') as TableBodyCell | null;
+            const table = cellBlock?.table ?? null;
+            if (table) {
+                tableSelection.selectTable(table);
+                return;
+            }
+        }
+
+        // Caret / range inside table cells. A 1x1 selection freezes that cell;
+        // a range across two cells of the same table selects the whole table;
+        // a range across two different tables is a no-op (no document select).
+        if (
+            anchorBlock?.blockName === 'table.cell.content'
+            && focusBlock?.blockName === 'table.cell.content'
+        ) {
+            const anchorTable = anchorBlock.closestBlock('table') as Table | null;
+            const focusTable = focusBlock.closestBlock('table') as Table | null;
+            if (anchorBlock === focusBlock) {
+                const cellBlock = anchorBlock.closestBlock('table.cell') as TableBodyCell | null;
+                if (cellBlock) {
+                    tableSelection.selectSingleCell(cellBlock);
+                    return;
+                }
+            }
+            else if (anchorTable && focusTable && anchorTable === focusTable) {
+                tableSelection.selectTable(anchorTable);
+                return;
+            }
+            else {
+                return;
+            }
+        }
+
+        // Code content (`codeblock.content`: code-block, html-block, math-block,
+        // diagram, front-matter) and the fenced language input clamp inside
+        // their own block and stay idempotent on repeated Cmd+A — never
+        // escalate to the whole document.
+        if (
+            anchorBlock
+            && (anchorBlock.blockName === 'codeblock.content'
+                || anchorBlock.blockName === 'language-input')
+        ) {
+            const cursor: ICursor = {
+                anchor: { offset: 0 },
+                focus: { offset: anchorBlock.text.length },
+                block: anchorBlock,
+                path: anchorPath,
+            };
+
+            this.setSelection(cursor);
+            return;
+        }
         // Select all in one content block.
         // Can use getSelection here?
         if (
@@ -191,6 +255,11 @@ class Selection {
             return;
         }
         // Select all content in all blocks.
+        this._selectAllContent();
+    }
+
+    private _selectAllContent() {
+        const { scrollPage } = this;
         const aBlock = scrollPage?.firstContentInDescendant();
         const fBlock = scrollPage?.lastContentInDescendant();
 

--- a/packages/muya/src/utils/__tests__/standaloneTableGuard.spec.ts
+++ b/packages/muya/src/utils/__tests__/standaloneTableGuard.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { isStandaloneTableHtml } from '../paste';
+
+// Track D / sub-item 3: tighten `isStandaloneTableHtml` so the regex match is
+// followed by a "exactly one root element" check (legacy
+// `pasteCtrl.checkCopyType` parses the blob into a temp container and only
+// promotes it when `childElementCount === 1`). A payload whose regex spans two
+// sibling `<table>`s (so `<table>...</table>...<table>...</table>` matches the
+// greedy `^<table ... </table>$`) is NOT a standalone table and must fall
+// through to the normal HTML path.
+
+describe('isStandaloneTableHtml — single-root guard (legacy childElementCount === 1)', () => {
+    it('still accepts a genuine lone table', () => {
+        expect(
+            isStandaloneTableHtml('<table><tr><td>a</td></tr></table>'),
+        ).toBe(true);
+    });
+
+    it('tolerates leading/trailing whitespace around the single table', () => {
+        expect(
+            isStandaloneTableHtml('  <table border="1"><tr><td>a</td></tr></table>\n'),
+        ).toBe(true);
+    });
+
+    it('rejects two sibling tables even though the greedy regex spans them', () => {
+        const twoTables
+            = '<table><tr><td>a</td></tr></table><table><tr><td>b</td></tr></table>';
+        // The greedy `^<table\b[\s\S]*<\/table>$` matches this whole string, but
+        // the parsed container has two root elements — not a standalone table.
+        expect(isStandaloneTableHtml(twoTables)).toBe(false);
+    });
+
+    it('rejects a table followed by a sibling element', () => {
+        const tablePlusDiv
+            = '<table><tr><td>a</td></tr></table><div>after</div>';
+        expect(isStandaloneTableHtml(tablePlusDiv)).toBe(false);
+    });
+
+    it('still rejects non-table HTML and plain text', () => {
+        expect(isStandaloneTableHtml('<p>hi</p>')).toBe(false);
+        expect(isStandaloneTableHtml('plain string')).toBe(false);
+        expect(isStandaloneTableHtml('')).toBe(false);
+    });
+});

--- a/packages/muya/src/utils/marked/getClipboardHtml.ts
+++ b/packages/muya/src/utils/marked/getClipboardHtml.ts
@@ -1,5 +1,7 @@
 import type { ILexOption } from './types';
 import { Marked } from 'marked';
+import { EXPORT_DOMPURIFY_CONFIG } from '../../config';
+import { sanitize } from '../index';
 import cjkEmStrongExtension from './extensions/cjkEmStrong';
 import mathExtension from './extensions/math';
 import superSubScriptExtension from './extensions/superSubscript';
@@ -50,4 +52,10 @@ export function getClipBoardHtml(src: string, options: ILexOption = {}) {
     html += marked.parse(src);
 
     return html;
+}
+
+export function getSanitizeClipboardHtml(src: string, options: ILexOption = {}) {
+    const html = getClipBoardHtml(src, options);
+
+    return sanitize(html, EXPORT_DOMPURIFY_CONFIG, false) as string;
 }

--- a/packages/muya/src/utils/marked/index.ts
+++ b/packages/muya/src/utils/marked/index.ts
@@ -1,3 +1,3 @@
-export { getClipBoardHtml } from './getClipboardHtml';
+export { getClipBoardHtml, getSanitizeClipboardHtml } from './getClipboardHtml';
 export { getHighlightHtml } from './getHighlightHtml';
 export { lexBlock } from './lexBlock';

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -112,18 +112,33 @@ export async function normalizePastedHTML(html: string) {
     return tempWrapper.innerHTML;
 }
 
-// Sniffs whether `text` looks like an HTML `<table>` blob and nothing else
-// (no surrounding prose). The regex deliberately doesn't enforce "exactly
-// one root element" — sibling tables in the same payload still belong on
-// the HTML→Markdown path. Some clipboard sources (notably Apple Numbers,
-// marktext #1271) put raw HTML into `text/plain` with no `text/html`
-// flavour; the paste handler promotes such text into the html slot so it
-// goes through `HtmlToMarkdown` instead of being inserted verbatim.
+// Sniffs whether `text` looks like a single HTML `<table>` blob and nothing
+// else (no surrounding prose, no sibling root element). The regex match is
+// followed by a parse + `childElementCount === 1` check (legacy
+// `pasteCtrl.checkCopyType`), so a payload whose greedy regex spans two sibling
+// tables falls through to the normal HTML→Markdown path. Some clipboard sources
+// (notably Apple Numbers, marktext #1271) put raw HTML into `text/plain` with
+// no `text/html` flavour; the paste handler promotes such text into the html
+// slot so it goes through `HtmlToMarkdown` instead of being inserted verbatim.
 const STANDALONE_TABLE_REG = /^<table\b[\s\S]*<\/table>$/i;
 export function isStandaloneTableHtml(text: string) {
     if (!text)
         return false;
-    return STANDALONE_TABLE_REG.test(text.trim());
+
+    const trimmed = text.trim();
+    if (!STANDALONE_TABLE_REG.test(trimmed))
+        return false;
+
+    // The greedy regex above also matches two sibling `<table>`s, so parse the
+    // blob into a temporary container and require exactly one root element
+    // (legacy `pasteCtrl.checkCopyType`'s `tmp.childElementCount === 1` guard).
+    if (typeof document === 'undefined')
+        return true;
+
+    const tmp = document.createElement('div');
+    tmp.innerHTML = trimmed;
+
+    return tmp.childElementCount === 1;
 }
 
 /**


### PR DESCRIPTION
## What

The desktop editor now ships the TypeScript `@muyajs/core` engine (`packages/muya`) instead of the legacy `@marktext/muyajs`. A deep behavioral diff of the two engines surfaced several **live regressions** in the core keyboard shortcuts relative to the legacy behavior. This PR aligns **Cmd+A select-all**, **copy**, **cut**, and **paste** back to the legacy `muyajs` semantics.

Context: follows the `@muyajs/core` migration (#4443, #4437, #4435).

## Why

These are everyday-editing regressions versus the engine MarkText shipped for years — e.g. a plain Cmd+C started emitting rich HTML, pasting a line of markdown stopped becoming a real block, and a cross-block cut could silently drop text.

## Changes

### Cmd+A select-all
- Table escalation restored: caret in a cell → that cell → whole table → whole document; cross-cell in one table → whole table; across two tables → no-op.
- Code-block / math / html / mermaid / frontmatter content and the fenced language input are clamped to their own block (a repeated Cmd+A no longer escapes to the whole document).
- `Muya.selectAll()` no-ops when the editor is unfocused and no table-cell selection is frozen.

### Copy
- Default Cmd+C (`normal`) writes only markdown to `text/plain` and blanks `text/html` — restores lossless in-editor round-trip and markdown-on-external-paste (it had been emitting rendered HTML, i.e. legacy `copyAsRich`).
- `copyAsHtml` output is DOMPurify-sanitized and guarded on text length.
- A selected inline image copies its raw `![alt](src)` markdown.

### Cut
- A cross-block cut (and typing/Backspace/Delete over a multi-block selection) merges the endpoint's surviving tail at the leaf level instead of discarding a list/quote/table/code-block endpoint's text.
- Select-all then Backspace/cut resets the document to a single empty paragraph.
- Cutting an empty whole row/column/table structurally deletes it.

### Paste
- Single-line / single-paragraph markdown is parsed into real blocks (heading, list, quote, table, inline formats); literal insert is kept only for language-input / table-cell / code-block anchors.
- Standalone block-level HTML becomes a live `html-block`, not a fenced code block.
- Standalone-table detection requires exactly one root element.
- Single/multi table-cell paste guards; image paste shows a loading placeholder before `imageAction` resolves.

## Testing

- New specs: `selectAll`, `trackBCopy`, `trackCCut`, `pasteHandlerParity`, `pasteImageLoading`, `standaloneTableGuard`.
- `lint:types` clean · `lint` 0 errors · `check-circular` no cycles · unit `729/730` (the 1 failure is a pre-existing `github-markdown-css …?inline` env issue, reproduced on a clean base) · conformance `1347/1347` (CommonMark 0.31 + GFM 0.29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
