### PR TITLE
fix(editor): restore caret on source-mode undo and tab switch

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1759,6 +1759,12 @@ onMounted(() => {
     }
 
     selectionChange.value = changes
+    // Persist the caret so a click/arrow-key move (which never fires
+    // `json-change`) survives an in-session tab switch — `tab.cursor` is what
+    // `handleFileChange` replays on re-activation. Cheap: serialized caret only.
+    if (currentFile.value?.id && editor.value) {
+      editorStore.PERSIST_CURSOR(currentFile.value.id, serializeCursor(editor.value.getSelection()))
+    }
     editorStore.SELECTION_CHANGE(adaptSelectionChange(changes))
     // The active inline formats now ride along on selection-change (replacing
     // the old separate `selectionFormats` event) — drive the format menu/toolbar

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -275,6 +275,14 @@ let scrollHandler: ((e: Event) => void) | null = null
 // store a SYNTHETIC desktop-shaped history.
 const engineHistoryByTab = new Map<string, unknown>()
 
+// The WYSIWYG caret captured the instant the user switches INTO source mode.
+// Focus moves to CodeMirror while source mode is up, so by the time the tab is
+// handed back (`replaceContent`) the live DOM selection no longer points into
+// the muya tree. We stash the pre-source caret here and feed it to
+// `replaceContent` as the rebuild boundary's restore-selection, so the first
+// undo after the handoff returns the caret to where source mode was entered.
+let preSourceModeSelection: unknown = null
+
 // Per-tab monotonic save-tracking id allocator. The synthetic history entry id
 // is a MONOTONIC, never-reused id keyed on the live document content (see
 // `syntheticHistory.ts`), NOT the engine undo-stack depth: depth is reused
@@ -768,6 +776,10 @@ watch(
         if (currentFile.value) {
           currentFile.value.muyaIndexCursor = editor.value.getCursorOffset() ?? null
         }
+        // Capture the block-key caret too (same fresh selection getCursorOffset
+        // reads) so the post-handoff undo can restore it — see
+        // `preSourceModeSelection`.
+        preSourceModeSelection = editor.value.getSelection()
       }
     }
   },
@@ -1413,7 +1425,8 @@ const handleFileChange = (payload: unknown) => {
       // document is unchanged this is a no-op (returns false) and the existing
       // history/content already match — either way the caret still needs
       // remapping below.
-      editor.value.replaceContent(newMarkdown)
+      editor.value.replaceContent(newMarkdown, preSourceModeSelection)
+      preSourceModeSelection = null
       // Map the CodeMirror `{ line, ch }` cursor onto a block-key cursor so the
       // WYSIWYG caret lands where the source-mode cursor was (PG2).
       editor.value.setCursorByOffset(muyaIndexCursor)

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1456,6 +1456,21 @@ export const useEditorStore = defineStore('editor', {
       )
     },
 
+    // Persist the caret for a tab without the heavy content-change pipeline. A
+    // pure caret move (click / arrow key) fires `selection-change` but NOT
+    // `json-change`, so `tab.cursor` — the position replayed when the tab is
+    // re-activated — would otherwise only ever track the last EDIT, losing a
+    // click-moved caret across an in-session tab switch. Lightweight by design:
+    // it only stores the serialized caret, skipping markdown/blocks/TOC re-derivation
+    // and the save/dirty bookkeeping LISTEN_FOR_CONTENT_CHANGE performs.
+    PERSIST_CURSOR(id: string, cursor: unknown): void {
+      if (!id || !cursor) return
+      const index = this.tabIdToIndex[id]
+      if (index == null) return
+      const tab = this.tabs[index]
+      if (tab) tab.cursor = cursor
+    },
+
     SELECTION_FORMATS(formats: SelectionFormat[]): void {
       const { windowId } = window.marktext?.env ?? { windowId: -1 }
       window.electron.ipcRenderer.send(

--- a/packages/muya/src/__tests__/replaceContent.spec.ts
+++ b/packages/muya/src/__tests__/replaceContent.spec.ts
@@ -341,6 +341,41 @@ describe('muya replaceContent — single undo boundary', () => {
         });
     });
 
+    it('records an explicit recordSelection for the rebuild boundary', async () => {
+        // When the desktop shell hands a tab back from source-code mode, focus
+        // lives in CodeMirror, so the live DOM selection no longer points into
+        // the muya tree. The caller therefore passes the PRE-source-mode caret
+        // explicitly so the first undo after the handoff restores the caret to
+        // where it was when the user switched to source mode — not wherever the
+        // (stale/empty) live DOM selection happened to be.
+        const muya = bootMuya('first\n\nsecond\n');
+        await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('first\n\nsecond'));
+
+        // Capture a selection pointing at the SECOND block — the pre-source caret.
+        const second = muya.editor.scrollPage!.lastContentInDescendant()!;
+        muya.editor.activeContentBlock = second;
+        second.setCursor(1, 1, true);
+        const recordSelection = muya.getSelection();
+        const recordPath = recordSelection?.anchorPath;
+        expect(recordPath?.length ?? 0).toBeGreaterThan(0);
+
+        // Move the LIVE caret to the FIRST block — this is what an unguarded
+        // getSelection() would record at replaceContent time.
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.editor.activeContentBlock = first;
+        first.setCursor(0, 0, true);
+        const livePath = muya.getSelection()?.anchorPath;
+        expect(livePath).not.toEqual(recordPath);
+
+        muya.replaceContent('first\n\nsecond\n\nthird\n', recordSelection);
+
+        // The boundary recorded the EXPLICIT pre-source selection (second block),
+        // not the live DOM caret (first block).
+        // @ts-expect-error — reach into the private stack for assertions.
+        const storedSel = muya.editor.history._stack.undo[0].selection;
+        expect(storedSel?.anchorPath).toEqual(recordPath);
+    });
+
     it('accepts a state array as well as markdown', async () => {
         const muya = bootMuya('one\n');
         await vi.waitFor(() => expect(muya.getMarkdown().trim()).toBe('one'));

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -3,10 +3,10 @@ import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
 import type { IIndexCursor } from './selection/offsetCursor';
-import type { ICursor } from './selection/types';
+import type { ICursor, IHistorySelection } from './selection/types';
 import type { ITocItem } from './state/getTOC';
 import type { IBulletListState, IOrderListState, ITableState, ITaskListState, TState } from './state/types';
-import type { IMuyaOptions } from './types';
+import type { IMuyaOptions, Nullable } from './types';
 import Format from './block/base/format';
 import { ScrollPage } from './block/scrollPage';
 import emptyStates from './config/emptyStates';
@@ -268,9 +268,16 @@ export class Muya {
      * safe to round-trip. No-op when `content` is identical to the current
      * document.
      *
+     * `recordSelection` overrides the caret stored on the rebuild boundary (the
+     * one the first `undo()` restores). Pass it when the live DOM selection no
+     * longer points into the muya tree at call time — notably the source-mode
+     * handoff, where focus has moved to CodeMirror, so the desktop shell hands
+     * back the caret captured when the user switched INTO source mode. Omitted,
+     * it falls back to the current live selection.
+     *
      * @returns `true` if a boundary was recorded, `false` if nothing changed.
      */
-    replaceContent(content: TState[] | string): boolean {
+    replaceContent(content: TState[] | string, recordSelection?: Nullable<IHistorySelection>): boolean {
         const { jsonState, history } = this.editor;
         const { op, prevState } = jsonState.buildReplaceOp(content);
 
@@ -278,11 +285,12 @@ export class Muya {
             return false;
 
         const selection = this.editor.selection.getSelection();
+        const boundarySelection = recordSelection !== undefined ? recordSelection : selection;
         // Record the lossless inverse as a standalone rebuild boundary BEFORE
         // applying the forward op, so the recorded `prevState` matches the doc
         // the inverse must restore. The forward apply dispatches a json-change,
         // so suppress History's own recording of it to avoid a duplicate entry.
-        history.recordRebuild(op, prevState, selection);
+        history.recordRebuild(op, prevState, boundarySelection);
         history.suppressRecording(() => {
             this.editor.rebuildContents(op, selection, 'api');
         });


### PR DESCRIPTION
## What & why

Two cursor-restoration bugs surfaced by the migration test checklist (#14, #15). Different root causes, fixed in three single-responsibility commits.

### Bug #14 — caret not restored when undoing a source-mode round-trip
Returning from source-code mode records the bulk edit as one rebuild undo boundary via muya's `replaceContent`. That boundary captured the **live DOM selection** as the caret to restore — but at handoff time focus is in CodeMirror, so `getSelection()` is `null` and the first Ctrl+Z reverted the content **without moving the caret**.

- `feat(muya)`: `replaceContent(content, recordSelection?)` — optional override for the boundary's restore-selection (falls back to the live selection; existing callers unaffected).
- `fix(editor)`: capture the WYSIWYG caret the instant the user *enters* source mode and pass it through, so undo returns the caret to where source mode was entered.

### Bug #15 — click-moved caret lost across an in-session tab switch
A tab's persisted `cursor` (replayed on re-activation) was updated only on `json-change`. A pure caret move (click / arrow key) fires `selection-change`, not `json-change`, so the click position was never saved — switching away and back restored the stale last-edit caret. Caret moves that *accompany* edits worked, matching the report.

- `fix(editor)`: lightweight `PERSIST_CURSOR` store action (serialized caret only — no markdown/blocks/TOC re-derivation or dirty tracking), called from the `selection-change` handler.

## Testing
- New muya unit test covers the rebuild-boundary selection fix (written failing first, then green).
- `packages/muya`: 730/730 unit tests pass. `packages/desktop`: 465/465 unit tests pass.
- `lint:types` (muya) and `vue-tsc typecheck` (desktop) pass.

Bug #15 is renderer integration behavior; the test checklist itself flags it as a desktop-e2e gap (`tabs.spec.ts`). Happy to add an e2e in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)