### PR TITLE
fix(muya): restore Paste as Plain Text via async clipboard read

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1580,6 +1580,8 @@ onMounted(() => {
     spellcheckEnabled: spellcheckerEnabled.value,
     // Resolve the OS clipboard to a local file path on paste (image-from-file).
     clipboardFilePath: guessClipboardFilePath,
+    // Read the OS clipboard's plain text for "Paste as Plain Text" (execCommand('paste') no longer fires).
+    clipboardText: () => window.electron.clipboard.readText(),
     // Image-persist callbacks read by the engine's clipboard + drag-drop handlers
     // from `muya.options.*` (distinct from the ImageEditTool plugin option above).
     // Without these, local-file drag-drop, screenshot/binary clipboard paste, and

--- a/packages/muya/e2e/tests/editing/paste-as-plain-text.spec.ts
+++ b/packages/muya/e2e/tests/editing/paste-as-plain-text.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+
+/**
+ * Regression: "Paste as Plain Text" must insert the clipboard's plain text
+ * without converting rich HTML to markdown.
+ *
+ * The bug: `pasteAsPlainText()` relied on `document.execCommand('paste')`,
+ * which Chromium turned into a no-op (returns false, fires no paste event),
+ * so nothing pasted at all. The fix reads the clipboard text via the async
+ * Clipboard API (here the `navigator.clipboard.readText()` fallback, since the
+ * e2e host wires no `clipboardText` hook) and routes it through the pipeline
+ * with the plain-text flag.
+ */
+test.describe('pasteAsPlainText', () => {
+    test('inserts plain text, ignoring clipboard HTML formatting', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem/readText unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+        await page.evaluate(() => window.muya!.setContent(''));
+
+        // Rich HTML + matching plain text on the clipboard. A normal paste would
+        // emit **foo** / a markdown link; paste-as-plain-text must not.
+        await page.evaluate(async () => {
+            await navigator.clipboard.write([
+                new ClipboardItem({
+                    'text/html': new Blob(
+                        ['<b>foo</b> and <a href="https://example.test/">bar</a>'],
+                        { type: 'text/html' },
+                    ),
+                    'text/plain': new Blob(['foo and bar'], { type: 'text/plain' }),
+                }),
+            ]);
+        });
+
+        await page.evaluate(async () => {
+            window.muya!.focus();
+            window.muya!.domNode.focus();
+            await window.muya!.pasteAsPlainText();
+        });
+
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toContain('foo and bar');
+
+        const md = await getMarkdown(page);
+        // No bold markers and no markdown link syntax — proves the HTML was
+        // ignored and the raw plain text was inserted.
+        expect(md).not.toMatch(/\*\*/);
+        expect(md).not.toMatch(/\]\(/);
+    });
+});

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -4,7 +4,7 @@ import { fromEvent, merge } from 'rxjs';
 import { isClipboardEvent, isKeyboardEvent } from '../utils';
 import { getClipboardData, writeClipboardData } from './copyData';
 import { cutSelection } from './cut';
-import { pasteSelection } from './paste';
+import { pastePlainText, pasteSelection } from './paste';
 import { CopyType, PasteType } from './types';
 
 class Clipboard {
@@ -123,10 +123,41 @@ class Clipboard {
         this.copyType = CopyType.NORMAL;
     }
 
-    pasteAsPlainText() {
-        this.pasteType = PasteType.PASTE_AS_PLAIN_TEXT;
-        document.execCommand('paste');
-        this.pasteType = PasteType.NORMAL;
+    // Chromium removed programmatic clipboard reads via
+    // `document.execCommand('paste')` — it returns false and fires no paste
+    // event, so the old flag + execCommand approach pasted nothing. Read the
+    // clipboard text ourselves and feed it through the paste pipeline.
+    async pasteAsPlainText(): Promise<void> {
+        const text = await this._readClipboardText();
+        if (text)
+            await pastePlainText(this, text);
+    }
+
+    async _readClipboardText(): Promise<string> {
+        // Sandboxed Electron renderers can't reach the system clipboard
+        // directly, so the embedder supplies a reader (e.g. an IPC bridge to
+        // Electron's native `clipboard`). Fall back to the async Clipboard API
+        // for standalone (browser) use.
+        const reader = this.muya.options.clipboardText;
+        if (typeof reader === 'function') {
+            try {
+                return await reader();
+            }
+            catch {
+                return '';
+            }
+        }
+
+        if (typeof navigator !== 'undefined' && navigator.clipboard?.readText) {
+            try {
+                return await navigator.clipboard.readText();
+            }
+            catch {
+                return '';
+            }
+        }
+
+        return '';
     }
 
     copy(type: CopyType, info: string) {

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -12,6 +12,7 @@ import { isParagraphState } from '../state/types';
 import { getClipboardImageFile, getCopyTextType, isStandaloneTableHtml, normalizePastedHTML } from '../utils/paste';
 import { mergePasteIntoHeading } from './mergePasteIntoHeading';
 import { tryPasteImage } from './pasteImage';
+import { PasteType } from './types';
 
 // Everything the per-anchor paste handlers need from the synchronous snapshot
 // taken before any block mutation: the target leaf, its wrapper block, and the
@@ -195,22 +196,23 @@ function applyHtmlBlockPaste(
     newBlock.lastContentInDescendant().setCursor(offset, offset, true);
 }
 
-export async function pasteSelection(
-    clipboard: Clipboard,
-    event: ClipboardEvent,
-    // `event.clipboardData` is only valid synchronously while the paste
-    // event is being dispatched. Once `pasteSelection` yields at its first
-    // `await` (the `clipboardFilePath` hook), the browser may detach the
-    // DataTransfer and subsequent `getData()` calls return ''. We snapshot
-    // text/html synchronously below and thread the snapshot through the
-    // `!isSelectionInSameBlock` recursion via these optional params so the
-    // re-entry doesn't read a detached clipboard.
-    rawText?: string,
-    rawHtml?: string,
-): Promise<void> {
-    event.preventDefault();
-    event.stopPropagation();
+// Everything the paste pipeline needs, snapshotted up front so it survives the
+// async hops (image hook, HTML normalization) without re-reading a possibly
+// detached clipboard.
+interface IPasteData {
+    text: string;
+    html: string;
+    imageFile: File | null;
+    pasteType: PasteType;
+}
 
+// The paste pipeline, decoupled from the DOM `paste` event so it can be driven
+// either by a trusted paste event (`pasteSelection`) or by an explicit
+// clipboard read (`pastePlainText`). The latter exists because Chromium removed
+// programmatic clipboard reads via `document.execCommand('paste')`, so the
+// "set a flag → execCommand('paste') → handle the synthetic event" approach no
+// longer fires any paste event at all.
+async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void> {
     const { muya } = clipboard;
     const { bulletListMarker } = muya.options;
     const selection = clipboard.selection.getSelection();
@@ -219,25 +221,16 @@ export async function pasteSelection(
 
     const { isSelectionInSameBlock, anchorBlock } = selection;
 
-    if (!anchorBlock || !event.clipboardData)
+    if (!anchorBlock)
         return;
 
-    // Snapshot everything we need from `event.clipboardData` synchronously,
-    // BEFORE any `await` — after the first yield the DataTransfer can be
-    // detached and `getData()` returns ''. On the `!isSelectionInSameBlock`
-    // recursion we reuse the snapshot captured by the outer call rather than
-    // re-reading the (now possibly detached) clipboard.
-    const text = rawText ?? event.clipboardData.getData('text/plain');
-    let html = rawHtml ?? event.clipboardData.getData('text/html');
-    // Snapshot any in-memory image File (the bitmap / "Copy Image" /
-    // screenshot case) synchronously too — `clipboardData.files`
-    // is also detached after the first `await`.
-    const imageFile = getClipboardImageFile(event.clipboardData);
+    const { text, imageFile, pasteType } = data;
+    let { html } = data;
 
     if (!isSelectionInSameBlock) {
         clipboard.cutHandler();
 
-        return clipboard.pasteHandler(event, text, html);
+        return applyPaste(clipboard, data);
     }
 
     // When the clipboard holds an image — either a file resolved to a path
@@ -259,7 +252,7 @@ export async function pasteSelection(
 
     // Remove crap from HTML such as meta data and styles.
     html = await normalizePastedHTML(html);
-    const copyType = getCopyTextType(html, text, clipboard.pasteType);
+    const copyType = getCopyTextType(html, text, pasteType);
 
     const { start, end } = anchorBlock.getCursor()!;
     const { text: content } = anchorBlock;
@@ -295,4 +288,47 @@ export async function pasteSelection(
     else {
         applyHtmlBlockPaste(clipboard, ctx, text);
     }
+}
+
+// Entry for a trusted DOM `paste` event (native Cmd/Ctrl+V).
+export function pasteSelection(
+    clipboard: Clipboard,
+    event: ClipboardEvent,
+    // `event.clipboardData` is only valid synchronously while the paste event
+    // is being dispatched. Once the pipeline yields at its first `await`, the
+    // browser may detach the DataTransfer and subsequent `getData()` calls
+    // return ''. We snapshot text/html/image synchronously below; the snapshot
+    // is then threaded through the `!isSelectionInSameBlock` recursion inside
+    // `applyPaste` rather than re-reading the (now possibly detached) clipboard.
+    rawText?: string,
+    rawHtml?: string,
+): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!event.clipboardData)
+        return Promise.resolve();
+
+    const text = rawText ?? event.clipboardData.getData('text/plain');
+    const html = rawHtml ?? event.clipboardData.getData('text/html');
+    // Snapshot any in-memory image File (the bitmap / "Copy Image" /
+    // screenshot case) synchronously too — `clipboardData.files` is also
+    // detached after the first `await`.
+    const imageFile = getClipboardImageFile(event.clipboardData);
+
+    return applyPaste(clipboard, { text, html, imageFile, pasteType: clipboard.pasteType });
+}
+
+// Entry for "Paste as Plain Text". The caller has already read the clipboard's
+// plain text (Chromium no longer fires a paste event for
+// `document.execCommand('paste')`), so feed it straight into the pipeline with
+// the plain-text flag and no HTML — the text is treated as markdown source
+// rather than being synthesized from rich HTML.
+export function pastePlainText(clipboard: Clipboard, text: string): Promise<void> {
+    return applyPaste(clipboard, {
+        text,
+        html: '',
+        imageFile: null,
+        pasteType: PasteType.PASTE_AS_PLAIN_TEXT,
+    });
 }

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -534,8 +534,8 @@ export class Muya {
     /**
      * Paste the clipboard content as plain text at the current cursor.
      */
-    pasteAsPlainText() {
-        this.editor.clipboard.pasteAsPlainText();
+    pasteAsPlainText(): Promise<void> {
+        return this.editor.clipboard.pasteAsPlainText();
     }
 
     /**

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -49,6 +49,16 @@ export interface IMuyaOptions {
      */
     clipboardFilePath?: () => Promise<string>;
     /**
+     * Read the OS clipboard's plain text for "Paste as Plain Text".
+     *
+     * The embedder supplies this because Chromium removed programmatic
+     * clipboard reads via `document.execCommand('paste')`, and a sandboxed
+     * renderer cannot reach the system clipboard directly. Electron embedders
+     * typically wire this to an IPC bridge over the native `clipboard` module.
+     * When omitted, muya falls back to `navigator.clipboard.readText()`.
+     */
+    clipboardText?: () => Promise<string>;
+    /**
      * Persist an image per the embedder's insert preference (copy into the
      * document's assets folder, upload to an image host, or keep the path) and
      * resolve to the src that should be written into the document.


### PR DESCRIPTION
## Problem

"Paste as Plain Text" (Edit menu / shortcut / context menu) pasted **nothing** after the muya engine migration — no content was inserted at all.

## Root cause (verified empirically)

`document.execCommand('paste')` is a **no-op in Electron 42's Chromium**: it returns `false` and fires **no** paste event — Chromium removed programmatic clipboard *reads* via `execCommand`. The previous `pasteAsPlainText()` set a `pasteType` flag and called `execCommand('paste')` to re-trigger a synthetic paste event, so the handler never ran and nothing pasted.

Confirmed with a real-Chromium e2e probe:
- `document.execCommand('paste')` → `false`, document left empty (`"\n"`)
- `navigator.clipboard.readText()` → works
- `document.execCommand('copy')` → still `true` (copy paths unaffected)

Native `Cmd/Ctrl+V` was never affected — it dispatches a *trusted* paste event whose `clipboardData` is populated.

## Fix

- Decouple the paste pipeline from the DOM `paste` event: extract `applyPaste(clipboard, data)`, and add `pastePlainText(clipboard, text)`.
- `pasteAsPlainText()` now reads the clipboard's plain text directly and feeds it through the pipeline with the plain-text flag (no HTML → no rich-format conversion).
- Clipboard read goes through a new `IMuyaOptions.clipboardText` hook, falling back to `navigator.clipboard.readText()` for standalone/browser use.
- The desktop (sandboxed renderer) wires the hook to the existing IPC bridge `window.electron.clipboard.readText()`.

## Tests

- New chromium e2e regression: `packages/muya/e2e/tests/editing/paste-as-plain-text.spec.ts` — rich HTML on the clipboard is pasted as raw plain text (no `**`, no markdown link).
- All existing muya unit tests (733) and clipboard/table e2e tests pass; `lint`, `lint:types`, `check-circular`, and desktop `typecheck` are green.