### PR TITLE
fix: #4356 crash when using the link popover on a link with an unsupported protocol

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -813,9 +813,12 @@ watch(
 )
 
 // Methods
-const jumpClick = (linkInfo: { href: string }) => {
+// muya types the callback as (linkInfo: ILinkInfo | null) and href itself can
+// be null when the rendered link has no usable href (see issue #4356).
+const jumpClick = (linkInfo: { href?: string | null } | null) => {
+  if (!linkInfo) return
   const { href } = linkInfo
-  editorStore.FORMAT_LINK_CLICK({ data: { href }, dirname: window.DIRNAME })
+  editorStore.FORMAT_LINK_CLICK({ data: { href: href ?? null }, dirname: window.DIRNAME })
 }
 
 interface ImagePathSuggestion {

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -76,7 +76,9 @@ interface FileChangePayload {
 }
 
 interface FormatLinkClickPayload {
-  data: { href: string; [key: string]: unknown }
+  // muya's getLinkInfo yields `href: null` when the rendered link carries no
+  // usable href (e.g. an unsupported protocol stripped by sanitizeHyperlink).
+  data: { href: string | null; [key: string]: unknown }
   dirname: string
 }
 
@@ -398,8 +400,7 @@ export const useEditorStore = defineStore('editor', {
 
     FORMAT_LINK_CLICK({ data, dirname }: FormatLinkClickPayload): void {
       // Check if the link starts with a #, that is a local anchor link.
-
-      if (data.href.length > 0 && data.href[0] === '#') {
+      if (data.href && data.href[0] === '#') {
         const anchorSlug = data.href.substring(1)
         if (!anchorSlug) return
 

--- a/packages/desktop/test/e2e/issue-4356.spec.ts
+++ b/packages/desktop/test/e2e/issue-4356.spec.ts
@@ -1,0 +1,73 @@
+// Regression guard for issue #4356: TypeError: Cannot read properties of
+// null (reading 'length') in FORMAT_LINK_CLICK.
+//
+// A markdown link with a custom protocol (e.g. sambesi://) gets its href
+// stripped by muya's sanitizeHyperlink (DOMPurify protocol allowlist), so
+// getLinkInfo returns href: null. Clicking the linkTools popover's "jump"
+// button then forwarded { href: null } to the editor store, which crashed on
+// data.href.length (packages/desktop/src/renderer/src/store/editor.ts).
+//
+// The fix is two-layered: muya's linkTools no longer offers "jump" when
+// there is no href, and FORMAT_LINK_CLICK guards null hrefs defensively.
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  launchWithMarkdown,
+  clearRendererErrors,
+  expectNoRendererErrors
+} from './helpers'
+
+const CUSTOM_PROTOCOL_DOC =
+  '# Repro\n\n[sambesi://localhost/node/11164](sambesi://localhost/node/11164)\n'
+
+const ANCHOR_LINK_DOC = '# Top\n\nsome text\n\n[go to top](#top)\n'
+
+test.describe('Issue #4356: link popover with an unsupported protocol href', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  test('popover offers only unlink and the renderer does not crash', async() => {
+    const launched = await launchWithMarkdown(CUSTOM_PROTOCOL_DOC, {
+      suppressErrorDialog: true
+    })
+    app = launched.app
+    page = launched.page
+    await clearRendererErrors(app)
+
+    const link = page.locator('span.mu-link').first()
+    await link.waitFor({ state: 'visible', timeout: 10000 })
+    await link.hover()
+
+    const popover = page.locator('.mu-link-tools-container')
+    await popover.locator('li.item.unlink').waitFor({ state: 'visible', timeout: 5000 })
+    await expect(popover.locator('li.item.jump')).toHaveCount(0)
+
+    await page.waitForTimeout(500)
+    await expectNoRendererErrors(app)
+  })
+
+  test('anchor links still offer jump and clicking it does not crash', async() => {
+    const launched = await launchWithMarkdown(ANCHOR_LINK_DOC, {
+      suppressErrorDialog: true
+    })
+    app = launched.app
+    page = launched.page
+    await clearRendererErrors(app)
+
+    const link = page.locator('span.mu-link').first()
+    await link.waitFor({ state: 'visible', timeout: 10000 })
+    await link.hover()
+
+    const jumpButton = page.locator('.mu-link-tools-container li.item.jump')
+    await jumpButton.waitFor({ state: 'visible', timeout: 5000 })
+    await jumpButton.click()
+
+    // Give a (potential) error time to propagate over IPC.
+    await page.waitForTimeout(500)
+    await expectNoRendererErrors(app)
+  })
+})

--- a/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -22,12 +22,14 @@ import LinkTools from '../index';
 interface ILinkToolsView {
     _linkBlock: Format | null;
     _linkInfo: {
-        href?: string;
+        href?: string | null;
         text?: string;
         raw?: string;
         range?: { start: number; end: number } | null;
     } | null;
     selectItem: (event: Event, item: { type: string; icon: string }) => void;
+    render: () => void;
+    container: HTMLElement | null;
     destroy: () => void;
 }
 
@@ -140,5 +142,40 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
 
         expect(jumpClick).toHaveBeenCalledTimes(1);
         expect(jumpClick).toHaveBeenCalledWith(linkInfo);
+    });
+});
+
+describe('linkTools.render — jump visibility tracks linkInfo.href', () => {
+    // Regression guard for issue #4356: a link whose href was sanitized away
+    // (unsupported custom protocol) reaches the popover with `href: null`.
+    // There is nothing to jump to, so the jump item must not render.
+    it('omits the jump item when linkInfo.href is null', () => {
+        const { tools } = bootLinkTools();
+        tools._linkInfo = {
+            href: null,
+            text: 'sambesi://localhost/node/11164',
+            raw: '[sambesi://localhost/node/11164](sambesi://localhost/node/11164)',
+            range: { start: 0, end: 64 },
+        };
+
+        tools.render();
+
+        expect(tools.container!.querySelectorAll('li.item.jump').length).toBe(0);
+        expect(tools.container!.querySelectorAll('li.item.unlink').length).toBe(1);
+    });
+
+    it('renders both unlink and jump when linkInfo.href is present', () => {
+        const { tools } = bootLinkTools();
+        tools._linkInfo = {
+            href: 'https://example.com',
+            text: 'hi',
+            raw: '[hi](https://example.com)',
+            range: { start: 0, end: 25 },
+        };
+
+        tools.render();
+
+        expect(tools.container!.querySelectorAll('li.item.jump').length).toBe(1);
+        expect(tools.container!.querySelectorAll('li.item.unlink').length).toBe(1);
     });
 });

--- a/packages/muya/src/ui/linkTools/index.ts
+++ b/packages/muya/src/ui/linkTools/index.ts
@@ -99,7 +99,14 @@ class LinkTools extends BaseFloat {
     }
 
     render() {
-        const { _icons: icons, _oldVNode: oldVNode, _linkContainer: linkContainer } = this;
+        const { _oldVNode: oldVNode, _linkContainer: linkContainer } = this;
+        // A link whose href was sanitized away (e.g. an unsupported custom
+        // protocol, issue #4356) carries `href: null` — there is nothing to
+        // jump to, so offer only "unlink" (the same nothing-to-act-on rule
+        // that keeps unresolved reference links out of the popover entirely).
+        const icons = this._linkInfo?.href
+            ? this._icons
+            : this._icons.filter(icon => icon.type !== 'jump');
         const children = icons.map((i) => {
             let icon: VNode | undefined;
             let iconWrapperSelector: string | undefined;


### PR DESCRIPTION
Closes #4356

## Summary

Clicking the "jump" button in the link popover on a link whose URL uses an unsupported protocol (e.g. `sambesi://localhost/node/11164`) crashed the renderer with `TypeError: Cannot read properties of null (reading 'length')`.

Root cause: muya's `sanitizeHyperlink` (DOMPurify's protocol allowlist) strips such hrefs at render time, so `getLinkInfo` captures `href: null`, and the popover's jump handler forwarded that to `FORMAT_LINK_CLICK`, which read `data.href.length` without a guard.

The fix is two-layered:

- `@muyajs/core`: the linkTools popover no longer offers "jump" when `linkInfo.href` is empty — there is nothing to jump to. This mirrors the existing nothing-to-act-on rule that keeps unresolved reference links out of the popover entirely.
- desktop: `FORMAT_LINK_CLICK` null-guards `data.href` (defense in depth), and the `jumpClick` / store payload types now match muya's actual contract (`href: string | null`).

Reproduced on macOS against `develop` (64e590c7) before the fix with the exact stack trace from the issue; the same scenario is clean after the fix.

Note on scope: even without the crash, custom-protocol links do not open — the main-process `mt::format-link-click` handler only opens `http(s)` URLs and deliberately swallows other schemes (`// Prevent other URLs.`). That behavior predates the engine rewrite and is left unchanged here, since opening arbitrary schemes via `shell.openExternal` is a security decision. Happy to follow up if supporting custom protocols (e.g. behind a confirmation prompt) is wanted — discussed in #4356.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: macOS

New tests:

- `packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts` — the popover omits the jump item when `linkInfo.href` is null and renders it when an href is present.
- `packages/desktop/test/e2e/issue-4356.spec.ts` — Playwright regression spec: the popover on a custom-protocol link offers only "unlink" without renderer errors, and anchor links still offer a working "jump".

Verified locally: muya unit tests (726 passed), desktop unit tests (465 passed), `pnpm run lint`, `pnpm run typecheck`, `pnpm -C packages/muya lint`, `pnpm -C packages/muya lint:types`, and the desktop e2e suite (97 passed; the one failure, `parity-source-undo-saved.spec.ts`, fails identically on unmodified `develop` and is unrelated).

## Notes for reviewers [optional]

The e2e spec follows the existing `issue-NNNN.spec.ts` crash-guard convention and uses the `suppressErrorDialog` + `expectNoRendererErrors` helpers from `test/e2e/helpers.ts`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
