### PR TITLE
fix(muya): support resizing images that share the same link

### DIFF
--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -439,7 +439,12 @@ class Format extends Content {
 
         const selector = `#${imageId.includes('_') ? imageId : `${imageId}_${token.range.start}`
         } img`;
-        const image: Nullable<HTMLElement> = document.querySelector<HTMLElement>(selector);
+        // Scope the lookup to this block: identical-src images share a DOM id,
+        // so a document-wide query would re-click the first occurrence. Within a
+        // single block the `_${range.start}` suffix is unique.
+        const image: Nullable<HTMLElement>
+            = this.domNode?.querySelector<HTMLElement>(selector)
+                ?? document.querySelector<HTMLElement>(selector);
 
         if (image)
             image.click();

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -128,10 +128,13 @@ class ImageSelection {
                 imageInfo,
             });
 
-            const imageSelector = `#${imageInfo.imageId}`;
-
-            const imageContainer = document.querySelector(
-                `${imageSelector} .${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+            // Resolve the image container from the clicked wrapper directly.
+            // Images that share the same src (and paragraph offset) render with
+            // duplicate DOM ids, so a `document.querySelector('#id ...')` lookup
+            // would resolve to the first occurrence and place the resize bar on
+            // the wrong image.
+            const imageContainer = imageWrapper.querySelector(
+                `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
             );
 
             eventCenter.emit('muya-transformer', {

--- a/packages/muya/src/selection/__tests__/duplicateImageResize.spec.ts
+++ b/packages/muya/src/selection/__tests__/duplicateImageResize.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// Regression: two images that share the same src render with a cache-derived,
+// duplicate DOM id (`loadImageMap` keys the image id by src). Clicking the
+// second image used to place the resize bar (`muya-transformer`) on the FIRST
+// image, because the handler located the container via a document-wide
+// `querySelector('#id ...')` that resolves to the first occurrence. The fix
+// resolves the container from the clicked wrapper instead.
+
+const bootedMuyas: Muya[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedMuyas.push(muya);
+    return muya;
+}
+
+// Inject the loaded <img> the async path would produce (it never resolves under
+// happy-dom) and return the per-wrapper image containers.
+function injectImages(muya: Muya, src: string): HTMLElement[] {
+    const wrappers = Array.from(
+        muya.domNode.querySelectorAll<HTMLElement>(`span.${CLASS_NAMES.MU_INLINE_IMAGE}`),
+    );
+    return wrappers.map((wrapper) => {
+        const container = wrapper.querySelector<HTMLElement>(
+            `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+        )!;
+        const img = document.createElement('img');
+        img.setAttribute('src', src);
+        container.appendChild(img);
+        return container;
+    });
+}
+
+describe('duplicate same-src images: resize bar targets the clicked image', () => {
+    it('emits muya-transformer with the clicked image\'s own container', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`![alt](${src})\n\n![alt](${src})`);
+
+        const wrappers = muya.domNode.querySelectorAll<HTMLElement>(
+            `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+        );
+        expect(wrappers).toHaveLength(2);
+
+        // Force the post-load collision: once the shared src has loaded, both
+        // wrappers re-render with the same cache-derived id.
+        wrappers[1]!.id = wrappers[0]!.id;
+        expect(wrappers[1]!.id).toBe(wrappers[0]!.id);
+
+        const containers = injectImages(muya, src);
+
+        const handler = vi.fn();
+        muya.eventCenter.on('muya-transformer', (payload: { reference?: unknown }) => {
+            if (payload && payload.reference)
+                handler(payload.reference);
+        });
+
+        // Click the SECOND image.
+        containers[1]!
+            .querySelector('img')!
+            .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        // The resize bar must reference the second image's own container.
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(containers[1]);
+    });
+});


### PR DESCRIPTION
## Problem

Insert two images with the **same link**, then click the second one — the resize bar (transformer) appears on the **first** image instead of the clicked one.

## Root cause

`loadImageAsync` caches an image's id **by `src`**, so two images sharing a link render with the same base id. When each image is alone in its own paragraph they also share `token.range.start` (`0`), so the wrapper DOM id `${id}_${range.start}` collapses to a **duplicate `${id}_0`**.

`ImageSelection` then located the resize-bar reference via:

```ts
document.querySelector(`#${imageInfo.imageId} .container`)
```

A document-wide `#id` query returns the **first** element with that id, so clicking the second image targeted the first. `format.ts`'s `updateImage` post-resize re-click had the same flaw.

## Fix

- **`ImageSelection.ts`**: resolve the container from the **clicked wrapper** (`imageWrapper.querySelector('.container')`) — unambiguous regardless of duplicate ids.
- **`format.ts`**: scope `updateImage`'s `#id` lookup to the block's own `domNode` (within a single block the `_${range.start}` suffix is unique).

## Tests

- New `duplicateImageResize.spec.ts`: boots two same-src images, forces the duplicate-id state, clicks the second, and asserts the `muya-transformer` reference is the **second** image's own container. Verified it fails against the pre-fix code and passes after. Selection/image/renderer suites: 68 passed. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)