### PR TITLE
fix(muya): clear the `/` trigger when quick-inserting front matter

### DIFF
--- a/packages/muya/src/__tests__/frontMatter.spec.ts
+++ b/packages/muya/src/__tests__/frontMatter.spec.ts
@@ -172,8 +172,10 @@ describe('muya.updateParagraph(\'front-matter\')', () => {
 // in-place `block.replaceWith` that could create front matter MID-document by
 // converting an empty paragraph — front matter is only valid at document start.
 describe('quick-insert front matter (replaceBlockByLabel)', () => {
-    it('inserts at document start, not in place, when triggered mid-document', async () => {
-        const muya = bootMuya('first para\n\nsecond para\n');
+    it('inserts at document start, clears the `/` trigger, keeps other blocks', async () => {
+        // The trigger paragraph carries the `/` the user typed to open the
+        // quick-insert menu (its whole text matches `/^[/、]\S*$/`).
+        const muya = bootMuya('first para\n\n/\n');
         // Quick-insert is triggered on the SECOND paragraph (mid-document). The
         // menu passes the leaf block at the cursor as `block`.
         const block = leafAt(muya, 1);
@@ -185,14 +187,16 @@ describe('quick-insert front matter (replaceBlockByLabel)', () => {
         });
 
         const state = muya.getState();
-        // The new front matter is prepended; both original paragraphs survive
-        // intact (the in-place replace bug would have destroyed the second one).
+        // The new front matter is prepended; the non-trigger paragraph survives
+        // intact (the in-place replace bug would have destroyed it) and the `/`
+        // trigger paragraph remains as an emptied block — its `/` is cleared,
+        // not left behind in the document.
         expect(state.length).toBe(3);
         expect(state[1].name).toBe('paragraph');
         expect(state[2].name).toBe('paragraph');
         const md = muya.getMarkdown();
         expect(md).toContain('first para');
-        expect(md).toContain('second para');
+        expect(md).not.toContain('/');
     });
 
     it('is idempotent — no second front matter block when one already exists', async () => {

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -236,6 +236,61 @@ describe('replaceBlockByLabel — paragraph→list keeps text verbatim (marktext
     });
 });
 
+// Front matter is prepended at the document start rather than replacing the
+// cursor block in place (`block.replaceWith`), so the `/` quick-insert trigger
+// text the user typed survives in the original paragraph unless we clear it
+// explicitly. Every other label drops the trigger implicitly via
+// `block.replaceWith(newBlock)`; front matter must clear the trigger paragraph
+// itself. Regression target: "通过 quick insert 菜单插入 Front matter 时候 `/`
+// 没有自动删除".
+function makeFrontMatterMuya(): Muya {
+    return {
+        options: {
+            preferLooseListItem: false,
+            bulletListMarker: '-',
+            orderListDelimiter: '.',
+            frontmatterType: '-',
+        },
+        editor: {
+            scrollPage: {
+                firstChild: { blockName: 'paragraph' },
+                insertBefore: vi.fn(),
+            },
+        },
+    } as unknown as Muya;
+}
+
+describe('replaceBlockByLabel — frontmatter clears the `/` trigger text', () => {
+    it('empties the trigger paragraph content and refreshes its DOM', () => {
+        const { restore } = setupCreateSpy();
+        try {
+            const update = vi.fn();
+            const content = { text: '/front', update };
+            const replaceWith = vi.fn();
+            const block = {
+                replaceWith,
+                firstContentInDescendant: () => content,
+            } as unknown as Parent;
+
+            replaceBlockByLabel({
+                block,
+                muya: makeFrontMatterMuya(),
+                label: 'frontmatter',
+            });
+
+            // The `/` typed to open the menu must be gone...
+            expect(content.text).toBe('');
+            // ...and the DOM re-rendered so it does not keep showing `/front`.
+            expect(update).toHaveBeenCalled();
+            // Front matter is prepended, never an in-place replace of the cursor block.
+            expect(replaceWith).not.toHaveBeenCalled();
+        }
+        finally {
+            restore();
+        }
+    });
+});
+
 // The in-editor "table" insert (the `/` quick-insert menu and the paragraph
 // front-menu both route through `replaceBlockByLabel`) must show the legacy
 // hover-grid dimension picker (`TableChessboard`) — NOT drop a fixed-size

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -64,14 +64,14 @@ export function frontmatterMeta(frontmatterType: string): IFrontmatterMeta {
  * the block. Shared by `Muya.updateParagraph('front-matter')` and the
  * quick-insert menu's `frontmatter` entry so both follow identical semantics.
  */
-export function insertFrontMatterAtStart(muya: Muya) {
+export function insertFrontMatterAtStart(muya: Muya): boolean {
     const { scrollPage } = muya.editor;
     if (!scrollPage)
-        return;
+        return false;
 
     const firstBlock = scrollPage.firstChild as Parent | null;
     if (firstBlock?.blockName === 'frontmatter')
-        return;
+        return false;
 
     const fmState = deepClone(emptyStates.frontmatter);
     Object.assign(fmState.meta, frontmatterMeta(muya.options.frontmatterType));
@@ -79,6 +79,8 @@ export function insertFrontMatterAtStart(muya: Muya) {
     const frontmatter = ScrollPage.loadBlock('frontmatter').create(muya, fmState);
     scrollPage.insertBefore(frontmatter, firstBlock);
     frontmatter.firstContentInDescendant()?.setCursor(0, 0, true);
+
+    return true;
 }
 
 const COMMAND_KEY = isOsx ? '⌘' : 'Ctrl';
@@ -463,7 +465,19 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
     // `block.replaceWith` below — sharing the idempotent doc-start logic with
     // `Muya.updateParagraph('front-matter')`.
     if (label === 'frontmatter') {
-        insertFrontMatterAtStart(muya);
+        // Every other label drops the `/` quick-insert trigger text implicitly
+        // via `block.replaceWith(newBlock)`. Front matter is prepended at the
+        // document start instead (the trigger paragraph survives), so clear its
+        // `/…` text and refresh the DOM. Only do so when a block was actually
+        // inserted — when the document already starts with front matter the
+        // insert is a no-op and the trigger paragraph must be left untouched.
+        if (insertFrontMatterAtStart(muya)) {
+            const triggerContent = block.firstContentInDescendant();
+            if (triggerContent) {
+                triggerContent.text = '';
+                triggerContent.update();
+            }
+        }
         return;
     }
 


### PR DESCRIPTION
## What

Inserting **Front Matter** via the `/` quick-insert menu left the typed `/` behind in the document.

## Why

Every other quick-insert label drops the `/` trigger text implicitly via `block.replaceWith(newBlock)` — the whole trigger paragraph (with its `/`) is swapped for the new block.

Front matter is only valid as the document's first block, so it goes through `insertFrontMatterAtStart`, which **prepends** a front matter block and returns early — the trigger paragraph (still holding `/`) was never touched, so the `/` lingered.

## Fix

After a front matter block is actually inserted, clear the trigger paragraph's text and refresh its DOM.

`insertFrontMatterAtStart` now returns a `boolean` so we only clear the trigger when something was inserted — the idempotent no-op case (document already starts with front matter) leaves the trigger paragraph's content intact.

## Tests

- New unit test in `replaceBlockByLabel.spec.ts` (mock layer): asserts the `/…` trigger text is emptied and the DOM is refreshed, and that front matter is never an in-place `replaceWith`.
- Updated the real-Muya integration tests in `frontMatter.spec.ts` to use a realistic `/` trigger paragraph: front matter is prepended, other content blocks survive intact, and the `/` is cleared. The idempotent case keeps existing content (regression guard for the new `boolean` guard).
- Full muya unit suite: **743 passed**. `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)