### PR TITLE
fix: #4474 unsaved indicator never clears after undoing back to on-disk content

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1450,6 +1450,13 @@ const handleFileChange = (payload: unknown) => {
       if (savedEngineHistory) {
         editor.value.setHistory(savedEngineHistory)
       }
+      // First activation of a tab the save-tracking allocator has never seen:
+      // seed its clean baseline from the engine's serialization now, before
+      // any edit. For a tab that already has a tracker this is a no-op —
+      // switching back must keep the existing content -> id map.
+      if (id) {
+        getSyntheticHistory(id, editor.value.getMarkdown())
+      }
     }
   } else if (newCursor) {
     editor.value.setCursor(newCursor)
@@ -1609,6 +1616,15 @@ onMounted(() => {
   // the document tree and instantiates the registered UI plugins).
   muya.init()
   editor.value = muya
+
+  // Seed the save-tracking baseline for the mount-loaded document (from the
+  // engine's OWN serialization, same reason as setMarkdownToEditor). Without
+  // this the allocator is created lazily on the first `json-change` — i.e.
+  // after the first edit — so the pristine content never maps to id 0 and
+  // undoing back to the on-disk content can never read as clean again (PG15).
+  if (currentFile.value?.id) {
+    getSyntheticHistory(currentFile.value.id, muya.getMarkdown())
+  }
 
   const container = getScrollContainer()!
 


### PR DESCRIPTION
Closes #4474

## Summary

After editing an opened file, undoing back to the exact on-disk content left the tab's unsaved dot lit forever. The repo's own parity spec encodes the expected behavior and failed deterministically on a clean `develop` checkout: `test/e2e/parity-source-undo-saved.spec.ts` — "PG15: undoing an edit back to disk content clears the unsaved indicator".

Root cause: the synthetic save-tracking allocator (`syntheticHistory.ts`) must map a tab's on-disk content to id 0 (matching the store's seeded `lastSavedHistoryId: 0`), but it was created lazily on the first `json-change` — which fires on the first edit, not on load. Only the `open-single-file` path (`setMarkdownToEditor`) seeded it eagerly; documents loaded at editor mount (`new Muya({ markdown })`) or activated via a tab switch (`handleFileChange` → `setContent`) never registered their pristine baseline. The content reached by undo therefore got a fresh monotonic id that could never equal the saved id. The mis-seeded baseline also opened a brief false-clean window right after the very first edit of a launch-opened document (closing after a single keystroke could skip the save prompt).

The fix seeds the allocator from the engine's own serialization at the two missing baseline points, exactly as `setMarkdownToEditor` already does: once after `muya.init()` for the mount-loaded document, and once after `setContent` on first tab activation. The activation-path call is creation-if-missing — a no-op for a tab that already has a tracker, which switch-back requires (the existing content → id map must survive).

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: macOS

No new test files: the regression test already exists in-repo — PG15 in `test/e2e/parity-source-undo-saved.spec.ts` drives the real built app through the exact user scenario (launch with file, type, undo, observe the tab indicator). It failed deterministically before this change and passes after; the adjacent G6 spec (a divergent re-edit at the saved undo depth must stay dirty — the false-clean/data-loss guard) still passes.

Verified locally on macOS (Apple Silicon): full desktop e2e suite 96 passed / 3 skipped / 0 failed, unit tests 465 passed, `pnpm run lint`, `pnpm run typecheck`.

## Notes for reviewers [optional]

One related path is intentionally left unchanged: a reload after an external on-disk change (`file-changed` emitted from the store's disk-reload handler) keeps the tab's existing tracker, so undoing to the new disk content does not read as clean. That edge predates this fix and seems better handled together with the store's `lastSavedHistoryId` reset semantics; happy to follow up if wanted.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
