### PR TITLE
fix: insert web images dragged from a browser

### DIFF
--- a/packages/desktop/src/renderer/src/pages/app.vue
+++ b/packages/desktop/src/renderer/src/pages/app.vue
@@ -143,6 +143,11 @@ const setupDragDropHandler = (): void => {
           bus.emit('importDialog', true)
         }
         e.dataTransfer.dropEffect = 'copy'
+      } else if (e.dataTransfer.types.indexOf('text/uri-list') >= 0) {
+        // A web-link / web-image drag (e.g. an <img> dragged from a browser).
+        // The muya editor's own dragover/drop handlers accept these and insert
+        // an image block, so leave the drop enabled — forcing dropEffect='none'
+        // here would clobber the editor's 'copy' and suppress the drop event.
       } else {
         e.stopPropagation()
         e.dataTransfer.dropEffect = 'none'

--- a/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
+++ b/packages/muya/src/editor/__tests__/dragDropImage.spec.ts
@@ -185,18 +185,28 @@ describe('attachDragDropImageHandlers — local image FILE', () => {
     });
 });
 
-// A browser image drag carries `text/uri-list` + `text/html` and (crucially)
-// NO `text/plain`; a plain hyperlink drag additionally carries `text/plain`.
-// The handler gates on that signature so it intercepts only likely images.
-function webImageDataTransfer(url: string): DataTransfer {
+// A browser image drag carries `text/uri-list` + `text/html` (an `<img>`) and
+// (crucially) NO `text/plain`; a plain hyperlink drag additionally carries
+// `text/plain`. The handler gates on that signature so it intercepts only
+// likely images. The `text/html` `<img>` is read synchronously alongside the
+// uri-list, so the web-image branch now resolves over microtasks rather than
+// inside the same tick — tests await `flushMicrotasks()` before asserting.
+function webImageDataTransfer(url: string, html = `<img src="${url}">`): DataTransfer {
     const dt = new DataTransfer();
     dt.items.add(url, 'text/uri-list');
-    dt.items.add(`<img src="${url}">`, 'text/html');
+    dt.items.add(html, 'text/html');
     return dt;
 }
 
+// Drain the microtask queue so the chained getAsString → checkImageContentType
+// promise in `handleWebLinkImage` settles before assertions.
+async function flushMicrotasks(): Promise<void> {
+    for (let i = 0; i < 5; i++)
+        await Promise.resolve();
+}
+
 describe('attachDragDropImageHandlers — web-link image', () => {
-    it('inserts `![](url)` for an image URL dragged from a browser', () => {
+    it('inserts `![](url)` for an image URL dragged from a browser', async () => {
         const muya = makeMuya();
         const contentDom = makeDropTarget(muya);
         attachDragDropImageHandlers(muya as unknown as Muya);
@@ -204,29 +214,65 @@ describe('attachDragDropImageHandlers — web-link image', () => {
         const dt = webImageDataTransfer('https://example.com/pic.png');
 
         muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        await flushMicrotasks();
 
-        // happy-dom fires getAsString synchronously and the URL has an image
-        // extension, so the block is inserted within the same tick.
         expect(createdBlocks).toHaveLength(1);
         expect(createdBlocks[0].text).toBe('![](https://example.com/pic.png)');
         expect(createdBlocks[0].insertedBefore).toBe(true);
     });
 
-    it('ignores a non-image URL even with the web-image signature', () => {
+    it('inserts an extension-less image URL using the dragged `<img>` html signal', async () => {
         const muya = makeMuya();
         const contentDom = makeDropTarget(muya);
         attachDragDropImageHandlers(muya as unknown as Muya);
 
-        // Well-formed signature, but the URL is not an image and the
-        // content-type sniff (HEAD fetch) fails under happy-dom → no insert.
-        const dt = webImageDataTransfer('https://example.com/page.html');
+        // A real-world CDN image: no file extension, query string — `IMAGE_EXT_REG`
+        // misses and the cross-origin HEAD sniff fails, but the `<img>` html proves
+        // it is an image without any network call.
+        const dt = webImageDataTransfer('https://images.example.com/photo?id=123');
 
         muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        await flushMicrotasks();
+
+        expect(createdBlocks).toHaveLength(1);
+        expect(createdBlocks[0].text).toBe('![](https://images.example.com/photo?id=123)');
+    });
+
+    it('strips uri-list line terminators from the inserted URL', async () => {
+        const muya = makeMuya();
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        // `text/uri-list` is a CRLF-delimited format; a trailing CRLF must not
+        // leak into the markdown nor defeat the extension match.
+        const dt = webImageDataTransfer('https://example.com/pic.png\r\n');
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        await flushMicrotasks();
+
+        expect(createdBlocks).toHaveLength(1);
+        expect(createdBlocks[0].text).toBe('![](https://example.com/pic.png)');
+    });
+
+    it('ignores a non-image URL with no `<img>` html and a failing content-type sniff', async () => {
+        const muya = makeMuya();
+        const contentDom = makeDropTarget(muya);
+        attachDragDropImageHandlers(muya as unknown as Muya);
+
+        // Web-image signature shape, but the html is a link (not an `<img>`), the
+        // URL has no image extension, and the HEAD sniff fails under happy-dom.
+        const dt = webImageDataTransfer(
+            'https://example.com/page.html',
+            '<a href="https://example.com/page.html">link</a>',
+        );
+
+        muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        await flushMicrotasks();
 
         expect(createdBlocks).toHaveLength(0);
     });
 
-    it('ignores a plain hyperlink drag (uri-list + text/plain, no html)', () => {
+    it('ignores a plain hyperlink drag (uri-list + text/plain, no html)', async () => {
         const muya = makeMuya();
         const contentDom = makeDropTarget(muya);
         attachDragDropImageHandlers(muya as unknown as Muya);
@@ -237,6 +283,7 @@ describe('attachDragDropImageHandlers — web-link image', () => {
         dt.items.add('https://example.com/pic.png', 'text/plain');
 
         muya.domNode.dispatchEvent(dropEvent(contentDom, dt));
+        await flushMicrotasks();
 
         expect(createdBlocks).toHaveLength(0);
     });

--- a/packages/muya/src/editor/dragDropImage.ts
+++ b/packages/muya/src/editor/dragDropImage.ts
@@ -123,9 +123,33 @@ function insertImageParagraph(
     return imageBlock;
 }
 
-// Drop path 1 — a web-link image carried as `text/uri-list`. Verify the URL
-// resolves to an image (by extension, or by content-type sniff), then insert
-// `![](url)` verbatim.
+// `text/uri-list` is a CRLF-delimited format whose lines may include `#`
+// comments; the dragged image URL is the first non-comment line. Trimming it
+// also keeps a trailing CRLF out of the inserted markdown and out of the way of
+// `IMAGE_EXT_REG`'s end-of-string anchor.
+function firstUri(uriList: string): string {
+    return (
+        uriList
+            .split(/[\r\n]+/)
+            .map(line => line.trim())
+            .find(line => line.length > 0 && !line.startsWith('#')) ?? ''
+    );
+}
+
+// Read a `DataTransferItem` string synchronously-initiated as a promise. The
+// `getAsString` call must happen while the drag data store is still readable
+// (inside the drop handler), so every item is kicked off before the first
+// `await`; the callback merely resolves later.
+function readItem(item: DataTransferItem | undefined): Promise<string> {
+    if (!item)
+        return Promise.resolve('');
+    return new Promise(resolve => item.getAsString(resolve));
+}
+
+// Drop path 1 — a web-link image carried as `text/uri-list`. A browser image
+// drag also carries a `text/html` `<img>` payload, which is a definitive image
+// signal and needs no network round-trip; fall back to the URL extension and a
+// content-type HEAD sniff only when that payload is absent.
 function handleWebLinkImage(
     muya: Muya,
     event: DragEvent,
@@ -138,17 +162,30 @@ function handleWebLinkImage(
     if (!uriItem)
         return false;
 
-    uriItem.getAsString(async (url) => {
+    const htmlItem = items.find(
+        item => item.kind === 'string' && item.type === 'text/html',
+    );
+
+    // Both reads are initiated synchronously, before any await, so the data
+    // store is still in read-only (not protected) mode.
+    const uriPromise = readItem(uriItem);
+    const htmlPromise = readItem(htmlItem);
+
+    void (async () => {
+        const url = firstUri(await uriPromise);
         if (!URL_REG.test(url))
             return;
 
+        const html = await htmlPromise;
         const isImage
-            = IMAGE_EXT_REG.test(url) || (await checkImageContentType(url));
+            = /<img\b/i.test(html)
+                || IMAGE_EXT_REG.test(url)
+                || (await checkImageContentType(url));
         if (!isImage)
             return;
 
         insertImageParagraph(muya, target, `![](${url})`);
-    });
+    })();
 
     return true;
 }


### PR DESCRIPTION
## Problem

Dragging a bare `<img>` from a web page onto the editor did nothing — no image was inserted. The legacy `muyajs` engine supported this.

## Root cause

Two issues, found by instrumenting the live drag and reading the console:

1. **The drop event never fired.** A web-image drag carries `text/uri-list` + `text/html` and no `Files`. The window-level `dragover` handler in `app.vue` forced `dropEffect = 'none'` for every non-`Files` drag. Because it runs *after* the editor's own dragover handler (bubble phase), it clobbered the editor's `'copy'`. With the final `dropEffect = 'none'`, Chromium does not dispatch the `drop` event at all (even on a contenteditable), so the editor's image-drop logic was never reached.

2. **Fragile image detection (robustness).** Even once the drop fires, `handleWebLinkImage` only recognized an image by URL extension or a cross-origin `HEAD` content-type sniff. Many CDN image URLs have no extension or are served without CORS headers, so the sniff failed and the image was silently dropped.

## Fix

- **`app.vue`**: leave `text/uri-list` drags untouched in the global dragover handler so the editor can accept them.
- **`dragDropImage.ts`**: use the dragged `text/html` `<img>` payload as a definitive, network-free image signal; normalize the `text/uri-list` value (first non-comment line, trimmed) so a trailing CRLF doesn't corrupt the inserted markdown or defeat `IMAGE_EXT_REG`.

## Tests

- `dragDropImage.spec.ts`: added regression coverage for extension-less CDN URLs (via the `<img>` html signal) and uri-list CRLF stripping. Full spec: 9 passed. Lint + typecheck clean.

> Note: a real cross-application browser drag can't be exercised headlessly; the unit tests drive a synthetic `drop`. Manually verified in `pnpm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)