### PR TITLE
fix(muya): stop in-flight float positioning from re-revealing a hidden float

### DIFF
--- a/packages/muya/src/ui/baseFloat/__tests__/hideRace.spec.ts
+++ b/packages/muya/src/ui/baseFloat/__tests__/hideRace.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../../index';
+import { describe, expect, it, vi } from 'vitest';
+import BaseFloat from '../index';
+
+// REGRESSION GUARD — table row menu (and any baseFloat) failing to auto-hide.
+//
+// baseFloat.show() positions the float through @floating-ui's async
+// `computePosition().then()`, which sets `opacity: 1`. If `hide()` runs while
+// such an update is still in flight (or the update resolves afterwards), the
+// pending `.then()` re-reveals an already-hidden float — and because it never
+// restores `status`, a later `hide()` early-returns and the float is stuck
+// visible. Reported against "Insert Row Above/Below": the TableRowColumMenu
+// stayed on screen after picking an item.
+
+class TestFloat extends BaseFloat {}
+
+function makeFloat(): TestFloat {
+    const muya = { eventCenter: { emit: vi.fn() } } as unknown as Muya;
+    return new TestFloat(muya, 'mu-test-float');
+}
+
+const reference = {
+    getBoundingClientRect: () => ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        toJSON() {},
+    }),
+};
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 20));
+
+describe('baseFloat hide() vs in-flight position update', () => {
+    it('stays hidden when hide() interrupts the initial position update', async () => {
+        const float = makeFloat();
+        float.show(reference);
+        // hide() before the async computePosition().then() resolves.
+        float.hide();
+        await tick();
+
+        expect(float.floatBox!.style.opacity).toBe('0');
+        expect(float.status).toBe(false);
+    });
+
+    it('a stale position update cannot resurrect a hidden float', async () => {
+        const float = makeFloat();
+        float.show(reference);
+        await tick();
+        expect(float.floatBox!.style.opacity).toBe('1');
+
+        float.hide();
+        // Even after every pending microtask/timer settles, the float must
+        // remain hidden — no late `.then()` may flip opacity back to 1.
+        await tick();
+        expect(float.floatBox!.style.opacity).toBe('0');
+    });
+});

--- a/packages/muya/src/ui/baseFloat/index.ts
+++ b/packages/muya/src/ui/baseFloat/index.ts
@@ -165,11 +165,18 @@ abstract class BaseFloat {
         // `unknown[]` so internal call sites can forward arbitrary args.
         this.cb = cb as (...args: unknown[]) => void;
 
-        this._cleanup = autoUpdate(reference, floatBox, () => {
+        const cleanup = autoUpdate(reference, floatBox, () => {
             computePosition(reference, floatBox, {
                 placement,
                 middleware: [offset(offsetOptions), flip()],
             }).then(({ x, y }) => {
+                // `computePosition` is async: a `hide()` (or a newer `show()`)
+                // can land before this resolves. Applying it then would set
+                // `opacity: 1` on an already-hidden float without restoring
+                // `status`, so the next `hide()` early-returns and the float is
+                // stuck visible. Bail unless this pass is still the active one.
+                if (this._cleanup !== cleanup)
+                    return;
                 Object.assign(floatBox.style, {
                     left: `${x}px`,
                     top: `${y}px`,
@@ -177,6 +184,7 @@ abstract class BaseFloat {
                 });
             });
         });
+        this._cleanup = cleanup;
 
         this.status = true;
 


### PR DESCRIPTION
## Problem

Reported against the table row menu (**Insert Row Above / Insert Row Below**): after choosing an item, the menu (`TableRowColumMenu`) stays on screen instead of auto-hiding.

`selectItem()` already calls `this.hide()` for every action, so the bug is one layer down in `baseFloat.show()`:

```ts
computePosition(...).then(({ x, y }) => {
  Object.assign(floatBox.style, { left, top, opacity: 1 }) // async, unguarded
})
```

`computePosition` is **async**. When `hide()` runs while a positioning pass is in flight (or the pass resolves just after), the pending `.then()` re-applies `opacity: 1` to an already-hidden float — and never restores `status`. The float reappears, and the next `hide()` early-returns (`if (!this.status) return`), so it's stuck visible.

This is timing-dependent: inserting a row triggers a reflow/scroll that ticks the menu's positioner exactly as `hide()` runs. It reproduces in the desktop app but not through a clean synthetic e2e click. The legacy `muyajs` never had this because popper.js set opacity synchronously via a CSS attribute.

## Fix

Guard the async positioning callback with **cleanup identity**: a pass only applies its result while it is still the active one. A hidden (or superseded by a newer `show()`) pass can neither re-reveal the float nor write stale coordinates. This is strictly more robust than a bare `status` check and never blocks legitimate repositioning.

Because the fix lives in `baseFloat`, it hardens **every** floating menu/toolbar against this auto-hide race, not just the table row menu.

## Tests

- New deterministic happy-dom regression test (`src/ui/baseFloat/__tests__/hideRace.spec.ts`): `show()` → immediate `hide()` must stay hidden. **Fails before the fix, passes after.**
- Full muya unit suite: 745/745 pass.
- `eslint` clean · `tsc --noEmit` clean.
- Existing `tests/drag/table-drag-bar.spec.ts` e2e: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)