### PR TITLE
Change appearance of how front matters are displayed

### DIFF
--- a/packages/muya/e2e/tests/blocks/frontmatter.spec.ts
+++ b/packages/muya/e2e/tests/blocks/frontmatter.spec.ts
@@ -14,13 +14,21 @@ import { editor } from '../helpers/selectors';
  * renders + the markdown round-trip preserves the right delimiter shape.
  */
 
+interface IPropertyRow {
+    name: 'frontmatter.row';
+    key: string;
+    value: string;
+}
+
 interface IStyleCase {
     label: string;
     lang: 'yaml' | 'toml' | 'json';
     style: '-' | '+' | ';' | '{';
-    text: string;
+    properties: IPropertyRow[];
     expectedStart: string;
     expectedEnd: string;
+    expectedKey: string;
+    expectedValue: string;
 }
 
 const STYLE_CASES: IStyleCase[] = [
@@ -28,33 +36,53 @@ const STYLE_CASES: IStyleCase[] = [
         label: 'YAML (---)',
         lang: 'yaml',
         style: '-',
-        text: 'title: hi\nauthor: me',
+        properties: [
+            { name: 'frontmatter.row', key: 'title', value: 'hi' },
+            { name: 'frontmatter.row', key: 'author', value: 'me' },
+        ],
         expectedStart: '---\n',
         expectedEnd: '---\n',
+        expectedKey: 'title',
+        expectedValue: 'hi',
     },
     {
         label: 'TOML (+++)',
         lang: 'toml',
         style: '+',
-        text: 'title = "hi"\nauthor = "me"',
+        properties: [
+            { name: 'frontmatter.row', key: 'title', value: 'hi' },
+            { name: 'frontmatter.row', key: 'author', value: 'me' },
+        ],
         expectedStart: '+++\n',
         expectedEnd: '+++\n',
+        expectedKey: 'title',
+        expectedValue: 'hi',
     },
     {
         label: 'JSON (;;;)',
         lang: 'json',
         style: ';',
-        text: '"title": "hi",\n"author": "me"',
+        properties: [
+            { name: 'frontmatter.row', key: 'title', value: 'hi' },
+            { name: 'frontmatter.row', key: 'author', value: 'me' },
+        ],
         expectedStart: ';;;\n',
         expectedEnd: ';;;\n',
+        expectedKey: 'title',
+        expectedValue: 'hi',
     },
     {
         label: 'JSON ({})',
         lang: 'json',
         style: '{',
-        text: '"title": "hi",\n"author": "me"',
+        properties: [
+            { name: 'frontmatter.row', key: 'title', value: 'hi' },
+            { name: 'frontmatter.row', key: 'author', value: 'me' },
+        ],
         expectedStart: '{\n',
         expectedEnd: '}\n',
+        expectedKey: 'title',
+        expectedValue: 'hi',
     },
 ];
 
@@ -65,7 +93,7 @@ test.describe('frontmatter block', () => {
                 const state: TState[] = [{
                     name: 'frontmatter',
                     meta: { lang: c.lang, style: c.style },
-                    text: c.text,
+                    properties: c.properties,
                 }, {
                     name: 'paragraph',
                     text: 'body',
@@ -73,16 +101,24 @@ test.describe('frontmatter block', () => {
                 window.muya!.setContent(state);
             }, styleCase);
 
-            // The block mounts as `<pre.mu-frontmatter>` wrapping a code block.
+            // The block mounts as `.mu-frontmatter`.
             const fm = page.locator(editor.frontmatter);
             await expect(fm).toBeVisible();
             // Use a sync barrier on the paragraph too — its presence confirms
             // the document loaded fully.
             await expect(page.locator(editor.paragraph).first()).toContainText('body');
 
+            // The Properties header should be visible.
+            await expect(fm.locator('.mu-frontmatter-header')).toBeVisible();
+
+            // Key and value cells should contain the expected text.
+            await expect(fm.locator('.mu-frontmatter-key').first()).toContainText(styleCase.expectedKey);
+            await expect(fm.locator('.mu-frontmatter-value').first()).toContainText(styleCase.expectedValue);
+
             const md = await page.evaluate(() => window.muya!.getMarkdown());
             expect(md.startsWith(styleCase.expectedStart)).toBe(true);
-            expect(md).toContain(styleCase.text);
+            expect(md).toContain(styleCase.expectedKey);
+            expect(md).toContain(styleCase.expectedValue);
             // The closing delimiter immediately precedes the body paragraph.
             expect(md).toContain(styleCase.expectedEnd);
         });

--- a/packages/muya/e2e/tests/helpers/selectors.ts
+++ b/packages/muya/e2e/tests/helpers/selectors.ts
@@ -40,7 +40,6 @@ export const editor = {
     image: '.mu-inline-image',
     inlineFootnoteIdentifier: '.mu-inline-footnote-identifier',
     link: 'span.mu-link, a.mu-reference-link, a.mu-raw-html',
-    // Frontmatter block (renders as a `<pre.mu-frontmatter>` wrapping a code block).
     frontmatter: '.mu-frontmatter',
     // Inline reference link / reference image — see PR-16 regression area.
     referenceLink: 'a.mu-reference-link',

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -184,7 +184,6 @@
 
 /* code block */
 .mu-code-block,
-.mu-frontmatter,
 .mu-html-container,
 .mu-math-container,
 .mu-diagram-container {
@@ -760,10 +759,130 @@ figure.mu-math-block span.mu-codeblock-content:first-of-type:empty::after {
     content: attr(math);
 }
 
-pre.mu-frontmatter span.mu-codeblock-content:first-of-type:empty::after {
-    color: var(--editor-color-30);
+/* frontmatter properties table */
+.mu-frontmatter {
+    position: relative;
 
-    content: attr(frontMatter);
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+    padding: 0;
+
+    border: 1px solid var(--editor-color-10);
+    border-radius: 4px;
+    background: var(--code-block-bg-color);
+    overflow: hidden;
+}
+
+.mu-frontmatter-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--editor-color-50);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+    user-select: none;
+
+    border-bottom: 1px solid var(--editor-color-10);
+    background: var(--code-block-bg-color);
+}
+
+.mu-frontmatter-toggle {
+    display: inline-block;
+    transition: transform 0.15s ease;
+    transform: rotate(90deg);
+    font-size: 10px;
+}
+
+.mu-collapsed .mu-frontmatter-toggle {
+    transform: rotate(0deg);
+}
+
+.mu-frontmatter-body {
+    display: grid;
+    grid-template-columns: 24px max-content 1fr;
+    width: 100%;
+}
+
+/* display:contents makes the row transparent to the grid so all cells share
+   the same column tracks — this is what gives the key column a uniform width
+   sized to the longest key string. */
+.mu-frontmatter-row {
+    display: contents;
+}
+
+.mu-frontmatter-drag-handle {
+    display: flex;
+    align-items: flex-start;
+    padding: 7px 4px 6px 8px;
+    color: var(--editor-color-20);
+    font-size: 10px;
+    cursor: grab;
+    user-select: none;
+    border-bottom: 1px solid var(--editor-color-10);
+}
+
+.mu-frontmatter-key,
+.mu-frontmatter-value {
+    display: block;
+    padding: 4px 8px;
+    font-size: 14px;
+    font-family: 'DejaVu Sans Mono', 'Source Code Pro', 'Droid Sans Mono', Consolas, monospace;
+    outline: none;
+    word-break: break-word;
+    white-space: pre-wrap;
+    min-height: 1.4em;
+    border-bottom: 1px solid var(--editor-color-10);
+}
+
+.mu-frontmatter-key {
+    white-space: nowrap;
+    color: var(--editor-color-50);
+    font-weight: 500;
+    border-right: 1px solid var(--editor-color-10);
+}
+
+.mu-frontmatter-value {
+    color: var(--editor-color);
+}
+
+.mu-frontmatter-row:last-child .mu-frontmatter-drag-handle,
+.mu-frontmatter-row:last-child .mu-frontmatter-key,
+.mu-frontmatter-row:last-child .mu-frontmatter-value {
+    border-bottom: none;
+}
+
+.mu-frontmatter-footer {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+
+    font-size: 13px;
+    color: var(--editor-color-30);
+    cursor: pointer;
+    user-select: none;
+
+    border-top: 1px solid var(--editor-color-10);
+}
+
+.mu-frontmatter-footer:hover {
+    color: var(--editor-color-50);
+    background: var(--code-block-bg-color);
+}
+
+.mu-frontmatter-add-icon {
+    font-size: 16px;
+    line-height: 1;
+}
+
+.mu-collapsed .mu-frontmatter-body,
+.mu-collapsed .mu-frontmatter-footer {
+    display: none;
 }
 
 /* code html math ...code block style */

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -856,6 +856,18 @@ figure.mu-math-block span.mu-codeblock-content:first-of-type:empty::after {
     border-bottom: none;
 }
 
+.mu-frontmatter-row.mu-drop-above .mu-frontmatter-drag-handle,
+.mu-frontmatter-row.mu-drop-above .mu-frontmatter-key,
+.mu-frontmatter-row.mu-drop-above .mu-frontmatter-value {
+    border-top: 2px solid var(--editor-color-50);
+}
+
+.mu-frontmatter-row.mu-drop-below .mu-frontmatter-drag-handle,
+.mu-frontmatter-row.mu-drop-below .mu-frontmatter-key,
+.mu-frontmatter-row.mu-drop-below .mu-frontmatter-value {
+    border-bottom: 2px solid var(--editor-color-50);
+}
+
 .mu-frontmatter-footer {
     display: flex;
     align-items: center;

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -4,7 +4,6 @@ import type {
     CodeContentState,
     ICodeBlockState,
     IDiagramState,
-    IFrontmatterState,
 } from '../../../state/types';
 import type Code from '../../commonMark/codeBlock/code';
 import type HTMLPreview from '../../commonMark/html/htmlPreview';
@@ -77,8 +76,8 @@ const LANG_HASH = {
 
 function hasStateMeta(
     state: CodeContentState,
-): state is ICodeBlockState | IDiagramState | IFrontmatterState {
-    return /code-block|diagram|frontmatter/.test(state.name);
+): state is ICodeBlockState | IDiagramState {
+    return /code-block|diagram/.test(state.name);
 }
 
 class CodeBlockContent extends Content {
@@ -109,7 +108,7 @@ class CodeBlockContent extends Content {
     get outContainer() {
         const { codeContainer } = this;
 
-        return /code-block|frontmatter/.test(codeContainer!.blockName)
+        return codeContainer?.blockName === 'code-block'
             ? codeContainer
             : codeContainer!.parent;
     }

--- a/packages/muya/src/block/extra/frontmatter/body.ts
+++ b/packages/muya/src/block/extra/frontmatter/body.ts
@@ -35,6 +35,106 @@ class FrontmatterBody extends Parent {
         this.tagName = 'div';
         this.classList = ['mu-frontmatter-body'];
         this.createDomNode();
+        this._setupDragDrop();
+    }
+
+    private _rowFromEl(el: Element | null): FrontmatterRow | null {
+        if (!el) {
+            return null;
+        }
+        let found: FrontmatterRow | null = null;
+        this.forEach((row) => {
+            const r = row as FrontmatterRow;
+            if (found === null && r.domNode?.contains(el)) {
+                found = r;
+            }
+        });
+        return found;
+    }
+
+    private _setupDragDrop(): void {
+        const dom = this.domNode!;
+        let draggedRow: FrontmatterRow | null = null;
+        let dropRow: FrontmatterRow | null = null;
+        let dropBefore = true;
+
+        const clearIndicator = () => {
+            dropRow?.domNode?.classList.remove('mu-drop-above', 'mu-drop-below');
+            dropRow = null;
+        };
+
+        dom.addEventListener('dragstart', (e: DragEvent) => {
+            const target = e.target as Element;
+            if (!target?.classList?.contains('mu-frontmatter-drag-handle')) {
+                return;
+            }
+            const row = this._rowFromEl(target);
+            if (!row) {
+                return;
+            }
+            draggedRow = row;
+            if (e.dataTransfer) {
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', '');
+            }
+        });
+
+        dom.addEventListener('dragend', () => {
+            clearIndicator();
+            draggedRow = null;
+        });
+
+        dom.addEventListener('dragover', (e: DragEvent) => {
+            if (!draggedRow) {
+                return;
+            }
+            e.preventDefault();
+            if (e.dataTransfer) {
+                e.dataTransfer.dropEffect = 'move';
+            }
+
+            const target = this._rowFromEl(e.target as Element);
+            if (!target || target === draggedRow) {
+                return;
+            }
+
+            const cellRect = (e.target as Element).getBoundingClientRect();
+            const newBefore = e.clientY < cellRect.top + cellRect.height / 2;
+
+            if (dropRow !== target || dropBefore !== newBefore) {
+                clearIndicator();
+                dropRow = target;
+                dropBefore = newBefore;
+                target.domNode?.classList.add(newBefore ? 'mu-drop-above' : 'mu-drop-below');
+            }
+        });
+
+        dom.addEventListener('dragleave', (e: DragEvent) => {
+            if (dom.contains(e.relatedTarget as Node)) {
+                return;
+            }
+            clearIndicator();
+        });
+
+        dom.addEventListener('drop', (e: DragEvent) => {
+            e.preventDefault();
+            if (!draggedRow || !dropRow || draggedRow === dropRow) {
+                return;
+            }
+
+            const insertRef = dropBefore
+                ? dropRow
+                : (dropRow.next as FrontmatterRow | null);
+
+            clearIndicator();
+
+            if (insertRef !== draggedRow) {
+                draggedRow.remove('user');
+                this.insertBefore(draggedRow, insertRef, 'user');
+            }
+
+            draggedRow = null;
+        });
     }
 
     override getState(): IFrontmatterState {

--- a/packages/muya/src/block/extra/frontmatter/body.ts
+++ b/packages/muya/src/block/extra/frontmatter/body.ts
@@ -1,0 +1,50 @@
+import type { Muya } from '../../../muya';
+import type { IFrontmatterPropertyState, IFrontmatterState } from '../../../state/types';
+import type { TBlockPath } from '../../types';
+import type FrontmatterRow from './row';
+import { mixins } from '../../../utils';
+import { LinkedList } from '../../base/linkedList/linkedList';
+import Parent from '../../base/parent';
+import IContainerQueryBlock from '../../mixins/containerQueryBlock';
+import { ScrollPage } from '../../scrollPage';
+
+@mixins(IContainerQueryBlock)
+class FrontmatterBody extends Parent {
+    override children: LinkedList<FrontmatterRow> = new LinkedList();
+
+    static override blockName = 'frontmatter.body';
+
+    static create(muya: Muya, state: IFrontmatterState) {
+        const body = new FrontmatterBody(muya);
+
+        body.append(
+            ...state.properties.map(prop =>
+                ScrollPage.loadBlock('frontmatter.row').create(muya, prop),
+            ),
+        );
+
+        return body;
+    }
+
+    override get path(): TBlockPath {
+        return [...this.parent!.path, 'properties'];
+    }
+
+    constructor(muya: Muya) {
+        super(muya);
+        this.tagName = 'div';
+        this.classList = ['mu-frontmatter-body'];
+        this.createDomNode();
+    }
+
+    override getState(): IFrontmatterState {
+        // Should not be called directly — Frontmatter.getState() reads from this.
+        return {
+            name: 'frontmatter',
+            meta: { lang: 'yaml', style: '-' },
+            properties: this.map(row => (row as FrontmatterRow).getState()) as IFrontmatterPropertyState[],
+        };
+    }
+}
+
+export default FrontmatterBody;

--- a/packages/muya/src/block/extra/frontmatter/index.ts
+++ b/packages/muya/src/block/extra/frontmatter/index.ts
@@ -1,101 +1,109 @@
 import type { Muya } from '../../../muya';
-import type { IFrontmatterMeta, IFrontmatterState } from '../../../state/types';
-// import { operateClassName } from '../../../utils/dom'
+import type { IFrontmatterMeta, IFrontmatterPropertyState, IFrontmatterState } from '../../../state/types';
+import type { Nullable } from '../../../types';
+import type Content from '../../base/content';
 import type { TBlockPath } from '../../types';
-import logger from '../../../utils/logger';
-// import { diffToTextOp } from '../../../utils'
-import { loadLanguage } from '../../../utils/prism';
-// import diff from 'fast-diff'
+import type FrontmatterBody from './body';
+import type FrontmatterRow from './row';
+import { operateClassName } from '../../../utils/dom';
 import Parent from '../../base/parent';
 import { ScrollPage } from '../../scrollPage';
 
-const debug = logger('frontmatter:');
-
 class Frontmatter extends Parent {
     public meta: IFrontmatterMeta;
+
+    private _collapsed: boolean = false;
 
     static override blockName = 'frontmatter';
 
     static create(muya: Muya, state: IFrontmatterState) {
         const frontmatter = new Frontmatter(muya, state);
-        const { lang } = state.meta;
-        const code = ScrollPage.loadBlock('code').create(muya, state);
+        const body = ScrollPage.loadBlock('frontmatter.body').create(muya, state);
 
-        frontmatter.append(code);
-
-        if (lang)
-            frontmatter.lang = lang;
+        // appendAttachment sets body.parent and appends body's DOM after the header.
+        frontmatter.appendAttachment(body);
+        // After appending the body, add the footer button to the frontmatter domNode.
+        const footer = document.createElement('div');
+        footer.className = 'mu-frontmatter-footer';
+        footer.setAttribute('contenteditable', 'false');
+        footer.innerHTML = '<span class="mu-frontmatter-add-icon">+</span> Add property';
+        footer.addEventListener('click', () => frontmatter.addProperty());
+        frontmatter.domNode!.appendChild(footer);
 
         return frontmatter;
-    }
-
-    get lang() {
-        return this.meta.lang;
-    }
-
-    set lang(value) {
-        this.meta.lang = value;
-
-        !!value
-        && loadLanguage(value)
-            .then((infoList) => {
-                if (!Array.isArray(infoList))
-                    return;
-                // There are three status `loaded`, `noexist` and `cached`.
-                // if the status is `loaded`, indicated that it's a new loaded language
-                const needRender = infoList.some(
-                    ({ status }) => status === 'loaded' || status === 'cached',
-                );
-                if (needRender)
-                    this.lastContentInDescendant()?.update();
-            })
-            .catch((err) => {
-                // if no parameter provided, will cause error.
-                debug.warn(err);
-            });
     }
 
     override get path() {
         const { path: pPath } = this.parent!;
         const offset = this.parent!.offset(this);
-
         return [...pPath, offset];
     }
 
     constructor(muya: Muya, { meta }: IFrontmatterState) {
         super(muya);
-        this.tagName = 'pre';
+        this.tagName = 'div';
         this.meta = meta;
         this.classList = ['mu-frontmatter'];
         this.createDomNode();
+
+        // Prepend the "Properties" header.
+        const header = document.createElement('div');
+        header.className = 'mu-frontmatter-header';
+        header.setAttribute('contenteditable', 'false');
+        header.innerHTML = '<span class="mu-frontmatter-toggle">›</span><span class="mu-frontmatter-title">Properties</span>';
+        header.addEventListener('click', () => this._toggleCollapse());
+        this.domNode!.appendChild(header);
+    }
+
+    private _toggleCollapse() {
+        this._collapsed = !this._collapsed;
+        operateClassName(this.domNode!, this._collapsed ? 'add' : 'remove', 'mu-collapsed');
+    }
+
+    get body(): Nullable<FrontmatterBody> {
+        return this.attachments.head as Nullable<FrontmatterBody>;
     }
 
     queryBlock(path: TBlockPath) {
-        if (path.length === 0) {
+        if (path.length === 0)
             return this;
+
+        const first = path[0];
+        if (first === 'properties') {
+            path.shift();
+            if (path.length === 0)
+                return this.body;
+            const body = this.body as (Parent & { queryBlock: (p: TBlockPath) => Parent | Content | undefined }) | null;
+            return body?.queryBlock(path);
         }
-        else {
-            if (path[0] === 'meta' || path[0] === 'type') {
-                return this;
-            }
-            else if (path[0] === 'lang') {
-                // TODO is there right?
-                return this.firstContentInDescendant();
-            }
-            else {
-                return this.lastContentInDescendant();
-            }
-        }
+
+        return this;
+    }
+
+    addProperty() {
+        const emptyProp: IFrontmatterPropertyState = {
+            name: 'frontmatter.row',
+            key: '',
+            value: '',
+        };
+        const body = this.body;
+        if (!body)
+            return;
+
+        const newRow = ScrollPage.loadBlock('frontmatter.row').create(this.muya, emptyProp) as FrontmatterRow;
+        body.append(newRow, 'user');
+        newRow.firstContentInDescendant()?.setCursor(0, 0, true);
     }
 
     override getState(): IFrontmatterState {
-        const state: IFrontmatterState = {
+        const body = this.body;
+        return {
             name: 'frontmatter',
             meta: { ...this.meta },
-            text: this.lastContentInDescendant()?.text ?? '',
+            properties: body
+                ? (body.map(row => (row as FrontmatterRow).getState()) as IFrontmatterPropertyState[])
+                : [],
         };
-
-        return state;
     }
 }
 

--- a/packages/muya/src/block/extra/frontmatter/keyContent.ts
+++ b/packages/muya/src/block/extra/frontmatter/keyContent.ts
@@ -1,0 +1,85 @@
+import type { Muya } from '../../../muya';
+import type { ICursor } from '../../../selection/types';
+import type { TBlockPath } from '../../types';
+import Content from '../../base/content';
+
+class FrontmatterKeyContent extends Content {
+    static override blockName = 'frontmatter.key.content';
+
+    static create(muya: Muya, key: string) {
+        return new FrontmatterKeyContent(muya, key);
+    }
+
+    override get path(): TBlockPath {
+        if (this.parent == null)
+            return ['key'];
+        const { path: pPath } = this.parent;
+        return [...pPath, 'key'];
+    }
+
+    constructor(muya: Muya, key: string) {
+        super(muya, key);
+        this.classList = [...this.classList, 'mu-frontmatter-key'];
+        this.createDomNode();
+    }
+
+    override update(cursor?: ICursor) {
+        const { text } = this;
+        this.domNode!.innerHTML = `<span class="mu-syntax-text">${text}</span>`;
+        if (cursor)
+            this.selection.setSelection({ ...cursor, block: this, path: this.path });
+    }
+
+    override inputHandler(_event: Event) {
+        if (this.isComposed)
+            return;
+
+        const textContent = this.domNode!.textContent ?? '';
+        const { start, end } = this.getCursor()!;
+        this.text = textContent;
+        this.setCursor(start.offset, end.offset, true);
+    }
+
+    override enterHandler(event: Event) {
+        event.preventDefault();
+        // Tab from key to value of the same row.
+        const valueContent = this.nextContentInContext();
+        valueContent?.setCursor(0, 0, true);
+    }
+
+    override tabHandler(event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const isShift = 'shiftKey' in event && (event as KeyboardEvent).shiftKey;
+        if (isShift) {
+            const prev = this.previousContentInContext();
+            if (prev)
+                prev.setCursor(prev.text.length, prev.text.length, true);
+        }
+        else {
+            const valueContent = this.nextContentInContext();
+            valueContent?.setCursor(0, 0, true);
+        }
+    }
+
+    override backspaceHandler(event: Event) {
+        const { start, end } = this.getCursor()!;
+        if (start.offset !== 0 || start.offset !== end.offset)
+            return super.backspaceHandler(event);
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        // Delete the row when key is empty at start.
+        const row = this.parent;
+        if (!row)
+            return;
+
+        const prevContent = this.previousContentInContext();
+        row.remove('user');
+        if (prevContent)
+            prevContent.setCursor(prevContent.text.length, prevContent.text.length, true);
+    }
+}
+
+export default FrontmatterKeyContent;

--- a/packages/muya/src/block/extra/frontmatter/keyContent.ts
+++ b/packages/muya/src/block/extra/frontmatter/keyContent.ts
@@ -42,9 +42,12 @@ class FrontmatterKeyContent extends Content {
 
     override enterHandler(event: Event) {
         event.preventDefault();
-        // Tab from key to value of the same row.
-        const valueContent = this.nextContentInContext();
-        valueContent?.setCursor(0, 0, true);
+        // Enter in key → move to value of the same row.
+        const row = this.parent;
+        if (row && row.isParent()) {
+            const value = row.lastContentInDescendant();
+            value?.setCursor(0, 0, true);
+        }
     }
 
     override tabHandler(event: Event) {
@@ -52,13 +55,18 @@ class FrontmatterKeyContent extends Content {
         event.stopPropagation();
         const isShift = 'shiftKey' in event && (event as KeyboardEvent).shiftKey;
         if (isShift) {
+            // Shift+Tab: previous row's value, or exit frontmatter if first row.
             const prev = this.previousContentInContext();
             if (prev)
                 prev.setCursor(prev.text.length, prev.text.length, true);
         }
         else {
-            const valueContent = this.nextContentInContext();
-            valueContent?.setCursor(0, 0, true);
+            // Tab: move to value of the same row.
+            const row = this.parent;
+            if (row && row.isParent()) {
+                const value = row.lastContentInDescendant();
+                value?.setCursor(0, 0, true);
+            }
         }
     }
 

--- a/packages/muya/src/block/extra/frontmatter/row.ts
+++ b/packages/muya/src/block/extra/frontmatter/row.ts
@@ -1,0 +1,67 @@
+import type { Muya } from '../../../muya';
+import type { IFrontmatterPropertyState } from '../../../state/types';
+import type { TBlockPath } from '../../types';
+import type FrontmatterKeyContent from './keyContent';
+import type FrontmatterValueContent from './valueContent';
+import { LinkedList } from '../../base/linkedList/linkedList';
+import Parent from '../../base/parent';
+import { ScrollPage } from '../../scrollPage';
+
+class FrontmatterRow extends Parent {
+    override children: LinkedList<FrontmatterKeyContent | FrontmatterValueContent> = new LinkedList();
+
+    static override blockName = 'frontmatter.row';
+
+    static create(muya: Muya, state: IFrontmatterPropertyState) {
+        const row = new FrontmatterRow(muya);
+
+        row.append(
+            ScrollPage.loadBlock('frontmatter.key.content').create(muya, state.key),
+            ScrollPage.loadBlock('frontmatter.value.content').create(muya, state.value),
+        );
+
+        return row;
+    }
+
+    override get path(): TBlockPath {
+        const { path: pPath } = this.parent!;
+        const offset = this.parent!.offset(this);
+        return [...pPath, offset];
+    }
+
+    queryBlock(path: TBlockPath) {
+        if (path.length === 0)
+            return this;
+        const key = path[0];
+        if (key === 'key')
+            return this.firstContentInDescendant();
+        if (key === 'value')
+            return this.lastContentInDescendant();
+        return this;
+    }
+
+    constructor(muya: Muya) {
+        super(muya);
+        this.tagName = 'div';
+        this.classList = ['mu-frontmatter-row'];
+        this.createDomNode();
+
+        // Drag-handle icon — non-editable, not a block.
+        const handle = document.createElement('span');
+        handle.className = 'mu-frontmatter-drag-handle';
+        handle.contentEditable = 'false';
+        handle.setAttribute('contenteditable', 'false');
+        handle.textContent = '⋮⋮';
+        this.domNode!.appendChild(handle);
+    }
+
+    override getState(): IFrontmatterPropertyState {
+        return {
+            name: 'frontmatter.row',
+            key: (this.firstContentInDescendant() as FrontmatterKeyContent | null)?.text ?? '',
+            value: (this.lastContentInDescendant() as FrontmatterValueContent | null)?.text ?? '',
+        };
+    }
+}
+
+export default FrontmatterRow;

--- a/packages/muya/src/block/extra/frontmatter/row.ts
+++ b/packages/muya/src/block/extra/frontmatter/row.ts
@@ -51,6 +51,7 @@ class FrontmatterRow extends Parent {
         handle.className = 'mu-frontmatter-drag-handle';
         handle.contentEditable = 'false';
         handle.setAttribute('contenteditable', 'false');
+        handle.setAttribute('draggable', 'true');
         handle.textContent = '⋮⋮';
         this.domNode!.appendChild(handle);
     }

--- a/packages/muya/src/block/extra/frontmatter/valueContent.ts
+++ b/packages/muya/src/block/extra/frontmatter/valueContent.ts
@@ -55,20 +55,26 @@ class FrontmatterValueContent extends Content {
         event.stopPropagation();
         const isShift = 'shiftKey' in event && (event as KeyboardEvent).shiftKey;
         if (isShift) {
-            // Move to key of this row.
-            const keyContent = this.previousContentInContext();
-            keyContent?.setCursor(keyContent.text.length, keyContent.text.length, true);
+            // Shift+Tab: move to key of the same row.
+            const row = this.parent;
+            if (row && row.isParent()) {
+                const key = row.firstContentInDescendant();
+                if (key) {
+                    key.setCursor(key.text.length, key.text.length, true);
+                }
+            }
         }
         else {
-            // Move to key of next row, or create a new row.
+            // Tab: key of next row, or exit frontmatter when on the last row.
             const next = this.nextContentInContext();
             if (next) {
                 next.setCursor(0, 0, true);
             }
             else {
-                const frontmatter = this.closestBlock('frontmatter');
-                if (frontmatter && 'addProperty' in frontmatter)
-                    (frontmatter as { addProperty: () => void }).addProperty();
+                // No block after the frontmatter — create a paragraph below it.
+                const newPara = ScrollPage.loadBlock('paragraph').create(this.muya, { name: 'paragraph', text: '' });
+                this.scrollPage?.append(newPara, 'user');
+                newPara.firstContentInDescendant()?.setCursor(0, 0, true);
             }
         }
     }

--- a/packages/muya/src/block/extra/frontmatter/valueContent.ts
+++ b/packages/muya/src/block/extra/frontmatter/valueContent.ts
@@ -1,0 +1,110 @@
+import type { Muya } from '../../../muya';
+import type { ICursor } from '../../../selection/types';
+import type Parent from '../../base/parent';
+import type { TBlockPath } from '../../types';
+import Content from '../../base/content';
+import { ScrollPage } from '../../scrollPage';
+
+class FrontmatterValueContent extends Content {
+    static override blockName = 'frontmatter.value.content';
+
+    static create(muya: Muya, value: string) {
+        return new FrontmatterValueContent(muya, value);
+    }
+
+    override get path(): TBlockPath {
+        if (this.parent == null)
+            return ['value'];
+        const { path: pPath } = this.parent;
+        return [...pPath, 'value'];
+    }
+
+    constructor(muya: Muya, value: string) {
+        super(muya, value);
+        this.classList = [...this.classList, 'mu-frontmatter-value'];
+        this.createDomNode();
+    }
+
+    override update(cursor?: ICursor) {
+        const { text } = this;
+        this.domNode!.innerHTML = `<span class="mu-syntax-text">${text}</span>`;
+        if (cursor)
+            this.selection.setSelection({ ...cursor, block: this, path: this.path });
+    }
+
+    override inputHandler(_event: Event) {
+        if (this.isComposed)
+            return;
+
+        const textContent = this.domNode!.textContent ?? '';
+        const { start, end } = this.getCursor()!;
+        this.text = textContent;
+        this.setCursor(start.offset, end.offset, true);
+    }
+
+    override enterHandler(event: Event) {
+        event.preventDefault();
+        // Enter in value → add a new row after the current one.
+        const frontmatter = this.closestBlock('frontmatter');
+        if (frontmatter && 'addProperty' in frontmatter)
+            (frontmatter as { addProperty: () => void }).addProperty();
+    }
+
+    override tabHandler(event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const isShift = 'shiftKey' in event && (event as KeyboardEvent).shiftKey;
+        if (isShift) {
+            // Move to key of this row.
+            const keyContent = this.previousContentInContext();
+            keyContent?.setCursor(keyContent.text.length, keyContent.text.length, true);
+        }
+        else {
+            // Move to key of next row, or create a new row.
+            const next = this.nextContentInContext();
+            if (next) {
+                next.setCursor(0, 0, true);
+            }
+            else {
+                const frontmatter = this.closestBlock('frontmatter');
+                if (frontmatter && 'addProperty' in frontmatter)
+                    (frontmatter as { addProperty: () => void }).addProperty();
+            }
+        }
+    }
+
+    override arrowHandler(event: Event) {
+        if (!('key' in event))
+            return;
+        const ke = event as KeyboardEvent;
+        if (ke.key === 'ArrowDown' || ke.key === 'ArrowUp') {
+            event.preventDefault();
+            event.stopPropagation();
+            const target = ke.key === 'ArrowDown'
+                ? this.nextContentInContext()
+                : this.previousContentInContext();
+            if (target) {
+                const offset = ke.key === 'ArrowDown' ? 0 : target.text.length;
+                target.setCursor(offset, offset, true);
+            }
+            else if (ke.key === 'ArrowDown') {
+                // Navigate out of frontmatter.
+                const fm = this.closestBlock('frontmatter');
+                const next = (fm?.next as Parent | null | undefined)?.firstContentInDescendant();
+                if (next) {
+                    next.setCursor(0, 0, true);
+                }
+                else {
+                    const newPara = ScrollPage.loadBlock('paragraph').create(this.muya, { name: 'paragraph', text: '' });
+                    this.scrollPage?.append(newPara, 'user');
+                    newPara.firstContentInDescendant()?.setCursor(0, 0, true);
+                }
+            }
+        }
+        else {
+            super.arrowHandler(event);
+        }
+    }
+}
+
+export default FrontmatterValueContent;

--- a/packages/muya/src/block/index.ts
+++ b/packages/muya/src/block/index.ts
@@ -1,4 +1,8 @@
 import Frontmatter from './/extra/frontmatter';
+import FrontmatterBody from './/extra/frontmatter/body';
+import FrontmatterKeyContent from './/extra/frontmatter/keyContent';
+import FrontmatterRow from './/extra/frontmatter/row';
+import FrontmatterValueContent from './/extra/frontmatter/valueContent';
 import AtxHeading from './commonMark/atxHeading';
 // container block
 import BlockQuote from './commonMark/blockQuote';
@@ -79,6 +83,10 @@ export function registerBlocks() {
     ScrollPage.register(MathContainer);
     // FrontMatter
     ScrollPage.register(Frontmatter);
+    ScrollPage.register(FrontmatterBody);
+    ScrollPage.register(FrontmatterRow);
+    ScrollPage.register(FrontmatterKeyContent);
+    ScrollPage.register(FrontmatterValueContent);
     // Diagram
     ScrollPage.register(DiagramBlock);
     ScrollPage.register(DiagramContainer);

--- a/packages/muya/src/config/emptyStates.ts
+++ b/packages/muya/src/config/emptyStates.ts
@@ -41,7 +41,7 @@ const emptyStates: IEmptyStates = {
     },
     'frontmatter': {
         name: 'frontmatter',
-        text: '',
+        properties: [],
         meta: {
             lang: 'yaml', // yaml | toml | json
             style: '-', // `-` for yaml | `+` for toml | `;;;` and `{}` for json

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -10,6 +10,7 @@ import type {
     ITaskListState,
     TState,
 } from './types';
+import { parseProperties } from '../utils/frontmatterUtils';
 import logger from '../utils/logger';
 import { lexBlock } from '../utils/marked';
 
@@ -98,7 +99,7 @@ export class MarkdownToState {
                             lang,
                             style,
                         },
-                        text: value,
+                        properties: parseProperties(value, lang),
                     };
 
                     parentList[0].push(state);

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -30,6 +30,7 @@ import type {
  * The output markdown needs to obey the standards of these Spec.
  */
 import { deepClone } from '../utils';
+import { serializeProperties } from '../utils/frontmatterUtils';
 
 import logger from '../utils/logger';
 
@@ -254,7 +255,7 @@ export default class ExportMarkdown {
 
         const result = [];
         result.push(startToken);
-        const { text } = state;
+        const text = serializeProperties(state.properties, state.meta.lang);
         const lines = text.split('\n');
 
         for (const line of lines)

--- a/packages/muya/src/state/types.ts
+++ b/packages/muya/src/state/types.ts
@@ -137,10 +137,16 @@ export interface IFrontmatterMeta {
     style: string; //  "-" | "+" | ";" | "{";
 }
 
+export interface IFrontmatterPropertyState {
+    name: 'frontmatter.row';
+    key: string;
+    value: string;
+}
+
 export interface IFrontmatterState {
     name: 'frontmatter';
     meta: IFrontmatterMeta;
-    text: string;
+    properties: IFrontmatterPropertyState[];
 }
 
 export interface IDiagramMeta {
@@ -174,6 +180,7 @@ export type TLeafState
         | ILinkReferenceDefinitionState
         | IMathBlockState
         | IFrontmatterState
+        | IFrontmatterPropertyState
         | IDiagramState
         | ITableCellState;
 
@@ -190,7 +197,7 @@ export type TContainerState
 
 export type TState = TLeafState | TContainerState;
 
-export type CodeContentState = ICodeBlockState | IHtmlBlockState | IDiagramState | IMathBlockState | IFrontmatterState;
+export type CodeContentState = ICodeBlockState | IHtmlBlockState | IDiagramState | IMathBlockState;
 
 // Discriminated-union type guards. `TState` is keyed by `name`, so consumers can
 // narrow without `as I<X>State` casts. Use `isStateOfName(state, 'atx-heading')`

--- a/packages/muya/src/utils/frontmatterUtils.ts
+++ b/packages/muya/src/utils/frontmatterUtils.ts
@@ -1,0 +1,129 @@
+import type { IFrontmatterPropertyState } from '../state/types';
+
+function parseYaml(text: string): IFrontmatterPropertyState[] {
+    const properties: IFrontmatterPropertyState[] = [];
+
+    for (const line of text.split('\n')) {
+        if (!line.trim() || line.trim().startsWith('#'))
+            continue;
+
+        const colonIdx = line.indexOf(':');
+        if (colonIdx === -1)
+            continue;
+
+        const key = line.substring(0, colonIdx).trim();
+        if (!key)
+            continue;
+
+        let value = line.substring(colonIdx + 1).trim();
+        if (
+            (value.startsWith('"') && value.endsWith('"'))
+            || (value.startsWith('\'') && value.endsWith('\''))
+        ) {
+            value = value.slice(1, -1);
+        }
+
+        properties.push({ name: 'frontmatter.row', key, value });
+    }
+
+    return properties;
+}
+
+function serializeYaml(properties: IFrontmatterPropertyState[]): string {
+    return properties
+        .map(({ key, value }) => {
+            if (!value)
+                return `${key}:`;
+            if (/[:#[\]{},&*?|>!%@`]/.test(value) || value.includes('\n'))
+                return `${key}: "${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+            return `${key}: ${value}`;
+        })
+        .join('\n');
+}
+
+function parseToml(text: string): IFrontmatterPropertyState[] {
+    const properties: IFrontmatterPropertyState[] = [];
+
+    for (const line of text.split('\n')) {
+        if (!line.trim() || line.trim().startsWith('#'))
+            continue;
+
+        const eqIdx = line.indexOf('=');
+        if (eqIdx === -1)
+            continue;
+
+        const key = line.substring(0, eqIdx).trim();
+        if (!key)
+            continue;
+
+        let value = line.substring(eqIdx + 1).trim();
+        if (
+            (value.startsWith('"') && value.endsWith('"'))
+            || (value.startsWith('\'') && value.endsWith('\''))
+        ) {
+            value = value.slice(1, -1);
+        }
+
+        properties.push({ name: 'frontmatter.row', key, value });
+    }
+
+    return properties;
+}
+
+function serializeToml(properties: IFrontmatterPropertyState[]): string {
+    return properties
+        .map(({ key, value }) =>
+            `${key} = "${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
+        )
+        .join('\n');
+}
+
+function parseJson(text: string): IFrontmatterPropertyState[] {
+    try {
+        // The JSON frontmatter body is the content between the delimiters
+        // but may be missing the outer braces for `{}` style.
+        const rawJson = text.trim().startsWith('{') ? text.trim() : `{${text}}`;
+        const obj = JSON.parse(rawJson) as Record<string, unknown>;
+
+        return Object.entries(obj).map(([key, value]) => ({
+            name: 'frontmatter.row' as const,
+            key,
+            value: typeof value === 'string' ? value : JSON.stringify(value),
+        }));
+    }
+    catch {
+        return text
+            .split('\n')
+            .filter(l => l.trim())
+            .map(line => ({ name: 'frontmatter.row' as const, key: line, value: '' }));
+    }
+}
+
+function serializeJson(properties: IFrontmatterPropertyState[]): string {
+    return properties
+        .map(({ key, value }) => `"${key}": "${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)
+        .join(',\n');
+}
+
+export function parseProperties(text: string, lang: string): IFrontmatterPropertyState[] {
+    const normalized = text.replace(/^\s+/, '').replace(/\s+$/, '');
+    if (!normalized)
+        return [];
+
+    switch (lang) {
+        case 'toml': return parseToml(normalized);
+        case 'json': return parseJson(normalized);
+        default: return parseYaml(normalized);
+    }
+}
+
+export function serializeProperties(
+    properties: IFrontmatterPropertyState[],
+    lang: string,
+): string {
+    switch (lang) {
+        case 'toml': return serializeToml(properties);
+        case 'json': return serializeJson(properties);
+        default: return serializeYaml(properties);
+    }
+}


### PR DESCRIPTION
Closes #2083

## Summary

Adds a WYSIWYG editor for front matters

- Option to collapse / expand the properties
- Cycle through the property cells using tab
- Drag / drop property rows to rearrange them
- Add new property rows

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on: macOS
- [x] pnpm run lint
Passes with existing warnings.
- [x] pnpm --filter marktext typecheck
- [x] pnpm --filter marktext build

## Screenshots

<img width="606" height="248" alt="Screenshot 2026-06-12 at 16 06 43" src="https://github.com/user-attachments/assets/598b3082-e2f7-4777-8e89-fa01489c366a" />

## Notes for reviewers

This code was developed using Claude Code - Sonnet 4.6 model. I myself don't have that much experience with electron. But I love this tool and wanted to make it look like obsidian a bit more.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
