### PR TITLE
fix(desktop): anchor theme card h3 label to its heading

### DIFF
--- a/packages/desktop/src/renderer/src/prefComponents/theme/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/theme/index.vue
@@ -415,6 +415,7 @@ const onSelectChange = (type: keyof PreferencesState, value: unknown): void => {
     }
   }
   & h3 {
+    position: relative;
     margin: 0;
     font-size: 16px;
     color: currentColor;


### PR DESCRIPTION
## Problem

On Preferences → Theme, the small "h3" marker next to each theme card title rendered in the top-left of the sidebar (above the "Preferences" heading) instead of inside its card.

## Cause

In `prefComponents/theme/index.vue`, the `h3::before` label (content: 'h3') used `position: absolute`, but neither the h3 nor its card had a positioning context. The absolute positioning therefore resolved against an outer panel container, pushing the label into the sidebar area.

## Fix

Add `position: relative` to `& h3` so the `::before` label anchors to the heading itself. The card has `padding-left: 32px`, which combined with `left: -20px` places the label inside the card, to the left of the theme name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)