### PR TITLE
fix(desktop): refresh muya locale on language switch (hint + quick-insert menu stay translated)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1510,9 +1510,10 @@ const handleResetPaddingBottom = () => {
   }
 }
 
-const handleLanguageChanged = () => {
+const handleLanguageChanged = (newLocale?: unknown) => {
   if (editor.value) {
-    editor.value.locale(getMuyaLocale(language.value))
+    const locale = typeof newLocale === 'string' ? newLocale : language.value
+    editor.value.locale(getMuyaLocale(locale))
   }
 }
 const resizeObserverForEditor = new ResizeObserver(handleResetPaddingBottom)

--- a/packages/desktop/test/e2e/parity-cursor-lang.spec.ts
+++ b/packages/desktop/test/e2e/parity-cursor-lang.spec.ts
@@ -119,11 +119,13 @@ test.describe('Parity G8 — language switch refreshes inline hints', () => {
     const enHint = await hintFor()
     expect(enHint).toBeTruthy()
 
-    // Switch the language the way the preference change does: update the
-    // preferences store (so `getMuyaLocale(language.value)` resolves zh-CN),
-    // then fire `language-changed`, which calls `editor.locale(...)`.
-    await sendIpcToRenderer(app, 'mt::user-preference', { language: 'zh-CN' })
+    // Mirror the real main-process order: AppMenu registers its
+    // `broadcast-preferences-changed` listener before WindowManager, so
+    // `language-changed` reaches the renderer BEFORE the `mt::user-preference`
+    // that syncs the preferences store. The handler must therefore read the
+    // locale from the event payload, not from the still-stale `language.value`.
     await sendIpcToRenderer(app, 'language-changed', 'zh-CN')
+    await sendIpcToRenderer(app, 'mt::user-preference', { language: 'zh-CN' })
     await page.waitForTimeout(400)
 
     const zhHint = await hintFor()


### PR DESCRIPTION
## Problem

Switching the UI language at runtime (e.g. English → 中文 or back) left the in-editor **quick-insert hint** (`Type / to insert…`) and the **`/` quick-insert menu** items stuck in the *previous* language, even though the rest of the app UI updated correctly.

## Root cause

`handleLanguageChanged` in `editor.vue` resolved the muya locale from the reactive `language.value` (preferences store):

```ts
const handleLanguageChanged = () => {
  if (editor.value) editor.value.locale(getMuyaLocale(language.value))
}
```

The preferences store is synced via a **separate** `mt::user-preference` IPC, which the main process emits **after** `language-changed`:

- In `accessor.ts`, `new AppMenu(...)` (line 46) registers its `broadcast-preferences-changed` listener **before** `new WindowManager(...)` (line 47).
- `preferences.setItem` fires `broadcast-preferences-changed` synchronously, so AppMenu's listener (→ `setLanguage` → `language-changed` IPC) runs **before** WindowManager's (→ `mt::user-preference` IPC).

So when `handleLanguageChanged` runs, `language.value` is **still the old locale**, and `editor.locale(...)` re-applies the previous language. Both symptoms share this single cause: the hint is rebuilt by `_forceRender()` via `muya.i18n.t`, and the `/` menu re-renders on open via `muya.i18n.t` — both read `muya.i18n.lang`, which never switched.

## Fix

Resolve the locale from the `language-changed` event payload (already carried by `bus.emit('language-changed', newLocale)`), removing the dependency on cross-IPC ordering.

## Tests

The existing `G8` e2e masked the bug by sending `mt::user-preference` *before* `language-changed`. Reordered it to match the real main-process sequence (`language-changed` first), so it now fails without the fix and passes with it.

- ✅ `pnpm run typecheck`
- ✅ `pnpm run lint` (changed files clean)
- ✅ `pnpm -C packages/desktop exec playwright test test/e2e/parity-cursor-lang.spec.ts -g 'G8'` — passes with fix, verified to fail without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)