### PR TITLE
fix(muya): stop drag-selection from expanding to whole blocks

### DIFF
--- a/packages/muya/e2e/tests/editing/text-selection-no-expand.spec.ts
+++ b/packages/muya/e2e/tests/editing/text-selection-no-expand.spec.ts
@@ -1,0 +1,96 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+/**
+ * Text drag-selection must NOT auto-expand to whole structural blocks. A
+ * selection whose anchor/focus lands inside a list item, code block, or table
+ * cell used to grow to cover the entire list item / code block / table
+ * (`TextSelection.handleMousemoveOrClick`). Expectation: the selection ends
+ * exactly where the pointer lands — interior offsets stay interior.
+ *
+ * Real pointer drag → Chromium only (system Chrome locally / bundled in CI),
+ * same constraint as the other `editing/` pointer specs.
+ */
+
+interface SelectionSnapshot {
+    anchorText: string | null;
+    focusText: string | null;
+    anchorOffset: number | null;
+    focusOffset: number | null;
+}
+
+async function readSelection(page: Page): Promise<SelectionSnapshot> {
+    return page.evaluate(() => {
+        const sel = window.muya!.editor.selection;
+        return {
+            anchorText: sel.anchorBlock?.text ?? null,
+            focusText: sel.focusBlock?.text ?? null,
+            anchorOffset: sel.anchor?.offset ?? null,
+            focusOffset: sel.focus?.offset ?? null,
+        };
+    });
+}
+
+// Pixel centre of a single character in the nth matched paragraph, measured
+// from a real DOM Range so the drag lands on an exact text offset (list-item
+// paragraphs stretch full editor width, so a width-fraction would overshoot
+// the rendered text).
+async function pointAtChar(
+    page: Page,
+    selector: string,
+    paragraphIndex: number,
+    charOffset: number,
+): Promise<{ x: number; y: number }> {
+    return page.evaluate(
+        ({ selector, paragraphIndex, charOffset }) => {
+            const p = document.querySelectorAll(selector)[paragraphIndex] as HTMLElement;
+            const textNode = document.createTreeWalker(p, NodeFilter.SHOW_TEXT).nextNode()!;
+            const range = document.createRange();
+            range.setStart(textNode, charOffset);
+            range.setEnd(textNode, charOffset + 1);
+            const r = range.getBoundingClientRect();
+            return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+        },
+        { selector, paragraphIndex, charOffset },
+    );
+}
+
+async function dragBetween(
+    page: Page,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+): Promise<void> {
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.mouse.move((from.x + to.x) / 2, (from.y + to.y) / 2, { steps: 4 });
+    await page.mouse.move(to.x, to.y, { steps: 4 });
+    await page.mouse.up();
+}
+
+test.describe('text selection does not auto-expand blocks', () => {
+    test('dragging between two list items keeps interior offsets', async ({ page }) => {
+        await page.evaluate(() =>
+            window.muya!.setContent('- first item here\n- second item here\n'));
+        const sel = `${editor.bulletList} ${editor.paragraph}`;
+        await expect(page.locator(sel)).toHaveCount(2);
+
+        // Start at offset 12 of item 1, end at offset 3 of item 2 — both well
+        // inside the rendered text. The old whole-item expansion snapped these
+        // to 0 (anchor) and text.length (focus); without it they stay interior.
+        await dragBetween(
+            page,
+            await pointAtChar(page, sel, 0, 12),
+            await pointAtChar(page, sel, 1, 3),
+        );
+
+        await expect.poll(() => readSelection(page).then(s => s.focusText)).toBe('second item here');
+        const snap = await readSelection(page);
+        expect(snap.anchorText).toBe('first item here');
+        // The whole-block expansion forced anchor→0 and focus→text.length.
+        expect(snap.anchorOffset).toBeGreaterThan(0);
+        expect(snap.anchorOffset).toBeLessThan('first item here'.length);
+        expect(snap.focusOffset).toBeGreaterThan(0);
+        expect(snap.focusOffset).toBeLessThan('second item here'.length);
+    });
+});

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -1,8 +1,5 @@
 import type Content from '../block/base/content';
 import type Format from '../block/base/format';
-import type Parent from '../block/base/parent';
-import type ListItem from '../block/commonMark/listItem';
-import type TaskListItem from '../block/gfm/taskListItem';
 import type { Muya } from '../muya';
 import type Selection from './index';
 import type { ICursor, INodeOffset, ISelection } from './types';
@@ -298,7 +295,6 @@ class TextSelection {
                 anchorBlock,
                 focusBlock,
                 isSelectionInSameBlock,
-                direction,
             } = selection;
 
             if (isSelectionInSameBlock) {
@@ -313,95 +309,6 @@ class TextSelection {
                 anchorPath: anchorBlock.path,
                 focusPath: focusBlock.path,
             };
-
-            const anchorOutMostBlock = anchorBlock.outMostBlock as Parent;
-            const focusOutMostBlock = focusBlock.outMostBlock as Parent;
-            if (
-                /block-quote|code-block|html-block|table|math-block|frontmatter|diagram/.test(
-                    anchorOutMostBlock.blockName,
-                )
-            ) {
-                const firstContent = anchorOutMostBlock.firstContentInDescendant()!;
-                const lastContent = anchorOutMostBlock.lastContentInDescendant()!;
-
-                if (direction === 'forward') {
-                    newSelection.anchorBlock = firstContent;
-                    newSelection.anchorPath = firstContent.path;
-                    newSelection.anchor.offset = 0;
-                }
-                else {
-                    newSelection.anchorBlock = lastContent;
-                    newSelection.anchorPath = lastContent.path;
-                    newSelection.anchor.offset = lastContent.text.length;
-                }
-            }
-
-            if (
-                /block-quote|code-block|html-block|table|math-block|frontmatter|diagram/.test(
-                    focusOutMostBlock.blockName,
-                )
-            ) {
-                const firstContent = focusOutMostBlock.firstContentInDescendant()!;
-                const lastContent = focusOutMostBlock.lastContentInDescendant()!;
-                if (direction === 'forward') {
-                    newSelection.focusBlock = lastContent;
-                    newSelection.focusPath = lastContent.path;
-                    newSelection.focus.offset = lastContent.text.length;
-                }
-                else {
-                    newSelection.focusBlock = firstContent;
-                    newSelection.focusPath = firstContent.path;
-                    newSelection.focus.offset = 0;
-                }
-            }
-
-            if (
-                /bullet-list|order-list|task-list/.test(anchorOutMostBlock.blockName)
-            ) {
-                const listItemBlockName
-                    = anchorOutMostBlock.blockName === 'task-list'
-                        ? 'task-list-item'
-                        : 'list-item';
-                const listItem = anchorBlock.farthestBlock(listItemBlockName) as
-                    | ListItem
-                    | TaskListItem;
-                const firstContent = listItem.firstContentInDescendant()!;
-                const lastContent = listItem.lastContentInDescendant()!;
-                if (direction === 'forward') {
-                    newSelection.anchorBlock = firstContent;
-                    newSelection.anchorPath = firstContent.path;
-                    newSelection.anchor.offset = 0;
-                }
-                else {
-                    newSelection.anchorBlock = lastContent;
-                    newSelection.anchorPath = lastContent.path;
-                    newSelection.anchor.offset = lastContent.text.length;
-                }
-            }
-
-            if (
-                /bullet-list|order-list|task-list/.test(focusOutMostBlock.blockName)
-            ) {
-                const listItemBlockName
-                    = focusOutMostBlock.blockName === 'task-list'
-                        ? 'task-list-item'
-                        : 'list-item';
-                const listItem = focusBlock.farthestBlock(listItemBlockName) as
-                    | ListItem
-                    | TaskListItem;
-                const firstContent = listItem.firstContentInDescendant()!;
-                const lastContent = listItem.lastContentInDescendant()!;
-                if (direction === 'forward') {
-                    newSelection.focusBlock = lastContent;
-                    newSelection.focusPath = lastContent.path;
-                    newSelection.focus.offset = lastContent.text.length;
-                }
-                else {
-                    newSelection.focusBlock = firstContent;
-                    newSelection.focusPath = firstContent.path;
-                    newSelection.focus.offset = 0;
-                }
-            }
 
             if (type === 'mousemove')
                 this._selectInfo.selection = newSelection;


### PR DESCRIPTION
## What

Text drag-selection no longer auto-expands to whole structural blocks. Previously, when a selection's anchor or focus landed inside a **code block**, **list item**, or **table cell**, `TextSelection.handleMousemoveOrClick` grew the selection to cover the entire enclosing block — snapping the anchor offset to `0` and the focus offset to `text.length`. The result was that landing in a list item selected the whole item, landing in a code block selected the whole code block, and landing in a table cell selected the whole table.

Expectation (and new behavior): the selection ends exactly where the pointer lands — interior offsets stay interior.

## How

- Removed the four expansion branches in `TextSelection.handleMousemoveOrClick` (and the now-unused `direction` destructure + `Parent` / `ListItem` / `TaskListItem` imports).
- The `isSelectionInSameBlock` early return is unchanged.
- This is isolated to the `TextSelection` text-drag path. It does **not** affect:
  - `TableRectSelection` — rectangular cross-cell drag selection (collapses the native range before this code runs, so the same-block early return fires).
  - `selectAll()` — the Cmd+A escalation lives in a separate facade method.

## Testing

- New Chromium e2e regression test (`editing/text-selection-no-expand.spec.ts`): drags between two list items at interior char offsets and asserts the offsets stay interior (the old expansion forced 0 / text.length). Confirmed red before the fix, green after.
- `pnpm -C packages/muya lint:types` clean, ESLint clean.
- Full unit suite: 733 passed; `check-circular` clean.
- Related e2e (editing/ + typing/lists): 21 passed, including `table-cell-selection` (rectangle selection intact) and `selection.spec.ts` (Cmd+A across blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)