### PR TITLE
fix: reflect the current block in the Paragraph menu (PG1)

### DIFF
--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1869,6 +1869,7 @@ const createApplicationMenuState = ({
       if (b.functionType === 'table') {
         state.isTable = true
         state.isDisabled = true
+        state.affiliation[b.type] = true
       }
       break
     } else if (isMultiline && /^h{1,6}$/.test(b.type)) {

--- a/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
+++ b/packages/desktop/test/e2e/parity-pg1-menu-state.spec.ts
@@ -13,42 +13,98 @@ import { launchWithMarkdown, setSourceMarkdown, waitForMenuReady } from './helpe
 // affiliation chain + per-endpoint block info on the `selection-change`
 // payload, and the desktop adapter (`adaptSelectionChange`) now feeds them to
 // the store, so the Paragraph-menu check marks light up again. Here we read the
-// live application-menu `checked` state after placing the caret in a heading.
+// live application-menu `checked` state after placing the caret in each block
+// type and assert that exactly the matching menu item(s) are checked.
 
-const headingMenuChecked = async(app: ElectronApplication, id: string): Promise<boolean> => {
-  return await app.evaluate(({ Menu }, menuId) => {
+interface MenuItemState { id: string; checked: boolean; enabled: boolean }
+
+// Read the id/checked/enabled state of every identifiable Paragraph submenu item.
+const paragraphItemStates = async(app: ElectronApplication): Promise<MenuItemState[]> => {
+  return await app.evaluate(({ Menu }) => {
     const menu = Menu.getApplicationMenu()
-    if (!menu) return false
-    const item = menu.getMenuItemById(menuId)
-    return !!(item && item.checked)
-  }, id)
+    if (!menu) return []
+    const entry = menu.getMenuItemById('paragraphMenuEntry')
+    const submenu = entry?.submenu
+    if (!submenu) return []
+    return submenu.items
+      .filter((item) => item.id)
+      .map((item) => ({ id: item.id as string, checked: !!item.checked, enabled: !!item.enabled }))
+  })
 }
 
-// A heading renders `span.mu-atxheading-content`, not `mu-paragraph-content`,
-// so the paragraph-only `placeCaretInEditor` helper would not place the caret
-// here. Collapse the selection inside the heading's content span and nudge the
-// engine to recompute its active block (same keyup trick the helper uses).
-const placeCaretInHeading = async(page: Page): Promise<boolean> => {
-  const ok = await page.evaluate(() => {
-    const root = document.querySelector('.editor-component') as HTMLElement | null
-    if (!root) return false
-    const span = root.querySelector('h1 span.mu-content') as HTMLElement | null
-    if (!span) return false
-    root.focus()
+const checkedIds = (states: MenuItemState[]): string[] =>
+  states.filter((s) => s.checked).map((s) => s.id)
+
+// Click into the block's content span the way a user would (the bug repro is
+// "click into each block"). A real click drives Muya's own selection handling,
+// which emits the `selection-change` that updates the application menu.
+const placeCaretIn = async(page: Page, selector: string): Promise<void> => {
+  await page.evaluate((sel) => {
+    const span = document.querySelector(sel) as HTMLElement | null
+    if (!span) throw new Error(`no element for ${sel}`)
+    span.scrollIntoView({ block: 'center' })
     const range = document.createRange()
     range.selectNodeContents(span)
     range.collapse(false)
-    const sel = window.getSelection()
-    if (!sel) return false
-    sel.removeAllRanges()
-    sel.addRange(range)
-    document.dispatchEvent(new Event('selectionchange'))
-    root.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true, cancelable: true }))
-    return true
-  })
-  await page.waitForTimeout(150)
-  return ok
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    // A real bubbling click drives Muya's editor dispatch → block clickHandler,
+    // the path that emits selection-change. Viewport-independent (the editor
+    // scrolls its own container, defeating Playwright's click viewport check).
+    span.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+  }, selector)
+  await page.waitForTimeout(120)
 }
+
+// Poll the Paragraph submenu until its checked set matches `expected` (the
+// selection-change → menu-state IPC round-trip is async), or time out.
+const waitForMenuState = async(
+  app: ElectronApplication,
+  expected: string[],
+  timeout = 3000
+): Promise<MenuItemState[]> => {
+  const want = [...expected].sort()
+  let last: MenuItemState[] = []
+  const deadline = Date.now() + timeout
+  do {
+    last = await paragraphItemStates(app)
+    const got = checkedIds(last).sort()
+    if (got.length === want.length && got.every((id, i) => id === want[i])) return last
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  } while (Date.now() < deadline)
+  return last
+}
+
+interface MenuCase {
+  name: string
+  markdown: string
+  selector: string
+  expected: string[]
+  // 0.19.1 parity: code-fence-like blocks (math/html/front matter) and tables
+  // check their item but keep the whole Paragraph submenu disabled. Only the
+  // code fence (and editable leaves) stay enabled.
+  disabled?: boolean
+}
+
+// Each block type and the Paragraph-menu item(s) that must light up for it.
+// `expected` lists every item that should be checked — and, by exclusion,
+// asserts no residual checks leak from a previously visited block.
+const cases: MenuCase[] = [
+  { name: 'h1 heading', markdown: '# A heading\n', selector: 'h1 .mu-atxheading-content', expected: ['heading1MenuItem'] },
+  { name: 'paragraph', markdown: 'hello world\n', selector: '.mu-paragraph-content', expected: ['paragraphMenuItem'] },
+  { name: 'bullet list', markdown: '- item\n', selector: '.mu-bullet-list .mu-paragraph-content', expected: ['bulletListMenuItem'] },
+  { name: 'ordered list', markdown: '1. item\n', selector: '.mu-order-list .mu-paragraph-content', expected: ['orderListMenuItem'] },
+  { name: 'task list', markdown: '- [ ] task\n', selector: '.mu-task-list .mu-paragraph-content', expected: ['taskListMenuItem'] },
+  { name: 'loose list', markdown: '- one\n\n- two\n', selector: '.mu-bullet-list .mu-paragraph-content', expected: ['bulletListMenuItem', 'looseListItemMenuItem'] },
+  { name: 'quote block', markdown: '> quote\n', selector: '.mu-block-quote .mu-paragraph-content', expected: ['quoteBlockMenuItem'] },
+  { name: 'code block', markdown: '```js\nconst a = 1\n```\n', selector: '.mu-code-block .mu-codeblock-content', expected: ['codeFencesMenuItem'] },
+  { name: 'math block', markdown: '$$\na = b\n$$\n', selector: '.mu-math-block .mu-codeblock-content', expected: ['mathBlockMenuItem'], disabled: true },
+  { name: 'html block', markdown: '<div>hi</div>\n', selector: '.mu-html-block .mu-codeblock-content', expected: ['htmlBlockMenuItem'], disabled: true },
+  { name: 'table cell', markdown: '| a | b |\n| - | - |\n| 1 | 2 |\n', selector: '.mu-table-cell-content', expected: ['tableMenuItem'], disabled: true },
+  { name: 'horizontal rule', markdown: 'before\n\n---\n\nafter\n', selector: '.mu-thematic-break-content', expected: ['horizontalLineMenuItem'] },
+  { name: 'front matter', markdown: '---\ntitle: x\n---\n\nbody\n', selector: '.mu-frontmatter .mu-codeblock-content', expected: ['frontMatterMenuItem'], disabled: true }
+]
 
 test.describe('Parity PG1 — Paragraph menu reflects the current block', () => {
   let app: ElectronApplication
@@ -65,18 +121,68 @@ test.describe('Parity PG1 — Paragraph menu reflects the current block', () => 
     if (app) await app.close()
   })
 
-  test('PG1: placing the caret in an H1 checks heading1MenuItem in the Paragraph menu', async() => {
-    await setSourceMarkdown(page, app, '# A heading\n')
-    // Sanity: the heading rendered and the caret landed inside it (so a `false`
-    // result below is the affiliation gap, not a missed caret placement).
-    await expect(page.locator('.editor-component h1')).toBeVisible()
-    const placed = await placeCaretInHeading(page)
-    expect(placed).toBe(true)
-    // Give the selection-change → menu-state IPC round-trip time to settle.
-    await page.waitForTimeout(400)
+  for (const block of cases) {
+    test(`PG1: caret in ${block.name} checks ${block.expected.join(' + ')}`, async() => {
+      await setSourceMarkdown(page, app, block.markdown)
+      await expect(page.locator(block.selector).first()).toBeAttached()
+      await placeCaretIn(page, block.selector)
 
-    const checked = await headingMenuChecked(app, 'heading1MenuItem')
-    // Desired: the Paragraph menu shows H1 as the active block type.
-    expect(checked).toBe(true)
+      const states = await waitForMenuState(app, block.expected)
+      // Exactly the matching item(s) are checked — no residual checks.
+      expect(checkedIds(states).sort()).toEqual([...block.expected].sort())
+      // 0.19.1 parity for the enabled state: code-fence-like blocks and tables
+      // keep the submenu disabled (check mark stays, greyed); everything else is
+      // enabled.
+      for (const id of block.expected) {
+        expect(
+          states.find((s) => s.id === id)?.enabled,
+          `${id} enabled === ${!block.disabled}`
+        ).toBe(!block.disabled)
+      }
+    })
+  }
+})
+
+// Clicking between blocks within ONE document must re-derive the menu. The
+// per-case suite above can pass on the post-load selection alone; this suite
+// proves the click itself emits the selection-change. The regression: code /
+// math / html content (non-Format leaves) did not emit on click, so the menu
+// stayed stale — note the code→math→html transitions below all share the same
+// content DOM class.
+test.describe('Parity PG1 — Paragraph menu updates when switching blocks', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('seed\n')
+    app = launched.app
+    page = launched.page
+    await waitForMenuReady(app)
+    await setSourceMarkdown(
+      page,
+      app,
+      '# Heading\n\nplain paragraph\n\n```js\ncode\n```\n\n$$\na = b\n$$\n\n<div>hi</div>\n'
+    )
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  const sequence: Array<{ name: string; selector: string; expected: string }> = [
+    { name: 'paragraph', selector: '.mu-paragraph .mu-paragraph-content', expected: 'paragraphMenuItem' },
+    { name: 'code', selector: '.mu-code-block .mu-codeblock-content', expected: 'codeFencesMenuItem' },
+    { name: 'math', selector: '.mu-math-block .mu-codeblock-content', expected: 'mathBlockMenuItem' },
+    { name: 'html', selector: '.mu-html-block .mu-codeblock-content', expected: 'htmlBlockMenuItem' },
+    { name: 'heading', selector: 'h1 .mu-atxheading-content', expected: 'heading1MenuItem' },
+    { name: 'code (again)', selector: '.mu-code-block .mu-codeblock-content', expected: 'codeFencesMenuItem' }
+  ]
+
+  test('PG1: clicking from block to block re-derives the checked item', async() => {
+    for (const step of sequence) {
+      await placeCaretIn(page, step.selector)
+      const states = await waitForMenuState(app, [step.expected])
+      expect(checkedIds(states), `after clicking ${step.name}`).toEqual([step.expected])
+    }
   })
 })

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -14,6 +14,7 @@ import {
     diffToTextOp,
     isInputEvent,
     isKeyboardEvent,
+    isMouseEvent,
 } from '../../utils';
 
 // import logger from './utils/logger'
@@ -166,8 +167,20 @@ class Content extends TreeNode {
         return null;
     }
 
-    clickHandler(_event: Event): void {
-    // Do nothing.
+    clickHandler(event: Event): void {
+        if (!isMouseEvent(event))
+            return;
+
+        requestAnimationFrame(() => {
+            if (event.shiftKey && this.selection.anchorBlock !== this)
+                return;
+
+            const cursor = this.getCursor();
+            if (!cursor)
+                return;
+
+            this.setCursor(cursor.start.offset, cursor.end.offset);
+        });
     }
 
     tabHandler(_event: Event): void {

--- a/packages/muya/src/selection/affiliation.ts
+++ b/packages/muya/src/selection/affiliation.ts
@@ -33,6 +33,7 @@ const PARAGRAPH_TYPES: ReadonlySet<string> = new Set([
     'ol',
     'li',
     'figure',
+    'hr',
 ]);
 
 /**
@@ -50,9 +51,10 @@ const CONTAINER_TYPE_BY_NAME: Readonly<Record<string, string>> = {
     'code-block': 'pre',
     'frontmatter': 'pre',
     'table': 'figure',
-    'html-block': 'figure',
-    'math-block': 'figure',
+    'html-block': 'pre',
+    'math-block': 'pre',
     'diagram': 'figure',
+    'thematic-break': 'hr',
 };
 
 /**
@@ -87,7 +89,7 @@ const LIST_TYPE_BY_NAME: Readonly<Record<string, string>> = {
  * needs.
  */
 export interface IAffiliationEntry {
-    /** Markdown block type: `p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`. */
+    /** Markdown block type: `p`, `h1`…`h6`, `ul`, `ol`, `li`, `pre`, `figure`, `blockquote`, `hr`. */
     type: string;
     /** Engine block name (`bullet-list`, `code-block`, …) for callers that want the precise block. */
     blockName: string;


### PR DESCRIPTION
## Summary

After the engine switch to `@muyajs/core`, the **Paragraph** menu's check marks stopped reflecting the block the caret sits in. Placing the caret in a **code block, math block, HTML block, table, horizontal rule, or front matter** left the matching menu item unchecked, and clicking between blocks didn't always update it.

This restores 0.19.1 parity: caret in a block ⇒ exactly that block's menu item is checked and updated on every click. The submenu's enabled/disabled behaviour is unchanged from 0.19.1 (code-fence-like blocks and tables stay disabled, so their check mark shows greyed).

## Root causes

1. **Engine affiliation vocabulary** (`packages/muya/src/selection/affiliation.ts`)
   - `math-block` / `html-block` were emitted as `figure`, which the desktop menu-state builder only handles for tables — their functionType (`multiplemath` / `html`) was dropped. Mapped to `pre`, matching the legacy engine that surfaced them via the inner `pre`.
   - `thematic-break` (hr) wasn't in the affiliation vocabulary, so the horizontal-rule item was unreachable. Added `thematic-break → hr` and `hr` to the paragraph-type set.

2. **Table never recorded an affiliation key** (`store/editor.ts`)
   - The table branch set `isTable`/`isDisabled` but no affiliation key, and the main-process checker only evaluates its `isTable` branch while iterating affiliation keys — so with an empty affiliation the Table item was never checked. Now records the `figure` key (submenu stays disabled, per 0.19.1; only the check mark is restored).

3. **Clicking into code/non-Format content didn't emit a selection-change** (`muya/.../base/content.ts`)
   - `Format.clickHandler` re-emits the selection on click, but the base `Content.clickHandler` was a no-op. Code/math/html/front-matter all use `codeBlockContent` (a non-Format `Content` leaf), so clicking into them moved the caret without emitting `selection-change`, leaving the menu stale until a keystroke. The base handler now emits the selection.

## Testing

`test/e2e/parity-pg1-menu-state.spec.ts`:
- Suite 1 clicks into every block type and asserts exactly the matching item(s) are checked, with the 0.19.1 enabled/disabled state (code-fence-like blocks and tables checked-but-disabled).
- Suite 2 clicks between blocks within one document (incl. code→math→html) and asserts the menu re-derives on each click.

Verified as real regression guards by reverting each fix and watching the corresponding cases fail; with all fixes, **14/14 pass**. `pnpm -C packages/muya test` (753 passed), `check-circular`, `typecheck`, and lint all pass.

Relates to the Phase-G #4432 engine-migration parity work (gap PG1).