### PR TITLE
fix: Copy as Rich Text/HTML copies nothing (Electron 42 execCommand no-op)

### DIFF
--- a/packages/desktop/src/main/ipc/shell.ts
+++ b/packages/desktop/src/main/ipc/shell.ts
@@ -38,6 +38,14 @@ export const registerShellHandlers = (): void => {
       log.error('clipboard.writeText failed:', err)
     }
   })
+  ipcMain.on('mt::clipboard::write', (_e, data: { text: string; html: string }) => {
+    try {
+      const { text = '', html = '' } = data ?? {}
+      clipboard.write(html ? { text, html } : { text })
+    } catch (err) {
+      log.error('clipboard.write failed:', err)
+    }
+  })
   ipcMain.handle('mt::clipboard::read-text', () => {
     try {
       return clipboard.readText()

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -75,6 +75,7 @@ const shellAPI = {
 
 const clipboardAPI = {
   writeText: (text: string) => send('mt::clipboard::write-text', text),
+  write: (data: { text: string; html: string }) => send('mt::clipboard::write', data),
   readText: () => invoke('mt::clipboard::read-text'),
   guessFilePath: () => invoke('mt::clipboard::guess-file-path')
 }

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1583,6 +1583,8 @@ onMounted(() => {
     clipboardFilePath: guessClipboardFilePath,
     // Read the OS clipboard's plain text for "Paste as Plain Text" (execCommand('paste') no longer fires).
     clipboardText: () => window.electron.clipboard.readText(),
+    // Write rendered slots for "Copy as Rich Text/HTML/Markdown" (execCommand('copy') no-ops from menu IPC).
+    clipboardWrite: (data: { text: string; html: string }) => window.electron.clipboard.write(data),
     // Image-persist callbacks read by the engine's clipboard + drag-drop handlers
     // from `muya.options.*` (distinct from the ImageEditTool plugin option above).
     // Without these, local-file drag-drop, screenshot/binary clipboard paste, and

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -110,6 +110,7 @@ export interface IpcSendChannels {
   'mt::ask-for-user-preference': []
   'mt::check-for-update': []
   'mt::clipboard::write-text': [text: string]
+  'mt::clipboard::write': [data: { text: string; html: string }]
   'mt::close-window': []
   'mt::close-window-confirm': [unsavedFiles: UnsavedFile[]]
   'mt::cmd-close-window': []

--- a/packages/desktop/src/types/global.d.ts
+++ b/packages/desktop/src/types/global.d.ts
@@ -50,6 +50,7 @@ declare global {
 
   interface ElectronClipboardAPI {
     writeText(text: string): void
+    write(data: { text: string; html: string }): void
     readText(): Promise<string>
     guessFilePath(): Promise<string | null>
   }

--- a/packages/muya/src/clipboard/__tests__/embedderClipboardWrite.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/embedderClipboardWrite.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../muya';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// happy-dom does not implement `document.execCommand`; install a mock so each
+// test can assert whether the copy path fell back to it.
+let execCommand: ReturnType<typeof vi.fn>;
+beforeEach(() => {
+    execCommand = vi.fn(() => true);
+    (document as unknown as { execCommand: unknown }).execCommand = execCommand;
+});
+
+// `copyAsRich` / `copyAsHtml` used to rely on `document.execCommand('copy')`,
+// which no-ops when triggered from a main->renderer IPC message (menu /
+// context menu) in Electron 42 Chromium — same tightening that broke
+// `execCommand('paste')`. The embedder now supplies a `clipboardWrite` hook
+// (backed by Electron's native clipboard) so the slots reach the OS clipboard
+// without depending on a synthetic copy event.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const Clipboard = (await import('../index')).default;
+
+function fakeMuya(options: Record<string, unknown> = {}) {
+    return {
+        options: { frontMatter: true, ...options },
+        editor: { selection: { image: null } },
+    } as unknown as Muya;
+}
+
+function clipboardWithData(html: string, text: string, muya: Muya) {
+    const clipboard = new Clipboard(muya);
+    clipboard.getClipboardData = () => ({ html, text });
+    return clipboard;
+}
+
+describe('copyAs* write through the clipboardWrite embedder hook', () => {
+    it('copyAsRich sends rendered html + markdown to clipboardWrite, not execCommand', () => {
+        const clipboardWrite = vi.fn();
+        const clipboard = clipboardWithData('<p>hi</p>', 'hi', fakeMuya({ clipboardWrite }));
+        clipboard.copyAsRich();
+
+        expect(clipboardWrite).toHaveBeenCalledWith({ html: '<p>hi</p>', text: 'hi' });
+        expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    it('copyAsHtml sends sanitized html in the text slot and blanks the html slot', () => {
+        const clipboardWrite = vi.fn();
+        const clipboard = clipboardWithData('', '# Heading\n\nhello', fakeMuya({ clipboardWrite }));
+
+        clipboard.copyAsHtml();
+
+        expect(clipboardWrite).toHaveBeenCalledTimes(1);
+        const arg = clipboardWrite.mock.calls[0][0] as { html: string; text: string };
+        expect(arg.html).toBe('');
+        expect(arg.text).toContain('<h1');
+        expect(arg.text).toContain('hello');
+    });
+
+    it('does not write (leaves clipboard untouched) when the selection is empty', () => {
+        const clipboardWrite = vi.fn();
+        const clipboard = clipboardWithData('', '', fakeMuya({ clipboardWrite }));
+        clipboard.copyAsRich();
+
+        expect(clipboardWrite).not.toHaveBeenCalled();
+        expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    it('falls back to execCommand("copy") when no clipboardWrite hook is provided', () => {
+        const clipboard = clipboardWithData('<p>hi</p>', 'hi', fakeMuya());
+
+        clipboard.copyAsRich();
+
+        expect(execCommand).toHaveBeenCalledWith('copy');
+    });
+});

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -288,23 +288,21 @@ export function getClipboardData(clipboard: Clipboard): IClipboardPayload {
     return { html, text };
 }
 
-export function writeClipboardData(
+// Resolve the `text/html` and `text/plain` slots to place on the system
+// clipboard for the clipboard's current `copyType`, or `null` when nothing
+// should be written. Shared by the native `copy`-event path
+// ({@link writeClipboardData}) and the direct embedder-write path (used when a
+// `clipboardWrite` hook is supplied, since `document.execCommand('copy')` is a
+// no-op when triggered from a main->renderer IPC message in Electron 42).
+export function resolveClipboardSlots(
     clipboard: Clipboard,
-    event: ClipboardEvent,
-): void {
-    if (!event.clipboardData)
-        return;
-
+): Nullable<IClipboardPayload> {
     // A selected inline image copies its raw `![alt](src)` markdown
     // verbatim, short-circuiting the text-selection clipboard data.
     const selectedImage = clipboard.muya.editor?.selection?.image;
     if (selectedImage) {
         const { raw } = selectedImage.token;
-        if (raw.length > 0) {
-            event.clipboardData.setData('text/html', raw);
-            event.clipboardData.setData('text/plain', raw);
-        }
-        return;
+        return raw.length > 0 ? { html: raw, text: raw } : null;
     }
 
     const { copyType } = clipboard;
@@ -314,56 +312,48 @@ export function writeClipboardData(
     // Mirror native copy behavior: leave the system clipboard untouched
     // when the selection has nothing to contribute, so a previous copy
     // from another app isn't silently clobbered (marktext #3130).
+    if (text.length === 0)
+        return null;
+
     switch (copyType) {
-        case CopyType.NORMAL: {
-            if (text.length === 0)
-                return;
-            event.clipboardData.setData('text/html', '');
-            event.clipboardData.setData('text/plain', text);
-            break;
-        }
-
-        case CopyType.COPY_AS_HTML: {
-            if (text.length === 0)
-                return;
-            event.clipboardData.setData('text/html', '');
-            event.clipboardData.setData(
-                'text/plain',
-                getSanitizeClipboardHtml(
-                    text,
-                    buildHtmlOptions(clipboard.muya.options ?? {}),
-                ),
-            );
-            break;
-        }
-
         // "Copy as Rich Text": put the rendered HTML in the html slot so a
         // rich-text target (Word, email, contenteditable) renders formatted
         // content, and keep the markdown source in the plain slot. Mirrors
         // the `normal` branch; `copyAsHtml` instead blanks text/html and
         // drops the markup into text/plain as literal source.
-        case CopyType.COPY_AS_RICH: {
-            if (text.length === 0)
-                return;
-            event.clipboardData.setData('text/html', html);
-            event.clipboardData.setData('text/plain', text);
-            break;
-        }
+        case CopyType.COPY_AS_RICH:
+            return { html, text };
 
-        case CopyType.COPY_AS_MARKDOWN: {
-            if (text.length === 0)
-                return;
-            event.clipboardData.setData('text/html', '');
-            event.clipboardData.setData('text/plain', text);
-            break;
-        }
+        case CopyType.COPY_AS_HTML:
+            return {
+                html: '',
+                text: getSanitizeClipboardHtml(
+                    text,
+                    buildHtmlOptions(clipboard.muya.options ?? {}),
+                ),
+            };
 
-        case CopyType.COPY_CODE_CONTENT: {
-            if (text.length === 0)
-                return;
-            event.clipboardData.setData('text/html', '');
-            event.clipboardData.setData('text/plain', text);
-            break;
-        }
+        case CopyType.NORMAL:
+        case CopyType.COPY_AS_MARKDOWN:
+        case CopyType.COPY_CODE_CONTENT:
+            return { html: '', text };
+
+        default:
+            return null;
     }
+}
+
+export function writeClipboardData(
+    clipboard: Clipboard,
+    event: ClipboardEvent,
+): void {
+    if (!event.clipboardData)
+        return;
+
+    const slots = resolveClipboardSlots(clipboard);
+    if (slots == null)
+        return;
+
+    event.clipboardData.setData('text/html', slots.html);
+    event.clipboardData.setData('text/plain', slots.text);
 }

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -2,7 +2,7 @@ import type { Muya } from '../muya';
 import type { IClipboardPayload } from './copyData';
 import { fromEvent, merge } from 'rxjs';
 import { isClipboardEvent, isKeyboardEvent } from '../utils';
-import { getClipboardData, writeClipboardData } from './copyData';
+import { getClipboardData, resolveClipboardSlots, writeClipboardData } from './copyData';
 import { cutSelection } from './cut';
 import { pastePlainText, pasteSelection } from './paste';
 import { CopyType, PasteType } from './types';
@@ -107,20 +107,44 @@ class Clipboard {
 
     copyAsMarkdown() {
         this.copyType = CopyType.COPY_AS_MARKDOWN;
-        document.execCommand('copy');
+        if (!this._writeViaEmbedder())
+            document.execCommand('copy');
         this.copyType = CopyType.NORMAL;
     }
 
     copyAsHtml() {
         this.copyType = CopyType.COPY_AS_HTML;
-        document.execCommand('copy');
+        if (!this._writeViaEmbedder())
+            document.execCommand('copy');
         this.copyType = CopyType.NORMAL;
     }
 
     copyAsRich() {
         this.copyType = CopyType.COPY_AS_RICH;
-        document.execCommand('copy');
+        if (!this._writeViaEmbedder())
+            document.execCommand('copy');
         this.copyType = CopyType.NORMAL;
+    }
+
+    // `document.execCommand('copy')` no-ops when these methods are triggered
+    // from a main->renderer IPC message (menu / context menu / accelerator) in
+    // Electron 42 Chromium — no renderer user gesture and the editor is often
+    // unfocused — so the synthetic copy event never fires. When the embedder
+    // supplies a `clipboardWrite` hook (backed by the native OS clipboard) write
+    // the resolved slots through it directly and skip execCommand. Returns
+    // `true` when the embedder handled the write (including the deliberate
+    // no-write for an empty selection), `false` to fall back to execCommand for
+    // standalone/browser use.
+    private _writeViaEmbedder(): boolean {
+        const writer = this.muya.options.clipboardWrite;
+        if (typeof writer !== 'function')
+            return false;
+
+        const slots = resolveClipboardSlots(this);
+        if (slots != null)
+            writer(slots);
+
+        return true;
     }
 
     // Chromium removed programmatic clipboard reads via

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -59,6 +59,19 @@ export interface IMuyaOptions {
      */
     clipboardText?: () => Promise<string>;
     /**
+     * Write the rendered slots for "Copy as Rich Text" / "Copy as HTML" /
+     * "Copy as Markdown" to the OS clipboard.
+     *
+     * The embedder supplies this because `document.execCommand('copy')` no-ops
+     * when these commands are triggered from a main->renderer IPC message
+     * (menu / context menu / accelerator) in Electron 42 Chromium — the editor
+     * is unfocused and there is no renderer user gesture, so the synthetic copy
+     * event never fires. Electron embedders wire this to an IPC bridge over the
+     * native `clipboard.write({ text, html })`. When omitted, muya falls back to
+     * `document.execCommand('copy')` for standalone/browser use.
+     */
+    clipboardWrite?: (data: { text: string; html: string }) => void;
+    /**
      * Persist an image per the embedder's insert preference (copy into the
      * document's assets folder, upload to an image host, or keep the path) and
      * resolve to the src that should be written into the document.


### PR DESCRIPTION
## Problem

"Copy as Rich Text" and "Copy as HTML" (Edit menu **and** right-click menu) put nothing on the clipboard — pasting into Word/email/anywhere yields nothing.

## Root cause

Both paths converge on muya's `clipboard.copyAsRich()` / `copyAsHtml()`, which set a `copyType` then call **`document.execCommand('copy')`** to fire a synthetic `copy` event that `writeClipboardData` fills.

These commands are triggered from a **main→renderer IPC message** (menu / context menu / accelerator, via `mt::editor-edit-action` and `mt::cm-copy-as-*`), so they run with **no renderer user gesture and the editor unfocused** (the native menu handled the click). In Electron 42 Chromium that makes `execCommand('copy')` a no-op — the same clipboard tightening that previously broke `execCommand('paste')` (which was fixed for paste by reading through the Electron clipboard bridge). The copy side was never migrated, so the `copy` event never fires.

Existing unit tests call `copyHandler(event)` directly with a synthetic event, bypassing `execCommand`, so the broken runtime trigger was invisible to CI.

## Fix

Stop relying on `execCommand('copy')`. Compute the `{ text, html }` slots and write them directly to the system clipboard through an embedder hook backed by Electron's native `clipboard.write({ text, html })` — symmetric to the existing `clipboardText` paste bridge. `execCommand('copy')` is kept only as the standalone/browser fallback.

- **muya**: extract the per-`copyType` slot logic into `resolveClipboardSlots()` (shared with the native copy-event path, so that path is unchanged); add a `clipboardWrite` option; route `copyAsRich`/`copyAsHtml`/`copyAsMarkdown` through it.
- **desktop**: add a `mt::clipboard::write` channel (renderer `clipboard.write` → main native `clipboard.write`) and wire `clipboardWrite` in the editor's muya options.

The in-editor code-block "copy" button (`copy(COPY_CODE_CONTENT)`) is a real in-renderer click (user gesture) where `execCommand('copy')` still works, so it is intentionally left unchanged.

## Testing

- New spec `embedderClipboardWrite.spec.ts` (TDD: written failing first) asserting `copyAsRich`/`copyAsHtml` write the correct slots through `clipboardWrite` instead of `execCommand`, and that `execCommand` remains the fallback when no hook is provided.
- muya: full suite **757/757**; `lint:types` clean; `lint` 0 errors.
- desktop: `typecheck` passes; changed files lint clean.
- ⚠️ End-to-end (paste into Word/email yields formatted rich text) is **manual only** — the OS-clipboard round-trip cannot be unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)