### PR TITLE
fix(muya): stop arrow nav from crashing on null cursor coords

### DIFF
--- a/packages/muya/src/__tests__/arrowHtmlBlockCrash.spec.ts
+++ b/packages/muya/src/__tests__/arrowHtmlBlockCrash.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../muya';
+
+// Regression: pressing ArrowDown inside an HTML block's code content used to
+// crash with "Cannot destructure property 'y' of getCursorCoords(...) as it is
+// null". `getCursorCoords()` returns `DOMRect | null` (no client rects for the
+// collapsed caret), but `getCursorYOffset` dereferenced it with a `!`.
+// In happy-dom `Range.getClientRects()` always returns an empty list, so this
+// reproduces the null-coords condition deterministically.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('arrowHandler from an HTML block (null cursor coords)', () => {
+    it('does not throw on ArrowDown when getCursorCoords() returns null', () => {
+        const muya = bootMuya('<div>html content</div>\n\nafter\n');
+        const codeContent = muya.editor.scrollPage!.firstContentInDescendant()!;
+        codeContent.setCursor(0, 0, true);
+
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+
+        expect(() => codeContent.arrowHandler(event)).not.toThrow();
+    });
+});

--- a/packages/muya/src/selection/cursorCoords.ts
+++ b/packages/muya/src/selection/cursorCoords.ts
@@ -31,7 +31,14 @@ export function getSelectionStart(): Node | null {
 }
 
 export function getCursorYOffset(paragraph: HTMLElement): { topOffset: number; bottomOffset: number } {
-    const { y } = getCursorCoords()!;
+    const coords = getCursorCoords();
+    // The collapsed caret can yield no client rects (e.g. an HTML/code block
+    // boundary position), so `getCursorCoords()` returns null. Treat that as
+    // "position unknown" and let arrow navigation leave the block.
+    if (coords == null)
+        return { topOffset: 0, bottomOffset: 0 };
+
+    const { y } = coords;
     const { height, top } = paragraph.getBoundingClientRect();
     const lineHeight = Number.parseFloat(getComputedStyle(paragraph).lineHeight);
     const topOffset = Math.floor((y - top) / lineHeight);


### PR DESCRIPTION
## Problem

Pressing an arrow key to move out of an HTML block crashes the renderer:

```
TypeError: Cannot destructure property 'y' of 'getCursorCoords(...)' as it is null.
    at getCursorYOffset (selection/cursorCoords.ts)
    at CodeBlockContent.arrowHandler (block/base/content.ts)
```

## Root cause

`getCursorCoords()` is typed `DOMRect | null` and returns `null` when the collapsed caret yields no client rects (an HTML/code block boundary position is one such case). `getCursorYOffset` dereferenced it with a non-null assertion (`getCursorCoords()!`), so the destructure of `y` throws.

The legacy `packages/muyajs` engine never hit this because its `getCursorCoords` defaulted `y = 0` instead of returning null — the TS rewrite made the return nullable but left the consumer assuming non-null.

## Fix

When coords are unknown, return `{ topOffset: 0, bottomOffset: 0 }`. In `arrowHandler` neither `topOffset > 0` nor `bottomOffset > 0` holds, so arrow navigation proceeds to the adjacent block — the intended "move out of the HTML block" behavior.

## Tests

- Added `src/__tests__/arrowHtmlBlockCrash.spec.ts`. In happy-dom `Range.getClientRects()` always returns empty, so it reproduces the null-coords path deterministically — failing with the exact reported error before the fix, passing after.
- `src/__tests__/` + `src/selection/` suites: 181 tests pass. `lint:types` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)