### PR TITLE
fix: populate the table of contents on open and fix link navigation

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -130,6 +130,7 @@ import { isOsx, animatedScrollTo } from '@/util'
 import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
+import { resolveTocHeadingElement } from '@/util/tocNavigation'
 import { addCommonStyle, setEditorWidth, setWrapCodeBlocks } from '@/util/theme'
 import { usePreferencesStore } from '@/store/preferences'
 import { useEditorStore } from '@/store/editor'
@@ -1159,41 +1160,35 @@ const scrollToCords = (y: number) => {
   })
 }
 
+// Smoothly scroll the editor so `anchor` sits at the standard top offset.
+// Shared by the TOC, search-highlight, and any other "reveal this element"
+// caller so the getBoundingClientRect + animatedScrollTo math lives once.
+const scrollElementIntoView = (anchor: Element | null | undefined, duration = 300) => {
+  const container = getScrollContainer()
+  if (!container || !anchor) return
+  const { y } = anchor.getBoundingClientRect()
+  animatedScrollTo(container, container.scrollTop + y - STANDAR_Y, duration)
+}
+
 const scrollToHighlight = () => {
   return scrollToElement('.mu-highlight')
 }
 
 /**
- * Scrolls the editor to the heading for a TOC entry.
- *
- * `@muyajs/core` slugs are stable per-block ids that are NOT stamped onto the
- * heading DOM, so a `#slug` selector never matches. `getTOC` walks the headings
- * in document order, so the slug is resolved to its index in `listToc` and the
- * matching heading element (Nth `<h1>`-`<h6>`) is scrolled into view.
+ * Scrolls the editor to the heading for a TOC entry. See
+ * `resolveTocHeadingElement` for why the slug is resolved by document order
+ * against the top-level headings only.
  * @param slug The TOC entry's slug from the `scroll-to-header` bus event.
  */
 const scrollToHeader = (slug: unknown) => {
-  const index = editorStore.listToc.findIndex((item) => item.slug === slug)
-  if (index < 0) return
   const container = getScrollContainer()
   if (!container) return
-  const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6')
-  const anchor = headings[index]
-  if (!anchor) return
-  const { y } = anchor.getBoundingClientRect()
-  animatedScrollTo(container, container.scrollTop + y - STANDAR_Y, 300)
+  scrollElementIntoView(resolveTocHeadingElement(container, editorStore.listToc, slug))
 }
 
 const scrollToElement = (selector: string) => {
   // Scroll to search highlight word
-  const container = getScrollContainer()
-  if (!container) return
-  const anchor = document.querySelector(selector)
-  if (anchor) {
-    const { y } = anchor.getBoundingClientRect()
-    const DURATION = 300
-    animatedScrollTo(container, container.scrollTop + y - STANDAR_Y, DURATION)
-  }
+  scrollElementIntoView(document.querySelector(selector))
 }
 
 const handleFindAction = (action: unknown) => {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1163,8 +1163,25 @@ const scrollToHighlight = () => {
   return scrollToElement('.mu-highlight')
 }
 
+/**
+ * Scrolls the editor to the heading for a TOC entry.
+ *
+ * `@muyajs/core` slugs are stable per-block ids that are NOT stamped onto the
+ * heading DOM, so a `#slug` selector never matches. `getTOC` walks the headings
+ * in document order, so the slug is resolved to its index in `listToc` and the
+ * matching heading element (Nth `<h1>`-`<h6>`) is scrolled into view.
+ * @param slug The TOC entry's slug from the `scroll-to-header` bus event.
+ */
 const scrollToHeader = (slug: unknown) => {
-  return scrollToElement(`#${slug}`)
+  const index = editorStore.listToc.findIndex((item) => item.slug === slug)
+  if (index < 0) return
+  const container = getScrollContainer()
+  if (!container) return
+  const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6')
+  const anchor = headings[index]
+  if (!anchor) return
+  const { y } = anchor.getBoundingClientRect()
+  animatedScrollTo(container, container.scrollTop + y - STANDAR_Y, 300)
 }
 
 const scrollToElement = (selector: string) => {
@@ -1363,6 +1380,10 @@ const setMarkdownToEditor = (payload: unknown) => {
     if (newCursor) {
       editor.value.setCursor(newCursor)
     }
+    // `setContent` rebuilds the block tree synchronously but fires no
+    // `json-change`, so seed the TOC explicitly (otherwise it stays empty until
+    // the first edit, and a file switch keeps the previous file's TOC).
+    editorStore.UPDATE_TOC(editor.value.getTOC())
   }
 }
 
@@ -1435,6 +1456,7 @@ const handleFileChange = (payload: unknown) => {
       // remapping below.
       editor.value.replaceContent(newMarkdown, preSourceModeSelection)
       preSourceModeSelection = null
+      editorStore.UPDATE_TOC(editor.value.getTOC())
       // Map the CodeMirror `{ line, ch }` cursor onto a block-key cursor so the
       // WYSIWYG caret lands where the source-mode cursor was (PG2).
       editor.value.setCursorByOffset(muyaIndexCursor)
@@ -1445,6 +1467,9 @@ const handleFileChange = (payload: unknown) => {
       // `history` in the payload is the synthetic desktop-shaped history used
       // for save tracking, not the engine history.
       editor.value.setContent(newMarkdown)
+      // Tab switch swaps content without firing `json-change`, so re-seed the
+      // TOC (otherwise returning to an open tab keeps the other tab's TOC).
+      editorStore.UPDATE_TOC(editor.value.getTOC())
       if (newCursor) {
         editor.value.setCursor(newCursor)
       } else if (isIndexCursor(muyaIndexCursor)) {
@@ -1628,6 +1653,9 @@ onMounted(() => {
   // the document tree and instantiates the registered UI plugins).
   muya.init()
   editor.value = muya
+  // The first document's content is set via constructor options, so no
+  // `file-loaded` / `setMarkdownToEditor` runs for it — seed its TOC here.
+  editorStore.UPDATE_TOC(muya.getTOC())
 
   // Seed the save-tracking baseline for the mount-loaded document (from the
   // engine's OWN serialization, same reason as setMarkdownToEditor). Without

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1321,6 +1321,21 @@ export const useEditorStore = defineStore('editor', {
       }
     },
 
+    /**
+     * Replaces the table of contents with a fresh snapshot from the engine.
+     *
+     * Used on file load and tab switch, where the engine fires no `json-change`
+     * event (so `LISTEN_FOR_CONTENT_CHANGE` never runs and the TOC would
+     * otherwise stay empty until the first edit). Always assigns — no `equal`
+     * guard, which previously kept a stale TOC when the new document's TOC was
+     * a subset of the old one.
+     * @param toc Flat list of headings returned by `muya.getTOC()`.
+     */
+    UPDATE_TOC(toc: TocItem[]): void {
+      this.listToc = toc ?? []
+      this.toc = listToTree<TocItem>(toc ?? [])
+    },
+
     // Content change from realtime preview editor and source code editor
     // There is a chance that this event is fired AFTER the tab is switched.
     LISTEN_FOR_CONTENT_CHANGE({

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1326,9 +1326,10 @@ export const useEditorStore = defineStore('editor', {
      *
      * Used on file load and tab switch, where the engine fires no `json-change`
      * event (so `LISTEN_FOR_CONTENT_CHANGE` never runs and the TOC would
-     * otherwise stay empty until the first edit). Always assigns — no `equal`
-     * guard, which previously kept a stale TOC when the new document's TOC was
-     * a subset of the old one.
+     * otherwise stay empty until the first edit). Assigns unconditionally: this
+     * is a re-seed on load/switch, so there is no `equal` guard to short-circuit
+     * — the incoming snapshot always wins, even if it happens to deep-equal the
+     * current TOC.
      * @param toc Flat list of headings returned by `muya.getTOC()`.
      */
     UPDATE_TOC(toc: TocItem[]): void {

--- a/packages/desktop/src/renderer/src/util/tocNavigation.ts
+++ b/packages/desktop/src/renderer/src/util/tocNavigation.ts
@@ -7,13 +7,17 @@
 // list and pick the heading at the same index in the DOM.
 //
 // The DOM query MUST match the exact set `getTOC` enumerates. `getTOC` only
-// walks top-level `scrollPage` children (it does not recurse), so the query is
-// scoped to direct-child headings of the container. Headings nested in
-// blockquotes / list items, or `<h1>`-`<h6>` inside raw-HTML blocks, are NOT in
-// `getTOC`'s list; an unscoped `querySelectorAll('h1..h6')` would count them and
+// walks top-level `scrollPage` children (it does not recurse), and those blocks
+// are the DIRECT children of the scrollPage root element (`.mu-container`).
+// Note the scroll container we get from the host (`getScrollContainer()`,
+// i.e. muya's root `.mu-editor`) WRAPS `.mu-container` — the headings are one
+// level deeper — so we anchor on `.mu-container > hN` rather than the scroll
+// container's own direct children. Headings nested in blockquotes / list items,
+// or `<h1>`-`<h6>` inside raw-HTML blocks, are NOT direct children of
+// `.mu-container`; an unscoped `querySelectorAll('h1..h6')` would count them and
 // shift every later index, scrolling to the wrong heading.
 export const TOP_LEVEL_HEADINGS_SELECTOR =
-  ':scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > h5, :scope > h6'
+  '.mu-container > h1, .mu-container > h2, .mu-container > h3, .mu-container > h4, .mu-container > h5, .mu-container > h6'
 
 export const resolveTocHeadingElement = (
   container: Element,

--- a/packages/desktop/src/renderer/src/util/tocNavigation.ts
+++ b/packages/desktop/src/renderer/src/util/tocNavigation.ts
@@ -1,0 +1,27 @@
+// Maps a sidebar TOC entry (its slug) onto the matching heading element in the
+// live editor DOM, so the caller can scroll it into view.
+//
+// `@muyajs/core` slugs are stable per-block ids that are NOT stamped onto the
+// heading DOM, so a `#slug` selector never matches. `getTOC` instead enumerates
+// the headings in document order, so we resolve the slug to its index in that
+// list and pick the heading at the same index in the DOM.
+//
+// The DOM query MUST match the exact set `getTOC` enumerates. `getTOC` only
+// walks top-level `scrollPage` children (it does not recurse), so the query is
+// scoped to direct-child headings of the container. Headings nested in
+// blockquotes / list items, or `<h1>`-`<h6>` inside raw-HTML blocks, are NOT in
+// `getTOC`'s list; an unscoped `querySelectorAll('h1..h6')` would count them and
+// shift every later index, scrolling to the wrong heading.
+export const TOP_LEVEL_HEADINGS_SELECTOR =
+  ':scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > h5, :scope > h6'
+
+export const resolveTocHeadingElement = (
+  container: Element,
+  listToc: ReadonlyArray<{ slug?: unknown }>,
+  slug: unknown
+): Element | null => {
+  const index = listToc.findIndex((item) => item.slug === slug)
+  if (index < 0) return null
+  const headings = container.querySelectorAll(TOP_LEVEL_HEADINGS_SELECTOR)
+  return headings[index] ?? null
+}

--- a/packages/desktop/test/unit/specs/toc-navigation.spec.ts
+++ b/packages/desktop/test/unit/specs/toc-navigation.spec.ts
@@ -73,18 +73,23 @@ describe('useEditorStore UPDATE_TOC', () => {
 })
 
 describe('resolveTocHeadingElement', () => {
-  // Mirror the live editor structure: top-level blocks are direct children of
-  // `.mu-container`. A blockquote-nested heading and a raw-HTML heading sit
-  // BETWEEN the two top-level headings — `getTOC` skips both, so `listToc` only
-  // carries the two top-level headings.
+  // Mirror the live editor structure: the scroll container the host passes in is
+  // muya's root (`.mu-editor`), which WRAPS the scrollPage root (`.mu-container`)
+  // whose DIRECT children are the top-level blocks. A blockquote-nested heading
+  // and a raw-HTML heading sit BETWEEN the two top-level headings — `getTOC`
+  // skips both, so `listToc` only carries the two top-level headings. Building
+  // the wrapper here guards against re-introducing a `:scope >`-on-the-scroller
+  // selector that would match zero headings (the headings are one level deeper).
   const buildContainer = (): HTMLElement => {
     const container = document.createElement('div')
-    container.className = 'mu-container'
+    container.className = 'editor-component mu-editor'
     container.innerHTML = `
-      <h1>Top One</h1>
-      <blockquote><h2>Nested heading</h2></blockquote>
-      <div class="mu-html-block"><h2>Raw HTML heading</h2></div>
-      <h2>Top Two</h2>
+      <div class="mu-container">
+        <h1>Top One</h1>
+        <blockquote><h2>Nested heading</h2></blockquote>
+        <div class="mu-html-block"><h2>Raw HTML heading</h2></div>
+        <h2>Top Two</h2>
+      </div>
     `
     return container
   }
@@ -116,7 +121,8 @@ describe('resolveTocHeadingElement', () => {
 
   it('returns null when the index has no matching DOM heading', () => {
     const container = document.createElement('div')
-    container.innerHTML = '<h1>Only one</h1>'
+    container.className = 'mu-editor'
+    container.innerHTML = '<div class="mu-container"><h1>Only one</h1></div>'
     // listToc claims two headings but the DOM has one — guard against overrun.
     expect(resolveTocHeadingElement(container, listToc, 'uid-2')).toBeNull()
   })

--- a/packages/desktop/test/unit/specs/toc-navigation.spec.ts
+++ b/packages/desktop/test/unit/specs/toc-navigation.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `@/store/editor` transitively imports `@/config`, which reads `window.path`
+// at module load and reaches `window.electron` at runtime. Stub those surfaces
+// (normally injected by the preload bridge) before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: {
+        clipboard: { writeText: (s: string) => void }
+        ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void }
+      }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+import { resolveTocHeadingElement } from '@/util/tocNavigation'
+
+describe('useEditorStore UPDATE_TOC', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('seeds the flat listToc and the nested tree from an engine snapshot', () => {
+    const store = useEditorStore()
+    store.UPDATE_TOC([
+      { slug: 'uid-1', githubSlug: 'intro', content: 'Intro', lvl: 1 },
+      { slug: 'uid-2', githubSlug: 'details', content: 'Details', lvl: 2 }
+    ])
+
+    expect(store.listToc.map((i) => i.slug)).toEqual(['uid-1', 'uid-2'])
+    // listToTree nests the lvl-2 entry under the lvl-1 entry.
+    expect(store.toc).toHaveLength(1)
+    expect(store.toc[0].slug).toBe('uid-1')
+    expect(store.toc[0].children).toHaveLength(1)
+    expect(store.toc[0].children[0].slug).toBe('uid-2')
+  })
+
+  it('re-seeds unconditionally, even when the new snapshot deep-equals the old', () => {
+    const store = useEditorStore()
+    const first = [{ slug: 'uid-1', githubSlug: 'intro', content: 'Intro', lvl: 1 }]
+    store.UPDATE_TOC(first)
+    const prevListToc = store.listToc
+
+    // A fresh array with identical content (mirrors re-seeding the SAME document
+    // on a tab switch). There is no `equal` guard, so the new snapshot must
+    // replace the old reference rather than be short-circuited.
+    store.UPDATE_TOC([{ slug: 'uid-1', githubSlug: 'intro', content: 'Intro', lvl: 1 }])
+    expect(store.listToc).not.toBe(prevListToc)
+    expect(store.listToc).toEqual(prevListToc)
+  })
+
+  it('resets to empty for a nullish snapshot', () => {
+    const store = useEditorStore()
+    store.UPDATE_TOC([{ slug: 'uid-1', githubSlug: 'intro', content: 'Intro', lvl: 1 }])
+    store.UPDATE_TOC(undefined as unknown as never)
+    expect(store.listToc).toEqual([])
+    expect(store.toc).toEqual([])
+  })
+})
+
+describe('resolveTocHeadingElement', () => {
+  // Mirror the live editor structure: top-level blocks are direct children of
+  // `.mu-container`. A blockquote-nested heading and a raw-HTML heading sit
+  // BETWEEN the two top-level headings — `getTOC` skips both, so `listToc` only
+  // carries the two top-level headings.
+  const buildContainer = (): HTMLElement => {
+    const container = document.createElement('div')
+    container.className = 'mu-container'
+    container.innerHTML = `
+      <h1>Top One</h1>
+      <blockquote><h2>Nested heading</h2></blockquote>
+      <div class="mu-html-block"><h2>Raw HTML heading</h2></div>
+      <h2>Top Two</h2>
+    `
+    return container
+  }
+
+  const listToc = [
+    { slug: 'uid-1', githubSlug: 'top-one', content: 'Top One', lvl: 1 },
+    { slug: 'uid-2', githubSlug: 'top-two', content: 'Top Two', lvl: 2 }
+  ]
+
+  it('resolves the first top-level heading', () => {
+    const container = buildContainer()
+    const el = resolveTocHeadingElement(container, listToc, 'uid-1')
+    expect(el?.textContent).toBe('Top One')
+  })
+
+  it('resolves the second top-level heading, skipping nested / raw-HTML headings', () => {
+    const container = buildContainer()
+    const el = resolveTocHeadingElement(container, listToc, 'uid-2')
+    // The regression: an unscoped `querySelectorAll('h1..h6')[1]` would return
+    // the blockquote-nested "Nested heading" here. The scoped query lands on the
+    // real top-level "Top Two".
+    expect(el?.textContent).toBe('Top Two')
+  })
+
+  it('returns null when the slug is not in the TOC', () => {
+    const container = buildContainer()
+    expect(resolveTocHeadingElement(container, listToc, 'missing')).toBeNull()
+  })
+
+  it('returns null when the index has no matching DOM heading', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<h1>Only one</h1>'
+    // listToc claims two headings but the DOM has one — guard against overrun.
+    expect(resolveTocHeadingElement(container, listToc, 'uid-2')).toBeNull()
+  })
+})


### PR DESCRIPTION
Refs #2992, #4441

## Summary

The @muyajs/core migration broke table-of-contents generation (acknowledged in #4441): the sidebar TOC stayed empty until the first edit, and clicking a TOC entry did not scroll to the heading (the click-to-navigate behaviour requested in #2992). This restores both:

- Seed the TOC from the engine on file load and on tab switch. The engine emits no `json-change` in those paths, so `listToc`/`toc` stayed empty until a document change occurred.
- Resolve TOC link clicks by heading order: @muyajs/core slugs are stable per-block ids that are not stamped onto the heading DOM, so a `#slug` selector never matched. Headings are now walked in document order and the slug mapped to its index.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] Covered by the e2e TOC sidebar smoke test added in #4441, which targets exactly this regression (expected to fail on develop, should pass once this lands). No new unit test: the change is DOM/Muya-event integration.
- [x] Manually tested on: Windows

## Notes for reviewers

The slug→index mapping mirrors `getTOC()`, which walks headings in document order. If heading ids get stamped onto the DOM later (cf. #4412 for export), the `#slug` path could be restored.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

---
https://github.com/user-attachments/assets/8d98512e-6a2e-45a1-acac-f2d355e0b111