### PR TITLE
refactor(muya): rebuild ImageEditTool to match muyajs ImageSelector

### DIFF
--- a/packages/muya/src/locales/de.ts
+++ b/packages/muya/src/locales/de.ts
@@ -79,6 +79,17 @@ export const de = {
         // ImageSelector
         'Image src placeholder': 'Bild-URL',
         'Confirm Text': 'OK',
+        'Select': 'Auswählen',
+        'Embed link': 'Link einbetten',
+        'Choose Image': 'Bild wählen',
+        'Choose image from your computer.': 'Wählen Sie ein Bild von Ihrem Computer.',
+        'Alt text': 'Alternativtext',
+        'Image link or local path': 'Bildlink oder lokaler Pfad',
+        'Image title': 'Bildtitel',
+        'Embed Image': 'Bild einbetten',
+        'Paste web image or local image path. Use': 'Webbild oder lokalen Pfad einfügen. Modus wechseln',
+        'simple mode': 'einfacher Modus',
+        'full mode': 'vollständiger Modus',
         // preview block
         'Loading...': 'Wird geladen...',
         'Invalid Diagram Code': 'Ungültiger Diagramm-Code',

--- a/packages/muya/src/locales/en.ts
+++ b/packages/muya/src/locales/en.ts
@@ -79,6 +79,17 @@ export const en = {
         // ImageSelector
         'Image src placeholder': 'Image src',
         'Confirm Text': 'Ok',
+        'Select': 'Select',
+        'Embed link': 'Embed link',
+        'Choose Image': 'Choose Image',
+        'Choose image from your computer.': 'Choose image from your computer.',
+        'Alt text': 'Alt text',
+        'Image link or local path': 'Image link or local path',
+        'Image title': 'Image title',
+        'Embed Image': 'Embed Image',
+        'Paste web image or local image path. Use': 'Paste web image or local image path. Use',
+        'simple mode': 'simple mode',
+        'full mode': 'full mode',
         // preview block
         'Loading...': 'Loading...',
         'Invalid Diagram Code': 'Invalid Diagram Code',

--- a/packages/muya/src/locales/es.ts
+++ b/packages/muya/src/locales/es.ts
@@ -79,6 +79,17 @@ export const es = {
         // ImageSelector
         'Image src placeholder': 'URL de la imagen',
         'Confirm Text': 'Aceptar',
+        'Select': 'Seleccionar',
+        'Embed link': 'Insertar enlace',
+        'Choose Image': 'Elegir imagen',
+        'Choose image from your computer.': 'Elige una imagen de tu ordenador.',
+        'Alt text': 'Texto alternativo',
+        'Image link or local path': 'Enlace de imagen o ruta local',
+        'Image title': 'Título de la imagen',
+        'Embed Image': 'Insertar imagen',
+        'Paste web image or local image path. Use': 'Pega imagen web o ruta local. Cambiar modo',
+        'simple mode': 'modo simple',
+        'full mode': 'modo completo',
         // preview block
         'Loading...': 'Cargando...',
         'Invalid Diagram Code': 'Código de diagrama no válido',

--- a/packages/muya/src/locales/fr.ts
+++ b/packages/muya/src/locales/fr.ts
@@ -79,6 +79,17 @@ export const fr = {
         // ImageSelector
         'Image src placeholder': 'URL de l\'image',
         'Confirm Text': 'OK',
+        'Select': 'Sélectionner',
+        'Embed link': 'Intégrer un lien',
+        'Choose Image': 'Choisir une image',
+        'Choose image from your computer.': 'Choisissez une image depuis votre ordinateur.',
+        'Alt text': 'Texte alternatif',
+        'Image link or local path': 'Lien de l\'image ou chemin local',
+        'Image title': 'Titre de l\'image',
+        'Embed Image': 'Intégrer l\'image',
+        'Paste web image or local image path. Use': 'Collez une image web ou un chemin local. Changer de mode',
+        'simple mode': 'mode simple',
+        'full mode': 'mode complet',
         // preview block
         'Loading...': 'Chargement...',
         'Invalid Diagram Code': 'Code de diagramme invalide',

--- a/packages/muya/src/locales/ja.ts
+++ b/packages/muya/src/locales/ja.ts
@@ -79,6 +79,17 @@ export const ja = {
         // ImageSelector
         'Image src placeholder': '画像のURL',
         'Confirm Text': 'OK',
+        'Select': '選択',
+        'Embed link': 'リンクを埋め込む',
+        'Choose Image': '画像を選択',
+        'Choose image from your computer.': 'コンピュータから画像を選択します。',
+        'Alt text': '代替テキスト',
+        'Image link or local path': '画像リンクまたはローカルパス',
+        'Image title': '画像タイトル',
+        'Embed Image': '画像を埋め込む',
+        'Paste web image or local image path. Use': 'Web画像またはローカルパスを貼り付け。モードを切替',
+        'simple mode': 'シンプルモード',
+        'full mode': 'フルモード',
         // preview block
         'Loading...': 'ロード中...',
         'Invalid Diagram Code': 'グラフのレンダリングが失敗しました',

--- a/packages/muya/src/locales/ko.ts
+++ b/packages/muya/src/locales/ko.ts
@@ -79,6 +79,17 @@ export const ko = {
         // ImageSelector
         'Image src placeholder': '이미지 URL',
         'Confirm Text': '확인',
+        'Select': '선택',
+        'Embed link': '링크 삽입',
+        'Choose Image': '이미지 선택',
+        'Choose image from your computer.': '컴퓨터에서 이미지를 선택하세요.',
+        'Alt text': '대체 텍스트',
+        'Image link or local path': '이미지 링크 또는 로컬 경로',
+        'Image title': '이미지 제목',
+        'Embed Image': '이미지 삽입',
+        'Paste web image or local image path. Use': '웹 이미지 또는 로컬 경로를 붙여넣기. 모드 전환',
+        'simple mode': '간단 모드',
+        'full mode': '전체 모드',
         // preview block
         'Loading...': '로딩 중...',
         'Invalid Diagram Code': '잘못된 다이어그램 코드',

--- a/packages/muya/src/locales/pt.ts
+++ b/packages/muya/src/locales/pt.ts
@@ -79,6 +79,17 @@ export const pt = {
         // ImageSelector
         'Image src placeholder': 'URL da imagem',
         'Confirm Text': 'OK',
+        'Select': 'Selecionar',
+        'Embed link': 'Inserir link',
+        'Choose Image': 'Escolher imagem',
+        'Choose image from your computer.': 'Escolha uma imagem do seu computador.',
+        'Alt text': 'Texto alternativo',
+        'Image link or local path': 'Link da imagem ou caminho local',
+        'Image title': 'Título da imagem',
+        'Embed Image': 'Inserir imagem',
+        'Paste web image or local image path. Use': 'Cole imagem da web ou caminho local. Alternar modo',
+        'simple mode': 'modo simples',
+        'full mode': 'modo completo',
         // preview block
         'Loading...': 'Carregando...',
         'Invalid Diagram Code': 'Código de diagrama inválido',

--- a/packages/muya/src/locales/zh-CN.ts
+++ b/packages/muya/src/locales/zh-CN.ts
@@ -79,6 +79,17 @@ export const zhCN = {
         // ImageSelector
         'Image src placeholder': '图片链接',
         'Confirm Text': '确定',
+        'Select': '选择',
+        'Embed link': '插入链接',
+        'Choose Image': '选择图片',
+        'Choose image from your computer.': '从你的电脑选择图片。',
+        'Alt text': '替代文本',
+        'Image link or local path': '图片链接或本地路径',
+        'Image title': '图片标题',
+        'Embed Image': '嵌入图片',
+        'Paste web image or local image path. Use': '粘贴网络图片或本地路径。切换模式',
+        'simple mode': '简洁模式',
+        'full mode': '完整模式',
         // preview block
         'Loading...': '加载中...',
         'Invalid Diagram Code': '图表渲染失败',

--- a/packages/muya/src/locales/zh-TW.ts
+++ b/packages/muya/src/locales/zh-TW.ts
@@ -79,6 +79,17 @@ export const zhTW = {
         // ImageSelector
         'Image src placeholder': '圖片連結',
         'Confirm Text': '確定',
+        'Select': '選擇',
+        'Embed link': '插入連結',
+        'Choose Image': '選擇圖片',
+        'Choose image from your computer.': '從你的電腦選擇圖片。',
+        'Alt text': '替代文字',
+        'Image link or local path': '圖片連結或本機路徑',
+        'Image title': '圖片標題',
+        'Embed Image': '嵌入圖片',
+        'Paste web image or local image path. Use': '貼上網路圖片或本機路徑。切換模式',
+        'simple mode': '精簡模式',
+        'full mode': '完整模式',
         // preview block
         'Loading...': '載入中...',
         'Invalid Diagram Code': '圖表渲染失敗',

--- a/packages/muya/src/ui/imageEditTool/index.css
+++ b/packages/muya/src/ui/imageEditTool/index.css
@@ -3,88 +3,166 @@
 }
 
 .mu-image-selector {
-    width: 400px;
-    height: 32px;
+    width: 500px;
+    min-height: 190px;
+    max-height: 400px;
 }
 
-.mu-image-selector .image-edit-tool {
+.mu-image-selector > div {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
-    width: 100%;
-    height: 100%;
+    flex-direction: column;
+    max-height: 400px;
 }
 
-.mu-image-selector .image-edit-tool .more {
+.mu-image-selector ul.header {
+    display: flex;
+    flex-shrink: 0;
+    height: 40px;
+    margin: 0;
+    padding: 0;
+    padding-left: 40px;
+
+    border-bottom: 1px solid var(--editor-color-10);
+}
+
+.mu-image-selector ul.header li {
     position: relative;
 
     display: flex;
     align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 32px;
+    justify-content: space-around;
+    height: 100%;
 
-    border-right: 1px solid var(--float-border-color);
+    color: var(--editor-color);
+    font-size: 14px;
+}
+
+.mu-image-selector ul.header li span {
+    display: inline-block;
+    width: 100%;
+    height: 30px;
+    padding: 0 8px;
+
+    line-height: 30px;
+
+    border-radius: 5px;
     cursor: pointer;
 }
 
-.mu-image-selector .image-edit-tool .more-inner {
-    display: block;
-    width: 4px;
-    height: 4px;
-
-    background-color: var(--editor-color-50);
-    border-radius: 50%;
+.mu-image-selector ul.header li span:hover {
+    background: var(--editor-color-04);
 }
 
-.mu-image-selector .image-edit-tool .more::before,
-.mu-image-selector .image-edit-tool .more::after {
+.mu-image-selector ul.header li.active::before {
     position: absolute;
-    top: 14px;
+    bottom: 0;
+    left: 0;
 
     display: block;
-    width: 4px;
-    height: 4px;
+    width: 100%;
+    height: 3px;
 
-    background-color: var(--editor-color-50);
-    border-radius: 50%;
+    background: var(--theme-color);
 
     content: '';
 }
 
-.mu-image-selector .image-edit-tool .more::before {
-    left: 10px;
-}
-
-.mu-image-selector .image-edit-tool .more::after {
-    right: 10px;
-}
-
-.mu-image-selector .image-edit-tool .src {
+.mu-image-selector .image-select-body {
     flex: 1;
-    height: 32px;
-    margin: 0;
-    padding: 0 5px;
-
-    color: var(--editor-color-50);
-
-    border: none;
-    border-right: 1px solid var(--float-border-color);
-    border-radius: 0;
+    max-height: 359px;
+    overflow: auto;
 }
 
-.mu-image-selector .image-edit-tool .confirm {
-    width: 40px;
-    height: 32px;
+.mu-image-selector .image-select-body::-webkit-scrollbar:vertical {
+    width: 0;
+}
 
-    font-weight: 600;
-    line-height: 32px;
+.mu-image-selector .input-container {
+    display: flex;
+    box-sizing: border-box;
+    width: 100%;
+    height: 30px;
+    margin: 20px 0 15px;
+    padding: 0 25px;
+}
+
+.mu-image-selector .input-container input {
+    height: 30px;
+    margin-right: 10px;
+    padding: 0 15px;
+
+    color: var(--editor-color);
+    font-size: 14px;
+
+    background: var(--input-bg-color);
+    border: none;
+    border-radius: 15px;
+    outline: none;
+}
+
+.mu-image-selector .input-container input:last-of-type {
+    margin-right: 0;
+}
+
+.mu-image-selector .input-container input.src {
+    flex: 1;
+}
+
+.mu-image-selector .input-container input.alt,
+.mu-image-selector .input-container input.title {
+    flex: 0;
+    max-width: 80px;
+}
+
+.mu-image-selector button.role-button {
+    display: block;
+    box-sizing: border-box;
+    width: 240px;
+    margin: 0 auto 16px;
+    padding: 7px 14px;
+
+    color: var(--button-font-color);
+    font-size: 14px;
     text-align: center;
 
+    background: var(--button-bg-color);
+    border: var(--button-border);
+    border-radius: 8px;
     cursor: pointer;
+
+    user-select: none;
 }
 
-.mu-image-selector .image-edit-tool .confirm:hover {
+.mu-image-selector button.role-button:hover {
+    background: var(--button-bg-color-hover);
+    border: var(--button-border-hover);
+}
+
+.mu-image-selector button.role-button:active {
+    background: var(--button-bg-color-active);
+    border: var(--button-border-active);
+}
+
+.mu-image-selector button.role-button:focus {
+    border: var(--button-border-focus);
+    outline: none;
+}
+
+.mu-image-selector button.role-button.select {
+    margin-top: 35px;
+}
+
+.mu-image-selector span.description {
+    display: block;
+
+    color: var(--editor-color-30);
+    text-align: center;
+
+    user-select: none;
+}
+
+.mu-image-selector span.description a {
     color: var(--theme-color);
+
+    cursor: pointer;
 }

--- a/packages/muya/src/ui/imageEditTool/index.ts
+++ b/packages/muya/src/ui/imageEditTool/index.ts
@@ -89,6 +89,12 @@ export class ImageEditTool extends BaseFloat {
         title: '',
     };
 
+    /** Active tab: file picker ("select") or link/path input ("link") */
+    private _tab: 'select' | 'link' = 'link';
+
+    /** Whether the link tab shows the alt and title inputs as well as src */
+    private _isFullMode = false;
+
     /** Container element for the image selector */
     private _imageSelectorContainer: HTMLDivElement
         = document.createElement('div');
@@ -157,19 +163,53 @@ export class ImageEditTool extends BaseFloat {
     private _focusSrcInput() {
         const input = this.container ? query<HTMLInputElement>('input.src', this.container) : null;
         if (input) {
+            // Force the value — when reopening the tool snabbdom may skip the
+            // value prop (the user dirtied the DOM input between renders).
+            input.value = this._state.src;
             input.focus();
             input.select();
         }
     }
 
     /**
-     * Handle input change for image source
+     * Handle input change for an editable image field (src / alt / title).
      * @param event - Input event
+     * @param type - Which image field the input edits
      */
-    private _handleSrcInput(event: Event) {
+    private _inputHandler(event: Event, type: keyof IState) {
         if (!isHTMLInputElement(event.target))
             return;
-        this._state.src = event.target.value;
+        this._state[type] = event.target.value;
+    }
+
+    /**
+     * Switch the active tab and re-render.
+     * @param tab - Tab to activate
+     */
+    private _tabClick(tab: 'select' | 'link') {
+        this._tab = tab;
+        this._render();
+    }
+
+    /**
+     * Toggle between simple (src only) and full (alt + src + title) mode.
+     */
+    private _toggleMode() {
+        this._isFullMode = !this._isFullMode;
+        this._render();
+    }
+
+    /**
+     * Handle keydown on the alt / title inputs — Enter confirms the change.
+     * @param event - Keyboard event
+     */
+    private _handleKeyDown(event: Event) {
+        if (!isKeyboardEvent(event))
+            return;
+        if (event.key === EVENT_KEYS.Enter) {
+            event.stopPropagation();
+            this._handleConfirm();
+        }
     }
 
     /**
@@ -401,68 +441,130 @@ export class ImageEditTool extends BaseFloat {
     }
 
     /**
-     * Handle click on "more" button to open file picker
-     * Updates the src input with selected path
+     * Handle click on the "Choose Image" button in the select tab.
+     * Opens the one-shot native file picker and applies the chosen path
+     * directly (matching the legacy ImageSelector select-tab behavior).
      */
-    private async _handleMoreClick() {
-        if (!this.options.imagePathPicker)
+    private async _handleSelectButtonClick() {
+        if (!this.options.imagePathPicker) {
+            console.warn('You need to add a imagePathPicker option');
             return;
+        }
 
         const path = await this.options.imagePathPicker();
-        this._state.src = path;
-        this._render();
+        const { alt, title } = this._state;
+        return this._replaceImageAsync({ alt, title, src: path });
     }
 
     /**
-     * Render the image edit tool UI
-     * Creates virtual DOM with file picker button (optional), src input and confirm button
+     * Render the tab header (Select / Embed link).
      */
-    private _render() {
-        const { _oldVNode: oldVNode, _imageSelectorContainer: imageSelectorContainer, _state: { src } } = this;
+    private _renderHeader(): VNode {
         const { i18n } = this.muya;
+        const tabs: { label: string; value: 'select' | 'link' }[] = [
+            { label: i18n.t('Select'), value: 'select' },
+            { label: i18n.t('Embed link'), value: 'link' },
+        ];
 
-        // Optional file picker button
-        const moreButton = this.options.imagePathPicker
-            ? h(
-                    'span.more',
-                    {
-                        on: {
-                            click: () => this._handleMoreClick(),
-                        },
-                    },
-                    h('span.more-inner'),
-                )
-            : null;
+        const children = tabs.map((tab) => {
+            const selector = this._tab === tab.value ? 'li.active' : 'li';
+            return h(selector, [
+                h(
+                    'span',
+                    { on: { click: () => this._tabClick(tab.value) } },
+                    tab.label,
+                ),
+            ]);
+        });
 
-        // Image source input
-        const srcInput = h('input.src', {
-            props: {
-                placeholder: i18n.t('Image src placeholder'),
-                value: src,
-            },
+        return h('ul.header', children);
+    }
+
+    /**
+     * Render the "Select" tab body: a Choose Image button and a tip.
+     */
+    private _renderSelectBody(): VNode[] {
+        const { i18n } = this.muya;
+        return [
+            h(
+                'button.role-button.select',
+                { on: { click: () => this._handleSelectButtonClick() } },
+                i18n.t('Choose Image'),
+            ),
+            h('span.description', i18n.t('Choose image from your computer.')),
+        ];
+    }
+
+    /**
+     * Render the "Embed link" tab body: the input container (src, plus alt and
+     * title in full mode), the Embed button and the simple/full mode hint.
+     */
+    private _renderLinkBody(): VNode[] {
+        const { i18n } = this.muya;
+        const { alt, src, title } = this._state;
+
+        const altInput = h('input.alt', {
+            props: { placeholder: i18n.t('Alt text'), value: alt },
             on: {
-                input: event => this._handleSrcInput(event),
-                paste: event => this._handleSrcInput(event),
-                keydown: event => this._handleSrcKeyDown(event),
-                keyup: event => this._handleSrcKeyUp(event),
+                input: (event: Event) => this._inputHandler(event, 'alt'),
+                paste: (event: Event) => this._inputHandler(event, 'alt'),
+                keydown: (event: Event) => this._handleKeyDown(event),
+            },
+        });
+        const srcInput = h('input.src', {
+            props: { placeholder: i18n.t('Image link or local path'), value: src },
+            on: {
+                input: (event: Event) => this._inputHandler(event, 'src'),
+                paste: (event: Event) => this._inputHandler(event, 'src'),
+                keydown: (event: Event) => this._handleSrcKeyDown(event),
+                keyup: (event: Event) => this._handleSrcKeyUp(event),
+            },
+        });
+        const titleInput = h('input.title', {
+            props: { placeholder: i18n.t('Image title'), value: title },
+            on: {
+                input: (event: Event) => this._inputHandler(event, 'title'),
+                paste: (event: Event) => this._inputHandler(event, 'title'),
+                keydown: (event: Event) => this._handleKeyDown(event),
             },
         });
 
-        // Confirm button
-        const confirmButton = h(
-            'span.confirm',
-            {
-                on: {
-                    click: () => this._handleConfirm(),
-                },
-            },
-            i18n.t('Confirm Text'),
+        const inputWrapper = this._isFullMode
+            ? h('div.input-container', [altInput, srcInput, titleInput])
+            : h('div.input-container', [srcInput]);
+
+        const embedButton = h(
+            'button.role-button.link',
+            { on: { click: () => this._handleConfirm() } },
+            i18n.t('Embed Image'),
         );
 
-        const vnode = h('div.image-edit-tool', [
-            moreButton,
-            srcInput,
-            confirmButton,
+        const bottomDes = h('span.description', [
+            h('span', `${i18n.t('Paste web image or local image path. Use')} `),
+            h(
+                'a',
+                { on: { click: () => this._toggleMode() } },
+                `${this._isFullMode ? i18n.t('simple mode') : i18n.t('full mode')}.`,
+            ),
+        ]);
+
+        return [inputWrapper, embedButton, bottomDes];
+    }
+
+    /**
+     * Render the image edit tool UI as a tabbed selector matching the legacy
+     * ImageSelector: a header (Select / Embed link) and the active tab body.
+     */
+    private _render() {
+        const { _oldVNode: oldVNode, _imageSelectorContainer: imageSelectorContainer } = this;
+
+        const body = this._tab === 'select'
+            ? this._renderSelectBody()
+            : this._renderLinkBody();
+
+        const vnode = h('div', [
+            this._renderHeader(),
+            h('div.image-select-body', body),
         ]);
 
         patch(oldVNode || imageSelectorContainer, vnode);


### PR DESCRIPTION
## What

Refactors `packages/muya/src/ui/imageEditTool` so its functionality and UI match the legacy muyajs `ImageSelector`.

The muya `ImageEditTool` was a minimal single-line bar (`[⋯][src input][confirm]`) that could only edit the image `src`. This rebuilds it into the full tabbed property editor that muyajs shipped:

- **Select / Embed link** tabs
- **Embed link** tab: `src` input (with path autocomplete); in full mode also `alt` and `title` inputs; an **Embed Image** button; and a simple⇄full mode toggle hint
- **Select** tab: a **Choose Image** button + tip (drives the native `imagePathPicker`)
- 500px-wide layout, active-tab underline, rounded inputs — ported from the muyajs stylesheet, scoped under `.mu-image-selector` with muya's kebab-case theme variables (the simple/full link uses `--theme-color`)

## Preserved muya behavior

Intentionally kept muya's existing (better) implementation details rather than copying muyajs verbatim:

- `imagePathAutoComplete` wiring with the monotonic out-of-order guard
- `ImagePathPicker` lookup via the `ui.shownFloat` registry
- object-shaped `imageAction({ src, title, alt })` signature
- `block.replaceImage(...)` flow

## i18n

Adds 11 new ImageSelector strings to all nine muya locale files (en, zh-CN, zh-TW, de, es, fr, ja, ko, pt), translations ported from the desktop `editor.image.selector` block.

## Out of scope

The desktop `editor.image.selector.*` locale keys are now consumed only by the retired `packages/muyajs/lib/ui/imageSelector` (the desktop renderer registers `ImageEditTool` from `@muyajs/core`). They are already dead today; cleanup is deferred to a separate PR under the muyajs retirement (Phase H).

## Test plan

- [x] `pnpm -C packages/muya lint:types`
- [x] `pnpm -C packages/muya exec eslint src/ui/imageEditTool`
- [x] `pnpm -C packages/muya exec stylelint src/ui/imageEditTool/index.css`
- [x] `pnpm -C packages/muya test` — 724 tests pass (incl. the imageEditTool autocomplete spec, unchanged)
- [x] Manual: desktop dev — Edit image → tabbed selector, full/simple toggle, Choose Image, autocomplete, theming

🤖 Generated with [Claude Code](https://claude.com/claude-code)