### PR TITLE
fix(muya): match muyajs nested list spacing and bullet markers

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -405,6 +405,20 @@ ol.mu-order-list:last-child {
     margin-bottom: 0;
 }
 
+/* nested bullet markers follow the browser default cascade
+   (disc → circle → square), matching muyajs */
+ul.mu-bullet-list ul.mu-bullet-list,
+ol.mu-order-list ul.mu-bullet-list {
+    list-style-type: circle;
+}
+
+ul.mu-bullet-list ul.mu-bullet-list ul.mu-bullet-list,
+ul.mu-bullet-list ol.mu-order-list ul.mu-bullet-list,
+ol.mu-order-list ul.mu-bullet-list ul.mu-bullet-list,
+ol.mu-order-list ol.mu-order-list ul.mu-bullet-list {
+    list-style-type: square;
+}
+
 /* Focus mode (mirrors marktext muyajs `.ag-focus-mode`): when the editor
    container carries `mu-focus-mode`, dim every top-level block and restore full
    opacity on the active one. `mu-active` is applied to the whole ancestor chain

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -382,6 +382,12 @@ ul.mu-bullet-list {
     list-style: disc outside none;
 }
 
+/* nested lists carry no vertical margin (muyajs `li > ol, li > ul`) */
+li > ol.mu-order-list,
+li > ul.mu-bullet-list {
+    margin: 0;
+}
+
 /* list markers — default to `inherit` (current text color) so the bundled
    light theme is unchanged; themes can recolor the bullets / numbers. */
 ol.mu-order-list > li::marker,


### PR DESCRIPTION
## What

Brings nested list rendering in `@muyajs/core` back in line with the legacy `muyajs` engine, fixing two regressions visible in the editor:

1. **Vertical spacing** — `.mu-container ul/ol { margin: 0.5em 0 }` was also applying to *nested* lists, adding extra gaps between levels. muyajs neutralized this with `li > ol, li > ul { margin: 0 }`; that rule is now mirrored.
2. **Bullet markers** — muya forced `list-style: disc` on every `ul` level, so second-level bullets rendered as a solid disc. muyajs leaves the marker to the browser default cascade (disc → circle → square). The cascade is restored, so nested bullets show a hollow circle (and squares deeper), including mixed `ol`/`ul` nesting.

## Result

| | Before | After (matches muyajs) |
|---|---|---|
| Level-1 bullet | ● | ● |
| Level-2 bullet | ● | ○ (hollow circle) |
| Nested spacing | extra gap | flush |

## Notes

- CSS-only change in `packages/muya/src/assets/styles/blockSyntax.css`.
- `pnpm -C packages/muya lint:css` is at baseline (the 1 remaining error is pre-existing and unrelated).
- Split into two single-purpose commits (margin, marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)