### PR TITLE
fix(desktop): return relative image path for local-path-string inserts

### DIFF
--- a/packages/desktop/src/renderer/src/util/fileSystem.ts
+++ b/packages/desktop/src/renderer/src/util/fileSystem.ts
@@ -68,6 +68,10 @@ export const moveImageToFolder = async(
   currentPathname: string | null = null
 ): Promise<string> => {
   await window.fileUtils.ensureDir(outputDir)
+  const toResult = (absolutePath: string) =>
+    isRelative && currentPathname
+      ? window.path.relative(window.path.dirname(currentPathname), absolutePath)
+      : absolutePath
   const isPath = typeof image === 'string'
   if (isPath) {
     const dir = window.path.dirname(pathname)
@@ -78,12 +82,12 @@ export const moveImageToFolder = async(
       const ext = window.path.extname(imagePath)
       const noHashPath = window.path.join(outputDir, filename)
       if (noHashPath === imagePath) {
-        return imagePath
+        return toResult(imagePath)
       }
       const hash = await getContentHash(imagePath)
       const hashFilePath = window.path.join(outputDir, `${hash}${ext}`)
       await window.fileUtils.copy(imagePath, hashFilePath)
-      return hashFilePath
+      return toResult(hashFilePath)
     } else {
       return image as string
     }
@@ -97,11 +101,7 @@ export const moveImageToFolder = async(
     const buffer = new Uint8Array(await file.arrayBuffer())
     await window.fileUtils.writeFile(imagePath, buffer)
 
-    if (isRelative && currentPathname) {
-      return window.path.relative(window.path.dirname(currentPathname), imagePath)
-    }
-
-    return imagePath
+    return toResult(imagePath)
   }
 }
 

--- a/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
+++ b/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import path from 'path'
+import { moveImageToFolder } from '@/util/fileSystem'
+
+// moveImageToFolder relies on the preload contextBridge surface (window.path,
+// window.fileUtils). Stub them with the real node `path` and in-memory fakes so
+// the relative-path persistence logic can be exercised (real window.crypto is
+// used for the content hash).
+const copy = vi.fn((_src: string, _dest: string) => Promise.resolve())
+const writeFile = vi.fn(() => Promise.resolve())
+
+const win = window as unknown as {
+  path: typeof path
+  fileUtils: Record<string, unknown>
+}
+
+beforeEach(() => {
+  copy.mockClear()
+  writeFile.mockClear()
+  win.path = path
+  win.fileUtils = {
+    ensureDir: vi.fn(() => Promise.resolve()),
+    isImageFile: vi.fn(() => Promise.resolve(true)),
+    copy,
+    writeFile
+  }
+})
+
+describe('moveImageToFolder relative-directory persistence', () => {
+  const docPath = '/tmp/notes/a.md'
+  const assetsDir = '/tmp/notes/assets'
+
+  it('returns a relative path for a binary File when isRelative is set', async() => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'pic.png', { type: 'image/png' })
+    const result = await moveImageToFolder(docPath, file, assetsDir, true, docPath)
+    expect(result.startsWith('assets/')).toBe(true)
+    expect(path.isAbsolute(result)).toBe(false)
+  })
+
+  it('returns a relative path for a local path string when isRelative is set', async() => {
+    const source = '/Users/someone/pictures/pic.png'
+    const result = await moveImageToFolder(docPath, source, assetsDir, true, docPath)
+    // The image must be copied into the assets dir...
+    expect(copy).toHaveBeenCalledTimes(1)
+    expect(copy.mock.calls[0][1].startsWith(assetsDir)).toBe(true)
+    // ...and the inserted reference must be the portable relative path.
+    expect(path.isAbsolute(result)).toBe(false)
+    expect(result.startsWith('assets/')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

With **Insert action = Folder** + **Prefer relative directory** enabled (`imageRelativeDirectoryName='assets'`, base = file), inserting an image via **Format → Image** with a typed or picked local path did not produce a relative reference. The image was copied into the `assets/` folder, but the inserted markdown used an **absolute** path, ignoring the "prefer relative directory" preference.

## Root cause

In `packages/desktop/src/renderer/src/util/fileSystem.ts`, `moveImageToFolder` only applied the `isRelative` → `path.relative()` conversion in the binary `File` branch. A local **path string** (Format → Image) hits the `isPath` branch, which returned the absolute `hashFilePath`/`imagePath` regardless of `isRelative`.

This is the persistence half of the Phase-G relative-path image work (#4428); the two new code paths (persist-as-relative and render-relative) must stay consistent, and the path-string persistence half was the gap.

## Fix

Extract a `toResult()` helper and apply it to both branches so path-string inserts persist the portable relative reference too.

## Testing

- New `test/unit/specs/move-image-to-folder.spec.ts`: asserts the `File` branch returns a relative path (already passing) and the path-string branch both **copies into `assets/`** and **returns a relative path** (failing before the fix, passing after).
- Full unit suite: 467/467 pass. `typecheck` and `eslint` clean.

> Note: this covers the persistence half. The render half (muya `getImageSrc`/`resolveRelativePath` anchoring on `window.DIRNAME`) is GUI-dependent and not exercised here — manual verification of end-to-end display is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)