### PR TITLE
fix(muya): render vega-lite diagrams under the renderer CSP

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -856,6 +856,15 @@ pre.mu-active.mu-fenced-code::after {
     text-align: center;
 }
 
+.mu-diagram-error-detail {
+    margin-top: 6px;
+
+    font-size: 12px;
+    overflow-wrap: break-word;
+
+    opacity: 0.7;
+}
+
 /* content */
 .mu-content {
     display: block;

--- a/packages/muya/src/block/extra/diagram/diagramPreview.ts
+++ b/packages/muya/src/block/extra/diagram/diagramPreview.ts
@@ -34,6 +34,7 @@ async function renderDiagram({
             tooltip: false,
             renderer: 'svg',
             theme: vegaTheme,
+            ast: true,
         });
     }
     else if (type === 'sequence') {

--- a/packages/muya/src/block/extra/diagram/diagramPreview.ts
+++ b/packages/muya/src/block/extra/diagram/diagramPreview.ts
@@ -141,10 +141,17 @@ class DiagramPreview extends Parent {
                     sequenceTheme,
                 });
             }
-            catch {
+            catch (error) {
+                const detail
+                    = error instanceof Error ? error.message : String(error);
+                debug.error(`render ${type} diagram failed: ${detail}`);
                 this.domNode!.innerHTML = `<div class="mu-diagram-error">&lt; ${i18n.t(
                     'Invalid Diagram Code',
-                )} &gt;</div>`;
+                )} &gt;<div class="mu-diagram-error-detail">${sanitize(
+                    detail,
+                    PREVIEW_DOMPURIFY_CONFIG,
+                    true,
+                )}</div></div>`;
             }
         }
         else {


### PR DESCRIPTION
## Problem

Every vega-lite diagram fails to render in the editor. The block shows the generic `< Invalid Diagram Code >` with no further detail.

The real error, once surfaced, is:

```
EvalError: Evaluating a string as JavaScript violates the following Content
Security Policy directive because neither 'unsafe-eval' nor the string's hash
are an allowed source of script: script-src 'self'
    at expression (vega-embed ...)
    at runtime (vega-embed ...)
    at new View (vega-embed ...)
```

## Root cause

The Electron renderer enforces `script-src 'self'` without `unsafe-eval`. Vega's runtime compiles a chart's expression strings into functions via `new Function(...)`, which Chromium blocks under that CSP, so `new View(...)` throws before anything renders.

This only reproduces in the real renderer — Node/Vitest/happy-dom have no CSP, so `new Function` works there and unit tests can't catch it.

## Fix

Pass `ast: true` to `vega-embed`. Vega then evaluates expressions with the AST interpreter (`vega-interpreter`, already a vega-embed dependency and bundled) instead of generating code, which is the documented CSP-safe path. No new dependency.

A second commit improves diagnosability: the diagram preview's `catch` block previously swallowed the underlying error. It now logs the error and renders its sanitized message under the generic label, so broken specs and environment issues are debuggable from the editor.

## Verification

- Manually confirmed in the running app: the example bar chart now renders.
- Simulated the CSP block in Node (overriding `Function` to throw): `ast:false` reproduces the failure, `ast:true` renders the SVG.
- `pnpm -C packages/muya lint:types` passes; ESLint clean on the changed TS; Stylelint introduces no new findings over baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)