### PR TITLE
fix(muya): keep selection after applying an inline format to a range

### DIFF
--- a/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
@@ -1,21 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import Format from '../format';
 
-// Regression for marktext UX commit `f3b53427` (kickoff PR-10b): after
-// applying an inline format like **bold**, the caret should jump past the
-// closing marker so the next keystroke continues *after* the bold rather
-// than ending up between the markers (which feels broken — typing extends
-// the bold instead of returning to body text).
-//
 // `Format.prototype._addFormat` is the small text-rewriter that:
 //   1. Wraps `text[start..end]` with the format's opening + closing
 //      markers.
 //   2. Adjusts `start.offset` / `end.offset` so the public `format()` call
 //      can `setCursor(start, end, true)` afterwards.
 //
-// Before this fix, step 2 only shifted both offsets by the opening
-// marker's length, leaving the caret BETWEEN the markers. The new
-// behavior collapses both offsets PAST the closing marker.
+// Two distinct cursor states drive two distinct outcomes:
+//   - Non-empty selection: the originally-selected text must STAY selected
+//     after wrapping (matching legacy muyajs and every standard editor —
+//     select a word, bold it, the word is still highlighted). Both offsets
+//     shift by the OPENING marker length so the range lands on the original
+//     text now sitting inside the markers. (PR-10b's f3b53427 had collapsed
+//     this selection to a caret past the closing marker — a regression.)
+//   - Collapsed selection (toggle-then-type): the caret stays BETWEEN the
+//     markers so the next keystroke is captured INSIDE the format.
 //
 // `_addFormat` only reads/writes `this.text`, so a structurally-typed
 // fake `this` is enough — no Muya bootstrap needed.
@@ -46,79 +46,79 @@ function applyAddFormat(text: string, start: number, end: number, type: string) 
     return { text: fakeThis.text, start: startOffset.offset, end: endOffset.offset };
 }
 
-describe('format._addFormat caret-after-format placement (marktext f3b53427 UX)', () => {
-    describe('paired markdown markers — caret collapses past the closing marker', () => {
-        it('strong (`**`): "abc" -> "**abc**" with caret at end (offset 7)', () => {
+describe('format._addFormat caret/selection placement after wrapping', () => {
+    describe('paired markdown markers — selection stays on the wrapped text', () => {
+        it('strong (`**`): "abc" -> "**abc**" with "abc" still selected (2..5)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'strong');
             expect(text).toBe('**abc**');
-            expect(start).toBe(7);
-            expect(end).toBe(7);
+            expect(start).toBe(2);
+            expect(end).toBe(5);
         });
 
-        it('em (`*`): "abc" -> "*abc*" with caret at end (offset 5)', () => {
+        it('em (`*`): "abc" -> "*abc*" with "abc" still selected (1..4)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'em');
             expect(text).toBe('*abc*');
-            expect(start).toBe(5);
-            expect(end).toBe(5);
+            expect(start).toBe(1);
+            expect(end).toBe(4);
         });
 
-        it('inline_code (`` ` ``): "abc" -> "`abc`" with caret at end (offset 5)', () => {
+        it('inline_code (`` ` ``): "abc" -> "`abc`" with "abc" still selected (1..4)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'inline_code');
             expect(text).toBe('`abc`');
-            expect(start).toBe(5);
-            expect(end).toBe(5);
+            expect(start).toBe(1);
+            expect(end).toBe(4);
         });
 
-        it('del (`~~`): "abc" -> "~~abc~~" with caret at end (offset 7)', () => {
+        it('del (`~~`): "abc" -> "~~abc~~" with "abc" still selected (2..5)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'del');
             expect(text).toBe('~~abc~~');
-            expect(start).toBe(7);
-            expect(end).toBe(7);
-        });
-
-        it('inline_math (`$`): "abc" -> "$abc$" with caret at end (offset 5)', () => {
-            const { text, start, end } = applyAddFormat('abc', 0, 3, 'inline_math');
-            expect(text).toBe('$abc$');
-            expect(start).toBe(5);
+            expect(start).toBe(2);
             expect(end).toBe(5);
         });
 
-        it('mid-text selection: "hello world" select "world" -> caret lands past closing `**`', () => {
+        it('inline_math (`$`): "abc" -> "$abc$" with "abc" still selected (1..4)', () => {
+            const { text, start, end } = applyAddFormat('abc', 0, 3, 'inline_math');
+            expect(text).toBe('$abc$');
+            expect(start).toBe(1);
+            expect(end).toBe(4);
+        });
+
+        it('mid-text selection: "hello world" select "world" -> "world" still selected', () => {
             const { text, start, end } = applyAddFormat('hello world', 6, 11, 'strong');
             expect(text).toBe('hello **world**');
-            // 'hello ' (6) + '**world**' (9) = 15
-            expect(start).toBe(15);
-            expect(end).toBe(15);
+            // 'hello ' (6) + '**' (2) = 8 .. 8 + 'world' (5) = 13
+            expect(start).toBe(8);
+            expect(end).toBe(13);
         });
     });
 
-    describe('html-tag markers — caret collapses past the closing tag', () => {
-        it('u (`<u>...</u>`): "abc" -> "<u>abc</u>" with caret at end (offset 10)', () => {
+    describe('html-tag markers — selection stays on the wrapped text', () => {
+        it('u (`<u>...</u>`): "abc" -> "<u>abc</u>" with "abc" still selected (3..6)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'u');
             expect(text).toBe('<u>abc</u>');
-            expect(start).toBe(10);
-            expect(end).toBe(10);
+            expect(start).toBe(3);
+            expect(end).toBe(6);
         });
 
-        it('sub: "abc" -> "<sub>abc</sub>" with caret at end (offset 14)', () => {
+        it('sub: "abc" -> "<sub>abc</sub>" with "abc" still selected (5..8)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'sub');
             expect(text).toBe('<sub>abc</sub>');
-            expect(start).toBe(14);
-            expect(end).toBe(14);
+            expect(start).toBe(5);
+            expect(end).toBe(8);
         });
 
-        it('sup: "abc" -> "<sup>abc</sup>" with caret at end (offset 14)', () => {
+        it('sup: "abc" -> "<sup>abc</sup>" with "abc" still selected (5..8)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'sup');
             expect(text).toBe('<sup>abc</sup>');
-            expect(start).toBe(14);
-            expect(end).toBe(14);
+            expect(start).toBe(5);
+            expect(end).toBe(8);
         });
 
-        it('mark: "abc" -> "<mark>abc</mark>" with caret at end (offset 16)', () => {
+        it('mark: "abc" -> "<mark>abc</mark>" with "abc" still selected (6..9)', () => {
             const { text, start, end } = applyAddFormat('abc', 0, 3, 'mark');
             expect(text).toBe('<mark>abc</mark>');
-            expect(start).toBe(16);
-            expect(end).toBe(16);
+            expect(start).toBe(6);
+            expect(end).toBe(9);
         });
     });
 

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1669,26 +1669,18 @@ class Format extends Content {
             case 'inline_math': {
                 const MARKER = FORMAT_MARKER_MAP[type];
                 const oldText = this.text;
-                const wasCollapsed = start.offset === end.offset;
                 this.text
                     = oldText.substring(0, start.offset)
                         + MARKER
                         + oldText.substring(start.offset, end.offset)
                         + MARKER
                         + oldText.substring(end.offset);
-                if (wasCollapsed) {
-                    // Toggle-format-then-type: keep caret between markers
-                    // so the next keystroke is captured INSIDE the format.
-                    start.offset += MARKER.length;
-                    end.offset += MARKER.length;
-                }
-                else {
-                    // When wrapping a non-empty selection, collapse the caret
-                    // PAST the closing marker so the next keystroke lands
-                    // outside the format instead of extending it.
-                    end.offset += MARKER.length * 2;
-                    start.offset = end.offset;
-                }
+                // Shift both offsets past the opening marker. A collapsed
+                // cursor stays between the markers (toggle-then-type lands
+                // INSIDE the format); a non-empty selection keeps the
+                // original text selected now that it sits inside the markers.
+                start.offset += MARKER.length;
+                end.offset += MARKER.length;
                 break;
             }
 
@@ -1701,21 +1693,17 @@ class Format extends Content {
             case 'u': {
                 const MARKER = FORMAT_TAG_MAP[type];
                 const oldText = this.text;
-                const wasCollapsed = start.offset === end.offset;
                 this.text
                     = oldText.substring(0, start.offset)
                         + MARKER.open
                         + oldText.substring(start.offset, end.offset)
                         + MARKER.close
                         + oldText.substring(end.offset);
-                if (wasCollapsed) {
-                    start.offset += MARKER.open.length;
-                    end.offset += MARKER.open.length;
-                }
-                else {
-                    end.offset += MARKER.open.length + MARKER.close.length;
-                    start.offset = end.offset;
-                }
+                // Shift both offsets past the opening tag: a collapsed cursor
+                // stays between the tags, a non-empty selection keeps the
+                // wrapped text selected.
+                start.offset += MARKER.open.length;
+                end.offset += MARKER.open.length;
                 break;
             }
 


### PR DESCRIPTION
## Summary

Selecting text and applying an inline format via the **Format** menu (Bold / Italic / Underline, etc.) wrapped the text correctly but **lost the selection** — the caret jumped past the closing marker instead of keeping the original text highlighted.

Root cause is in `Format.prototype._addFormat` (`packages/muya/src/block/base/format.ts`). A prior UX change collapsed the caret past the closing marker for *every* wrap:

```ts
end.offset += MARKER.length * 2
start.offset = end.offset   // destroys the selection
```

That is only correct for a **collapsed** cursor (toggle-then-type). For a real selection it discarded the highlight. It was also asymmetric: toggling a format *off* already preserved the selection — only toggling *on* broke it.

## Fix

Shift **both** offsets by the opening-marker length (the legacy `muyajs` behavior and the standard editor convention). One path now serves both cases:

- **Collapsed cursor** → stays between the markers, so toggle-then-type still types *inside* the format.
- **Non-empty selection** → the original text stays selected, now sitting inside the markers.

Applies to the marker family (`strong` / `em` / `del` / `inline_code` / `inline_math`) and the tag family (`u` / `sub` / `sup` / `mark`). `link` / `image` caret placement is unchanged.

Side effect: because the selection stays within the formatted span, the next `selection-change` reports the format in its `formats` array, so the **Format menu checkmark now correctly reflects the active format** after applying.

## Testing

- Updated `formatCursor.spec.ts`: the 10 non-collapsed cases now assert the selection is preserved (they previously encoded the buggy collapse). Confirmed they fail before the fix and pass after. Collapsed + link/image cases unchanged.
- `formatCursor.spec.ts`: 17/17 pass.
- Full muya unit suite: 753/753 pass. `lint:types` clean; `lint` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)