### PR TITLE
chore(muya): remove redundant comments added during the muyajs port

### DIFF
--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -20,17 +20,13 @@ import {
 
 // const debug = logger('block.content:')
 
-// Word boundary regexes ported from legacy muyajs
-// (lib/marktext/spellchecker.js), which in turn derive from VSCode's wordHelper.
-// Used by `extractWord` to find the word at the cursor for spell-check
-// replacement.
+// Word boundary regexes derived from VSCode's wordHelper. Used by `extractWord`
+// to find the word at the cursor for spell-check replacement.
 const WORD_SEPARATORS = /[`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]/g;
 const WORD_DEFINITION = /-?\d*\.\d\w*|[^`~!@#$%^&*()\-=+[{\]}\\|;:'",.<>/?\s]+/g;
 
 /**
  * Extract the word at the given offset from the text.
- *
- * Ported from legacy muyajs `extractWord` (lib/marktext/spellchecker.js).
  *
  * @param text The line text.
  * @param offset Normalized cursor offset (e.g. `ab|c def` -> 2).
@@ -419,8 +415,8 @@ class Content extends TreeNode {
                 else {
                     // Not Unicode aware, since things like \p{Alphabetic} or \p{L} are not supported yet
 
-                    // marktext 358fa83d (#2960): only pair quotes/brackets
-                    // when the cursor is at end-of-line or before whitespace.
+                    // Only pair quotes/brackets when the cursor is at
+                    // end-of-line or before whitespace.
                     // Inserting `"foo` would otherwise become `""foo` and force
                     // the user to immediately delete the spurious closing char.
                     const postIsNotTouching = !/\S/.test(postInputChar);
@@ -511,11 +507,10 @@ class Content extends TreeNode {
     /**
      * Replace the word at/around the current cursor with `replacement`.
      *
-     * Ported from legacy muyajs `ContentState._replaceCurrentWordInlineUnsafe`
-     * (lib/contentState/marktext.js). Used by the desktop spell checker: right
+     * Used by the desktop spell checker: right
      * clicking a misspelled word selects the whole word via Chromium, and
-     * choosing a suggestion replaces it inline. `extractWord` mirrors the
-     * VSCode-derived word boundaries muyajs relied on.
+     * choosing a suggestion replaces it inline. `extractWord` uses
+     * VSCode-derived word boundaries.
      *
      * Unsafe: the caller asserts that exactly the word `word` is selected. If
      * the word found at the cursor does not match `word` the call is a no-op
@@ -532,7 +527,7 @@ class Content extends TreeNode {
 
         const { text } = this;
         // Use the start offset of the (possibly whole-word) selection as the
-        // probe point, matching the legacy `start.offset` behaviour.
+        // probe point.
         const wordInfo = extractWord(text, cursor.start.offset);
         if (wordInfo == null)
             return false;

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -447,11 +447,8 @@ class Format extends Content {
 
     // Replace the link's source text (e.g. `[Anthropic](https://…)`) with the
     // visible anchor text only (`Anthropic`), stripping the markdown / HTML
-    // around it. Port of marktext `linkCtrl.unlink` (cb25b3d4 / #1415), but
-    // simplified — marktext substituted `token.href` for plain markdown links,
-    // which was a long-standing UX quirk that turned a styled anchor into a
-    // bare URL. We keep the visible text instead, matching the contemporary
-    // norm (Notion, GDocs, Slack).
+    // around it. We keep the visible text rather than substituting the URL,
+    // matching the contemporary norm (Notion, GDocs, Slack).
     unlink({ range, text }: { range: { start: number; end: number } | null; text: string }) {
         if (!range)
             return;
@@ -1599,10 +1596,9 @@ class Format extends Content {
                     end.offset += MARKER.length;
                 }
                 else {
-                    // Backport of marktext f3b53427: when wrapping a
-                    // non-empty selection, collapse the caret PAST the
-                    // closing marker so the next keystroke lands outside
-                    // the format instead of extending it.
+                    // When wrapping a non-empty selection, collapse the caret
+                    // PAST the closing marker so the next keystroke lands
+                    // outside the format instead of extending it.
                     end.offset += MARKER.length * 2;
                     start.offset = end.offset;
                 }

--- a/packages/muya/src/block/content/langInputContent/escape.ts
+++ b/packages/muya/src/block/content/langInputContent/escape.ts
@@ -3,10 +3,9 @@ import { escapeHTML } from '../../../utils';
 import { getHighlightHtml, MARKER_HASH } from '../../../utils/highlightHTML';
 
 // Escape a code-block language identifier for direct assignment to
-// `domNode.innerHTML`. Mirrors the safe path used by `codeBlockContent`:
-// produce highlight markup with placeholder markers, escape the whole
-// string (turning raw `<`, `>`, etc. into entities), then restore only
-// the markers so legitimate `<span>` highlight wrappers survive.
+// `domNode.innerHTML`: produce highlight markup with placeholder markers,
+// escape the whole string (turning raw `<`, `>`, etc. into entities), then
+// restore only the markers so legitimate `<span>` highlight wrappers survive.
 //
 // Without this, `<img/src=x/onerror=alert(1)>` typed into the language
 // input would be injected verbatim (marktext fix 0dd09cc6 / #2548, #2601).

--- a/packages/muya/src/block/content/tableCell/index.ts
+++ b/packages/muya/src/block/content/tableCell/index.ts
@@ -237,9 +237,8 @@ class TableCellContent extends Format {
         event.preventDefault();
         event.stopPropagation();
 
-        // marktext 5fb130d9 (issue #2330, PR #2331): Shift+Tab back-navigates
-        // inside the table (header row's first cell stays put when there is
-        // no previous content).
+        // Shift+Tab back-navigates inside the table (header row's first cell
+        // stays put when there is no previous content).
         // Read shiftKey directly — pointer Tab is not a thing, so callers
         // always pass a KeyboardEvent in practice. The structural check just
         // keeps unit tests that pass a partial event object passing.

--- a/packages/muya/src/block/extra/footnote/index.ts
+++ b/packages/muya/src/block/extra/footnote/index.ts
@@ -30,7 +30,7 @@ class Footnote extends Parent {
 
         // Backlink arrow in the bottom-right of the figure. Clicking it
         // scrolls back up to the first inline `<sup id="noteref-{id}">`
-        // reference — mirrors marktext's `footnoteJumpIcon` UX.
+        // reference.
         const backlink = document.createElement('i');
         backlink.className = CLASS_NAMES.MU_FOOTNOTE_BACKLINK;
         backlink.textContent = '↩︎';
@@ -47,10 +47,10 @@ class Footnote extends Parent {
         return footnote;
     }
 
-    // Container-block path semantics: descendants address into `children`
-    // (mirrors BlockQuote / list-item). `Parent.getJsonPath` strips the
-    // trailing 'children' segment via `isContainerBlock`, which we override
-    // below so footnote participates in the same json1 op routing.
+    // Container-block path semantics: descendants address into `children`.
+    // `Parent.getJsonPath` strips the trailing 'children' segment via
+    // `isContainerBlock`, which we override below so footnote participates in
+    // the same json1 op routing.
     override get path() {
         const { path: pPath } = this.parent!;
         const offset = this.parent!.offset(this);

--- a/packages/muya/src/block/gfm/table/index.ts
+++ b/packages/muya/src/block/gfm/table/index.ts
@@ -188,7 +188,7 @@ class Table extends Parent {
         if (row == null)
             return;
 
-        // Marktext 6293d408 (#572) backport: capture a surviving neighbour
+        // Capture a surviving neighbour
         // BEFORE the detach so the caller can place the caret on a cell that
         // is still attached to the DOM. Prefer the next row, fall back to the
         // previous; if no rows remain after this delete, capture a content
@@ -231,8 +231,8 @@ class Table extends Parent {
 
         // Capture the first row's surviving neighbour cell before mutation so
         // the caller can setCursor on a still-attached cell after the column
-        // detach. Same intent as marktext 6293d408 — but applied per column
-        // since the new architecture removes one cell per row in a loop.
+        // detach. Applied per column since the new architecture removes one
+        // cell per row in a loop.
         const firstRow = table.firstChild as TableRow;
         const targetCellInFirstRow = firstRow.find(offset) as TableBodyCell | null;
         const neighbourCell
@@ -288,9 +288,9 @@ class Table extends Parent {
      * Build an `ITableState` for the rectangular block of cells bounded by
      * (`startRow`, `startColumn`) and (`endRow`, `endColumn`) inclusive. The
      * bounds may be passed in any order — they are normalised — and are clamped
-     * to the table's dimensions. Mirrors legacy `tableSelectCellsCtrl`'s
-     * sub-table extraction so a copied cell rectangle round-trips to GFM table
-     * markdown via `StateToMarkdown`. The first selected row becomes the header
+     * to the table's dimensions, so a copied cell rectangle round-trips to GFM
+     * table markdown via `StateToMarkdown`. The first selected row becomes the
+     * header
      * row of the resulting sub-table, preserving each cell's alignment.
      */
     getSubTableState(

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -37,7 +37,6 @@ interface ICopyOrder {
     endOffset: number;
 }
 
-// `frontMatter` defaults to `true` to match the legacy behavior.
 function buildHtmlOptions(options: Muya['options']) {
     const {
         frontMatter = true,
@@ -133,8 +132,7 @@ function resolveSelectionOrder(
 }
 
 // Handle the start / end outmost block of a cross-block selection, pushing the
-// partial state for whichever edge `position` names. Ported from the legacy
-// `getPartialState` closure.
+// partial state for whichever edge `position` names.
 function appendPartialState(
     copyState: TState[],
     order: ICopyOrder,
@@ -298,8 +296,7 @@ export function writeClipboardData(
         return;
 
     // A selected inline image copies its raw `![alt](src)` markdown
-    // verbatim (legacy `copyCutCtrl.copyHandler`), short-circuiting the
-    // text-selection clipboard data.
+    // verbatim, short-circuiting the text-selection clipboard data.
     const selectedImage = clipboard.muya.editor?.selection?.selectedImage;
     if (selectedImage) {
         const { raw } = selectedImage.token;

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -10,8 +10,7 @@ import { CLASS_NAMES } from '../config';
 import { getBlock } from '../utils/dom';
 
 /**
- * Whole-document selection predicate, ported from legacy
- * `paragraphCtrl.isSelectAll`: the selection spans from the very first
+ * Whole-document selection predicate: the selection spans from the very first
  * content leaf at offset 0 to the very last content leaf at its end.
  */
 function isSelectAll(
@@ -34,8 +33,7 @@ function isSelectAll(
 
 /**
  * Replace the whole document with a single empty paragraph and seat the
- * caret in it (legacy `backspaceCtrl` `isSelectAll` reset / empty-document
- * guard).
+ * caret in it.
  */
 function resetToEmptyParagraph(clipboard: Clipboard): void {
     const { scrollPage } = clipboard;
@@ -57,7 +55,7 @@ function resetToEmptyParagraph(clipboard: Clipboard): void {
 }
 
 // Empty every cell content leaf from `start` up to and including `after`,
-// keeping the table grid intact (legacy `removeBlocks` `td`/`th` exemption).
+// keeping the table grid intact.
 function emptyCellContentsUntil(
     start: Nullable<Content>,
     after: TreeNode,
@@ -80,7 +78,7 @@ function removeBlocksWithinTable(before: TreeNode, after: TreeNode): void {
 
 /**
  * Handle a cross-block cut whose end lands inside a table. The table grid is
- * exempt from structural removal (legacy `removeBlocks` `exemption`): remove
+ * exempt from structural removal: remove
  * the outmost blocks strictly between `before` and the table, then empty —
  * not remove — every cell from the table's first cell up to and including
  * `after`'s cell.
@@ -150,9 +148,8 @@ function pruneAfterBranch(afterBranch: TreeNode, after: TreeNode): void {
  * targets a still-attached path.
  */
 function removeBlocks(before: TreeNode, after: TreeNode): void {
-    // A table is exempt from structural removal (legacy `removeBlocks`
-    // `exemption` for `td`/`th`): empty the spanned cells in place and keep
-    // the grid rather than deleting cells/rows.
+    // A table is exempt from structural removal: empty the spanned cells in
+    // place and keep the grid rather than deleting cells/rows.
     const beforeTable = before.closestBlock('table');
     const afterTable = after.closestBlock('table');
 
@@ -251,7 +248,7 @@ function selectedTableCells(
  * Structurally delete an empty whole row / column / table when cutting a
  * frozen table-cell selection. Returns `true` when it handled the cut (the
  * caller then skips the in-place clear), `false` to fall through to the
- * in-place clear. Mirrors legacy `deleteSelectedTableCells` (152-211).
+ * in-place clear.
  */
 function cutEmptyTableStructure(clipboard: Clipboard): boolean {
     const selectedCells = selectedTableCells(clipboard);
@@ -308,8 +305,8 @@ function cutEmptyTableStructure(clipboard: Clipboard): boolean {
 export function cutSelection(clipboard: Clipboard): void {
     // A frozen cross-cell table selection. When every selected cell is
     // already empty and the rectangle covers a whole row / column / table,
-    // delete that structure (legacy `deleteSelectedTableCells`); otherwise
-    // empty the cells in place. The copy half already captured the
+    // delete that structure; otherwise empty the cells in place. The copy half
+    // already captured the
     // rectangle's markdown via `getClipboardData`.
     if (clipboard.tableSelection?.hasSelection) {
         if (!cutEmptyTableStructure(clipboard))
@@ -349,15 +346,14 @@ export function cutSelection(clipboard: Clipboard): void {
     const startOffset = direction === 'forward' ? anchor.offset : focus.offset;
     const endOffset = direction === 'forward' ? focus.offset : anchor.offset;
 
-    // Whole-document selection collapses to a single empty paragraph
-    // (legacy `backspaceCtrl` `isSelectAll` reset).
+    // Whole-document selection collapses to a single empty paragraph.
     if (isSelectAll(clipboard, startBlock, startOffset, endBlock, endOffset)) {
         resetToEmptyParagraph(clipboard);
 
         return;
     }
 
-    // Leaf-level merge (legacy `cutHandler` + `removeBlocks`): keep the
+    // Leaf-level merge: keep the
     // start head and the end tail in the start content block, then remove
     // only the structure strictly between the two leaves (and the emptied
     // end-side containers). The start block keeps its container — a list

--- a/packages/muya/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/muya/src/clipboard/mergePasteIntoHeading.ts
@@ -9,7 +9,7 @@ interface IPasteCursor {
 }
 
 /**
- * Backport of marktext commit 1c42555a (#671). When pasting multi-paragraph
+ * When pasting multi-paragraph
  * markdown into an atx/setext heading, splice the first paragraph state into
  * the heading's text — keeping the heading semantics intact — and return the
  * tail states so the caller can drop them in as new blocks below.

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -39,10 +39,10 @@ function isSingleCellSelected(clipboard: Clipboard): boolean {
     return state.children.length === 1 && state.children[0].children.length === 1;
 }
 
-// Parse a paste into real blocks (the common anchor case). Mirrors legacy
-// `pasteCtrl.pasteHandler`: parse markdown → state, splice a leading paragraph
-// back into a heading anchor, drop the selected range, insert the new blocks,
-// remove the emptied source paragraph, and seat the cursor at the end.
+// Parse a paste into real blocks (the common anchor case): parse markdown →
+// state, splice a leading paragraph back into a heading anchor, drop the
+// selected range, insert the new blocks, remove the emptied source paragraph,
+// and seat the cursor at the end.
 function applyParsedPaste(
     clipboard: Clipboard,
     ctx: IPasteContext,
@@ -52,9 +52,8 @@ function applyParsedPaste(
     const { anchorBlock, originWrapperBlock, start, end, content } = ctx;
     let wrapperBlock = ctx.wrapperBlock;
 
-    // An empty / whitespace-only paste is a no-op (legacy `pasteCtrl` bails
-    // on `stateFragments.length <= 0`); the parser would otherwise emit a
-    // lone empty paragraph and churn blocks.
+    // An empty / whitespace-only paste is a no-op; the parser would otherwise
+    // emit a lone empty paragraph and churn blocks.
     if (markdown.trim().length === 0)
         return;
 
@@ -76,7 +75,7 @@ function applyParsedPaste(
 
     // When pasting into a heading, splice the first paragraph back into the
     // heading text so the heading semantics survive. The helper also collapses
-    // any selection on the heading. Backport of marktext 1c42555a (#671).
+    // any selection on the heading.
     const remaining = mergePasteIntoHeading(
         anchorBlock,
         wrapperBlock,
@@ -111,8 +110,7 @@ function applyParsedPaste(
 }
 
 // `language-input`, `table.cell.content` and `codeblock.content` never parse a
-// paste into blocks — they take the text literally (legacy `pasteCtrl`
-// `languageInput` / `cellContent` / `codeContent` branches).
+// paste into blocks — they take the text literally.
 function applyLiteralPaste(
     clipboard: Clipboard,
     ctx: IPasteContext,
@@ -123,7 +121,7 @@ function applyLiteralPaste(
 
     // A frozen table-cell selection scopes the paste: a single cell gets its
     // text replaced (with `\n` → `<br/>`); a multi-cell rectangle cancels the
-    // paste (legacy `pasteCtrl.pasteHandler` `cellContent` branch).
+    // paste.
     if (
         anchorBlock.blockName === 'table.cell.content'
         && clipboard.tableSelection?.hasSelection
@@ -170,9 +168,8 @@ function applyLiteralPaste(
 }
 
 // Block-level HTML (`<ul>`/`<ol>`/`<pre>`/`<blockquote>` … — tags in
-// `PARAGRAPH_TYPES`) lands as a live html-block (legacy `pasteCtrl`
-// `copyAsHtml` → `insertHtmlBlock`), not a fenced ```html code block, so the
-// markup renders in place.
+// `PARAGRAPH_TYPES`) lands as a live html-block, not a fenced ```html code
+// block, so the markup renders in place.
 function applyHtmlBlockPaste(
     clipboard: Clipboard,
     ctx: IPasteContext,
@@ -207,8 +204,7 @@ export async function pasteSelection(
     // DataTransfer and subsequent `getData()` calls return ''. We snapshot
     // text/html synchronously below and thread the snapshot through the
     // `!isSelectionInSameBlock` recursion via these optional params so the
-    // re-entry doesn't read a detached clipboard. Mirrors the legacy
-    // `@muyajs` `pasteHandler(event, type, rawText, rawHtml)` signature.
+    // re-entry doesn't read a detached clipboard.
     rawText?: string,
     rawHtml?: string,
 ): Promise<void> {
@@ -234,7 +230,7 @@ export async function pasteSelection(
     const text = rawText ?? event.clipboardData.getData('text/plain');
     let html = rawHtml ?? event.clipboardData.getData('text/html');
     // Snapshot any in-memory image File (the bitmap / "Copy Image" /
-    // screenshot case, PG05) synchronously too — `clipboardData.files`
+    // screenshot case) synchronously too — `clipboardData.files`
     // is also detached after the first `await`.
     const imageFile = getClipboardImageFile(event.clipboardData);
 
@@ -245,7 +241,7 @@ export async function pasteSelection(
     }
 
     // When the clipboard holds an image — either a file resolved to a path
-    // (PG06) or an in-memory bitmap (PG05) — insert it as an inline image
+    // or an in-memory bitmap — insert it as an inline image
     // routed through `imageAction`, short-circuiting the text/HTML paste.
     if (await tryPasteImage(clipboard, anchorBlock, imageFile))
         return;
@@ -257,7 +253,7 @@ export async function pasteSelection(
     // Apple Numbers and a handful of other sources only put a raw
     // `<table>...</table>` blob in text/plain. Promote it to the HTML
     // slot so it goes through the HTML→Markdown converter rather than
-    // being inserted verbatim (marktext 067ec485 / #1271).
+    // being inserted verbatim.
     if (!html && isStandaloneTableHtml(text))
         html = text;
 

--- a/packages/muya/src/clipboard/pasteImage.ts
+++ b/packages/muya/src/clipboard/pasteImage.ts
@@ -69,14 +69,12 @@ function replacePlaceholderImage(
  * Insert a pasted image at the cursor, routing it through the embedder's
  * `imageAction` so the user's insert preference (copy-to-assets / upload /
  * keep-path) applies and a portable src is written. `src` is either a
- * resolved clipboard file path (PG06) or a `data:` URL for an in-memory
- * bitmap (PG05).
+ * resolved clipboard file path or a `data:` URL for an in-memory bitmap.
  *
  * A `loading-<id>` placeholder image is spliced in synchronously (with the
  * incoming `src` as a temporary preview) BEFORE awaiting `imageAction`, then
- * replaced with the resolved src once it settles — mirroring legacy
- * `pasteCtrl.pasteImage`'s loading-id insert → imageAction → replace flow,
- * so the user sees a placeholder while the upload/copy runs. When no
+ * replaced with the resolved src once it settles, so the user sees a
+ * placeholder while the upload/copy runs. When no
  * `imageAction` is configured the placeholder's src is the final one.
  */
 async function insertImageSrc(
@@ -107,11 +105,10 @@ async function insertImageSrc(
 
 /**
  * Insert a pasted image when the clipboard carries one. Tries a resolved
- * clipboard FILE path first (PG06, via the `clipboardFilePath` hook), then
- * an in-memory bitmap File (PG05, read as a base64 `data:` URL). Returns
+ * clipboard FILE path first (via the `clipboardFilePath` hook), then
+ * an in-memory bitmap File (read as a base64 `data:` URL). Returns
  * `true` when an image was inserted so the caller skips the text/HTML
- * paste, `false` to fall through. Ported from the legacy `@muyajs`
- * `pasteImage` ordering (file path, then binary).
+ * paste, `false` to fall through.
  */
 export async function tryPasteImage(
     clipboard: Clipboard,

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -395,8 +395,7 @@ export const isWin
 export const URL_REG
     = /^http(s)?:\/\/([\w\-.~]+\.[a-z]{2,}|[0-9.]+|localhost|\[[a-f0-9.:]+\])(:\d{1,5})?\/\S+/i;
 // A fully-formed base64/percent-encoded image data URL, e.g.
-// `data:image/png;base64,iVBORw0KGg...`. Mirrors legacy muyajs `DATA_URL_REG`
-// and `utils/image.ts` `getImageSrc`, so a bare `data:image/` prefix is not
+// `data:image/png;base64,iVBORw0KGg...`. A bare `data:image/` prefix is not
 // treated as a safe-to-embed source.
 export const DATA_URL_REG
     = /^data:image\/[\w+-]+(?:;[\w-]+=[\w-]+|;base64)*,[a-zA-Z0-9+/]+={0,2}$/;

--- a/packages/muya/src/editor/dragDropImage.ts
+++ b/packages/muya/src/editor/dragDropImage.ts
@@ -11,14 +11,11 @@ import logger from '../utils/logger';
 
 const debug = logger('editor:dragDropImage:');
 
-// Port of marktext `src/muya/lib/eventHandler/dragDrop.js` +
-// `contentState/dragDropCtrl.js`. The legacy engine bound
-// dragover/drop/dragleave/dragstart on the editor container and inserted a
-// dropped image — either a web-link image (`text/uri-list`) or a local image
-// FILE — as a new `![](src)` paragraph block. The TS rewrite shipped without
-// any DnD handler (#4406 parity gap PG4); this module restores it.
+// Drag-and-drop image insertion: a dropped image — either a web-link image
+// (`text/uri-list`) or a local image FILE — is inserted as a new `![](src)`
+// paragraph block.
 //
-// Two drop paths, mirroring the legacy controller:
+// Two drop paths:
 //   - web-link image (`text/uri-list`)  → verify it is an image, then insert
 //                                          `![](url)` verbatim.
 //   - local image FILE (`dataTransfer.files`) → resolve the file to a path via
@@ -56,10 +53,9 @@ function isImageFileDrag(dataTransfer: DataTransfer): boolean {
 }
 
 // The "image dragged from a browser" signature: a `text/uri-list` item that
-// also carries `text/html` but NOT `text/plain`. Mirrors legacy muyajs
-// (`dragDropCtrl.js` dragoverHandler) so that dragging a plain hyperlink — which
-// carries `text/uri-list` + `text/plain` — is left to the browser instead of
-// being intercepted and swallowed.
+// also carries `text/html` but NOT `text/plain`, so that dragging a plain
+// hyperlink — which carries `text/uri-list` + `text/plain` — is left to the
+// browser instead of being intercepted and swallowed.
 function isWebImageDrag(dataTransfer: DataTransfer): boolean {
     const items = Array.from(dataTransfer.items);
     const hasUri = items.some(i => i.type === 'text/uri-list');
@@ -158,7 +154,7 @@ function handleWebLinkImage(
 }
 
 // Replace a `![loading-id](path)` placeholder with the persisted src returned
-// by `imageAction`. Mirrors the imageEditTool upload flow.
+// by `imageAction`.
 async function persistDroppedImage(
     muya: Muya,
     path: string,
@@ -293,8 +289,8 @@ export function attachDragDropImageHandlers(muya: Muya): void {
     eventCenter.attachDOMEvent(domNode, 'dragstart', dragStartHandler);
     eventCenter.attachDOMEvent(domNode, 'dragover', dragOverHandler);
     eventCenter.attachDOMEvent(domNode, 'drop', dropHandler);
-    // Legacy muyajs bound `dragleave` on `window` to clear the ghost when the
-    // pointer leaves the page; `document` bubbles the same event and is within
-    // `attachDOMEvent`'s accepted target union.
+    // `dragleave` is bound on `document` (not `window`) to clear the ghost when
+    // the pointer leaves the page; `document` bubbles the same event and is
+    // within `attachDOMEvent`'s accepted target union.
     eventCenter.attachDOMEvent(document, 'dragleave', dragLeaveHandler);
 }

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -74,13 +74,13 @@ export class Editor {
         this.scrollPage = ScrollPage.create(muya, state);
 
         this._dispatchEvents();
-        // marktext cb25b3d4 (#1415): hovering a rendered link wrapper
-        // dispatches `muya-link-tools` so the staged popover lights up.
-        // Cleanup is handled by `muya.destroy()` → `detachAllDomEvents`.
+        // Hovering a rendered link wrapper dispatches `muya-link-tools` so the
+        // staged popover lights up. Cleanup is handled by `muya.destroy()` →
+        // `detachAllDomEvents`.
         attachLinkMouseHandlers(muya);
-        // marktext PG4 (#4406 follow-up): dropping an image file or web-link
-        // image into the editor inserts it as a new `![](src)` block. Cleanup
-        // is likewise handled by `detachAllDomEvents`.
+        // Dropping an image file or web-link image into the editor inserts it
+        // as a new `![](src)` block. Cleanup is likewise handled by
+        // `detachAllDomEvents`.
         attachDragDropImageHandlers(muya);
         this.focus();
     }

--- a/packages/muya/src/editor/linkMouseEvents.ts
+++ b/packages/muya/src/editor/linkMouseEvents.ts
@@ -4,9 +4,7 @@ import { BLOCK_DOM_PROPERTY, CLASS_NAMES } from '../config';
 import { findContentDOM } from '../selection/dom';
 import { getLinkInfo } from '../utils/getLinkInfo';
 
-// Port of marktext `src/muya/lib/eventHandler/mouseEvent.js` (cb25b3d4
-// + the surrounding hover dispatch infrastructure). The new repo's
-// linkTools popover subscribes to `muya-link-tools` but had no emitter;
+// The linkTools popover subscribes to `muya-link-tools` but had no emitter;
 // this module is that emitter.
 //
 // Three rendered link variants are detected, each by its wrapper class:
@@ -21,8 +19,7 @@ import { getLinkInfo } from '../utils/getLinkInfo';
 // For the markdown and reference-link variants we additionally require the
 // preceding sibling to be `.mu-hide` — i.e. the source-character markers
 // are hidden, which means the wrapper is rendered in *preview* mode
-// (cursor isn't editing inside the link). This mirrors marktext's
-// `parentPreSibling.classList.contains('ag-hide')` guard and keeps the
+// (cursor isn't editing inside the link), which keeps the
 // popover from flashing while the user types the URL.
 //
 // Click suppression: PR-11b removed the `pointer-events: none` rule that
@@ -145,8 +142,7 @@ export function attachLinkMouseHandlers(muya: Muya): void {
         // `data.href`. We gate on the modifier here too so plain clicks keep
         // their cursor-placement-only behavior. `getLinkInfo` resolves the
         // wrapper that hosts the href even when the IMG/text descendant was
-        // clicked, and returns a superset (`{ href, raw, text, range }`) of
-        // the legacy `{ text, href }` payload.
+        // clicked, and returns a superset (`{ href, raw, text, range }`).
         if (!isModifierClick(event))
             return;
 

--- a/packages/muya/src/editor/tableCellSelection.ts
+++ b/packages/muya/src/editor/tableCellSelection.ts
@@ -160,9 +160,8 @@ class TableCellSelection {
         // drag; collapse it again each move so only the cell rectangle shows.
         this._collapseCaretToAnchor();
 
-        // Off-table moves null the focus (legacy `tableSelectCellsCtrl` sets
-        // `focus = null`), so releasing outside the table cancels the selection
-        // rather than freezing a 1×1 anchor-cell range.
+        // Off-table moves null the focus, so releasing outside the table
+        // cancels the selection rather than freezing a 1×1 anchor-cell range.
         this._focus = overSameTable ? position : null;
         this._renderHighlight();
     };
@@ -171,8 +170,7 @@ class TableCellSelection {
         this._detachDragEvents();
 
         // Nothing to freeze when the drag never started (a plain click) or the
-        // pointer was released outside the table (focus is null) — legacy
-        // `handleCellMouseUp` bails on a null focus too.
+        // pointer was released outside the table (focus is null).
         if (!this._isSelecting || this._focus == null)
             this.clear();
     };

--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -43,7 +43,7 @@ class InlineRenderer {
      * in `urlMap`. When an image file changes on disk the cached entry would
      * otherwise keep the stale bitmap, so clearing both maps and re-rendering
      * every content block re-runs `loadImageAsync`, which loads the source
-     * afresh. Mirrors legacy muyajs `StateRender.invalidateImageCache`.
+     * afresh.
      */
     invalidateImageCache() {
         this.renderer.loadImageMap.clear();

--- a/packages/muya/src/inlineRenderer/renderer/image.ts
+++ b/packages/muya/src/inlineRenderer/renderer/image.ts
@@ -123,7 +123,7 @@ export default function image(
         }
         else if (isSuccess === true) {
             wrapperSelector += `.${CLASS_NAMES.MU_IMAGE_SUCCESS}`;
-            // marktext cb7be189 (#1318): tag images whose natural size is below
+            // Tag images whose natural size is below
             // 100px in either dimension. NOTE: no CSS in this package currently
             // consumes `.mu-small-image` — it is kept as a theming hook so
             // downstream stylesheets can shrink/hide the in-wrapper hover icons

--- a/packages/muya/src/inlineRenderer/renderer/loadImageAsync.ts
+++ b/packages/muya/src/inlineRenderer/renderer/loadImageAsync.ts
@@ -56,12 +56,11 @@ export default function loadImageAsync(
                         imageContainer!.appendChild(img);
                         imageText.classList.remove(CLASS_NAMES.MU_IMAGE_LOADING);
                         imageText.classList.add(CLASS_NAMES.MU_IMAGE_SUCCESS);
-                        // marktext cb7be189 (#1318): mirror the small-image tagging from
-                        // `image.ts` on the first async load — otherwise the class would
-                        // only appear on the next re-render after the cache is populated.
-                        // See `image.ts` for why the class is kept as a theming hook with
-                        // no in-package CSS consumer; downstream stylesheets own the
-                        // visual treatment.
+                        // Tag small images on the first async load — otherwise the class
+                        // would only appear on the next re-render after the cache is
+                        // populated. See `image.ts` for why the class is kept as a theming
+                        // hook with no in-package CSS consumer; downstream stylesheets own
+                        // the visual treatment.
                         if (width < 100 || height < 100)
                             imageText.classList.add(CLASS_NAMES.MU_SMALL_IMAGE);
                     }

--- a/packages/muya/src/inlineRenderer/renderer/referenceImage.ts
+++ b/packages/muya/src/inlineRenderer/renderer/referenceImage.ts
@@ -39,8 +39,8 @@ export default function referenceImage(
             CLASS_NAMES.MU_COPY_REMOVE,
         ));
     }
-    // Mirror `image.ts` (inline image): `loadImageMap` keys by `src`, so two
-    // reference images sharing the same `href` share the same cached `id`.
+    // `loadImageMap` keys by `src`, so two reference images sharing the same
+    // `href` share the same cached `id`.
     // Once the load has resolved (`isSuccess === true`), suffix the DOM id
     // with the token's start offset so each occurrence gets a unique element
     // id. While the load is in flight we keep the raw id so the
@@ -58,9 +58,9 @@ export default function referenceImage(
     return isSuccess
         ? [
                 h(selector, tag),
-                // Prefer the resolved URL from the loadImageAsync cache (marktext's
-                // `domsrc` parity); fall back to the raw src if the cache hasn't
-                // been populated for some reason.
+                // Prefer the resolved URL from the loadImageAsync cache; fall
+                // back to the raw src if the cache hasn't been populated for
+                // some reason.
                 h(`img.${CLASS_NAMES.MU_COPY_REMOVE}`, { props: { alt, src: resolvedSrc ?? src, title } }),
             ]
         : [h(selector, tag)];

--- a/packages/muya/src/inlineRenderer/utils.ts
+++ b/packages/muya/src/inlineRenderer/utils.ts
@@ -65,8 +65,7 @@ export const WHITELIST_ATTRIBUTES = [
 
 const UNICODE_WHITESPACE_REG = /^\s/;
 
-// NON-STANDARD EXTENSION — a deliberate divergence from CommonMark, ported
-// from the legacy muyajs tokenizer (packages/muyajs/lib/parser/utils.js).
+// NON-STANDARD EXTENSION — a deliberate divergence from CommonMark.
 //
 // CommonMark §6.2 only counts Unicode whitespace and Unicode punctuation as
 // emphasis flanking boundaries. CJK ideographs are Lo (Letter, other) —
@@ -74,7 +73,7 @@ const UNICODE_WHITESPACE_REG = /^\s/;
 // `中文**"加粗"**中文` MUST NOT open a strong run. But CJK scripts don't use
 // spaces between words, so that denies emphasis to virtually any CJK paragraph
 // that wraps the `**` run with punctuation (quotes, parentheses, brackets, …).
-// Typora, VSCode markdownlint, Joplin and the legacy muyajs engine all widen
+// Typora, VSCode markdownlint and Joplin all widen
 // the flanking check so CJK counts as a boundary; we match that here so the
 // live editor (inlineRenderer) bolds these spans consistently with the
 // marked-based static / export render path.
@@ -226,7 +225,7 @@ function canOpenEmphasis(src: string, marker: string, pending: string) {
 
     const precededChar = lastCodePointChar(pending) || '\n';
     // Past end of src → '' (matches neither whitespace nor punctuation),
-    // preserving the legacy `RegExp.test(undefined)` semantics type-safely.
+    // preserving the `RegExp.test(undefined)` semantics type-safely.
     const followedChar = codePointCharAt(src, marker.length) ?? '';
     // not followed by Unicode whitespace,
     if (UNICODE_WHITESPACE_REG.test(followedChar))

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -50,8 +50,8 @@ interface IPlugin {
     options: Record<string, unknown>;
 }
 
-// Maps the marktext/muyajs paragraph-menu labels the desktop sends through
-// `updateParagraph` to the muya `replaceBlockByLabel` vocabulary.
+// Maps the paragraph-menu labels the desktop sends through `updateParagraph`
+// to muya's `replaceBlockByLabel` vocabulary.
 const PARAGRAPH_LABEL_MAP: Record<string, string> = {
     'paragraph': 'paragraph',
     'hr': 'thematic-break',
@@ -111,8 +111,8 @@ export class Muya {
         this._bindFocusBlurEvents();
     }
 
-    // Backport of marktext 9eff8248: expose `focus` / `blur` lifecycle events
-    // so external SDK consumers can react to editor focus changes. Routed
+    // Expose `focus` / `blur` lifecycle events so external SDK consumers can
+    // react to editor focus changes. Routed
     // through attachDOMEvent so cleanup is automatic via detachAllDomEvents
     // in destroy().
     private _bindFocusBlurEvents() {
@@ -137,7 +137,7 @@ export class Muya {
     /**
      * Switch the editor's UI language at runtime. Swaps the i18n resources, then
      * re-renders the block tree so already-mounted blocks pick up the new
-     * translation (Phase G — G8). The inline placeholder hints (quick-insert
+     * translation. The inline placeholder hints (quick-insert
      * "Type / to insert…", code-block language, math, front matter) are DOM
      * attributes baked once in each block's constructor; without the re-render
      * they would keep the old language until the block was next recreated.
@@ -181,10 +181,9 @@ export class Muya {
     /**
      * Return a flat table of contents for the current document.
      *
-     * Mirrors marktext's `tocCtrl.getTOC` (including the 9cb2cbe8 regex
-     * fix). Only top-level atx / setext headings are surfaced; nested
-     * headings inside blockquotes / list items are ignored, same as
-     * marktext. `content` is the raw heading text (inline markdown not
+     * Only top-level atx / setext headings are surfaced; nested
+     * headings inside blockquotes / list items are ignored. `content` is the
+     * raw heading text (inline markdown not
      * parsed); `slug` is a stable per-block identifier; `githubSlug` is
      * the GitHub-style anchor derived from `content`.
      */
@@ -261,8 +260,8 @@ export class Muya {
      * history is preserved and a new boundary is pushed on top of it.
      *
      * Used by the desktop shell when handing a tab back from source-code mode:
-     * the bulk source-mode edit becomes one undo step (legacy muyajs parity,
-     * gap PG14). The change is recorded as a `rebuild` history entry, so undo /
+     * the bulk source-mode edit becomes one undo step. The change is recorded
+     * as a `rebuild` history entry, so undo /
      * redo re-create the block tree wholesale (`ScrollPage.updateState`) rather
      * than walking it incrementally — making arbitrary block-type changes
      * (paragraph<->heading, list/table/code/frontmatter, multi-block reorder…)
@@ -292,8 +291,8 @@ export class Muya {
     }
 
     /**
-     * Update editor options at runtime (mirrors marktext muyajs `setOptions`):
-     * merges `options` into `muya.options`, reflects the container-level ones
+     * Update editor options at runtime: merges `options` into `muya.options`,
+     * reflects the container-level ones
      * (spellcheck, quick-insert hint), and — when `forceRender` is set — fully
      * re-renders the document from its current state so render-affecting
      * options (superSubScript, footnote, disableHtml, frontmatterType,
@@ -334,7 +333,6 @@ export class Muya {
         // saved path and setting the cursor on it directly. (Passing only a
         // path to setSelection does not work — Selection._setCursor needs a
         // concrete block's domNode; a bare queryBlock result is not a Node.)
-        // Mirrors Editor.updateContents' same-block cursor restore.
         if (selection && selection.isSelectionInSameBlock) {
             const begin = Math.min(selection.anchor.offset, selection.focus.offset);
             const end = Math.max(selection.anchor.offset, selection.focus.offset);
@@ -344,7 +342,7 @@ export class Muya {
         }
     }
 
-    /** Update the editor font size / line height (mirrors muyajs `setFont`). */
+    /** Update the editor font size / line height. */
     setFont({ fontSize, lineHeight }: { fontSize?: IMuyaOptions['fontSize']; lineHeight?: IMuyaOptions['lineHeight'] }) {
         if (typeof fontSize === 'number')
             this.options.fontSize = fontSize;
@@ -367,7 +365,7 @@ export class Muya {
     }
 
     /**
-     * Toggle focus mode (mirrors marktext muyajs `setFocusMode`). When enabled,
+     * Toggle focus mode. When enabled,
      * every top-level block except the one holding the cursor is dimmed via the
      * `mu-focus-mode` class on the editor container; the dimming itself lives in
      * the stylesheet (`.mu-focus-mode .mu-container > * { opacity }`).
@@ -410,9 +408,8 @@ export class Muya {
         if (!isSelectionInSameBlock || !(anchorBlock instanceof Format))
             return;
 
-        // Restore the selection before applying the format, mirroring the
-        // inline format toolbar — the menu/IPC round-trip can drop the live
-        // DOM selection.
+        // Restore the selection before applying the format — the menu/IPC
+        // round-trip can drop the live DOM selection.
         selection.setSelection({
             anchor,
             focus,
@@ -429,8 +426,8 @@ export class Muya {
      * Replace the word at the current cursor with `replacement`, then place the
      * cursor after the replacement.
      *
-     * Mirrors legacy muyajs `_replaceCurrentWordInlineUnsafe`. The desktop spell
-     * checker calls this when the user picks a suggestion from the misspelled-word
+     * The desktop spell checker calls this when the user picks a suggestion
+     * from the misspelled-word
      * context menu (Chromium has already selected the whole word). Unsafe: the
      * call is a no-op unless the word at the cursor matches `word`.
      *
@@ -463,8 +460,8 @@ export class Muya {
     }
 
     /**
-     * Blur the editor (mirrors marktext muyajs `blur`). Always hides every
-     * floating tool and blurs the contenteditable node.
+     * Blur the editor. Always hides every floating tool and blurs the
+     * contenteditable node.
      * @param isRemoveAllRange Remove all native selection ranges.
      * @param unSelect Clear the selected inline image so its toolbar/resize
      * bar do not linger after the editor is blurred.
@@ -546,10 +543,9 @@ export class Muya {
 
     /**
      * The immediate block-level parent of the active content leaf — the
-     * paragraph/heading block that directly wraps the cursor. This mirrors the
-     * legacy `getAnchor`/`getParent` anchor used by the context-menu
-     * "Insert Paragraph Before/After" path, so a new paragraph lands as an
-     * inner sibling inside a list item / blockquote rather than jumping out to
+     * paragraph/heading block that directly wraps the cursor. Used by the
+     * context-menu "Insert Paragraph Before/After" path: a new paragraph lands
+     * as an inner sibling inside a list item / blockquote rather than jumping out to
      * the outermost container. Uses the persisted active content block (which
      * survives the menu/IPC round-trip), falling back to the selection anchor.
      */
@@ -633,7 +629,7 @@ export class Muya {
 
     /**
      * Insert a GFM table at the current cursor, replacing the block the cursor
-     * is in (legacy `createTableInFigure`/`createFigure`). The table has `rows`
+     * is in. The table has `rows`
      * rows × `columns` columns with the first row as the header; every cell is
      * empty with `align: 'none'`. The cursor lands in the first cell. No-op when
      * there is no current block. `rows`/`columns` are coerced to integers and
@@ -676,7 +672,7 @@ export class Muya {
 
     /**
      * Insert an inline image at the current cursor in the active formattable
-     * block, mirroring legacy `insertImage`. The `![alt](src)` markdown is
+     * block. The `![alt](src)` markdown is
      * written through the `Format` block's text setter so it dispatches a JSON
      * op (state stays in sync) rather than mutating the DOM directly. No-op when
      * there is no active formattable (`Format`) block — e.g. inside a code block
@@ -691,16 +687,14 @@ export class Muya {
         if (cursor == null)
             return;
 
-        // Derive a sensible alt from the file name when none is provided,
-        // matching legacy `insertImage`.
+        // Derive a sensible alt from the file name when none is provided.
         if (!alt) {
             const match = /[/\\]?([^./\\]+)\.[a-z]+$/i.exec(src);
             alt = match?.[1] ?? '';
         }
 
         // Only percent-encode plain paths; leave full URLs / well-formed data
-        // URLs as-is. Mirrors legacy `insertImage` / `replaceImage` src
-        // handling — `DATA_URL_REG` requires the full `data:image/<type>...,<payload>`
+        // URLs as-is. `DATA_URL_REG` requires the full `data:image/<type>...,<payload>`
         // shape (the same regex `utils/image.ts` `getImageSrc` uses), so a bare
         // `data:image/` prefix is not embedded verbatim and instead falls through
         // to the plain-path branch.
@@ -714,7 +708,7 @@ export class Muya {
 
         const { start, end } = cursor;
         const { text } = block;
-        // When there is a selection, use it as the alt text (legacy behaviour).
+        // When there is a selection, use it as the alt text.
         const imageAlt = start.offset !== end.offset ? text.substring(start.offset, end.offset) : alt;
         const imageText = `![${imageAlt}](${imgUrl})`;
 
@@ -763,7 +757,6 @@ export class Muya {
         if (anchorBlock == null || !anchorBlock.isContent())
             return;
 
-        // Same-block, mirror Editor.updateContents' selection-restore.
         if (anchorBlock === focusBlock || focusBlock == null) {
             const begin = Math.min(anchor.offset, focus.offset);
             const last = Math.max(anchor.offset, focus.offset);
@@ -786,8 +779,8 @@ export class Muya {
 
     /**
      * Restore the WYSIWYG caret from a source-mode (CodeMirror) `{ line, ch }`
-     * index cursor (PG2 parity). The block tree has no source-line mapping, so
-     * the offsets are resolved the way legacy muyajs did: inject sentinel
+     * index cursor. The block tree has no source-line mapping, so the offsets
+     * are resolved as follows: inject sentinel
      * strings into the current markdown at the line/ch positions, rebuild the
      * tree (sentinels embed as literal text), find which content blocks they
      * landed in, then rebuild the clean document and set the cursor by the
@@ -830,8 +823,8 @@ export class Muya {
 
     /**
      * Read the current WYSIWYG caret as a source-mode (CodeMirror) `{ line, ch }`
-     * index cursor — the INVERSE of `setCursorByOffset` (PG2 parity / Phase G —
-     * G7). The desktop emits this on every change so toggling WYSIWYG -> source
+     * index cursor — the INVERSE of `setCursorByOffset`. The desktop emits this
+     * on every change so toggling WYSIWYG -> source
      * opens CodeMirror at the same caret.
      *
      * The block tree has no source-line mapping, so the offset is recovered the
@@ -862,8 +855,8 @@ export class Muya {
     }
 
     /**
-     * Convert the block at the cursor to another type, mirroring marktext's
-     * `updateParagraph`. `type` uses the marktext/muyajs paragraph-menu
+     * Convert the block at the cursor to another type. `type` uses the
+     * paragraph-menu
      * vocabulary: `paragraph`, `heading 1`–`heading 6`, `upgrade heading`,
      * `degrade heading`, `blockquote`, `pre`, `mathblock`, `html`, `hr`,
      * `table`, `front-matter`, `ul-bullet`/`ol-order`/`ul-task`,
@@ -886,7 +879,7 @@ export class Muya {
 
         // `reset-to-paragraph` returns the current block to plain paragraph
         // form; structured containers (lists/blockquote) unwrap to preserve
-        // every child, tables are left untouched (matches legacy).
+        // every child, tables are left untouched.
         if (type === 'reset-to-paragraph') {
             this._resetToParagraph(block);
             return;
@@ -897,9 +890,9 @@ export class Muya {
             return;
 
         // Front matter is only valid as the very first block of a document, so
-        // it is never an in-place replacement of the cursor block. Mirror legacy
-        // muyajs `handleFrontMatter`: idempotent no-op if the document already
-        // starts with front matter, otherwise prepend one at the top.
+        // it is never an in-place replacement of the cursor block: idempotent
+        // no-op if the document already starts with front matter, otherwise
+        // prepend one at the top.
         if (label === 'frontmatter') {
             insertFrontMatterAtStart(this);
             return;
@@ -907,16 +900,13 @@ export class Muya {
 
         // The plain `paragraph` menu item only converts the *leaf* block that
         // directly wraps the cursor (heading, hr, …) back to a paragraph; it
-        // never touches the enclosing container. Mirror legacy muyajs
-        // (paragraphCtrl.js `case 'paragraph'`): there `parent = getParent(block)`
-        // is the cursor's immediate leaf and the conversion is a no-op only when
-        // `parent.type === 'p'` (already a paragraph) — otherwise it replaces
-        // just that leaf. Operating on the leaf (not the outermost container)
-        // means a heading inside a list item still converts while the list stays
-        // intact, and avoids the original G4 data loss where routing `paragraph`
-        // to the *whole* list/blockquote collapsed every item/line into a single
-        // paragraph built from the first content's text. `reset-to-paragraph`
-        // remains the explicit "unwrap the container" command (handled above).
+        // never touches the enclosing container. Operating on the leaf (not the
+        // outermost container) means a heading inside a list item still converts
+        // while the list stays intact, and avoids the data loss where routing
+        // `paragraph` to the *whole* list/blockquote collapsed every item/line
+        // into a single paragraph built from the first content's text.
+        // `reset-to-paragraph` remains the explicit "unwrap the container"
+        // command (handled above).
         if (label === 'paragraph')
             return this._convertLeafToParagraph();
 
@@ -932,8 +922,8 @@ export class Muya {
             return;
         }
 
-        // Legacy `isAllowedTransformation`: hr/table only replace an empty
-        // block so user content is never silently dropped.
+        // hr/table only replace an empty block so user content is never
+        // silently dropped.
         if (
             (label === 'thematic-break' || label === 'table')
             && this._blockLeadingText(block).trim() !== ''
@@ -970,8 +960,7 @@ export class Muya {
     /**
      * Convert the *leaf* block that directly wraps the cursor (the immediate
      * parent of the active content) to a plain paragraph. No-op when that leaf
-     * is already a paragraph — mirroring legacy muyajs `case 'paragraph'`
-     * (`parent.type === 'p'` returned early). Because it targets the leaf rather
+     * is already a paragraph. Because it targets the leaf rather
      * than the outermost container, a heading inside a list item / blockquote
      * converts to a paragraph while leaving the surrounding list/quote intact.
      */

--- a/packages/muya/src/selection/affiliation.ts
+++ b/packages/muya/src/selection/affiliation.ts
@@ -1,14 +1,12 @@
 // Block-affiliation derivation for the `selection-change` payload.
 //
-// PARITY (gap PG1): legacy `packages/muyajs` emitted `selectionChange` with an
-// `affiliation` chain — the shared ancestor PARAGRAPH-type blocks of the
-// selection endpoints — plus per-endpoint `.type` (the markdown block type,
-// e.g. `span` for a content leaf) and `.functionType` (`codeContent`,
-// `cellContent`, …). The desktop store (`createApplicationMenuState`) consumed
-// those to light up the Paragraph-menu check marks, the Loose/Task-list
-// toggles, table/code-fence detection, and to disable the Format menu inside
-// code. `@muyajs/core` models the document as a block tree keyed by
-// `blockName`, so this module re-derives the same shape from that tree.
+// The payload carries an `affiliation` chain — the shared ancestor
+// PARAGRAPH-type blocks of the selection endpoints — plus per-endpoint `.type`
+// (the markdown block type, e.g. `span` for a content leaf) and `.functionType`
+// (`codeContent`, `cellContent`, …). The desktop store
+// (`createApplicationMenuState`) consumes those to light up the Paragraph-menu
+// check marks, the Loose/Task-list toggles, table/code-fence detection, and to
+// disable the Format menu inside code.
 
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
@@ -58,8 +56,8 @@ const CONTAINER_TYPE_BY_NAME: Readonly<Record<string, string>> = {
 };
 
 /**
- * Leaf-content `blockName` → legacy `functionType`. Mirrors the muyajs content
- * blocks (`codeContent`, `cellContent`, `languageInput`, `paragraphContent`).
+ * Leaf-content `blockName` → `functionType` (`codeContent`, `cellContent`,
+ * `languageInput`, `paragraphContent`).
  */
 const FUNCTION_TYPE_BY_NAME: Readonly<Record<string, string>> = {
     'codeblock.content': 'codeContent',
@@ -71,8 +69,8 @@ const FUNCTION_TYPE_BY_NAME: Readonly<Record<string, string>> = {
 };
 
 /**
- * List-block `blockName` → list discriminator (matches muyajs's
- * `listType` / `listItemType`: `bullet` | `order` | `task`). Keyed only on the
+ * List-block `blockName` → list discriminator (`bullet` | `order` | `task`).
+ * Keyed only on the
  * list container blocks — list-item blocks share the `list-item` block name for
  * both bullet and ordered lists, so an item's discriminator is read from the
  * parent list, never from the item itself.
@@ -84,12 +82,12 @@ const LIST_TYPE_BY_NAME: Readonly<Record<string, string>> = {
 };
 
 /**
- * One ancestor block in the affiliation chain. `type` is the legacy markdown
+ * One ancestor block in the affiliation chain. `type` is the markdown
  * block type; the remaining fields carry the list-context the desktop menu
- * needs. Shape parity with muyajs's affiliation entries.
+ * needs.
  */
 export interface IAffiliationEntry {
-    /** Legacy markdown block type: `p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`. */
+    /** Markdown block type: `p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`. */
     type: string;
     /** Engine block name (`bullet-list`, `code-block`, …) for callers that want the precise block. */
     blockName: string;
@@ -111,15 +109,15 @@ export interface IAffiliationEntry {
 
 /**
  * Per-endpoint block info for one selection end. `type` is always `span` for a
- * content leaf (parity with muyajs's content-block `type`); `functionType`
- * distinguishes code / table-cell / language-input content.
+ * content leaf; `functionType` distinguishes code / table-cell / language-input
+ * content.
  */
 export interface IEndpointBlockInfo {
     /** Engine block name of the content leaf, e.g. `codeblock.content`. */
     blockName: string;
-    /** Legacy content-block type — always `span` for a content leaf. */
+    /** Content-block type — always `span` for a content leaf. */
     type: string;
-    /** Legacy `functionType`: `codeContent` | `cellContent` | `languageInput` | `paragraphContent`. */
+    /** `functionType`: `codeContent` | `cellContent` | `languageInput` | `paragraphContent`. */
     functionType?: string;
 }
 
@@ -182,8 +180,7 @@ function _buildEntry(block: Parent, type: string): IAffiliationEntry {
 /**
  * Walk from a content leaf up to the outermost block, collecting the
  * paragraph-type ancestor blocks. Ordered outermost-first (top block → … →
- * leaf's container), matching muyajs where `affiliation[0]` is the enclosing
- * list and deeper entries follow.
+ * leaf's container).
  */
 function _ancestorBlocks(leaf: Content | null): Parent[] {
     const blocks: Parent[] = [];
@@ -215,8 +212,7 @@ export function buildAffiliation(leaf: Content | null): IAffiliationEntry[] {
 /**
  * Compute the shared-ancestor affiliation for a selection. When both endpoints
  * sit in the same block the anchor chain is returned; otherwise the chain is
- * trimmed to the ancestor block instances shared by both endpoints (parity
- * with muyajs's `startParents.filter(p => endParents.includes(p))`).
+ * trimmed to the ancestor block instances shared by both endpoints.
  */
 export function buildSelectionAffiliation(
     anchorLeaf: Content | null,

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -174,7 +174,7 @@ class Selection {
         } = this;
         const { tableSelection } = this.muya.editor;
 
-        // Table escalation, mirroring legacy `selectAll`:
+        // Table escalation:
         //   whole table frozen → clear + select the whole document.
         //   single cell frozen → select the whole table.
         if (tableSelection.isWholeTableSelected()) {
@@ -380,7 +380,7 @@ class Selection {
             selectedImage,
         } = this;
 
-        // Backport of marktext's `selectionChange` payload extras the desktop
+        // The `selectionChange` payload extras the desktop
         // relies on: `cursorCoords` for typewriter-mode scrolling and the
         // active inline formats at the cursor for lighting up the toolbar.
         // Follow the caret (focus end) for forward selections so typewriter
@@ -396,8 +396,8 @@ class Selection {
                 ? anchorBlockRef.getFormatsInRange().formats
                 : [];
 
-        // PARITY (gap PG1): re-derive the legacy `selectionChange` block-context
-        // the desktop Paragraph/Format menu state builder consumes —
+        // Block-context the desktop Paragraph/Format menu state builder
+        // consumes —
         // `affiliation` is the shared ancestor PARAGRAPH-type chain, and the
         // per-endpoint `{ type, functionType }` describe the content leaves
         // (`type: 'span'`, `functionType: 'codeContent' | 'cellContent' | …`).
@@ -619,26 +619,25 @@ class Selection {
         // image click (`_handleClickInlineImage`) and is cleared on ANY
         // document click (`docHandlerClick`) and on every delete/preview here.
         // So this handler is inert unless the user has an image actively
-        // selected inside this editor — matching the legacy muyajs behavior.
+        // selected inside this editor.
         if (!selectedImage)
             return;
 
-        // marktext (#2816 era): pressing Space with an image selected asks the
-        // host to open the full-screen preview. Mirror the legacy `keyboard.js`
-        // emit (`preview-image` { data: src }) and resolve the src the same way
-        // the Cmd/Ctrl-click path does, so relative / file paths become
-        // loadable URLs. `preventDefault` stops the native space from being
-        // inserted next to the selected image.
+        // Pressing Space with an image selected asks the host to open the
+        // full-screen preview, resolving the src the same way the Cmd/Ctrl-click
+        // path does so relative / file paths become loadable URLs.
+        // `preventDefault` stops the native space from being inserted next to
+        // the selected image.
         if (key === ' ') {
             event.preventDefault();
             this._previewSelectedImage(selectedImage);
             return;
         }
 
-        // marktext ed1b3354 (#2816): `Delete` was missing from the
-        // image-selected key set, so it fell through to native contenteditable
-        // handling and removed the text *after* the image. Match key exactly
-        // to avoid substring-collisions like `BackspaceX`.
+        // `Delete` was missing from the image-selected key set, so it fell
+        // through to native contenteditable handling and removed the text
+        // *after* the image. Match key exactly to avoid substring-collisions
+        // like `BackspaceX`.
         if (/^(?:Backspace|Delete|Enter)$/.test(key)) {
             event.preventDefault();
             const { block, ...imageInfo } = selectedImage;
@@ -648,11 +647,9 @@ class Selection {
     };
 
     // Resolve the selected image's src and ask the host to full-screen
-    // preview it. Mirrors the legacy `preview-image` { data: src } payload so
-    // the desktop renderer's existing subscription opens `SimpleImageViewer`.
-    // Resolution matches the Cmd/Ctrl-click path: prefer the token src
-    // (run through `getImageSrc` so relative / file paths become loadable),
-    // and fall back to the rendered <img>'s own `src` attribute.
+    // preview it. Resolution: prefer the token src (run through `getImageSrc`
+    // so relative / file paths become loadable), and fall back to the rendered
+    // <img>'s own `src` attribute.
     private _previewSelectedImage(selectedImage: NonNullable<Selection['selectedImage']>) {
         const { token, imageId } = selectedImage;
         const tokenSrc = token.src || token.attrs.src || '';

--- a/packages/muya/src/selection/offsetCursor.ts
+++ b/packages/muya/src/selection/offsetCursor.ts
@@ -1,15 +1,7 @@
 // Index-cursor → block-key cursor conversion for the source-code → WYSIWYG
-// handoff.
-//
-// PARITY (gap PG2): when the desktop app switches a tab back from source-code
-// mode to WYSIWYG, the only cursor it holds is a CodeMirror `{ line, ch }`
-// offset pair (`muyaIndexCursor`). Legacy `packages/muyajs` translated that
-// into a real block-key cursor by injecting sentinel strings into the markdown
-// at the line/ch offsets, re-parsing, and walking the block tree to find which
-// block's text the sentinels landed in (`addCursorToMarkdown` +
-// `convertMuyaIndexCursortoCursor`). `@muyajs/core` had no equivalent, so the
-// WYSIWYG caret was lost on the handoff. This module reproduces that mapping by
-// resolving the offsets against the live block tree.
+// handoff. The desktop app hands back only a CodeMirror `{ line, ch }` offset
+// pair when switching a tab from source mode to WYSIWYG; this resolves those
+// offsets against the live block tree to recover the caret's block-key cursor.
 
 import type Content from '../block/base/content';
 import type { ScrollPage } from '../block/scrollPage';
@@ -30,10 +22,9 @@ export interface IIndexCursor {
 
 // Sentinel strings injected at the cursor offsets. They must be improbable in
 // real markdown AND survive the markdown -> state round-trip as literal text.
-// (The legacy engine used private-use-area code points, but this engine's
-// markdown parser strips non-ASCII control/PUA characters, so the markers are
-// plain ASCII with a long random-looking token unlikely to occur in real
-// documents.) The two markers share no common substring so neither can be
+// The markdown parser strips non-ASCII control/PUA characters, so the markers
+// are plain ASCII with a long random-looking token unlikely to occur in real
+// documents. The two markers share no common substring so neither can be
 // found inside the other.
 const ANCHOR_SENTINEL = 'mUyAcUrSoRzZqAnChOr9x7kPvWb';
 const FOCUS_SENTINEL = 'mUyAcUrSoRzZqFoCuS4t2nDhGj';
@@ -133,8 +124,7 @@ function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit |
  * (the sentinels only change text), so the paths stay valid.
  *
  * The returned offsets are sentinel-free: the focus offset is decremented when
- * the anchor sentinel precedes it in the same block, mirroring the legacy
- * two-sentinel bookkeeping.
+ * the anchor sentinel precedes it in the same block.
  */
 export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
     const anchorHit = _findSentinel(scrollPage, ANCHOR_SENTINEL);
@@ -168,15 +158,8 @@ export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
     };
 }
 
-// ---------------------------------------------------------------------------
-// INVERSE direction: WYSIWYG block-key selection -> source `{ line, ch }`
-// index cursor. The mirror of the index->path conversion above (PARITY gap
-// PG2 / Phase G — G7). Legacy muyajs computed this in
-// `ContentState.getMuyaIndexCursor` (block-path -> {line,ch} via sentinels +
-// ExportMarkdown) and emitted it on every change so the desktop could open
-// source-code mode at the same caret. `@muyajs/core` only shipped the WRITE
-// direction; this re-adds the READ direction reusing the same serialize path.
-// ---------------------------------------------------------------------------
+// INVERSE direction: WYSIWYG block-key selection -> source `{ line, ch }` index
+// cursor, reusing the same sentinel/serialize path as the forward conversion.
 
 /**
  * Walk a (cloned) state tree along a content block's json1 `path` — which ends

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -11,8 +11,8 @@ import { getHighlightHtml } from '../utils/marked';
 import { generateGithubSlug } from '../utils/slug';
 
 // Core stylesheets inlined into the exported document so the output is fully
-// self-contained and renders offline / behind CSP / air-gapped — matching the
-// legacy `packages/muyajs` `ExportHtml` behavior (PG7). Linking these from a
+// self-contained and renders offline / behind CSP / air-gapped. Linking these
+// from a
 // CDN left a saved `.html` file unstyled with no network access, a regression
 // for an offline desktop editor. Callers that explicitly want the lighter
 // CDN-linked shell can opt in via `generate({ inlineStyles: false })`.
@@ -133,7 +133,7 @@ export class MarkdownToHtml {
     // deduplicated by incrementing a `-N` suffix until the *full* candidate id
     // is unused — so a later heading whose text already looks like an earlier
     // `-N` slug (e.g. `heading`, `heading`, `heading-1`) still resolves to a
-    // unique anchor, matching github / the legacy muyajs Slugger.
+    // unique anchor, matching github.
     private _injectHeadingIds(container: HTMLElement) {
         const headings = container.querySelectorAll('h1, h2, h3, h4, h5, h6');
         const seen = new Set<string>();
@@ -184,7 +184,7 @@ export class MarkdownToHtml {
 
         // Inject github-compatible slug ids onto exported headings so the
         // exported document's [TOC] / `getHtmlToc` `href="#slug"` anchors
-        // resolve (PG8). Scoped to this export DOM path — the conformance
+        // resolve. Scoped to this export DOM path — the conformance
         // renderer (`renderToStaticHTML`) is deliberately left untouched.
         this._injectHeadingIds(exportContainer);
 

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -46,8 +46,6 @@ export interface IMuyaOptions {
      * and returns a non-empty path with an image extension, muya inserts that
      * path as an inline image at the cursor instead of running the default
      * text/HTML paste. Return `''` to fall through to the normal paste flow.
-     *
-     * Ported from the legacy `@muyajs` `clipboardFilePath` option.
      */
     clipboardFilePath?: () => Promise<string>;
     /**
@@ -55,15 +53,13 @@ export interface IMuyaOptions {
      * document's assets folder, upload to an image host, or keep the path) and
      * resolve to the src that should be written into the document.
      *
-     * Invoked on paste — both when a clipboard FILE path is resolved (PG06)
-     * and when an in-memory bitmap is read from `clipboardData` (PG05) — by
-     * the image-edit toolbar, and by the drag-and-drop image handler (PG04),
-     * so a dropped local image file is persisted exactly like one inserted
-     * through the toolbar. `src` is an absolute local path (or a `data:` URL
-     * for a freshly pasted bitmap). Returning the original `src` keeps the
-     * path as-is; omitting the hook uses the raw `src` verbatim.
-     *
-     * Ported from the legacy `@muyajs` `imageAction` option.
+     * Invoked on paste — both when a clipboard FILE path is resolved and when
+     * an in-memory bitmap is read from `clipboardData` — by the image-edit
+     * toolbar, and by the drag-and-drop image handler, so a dropped local image
+     * file is persisted exactly like one inserted through the toolbar. `src` is
+     * an absolute local path (or a `data:` URL for a freshly pasted bitmap).
+     * Returning the original `src` keeps the path as-is; omitting the hook uses
+     * the raw `src` verbatim.
      */
     imageAction?: (state: IImageActionState) => Promise<string>;
     /**
@@ -73,8 +69,6 @@ export interface IMuyaOptions {
      * path; only the embedder (e.g. Electron's `webUtils.getPathForFile`)
      * can resolve it. Provide this hook to enable dropping a local image
      * file into the document. Return `''` when no path is available.
-     *
-     * Ported from the legacy `@muyajs` direct `webUtils.getPathForFile` call.
      */
     getPathForFile?: (file: File) => string;
 }

--- a/packages/muya/src/types/global.d.ts
+++ b/packages/muya/src/types/global.d.ts
@@ -7,7 +7,7 @@ declare global {
         MUYA_VERSION: string;
         // Absolute directory of the document currently open in the host
         // (desktop) app. `getImageSrc` reads it to anchor relative local
-        // image paths, mirroring legacy muyajs `getImageInfo`. Undefined in
+        // image paths. Undefined in
         // non-desktop / headless contexts (the resolver then leaves relative
         // paths untouched rather than producing a broken `file://`).
         DIRNAME?: string;

--- a/packages/muya/src/ui/imageEditTool/index.ts
+++ b/packages/muya/src/ui/imageEditTool/index.ts
@@ -35,8 +35,8 @@ type Options = {
     /**
      * Local image path autocomplete hook. Given the current src input value,
      * returns a list of path suggestions to show in the floating
-     * {@link ImagePathPicker}. Mirrors the legacy `imagePathAutoComplete`
-     * option — typically backed by a filesystem directory listing.
+     * {@link ImagePathPicker}, typically backed by a filesystem directory
+     * listing.
      */
     imagePathAutoComplete?: (src: string) => Promise<IImagePathSuggestion[]>;
     /** Image upload action handler */
@@ -231,7 +231,7 @@ export class ImageEditTool extends BaseFloat {
      * Handle keydown on the src input.
      * When the autocomplete picker is open, arrow keys / Tab / Enter drive the
      * picker (navigate + choose) instead of confirming. Otherwise Enter
-     * confirms the change, mirroring the legacy `srcInputKeyDown` behavior.
+     * confirms the change.
      * @param event - Keyboard event
      */
     private _handleSrcKeyDown(event: Event) {
@@ -307,8 +307,7 @@ export class ImageEditTool extends BaseFloat {
             : null;
 
         // Write the chosen suggestion back into the src input. The new value is
-        // the directory portion of the current path plus the chosen basename,
-        // matching the legacy ImageSelector autocomplete UX.
+        // the directory portion of the current path plus the chosen basename.
         const cb = (item: IImagePathSuggestion) => {
             if (!reference)
                 return;

--- a/packages/muya/src/ui/imagePicker/index.ts
+++ b/packages/muya/src/ui/imagePicker/index.ts
@@ -39,8 +39,7 @@ const defaultOptions = {
 
 /**
  * Floating autocomplete dropdown that suggests local image file paths as the
- * user edits an image's `src` in the {@link ImageEditTool}. It is a faithful
- * port of the legacy `packages/muyajs/lib/ui/imagePicker` plugin: it listens
+ * user edits an image's `src` in the {@link ImageEditTool}. It listens
  * for the `muya-image-picker` event, renders a scrollable filtered list, and
  * supports arrow-key navigation plus Enter/click to choose. The chosen path is
  * written back through the callback supplied in the event payload.
@@ -84,8 +83,7 @@ export class ImagePathPicker extends BaseScrollFloat {
         const { renderArray, _oldVNode: oldVNode, scrollElement, activeItem } = this;
         const children = renderArray.map((item, index) => {
             const { text, iconClass } = item;
-            // Icons are font-icon classes (parity placeholder for the legacy
-            // inline SVGs — see PR notes). When the host omits `iconClass` we
+            // Icons are font-icon classes. When the host omits `iconClass` we
             // simply render the text without an icon.
             const iconContent = iconClass
                 ? [h('div.icon-wrapper', h(`span.${iconClass}`))]

--- a/packages/muya/src/ui/linkTools/index.ts
+++ b/packages/muya/src/ui/linkTools/index.ts
@@ -56,9 +56,9 @@ class LinkTools extends BaseFloat {
         this.options = opts;
         const linkContainer = (this.linkContainer = document.createElement('div'));
         this.container!.appendChild(linkContainer);
-        // Mirrors the per-instance hook ImageToolBar adds on its floatBox so
-        // the parent `.mu-float-wrapper` is identifiable in DOM and reachable
-        // by `.mu-float-wrapper.mu-link-tools-container { … }` selectors.
+        // Add a per-instance class on the floatBox so the parent
+        // `.mu-float-wrapper` is identifiable in DOM and reachable by
+        // `.mu-float-wrapper.mu-link-tools-container { … }` selectors.
         this.floatBox!.classList.add('mu-link-tools-container');
         this.listen();
     }

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -37,8 +37,7 @@ const debug = logger('quickInsert:');
 
 /**
  * Derive the frontmatter `lang`/`style` from the user's `frontmatterType`
- * preference, mirroring legacy muyajs `handleFrontMatter`
- * (contentState/paragraphCtrl.js): `-` -> yaml `---`, `+` -> toml `+++`,
+ * preference: `-` -> yaml `---`, `+` -> toml `+++`,
  * `;`/`{` -> json (`;;;`/`{}`). The serializer (`serializeFrontMatter`)
  * switches on `lang`, so getting `lang` right is what makes YAML/TOML emit
  * their fences instead of falling through to JSON braces.
@@ -58,8 +57,8 @@ export function frontmatterMeta(frontmatterType: string): IFrontmatterMeta {
 }
 
 /**
- * Prepend a front matter block at the very start of the document, mirroring
- * legacy muyajs `handleFrontMatter`. Front matter is only valid as the first
+ * Prepend a front matter block at the very start of the document. Front matter
+ * is only valid as the first
  * block, so this never replaces the block at the cursor. Idempotent: a no-op
  * when the document already starts with front matter, so it never duplicates
  * the block. Shared by `Muya.updateParagraph('front-matter')` and the
@@ -418,8 +417,7 @@ export function getLabelFromEvent(event: Event) {
 }
 
 /**
- * Show the in-editor table grid picker, porting legacy muyajs
- * `paragraphCtrl.showTablePicker`. The in-editor "table" insert (the `/`
+ * Show the in-editor table grid picker. The in-editor "table" insert (the `/`
  * quick-insert menu and the paragraph front-menu) must offer a hover-grid
  * dimension picker rather than dropping a fixed-size table — the picker UI
  * (`TableChessboard`) subscribes to `muya-table-picker` and invokes the
@@ -470,7 +468,7 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
     }
 
     // The in-editor "table" insert shows a hover-grid dimension picker
-    // (legacy muyajs `showTablePicker`) instead of dropping a fixed-size
+    // instead of dropping a fixed-size
     // table. The picker's callback creates the table at the chosen size, so
     // bail before the in-place empty-table replacement below.
     if (label === 'table') {

--- a/packages/muya/src/ui/tableColumnToolbar/index.ts
+++ b/packages/muya/src/ui/tableColumnToolbar/index.ts
@@ -152,8 +152,8 @@ export class TableColumnToolbar extends BaseFloat {
 
         switch (item.type) {
             case 'remove': {
-                // Marktext 6293d408 (#572) backport: removeColumn now returns
-                // a content block to re-anchor the caret on (inside the table
+                // removeColumn returns a content block to re-anchor the caret
+                // on (inside the table
                 // if columns remain, outside the table if the whole table was
                 // removed). Without this setCursor the caret stays in the
                 // detached cell.

--- a/packages/muya/src/ui/tableRowColumMenu/index.ts
+++ b/packages/muya/src/ui/tableRowColumMenu/index.ts
@@ -119,8 +119,8 @@ export class TableRowColumMenu extends BaseFloat {
                 cursorBlock.setCursor(0, 0);
         }
         else {
-            // Marktext 6293d408 (#572) backport: after a row/column delete,
-            // the caret used to live inside a now-detached cell. The table
+            // After a row/column delete, the caret used to live inside a
+            // now-detached cell. The table
             // mutators now return a surviving neighbour cell's content so we
             // can re-anchor the caret on a still-attached cell.
             const cursorBlock = target === 'row'

--- a/packages/muya/src/utils/diagram/sequence/index.ts
+++ b/packages/muya/src/utils/diagram/sequence/index.ts
@@ -3,7 +3,6 @@ import './sequence-diagram.css';
 
 // Vendored `js-sequence-diagrams` (bramp, BSD) wired to render via snap.svg.
 // The upstream `js-sequence-diagrams` npm package is a dead security-holder
-// placeholder, so the legacy muyajs engine vendored the library source. We do
-// the same here to keep feature parity. The exported `Diagram` exposes
-// `parse(code)` returning an object with `drawSVG(container, { theme })`.
+// placeholder, so the library source is vendored here. The exported `Diagram`
+// exposes `parse(code)` returning an object with `drawSVG(container, { theme })`.
 export default Diagram;

--- a/packages/muya/src/utils/getLinkInfo.ts
+++ b/packages/muya/src/utils/getLinkInfo.ts
@@ -1,8 +1,7 @@
 // Extract the `linkInfo` payload that the linkTools popover hands back to
 // `contentState.unlink` / `options.jumpClick`.
 //
-// Port of marktext `src/muya/lib/utils/getLinkInfo.js` (commit cb25b3d4,
-// #1415). The new repo's link renderers (`link.ts`, `referenceLink.ts`,
+// The link renderers (`link.ts`, `referenceLink.ts`,
 // `htmlTag.ts`) all emit `dataset.{start,end,raw}` on the rendered link
 // wrapper plus an `href` — markdown `[]()` via snabbdom `props.href`
 // (DOM property on the `<span>`), HTML `<a>` and reference link via real

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -27,8 +27,7 @@ export function getImageInfo(image: HTMLElement): IImageInfo {
 
 // A local image path that is already anchored to a filesystem root:
 // POSIX (`/foo`), Windows UNC (`\\host\share`), or a drive letter
-// (`C:\foo` / `C:/foo`). Mirrors legacy muyajs `getImageInfo`'s
-// `isAbsoluteLocal` check so absolute paths are NOT resolved against the
+// (`C:\foo` / `C:/foo`), so absolute paths are NOT resolved against the
 // document directory.
 const ABSOLUTE_LOCAL_REG = /^(?:\/|\\\\|[a-z]:\\|[a-z]:\/).+/i;
 
@@ -81,11 +80,10 @@ export function getImageSrc(src: string) {
     const isUrl = URL_REG.test(src) || (imageExtension && isFileUrl);
     if (imageExtension) {
         const isAbsoluteLocal = ABSOLUTE_LOCAL_REG.test(src);
-        // Anchor a relative local path to the document directory, mirroring
-        // legacy muyajs `getImageInfo(src, baseUrl = window.DIRNAME)`. The
+        // Anchor a relative local path to the document directory. The
         // engine runs in the host renderer where `window.DIRNAME` tracks the
         // current document's directory; when it is absent (headless / no open
-        // file) we fall back to the legacy `file://${src}` form.
+        // file) we fall back to the `file://${src}` form.
         const baseUrl
             = typeof window !== 'undefined' ? window.DIRNAME : undefined;
         if (isUrl) {

--- a/packages/muya/src/utils/marked/extensions/cjkEmStrong.ts
+++ b/packages/muya/src/utils/marked/extensions/cjkEmStrong.ts
@@ -1,7 +1,6 @@
 import type { MarkedExtension, TokenizerObject, Tokens } from 'marked';
 
-// NON-STANDARD EXTENSION — a deliberate divergence from CommonMark, ported
-// from the legacy muyajs tokenizer (packages/muyajs/lib/parser/utils.js).
+// NON-STANDARD EXTENSION — a deliberate divergence from CommonMark.
 //
 // CommonMark §6.2 only counts Unicode whitespace and Unicode punctuation as
 // emphasis flanking boundaries. CJK ideographs / Hangul / Kana are Lo
@@ -12,8 +11,8 @@ import type { MarkedExtension, TokenizerObject, Tokens } from 'marked';
 // But CJK scripts do not use spaces between words, so that rule denies
 // emphasis to virtually any CJK paragraph that wraps the `**` run with
 // punctuation (quotes, parentheses, brackets, …). Typora, VSCode
-// markdownlint, Joplin and most CJK-oriented Markdown tools — and the legacy
-// muyajs engine MarkText shipped — widen the flanking check so CJK counts as
+// markdownlint, Joplin and most CJK-oriented Markdown tools widen the flanking
+// check so CJK counts as
 // a boundary. This extension restores that behavior for the marked-based
 // static / export render path.
 //
@@ -23,7 +22,7 @@ import type { MarkedExtension, TokenizerObject, Tokens } from 'marked';
 //
 // Tracking: marktext/marktext#4307.
 
-// CJK ranges treated as punctuation for flanking (matches legacy CJK_REG):
+// CJK ranges treated as punctuation for flanking:
 //   U+3040–U+30FF  Hiragana + Katakana
 //   U+3400–U+4DBF  CJK Unified Ideographs Extension A
 //   U+4E00–U+9FFF  CJK Unified Ideographs

--- a/packages/muya/src/utils/marked/extensions/footnote.ts
+++ b/packages/muya/src/utils/marked/extensions/footnote.ts
@@ -12,10 +12,8 @@ interface IFootnoteRendererThis {
     parser?: { parse: (toks: Tokens.Generic[]) => string };
 }
 
-// Block-level rule for footnote definitions. Mirrors marktext's
-// src/muya/lib/parser/marked/blockRules.js after commit 1ecc3601, but
-// applied at the start of the marked tokenizer's remaining source rather
-// than the legacy parser's per-line buffer.
+// Block-level rule for footnote definitions, applied at the start of the
+// marked tokenizer's remaining source rather than against a per-line buffer.
 //
 // The `(?<!\\)` lookbehind in front of the closing `]` lets users escape
 // the bracket — `[^foo\]: bar` stays a paragraph instead of becoming a

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -23,8 +23,8 @@ export async function getPageTitle(url: string) {
             return '';
 
         // The response is HTML — read it as text and pluck `<title>`.
-        // Pre-fix this called `res.json()`, which always threw and made
-        // the helper silently return '' (marktext 141d25d8 / #1344).
+        // Reading it as `res.json()` would always throw and make the helper
+        // silently return ''.
         const body = await res.text();
         const match = body.match(/<title>([\s\S]*?)<\/title>/i);
 
@@ -115,8 +115,8 @@ export async function normalizePastedHTML(html: string) {
 
 // Sniffs whether `text` looks like a single HTML `<table>` blob and nothing
 // else (no surrounding prose, no sibling root element). The regex match is
-// followed by a parse + `childElementCount === 1` check (legacy
-// `pasteCtrl.checkCopyType`), so a payload whose greedy regex spans two sibling
+// followed by a parse + `childElementCount === 1` check, so a payload whose
+// greedy regex spans two sibling
 // tables falls through to the normal HTML→Markdown path. Some clipboard sources
 // (notably Apple Numbers, marktext #1271) put raw HTML into `text/plain` with
 // no `text/html` flavour; the paste handler promotes such text into the html
@@ -131,8 +131,7 @@ export function isStandaloneTableHtml(text: string) {
         return false;
 
     // The greedy regex above also matches two sibling `<table>`s, so parse the
-    // blob into a temporary container and require exactly one root element
-    // (legacy `pasteCtrl.checkCopyType`'s `tmp.childElementCount === 1` guard).
+    // blob into a temporary container and require exactly one root element.
     if (typeof document === 'undefined')
         return true;
 
@@ -148,8 +147,7 @@ export function isStandaloneTableHtml(text: string) {
  * Returns the resolved path only when the hook yields a non-empty string that
  * looks like an image file (its extension matches {@link IMAGE_EXT_REG});
  * otherwise returns `''` so the caller falls through to the normal text/HTML
- * paste. Ported from the legacy `@muyajs` `pasteImage` guard, which inserted
- * the resolved path as an image when it matched the same extension regex.
+ * paste.
  *
  * @param hook the `options.clipboardFilePath` callback, if configured
  */
@@ -170,12 +168,10 @@ export async function resolveClipboardImagePath(
 /**
  * Extract an in-memory image `File` from a paste `DataTransfer`.
  *
- * Covers the bitmap clipboard case (PG05): screenshots and browser
+ * Covers the bitmap clipboard case: screenshots and browser
  * "Copy Image" put image bytes — not a file path — on the clipboard. We
  * prefer `clipboardData.files` and fall back to scanning `clipboardData.items`
  * for the first `image/*` entry. Returns `null` when no image is present.
- *
- * Ported from the legacy `@muyajs` `pasteImage` `items[i].getAsFile()` snapshot.
  */
 export function getClipboardImageFile(
     clipboardData: DataTransfer | null,
@@ -208,9 +204,9 @@ export function getClipboardImageFile(
 /**
  * Read a `File`/`Blob` as a base64 `data:` URL.
  *
- * Used to turn a pasted bitmap (PG05) into a `data:` URL that the embedder's
+ * Used to turn a pasted bitmap into a `data:` URL that the embedder's
  * `imageAction` can persist. Prefers the native {@link FileReader}
- * (`readAsDataURL`), matching the legacy `@muyajs` path and covering the
+ * (`readAsDataURL`), covering the
  * `chrome70` build target where `Blob.arrayBuffer()` is unavailable; falls
  * back to `Blob.arrayBuffer()` + `btoa` where `FileReader` is absent (e.g. the
  * Node test environment). Resolves to `''` on read error.

--- a/packages/muya/src/utils/slug.ts
+++ b/packages/muya/src/utils/slug.ts
@@ -1,7 +1,5 @@
-// Mirrors marktext's `generateGithubSlug` from `src/muya/lib/utils/url.js`
-// (referenced verbatim by PR-15). The regex uses ASCII `\w`, so CJK and
-// emoji collapse to hyphens — same as marktext. A Unicode-aware variant
-// would be a separate, opt-in change.
+// The regex uses ASCII `\w`, so CJK and emoji collapse to hyphens. A
+// Unicode-aware variant would be a separate, opt-in change.
 export function generateGithubSlug(text: string): string {
     return text
         .trim()


### PR DESCRIPTION
## What

Removes the redundant comments that accumulated across `packages/muya/src/` while porting features from the legacy `packages/muyajs` engine into `@muyajs/core`.

The cleanup is **comment-only** — no code lines change (verified with a comment-only diff check). Net −97 lines across 41 files.

## What was removed

- **Phase / PR markers** — `PARITY (gap PG1)`, `PG05/PG06/PG14`, `Phase G — G7/G8`, etc.
- **Port-provenance lines** — `Ported from the legacy @muyajs X option`, `Port of marktext src/muya/lib/...`, `Backport of marktext <commit>`, `mirrors/matches legacy muyajs X`.
- **Bare commit-hash prefixes** — e.g. `marktext cb7be189 (#1318):` where only the prefix was noise and the actual explanation followed.

## What was kept

Comments that explain genuine non-obvious *why* were preserved, trimmed only of the port framing — e.g. the deliberate CommonMark divergence in the CJK flanking extension, the ASCII-sentinel requirement in the source↔WYSIWYG cursor mapping, the synchronous clipboard-snapshot rationale, and the XSS-escape path in the language-input renderer.

## Commits

Split per subsystem (core, clipboard, selection, editor, block, inlineRenderer, ui, utils+state) for easy review.

## Verification

- `pnpm -C packages/muya lint` — 0 errors (24 pre-existing complexity/naming warnings, unrelated)
- `pnpm -C packages/muya lint:types` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)