### PR TITLE
fix(muya): refresh local images on "Reload images" (View → Reload images)

### DIFF
--- a/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
@@ -21,7 +21,7 @@ interface IFakeRenderer {
     loadImageAsync: (
         info: { isUnknownType: boolean; src: string },
         attrs: Record<string, string>,
-    ) => { id: string; isSuccess: boolean | undefined; width?: number; height?: number };
+    ) => { id: string; isSuccess: boolean | undefined; width?: number; height?: number; url?: string };
     urlMap: Map<string, string>;
     muya: {
         editor: { selection: { image: null | unknown } };
@@ -34,6 +34,7 @@ function makeRenderer(loadResult: {
     isSuccess: boolean | undefined;
     width?: number;
     height?: number;
+    url?: string;
 }): IFakeRenderer {
     return {
         loadImageAsync: vi.fn(() => loadResult),
@@ -69,6 +70,24 @@ function makeImageToken(overrides: Partial<ImageToken['attrs']> = {}): ImageToke
 function getWrapperSelector(vnodes: VNode | VNode[]): string {
     const arr = Array.isArray(vnodes) ? vnodes : [vnodes];
     return arr[0].sel as string;
+}
+
+function findImgSrc(vnodes: VNode | VNode[]): string | undefined {
+    const arr = Array.isArray(vnodes) ? vnodes : [vnodes];
+    let found: string | undefined;
+    const walk = (node: unknown) => {
+        if (!node || typeof node !== 'object')
+            return;
+        const vnode = node as VNode;
+        if (vnode.sel === 'img') {
+            found = (vnode.data?.props?.src as string | undefined);
+            return;
+        }
+        if (Array.isArray(vnode.children))
+            vnode.children.forEach(walk);
+    };
+    arr.forEach(walk);
+    return found;
 }
 
 // Narrow casts shared by every test: the fake renderer and block stubs
@@ -161,5 +180,48 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         );
 
         expect(getWrapperSelector(out)).not.toContain('.mu-small-image');
+    });
+});
+
+// Regression: "Reload images" must keep showing the refreshed local file even
+// after the block re-renders (every keystroke rewrites the block's innerHTML).
+// `loadImageAsync` resolves a cache-busted `file://?mucache=...` URL; the
+// rendered <img> must use that resolved URL rather than the plain `file://`
+// path, otherwise innerHTML re-requests the un-busted URL and Chromium serves
+// the stale, previously cached bitmap. Remote URLs have no resolved override.
+describe('image renderer — uses the cache-busted url for local files', () => {
+    it('renders the resolved (cache-busted) url returned by loadImageAsync', () => {
+        const renderer = makeRenderer({
+            id: 'mu-image-6',
+            isSuccess: true,
+            width: 400,
+            height: 300,
+            url: 'file:///tmp/pic.png?mucache=mu-6',
+        });
+        const token = makeImageToken({ src: 'file:///tmp/pic.png' });
+
+        const out = image.call(
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
+        );
+
+        expect(findImgSrc(out)).toBe('file:///tmp/pic.png?mucache=mu-6');
+    });
+
+    it('falls back to the plain src when no resolved url is returned', () => {
+        const renderer = makeRenderer({
+            id: 'mu-image-7',
+            isSuccess: true,
+            width: 400,
+            height: 300,
+        });
+        const token = makeImageToken();
+
+        const out = image.call(
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
+        );
+
+        expect(findImgSrc(out)).toBe('https://example.com/x.png');
     });
 });

--- a/packages/muya/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
@@ -101,6 +101,77 @@ describe('loadImageAsync — failed cache should retry', () => {
     });
 });
 
+// Regression: "Reload images" (`muya.invalidateImageCache()`) did not refresh
+// a local image after its file was replaced on disk. The migration to the TS
+// engine dropped the legacy muyajs `?msec=` cache-buster, so a fresh load after
+// the cache was cleared re-requested the SAME `file://` URL — which Chromium
+// serves from its in-memory image cache, keeping the stale bitmap. Each load
+// of a `file://` source must therefore hit a unique URL so the browser
+// re-reads the file. Remote (http/https) URLs are left untouched.
+describe('loadImageAsync — local file cache-busting', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('appends a cache-busting query to file:// sources', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        const r = makeRenderer();
+
+        loadImageAsync.call(
+            asRenderer(r),
+            { isUnknownType: false, src: 'file:///tmp/pic.png' },
+            {},
+        );
+
+        expect(loadImage).toHaveBeenCalledTimes(1);
+        const loadedUrl = vi.mocked(loadImage).mock.calls[0][0];
+        expect(loadedUrl).toMatch(/^file:\/\/\/tmp\/pic\.png\?[^=]+=[^&]+$/);
+    });
+
+    it('does NOT touch remote http(s) sources', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        const r = makeRenderer();
+
+        loadImageAsync.call(
+            asRenderer(r),
+            { isUnknownType: false, src: 'https://example.com/a.png' },
+            {},
+        );
+
+        expect(loadImage).toHaveBeenCalledWith('https://example.com/a.png', false);
+    });
+
+    it('uses a different URL on each fresh load so a cleared cache refetches from disk', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        vi.mocked(loadImage).mockImplementation(url =>
+            Promise.resolve({ url, width: 10, height: 10 }),
+        );
+        const r = makeRenderer();
+
+        // First render loads the image and caches it.
+        loadImageAsync.call(
+            asRenderer(r),
+            { isUnknownType: false, src: 'file:///tmp/pic.png' },
+            {},
+        );
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        // The cache is keyed by the plain src so ordinary re-renders hit it.
+        expect(r.loadImageMap.has('file:///tmp/pic.png')).toBe(true);
+
+        // invalidateImageCache() clears the maps; the next render is a cache miss.
+        r.loadImageMap.clear();
+        loadImageAsync.call(
+            asRenderer(r),
+            { isUnknownType: false, src: 'file:///tmp/pic.png' },
+            {},
+        );
+
+        const firstUrl = vi.mocked(loadImage).mock.calls[0][0];
+        const secondUrl = vi.mocked(loadImage).mock.calls[1][0];
+        expect(secondUrl).not.toBe(firstUrl);
+    });
+});
+
 // Regression for Copilot review on PR-11a (#224): the `mu-small-image`
 // class added in `image.ts` was only applied on re-renders where the
 // `loadImageMap` cache held the dimensions. On the *first* render of a

--- a/packages/muya/src/inlineRenderer/renderer/image.ts
+++ b/packages/muya/src/inlineRenderer/renderer/image.ts
@@ -48,16 +48,25 @@ export default function image(
     let isSuccess: boolean | undefined;
     let naturalWidth: number | undefined;
     let naturalHeight: number | undefined;
-    let src = imageSrc.src;
+    let resolvedUrl: string | undefined;
+    // `src` stays the plain path — it is the key the `urlMap`/cache lookups use.
+    const src = imageSrc.src;
     const alt = token.attrs.alt;
     const title = token.attrs.title;
     const width = token.attrs.width;
     const height = token.attrs.height;
 
     if (src) {
-        ({ id, isSuccess, width: naturalWidth, height: naturalHeight }
+        ({ id, isSuccess, url: resolvedUrl, width: naturalWidth, height: naturalHeight }
             = this.loadImageAsync(imageSrc, token.attrs));
     }
+
+    // What the rendered <img> actually points at. For local files this is the
+    // cache-busted `file://?mucache=…` URL resolved by `loadImageAsync`, so a
+    // block re-render (`innerHTML = html`) re-requests the busted URL instead
+    // of the plain path Chromium has cached. Uploads in progress override it
+    // with the base64 preview below.
+    let imgSrc = resolvedUrl ?? src;
 
     let wrapperSelector = id
         ? `span#${isSuccess ? `${id}_${token.range.start}` : id}.${
@@ -101,7 +110,7 @@ export default function image(
             selectedImage.imageId = id;
         }
 
-        src = this.urlMap.get(src)!;
+        imgSrc = this.urlMap.get(src)!;
         isSuccess = true;
     }
 
@@ -111,7 +120,7 @@ export default function image(
             id: alt,
         });
         if (this.urlMap.has(alt)) {
-            src = this.urlMap.get(alt)!;
+            imgSrc = this.urlMap.get(alt)!;
             isSuccess = true;
         }
     }
@@ -162,7 +171,7 @@ export default function image(
             const data = {
                 props: {
                     alt: alt.replace(/[`*{}[\]()#+\-.!_>~:|<$]/g, ''),
-                    src,
+                    src: imgSrc,
                     title,
                 },
             };

--- a/packages/muya/src/inlineRenderer/renderer/loadImageAsync.ts
+++ b/packages/muya/src/inlineRenderer/renderer/loadImageAsync.ts
@@ -26,7 +26,17 @@ export default function loadImageAsync(
     // permanently poison the cache (marktext#3001 / #3010, commit bca2ed62).
     if (!cached || !cached.isSuccess) {
         id = getUniqueId();
-        loadImage(src, isUnknownType)
+        // Cache-bust local files so a fresh load reads the file off disk
+        // instead of Chromium's in-memory image cache. Without this, replacing
+        // an image on disk and running `invalidateImageCache()` (View → Reload
+        // images) re-requests the same `file://` URL and the stale bitmap is
+        // served. The cache key (`src`) stays unbusted so ordinary re-renders
+        // still hit the cache; only the load/`<img>` URL carries the token.
+        // `id` is monotonic (collision-free), unlike legacy muyajs's `?msec=`.
+        const loadSrc = /^file:\/\//i.test(src)
+            ? `${src}${src.includes('?') ? '&' : '?'}mucache=${id}`
+            : src;
+        loadImage(loadSrc, isUnknownType)
             .then(({ url, width, height }) => {
                 const imageText: HTMLElement | null = document.querySelector(`#${id}`);
                 const img = document.createElement('img');


### PR DESCRIPTION
## Problem

After replacing a local image file on disk (same path) and clicking **View → Reload images** (`mt::invalidate-image-cache`), the editor kept rendering the *old* image.

## Root cause

A migration regression. The legacy `packages/muyajs` engine cache-busted local `file://` images (`loadImageAsync.js` appended `?msec=<Date.now()>`), so `invalidateImageCache()` forced a fresh disk read. The TS rewrite in `packages/muya` dropped this:

- `getImageSrc` resolves local images to a bare `file://path` with no query.
- `invalidateImageCache()` clears `loadImageMap`/`urlMap` and re-renders, but `loadImageAsync` then re-requests the **same** `file://` URL.
- Chromium caches `file://` bitmaps by URL, so the stale bitmap is served and the on-disk replacement never shows.

(The comment at `loadImageAsync.ts` even claims local files "carry a cache-busting query" — the comment survived the migration, the implementation did not.)

## Fix

Two distinct stale-cache paths, one commit each:

1. **Cache-bust on load** — append `?mucache=<id>` to `file://` sources before loading. Reuses the per-load monotonic `id` (collision-free, unlike the legacy `Date.now()`). The cache key stays the plain src, so ordinary re-renders still hit the cache; only the load/`<img>` URL carries the token.
2. **Render the busted url** — a block re-render rewrites `innerHTML` from the vdom; rendering the plain path there meant the *next edit* after a reload re-requested the un-busted (stale-cached) URL. The rendered `<img src>` now uses the resolved `?mucache=…` URL, mirroring the legacy `domsrc`. Plain src is kept as the cache key and for image-selection comparisons; in-progress uploads still override with their base64 preview.

Remote `http(s)` images are untouched.

## Tests

- New unit tests: `file://` sources get a unique cache-busting query, a cleared cache refetches a different URL, `http(s)` is unchanged, the `<img>` renders the resolved url, and it falls back to the plain src when none is resolved.
- Full muya suite green (753 tests), `tsc --noEmit` clean.

## Verification note

happy-dom doesn't load or cache `file://` resources, so the unit tests assert the **mechanism** (unique URL per load). The end-to-end browser-cache behavior (disk swap → reload → see new image) should be confirmed manually in the running app. The legacy engine used the same `?query` approach in production, which is strong precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)