### PR TITLE
fix(desktop): make Promote Heading shortcut fire on macOS

### DIFF
--- a/packages/desktop/src/main/keyboard/keybindingsDarwin.ts
+++ b/packages/desktop/src/main/keyboard/keybindingsDarwin.ts
@@ -53,7 +53,7 @@ const keybindings: Map<string, string> = new Map([
   ['paragraph.heading-4', 'Command+4'],
   ['paragraph.heading-5', 'Command+5'],
   ['paragraph.heading-6', 'Command+6'],
-  ['paragraph.upgrade-heading', 'Command+Plus'],
+  ['paragraph.upgrade-heading', 'Command+='],
   ['paragraph.degrade-heading', 'Command+-'],
   ['paragraph.table', 'Command+Shift+T'],
   ['paragraph.code-fence', 'Command+Option+C'],


### PR DESCRIPTION
## What

On macOS the **Promote Heading** keyboard shortcut (`⌘ +`) had no effect, while **Demote Heading** (`⌘ -`) worked.

## Root cause

Editor shortcuts are matched **by key value** through `@hfelix/electron-localshortcut` (`registerEditorKeyHandlers`). The binding `Command+Plus` only matches when the normalized event key is `+`. Under the Command modifier on macOS, the `=`/`+` key does not resolve to `+`, so the `upgrade-heading` shortcut never matched and never fired.

`Command+-` (degrade) keeps working because `-` needs no Shift and resolves identically with or without the modifier — which is exactly why only the promote direction was reported broken.

Windows/Linux are unaffected (Ctrl does not strip Shift there, so `Ctrl+Plus` still matches `+`), so this is a macOS-only fix.

## Fix

Bind macOS `paragraph.upgrade-heading` to `Command+=` — the conventional macOS accelerator (same key as browser zoom-in). It matches the `=`/`+` physical key with or without Shift, so both `⌘=` and `⌘ Shift =` promote the heading. The menu item and command palette read the binding by id, so they pick up the new accelerator automatically (displayed as `⌘=`).

## Testing

- Verified the actual `@hfelix/electron-localshortcut` matcher: `Command+=` matches the normalized `{ key: '=', meta: true }` event the `=`/`+` key produces; `Command+Plus` does not.
- Manually confirmed in a running build (macOS): after the fix, `⌘=` promotes the heading (H2 → H1); `⌘-` demote unchanged.

Related: muya migration parity testing (paragraph menu / heading level changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)