### PR TITLE
fix(desktop): reflect underline/superscript/subscript/highlight in the Format menu

### DIFF
--- a/packages/desktop/src/main/menu/actions/format.ts
+++ b/packages/desktop/src/main/menu/actions/format.ts
@@ -5,6 +5,10 @@ import type { CommandManager } from '../../commands'
 const MENU_ID_FORMAT_MAP: Readonly<Record<string, string>> = Object.freeze({
   strongMenuItem: 'strong',
   emphasisMenuItem: 'em',
+  underlineMenuItem: 'u',
+  superscriptMenuItem: 'sup',
+  subscriptMenuItem: 'sub',
+  highlightMenuItem: 'mark',
   inlineCodeMenuItem: 'inline_code',
   strikeMenuItem: 'del',
   hyperlinkMenuItem: 'link',

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1896,10 +1896,16 @@ const createApplicationMenuState = ({
 /**
  * Creates a object that contains the formats selection state.
  */
-const createSelectionFormatState = (formats: SelectionFormat[]): Record<string, boolean> => {
+export const createSelectionFormatState = (
+  formats: SelectionFormat[]
+): Record<string, boolean> => {
   const state: Record<string, boolean> = {}
   for (const item of formats) {
-    state[item.type] = true
+    // Underline/superscript/subscript/highlight are carried as `html_tag`
+    // tokens whose `tag` (u/sup/sub/mark) is the real format key the menu
+    // map keys off — the bare `type` would only ever yield `html_tag`.
+    const key = item.type === 'html_tag' ? (item.tag as string) : item.type
+    if (key) state[key] = true
   }
   return state
 }

--- a/packages/desktop/test/unit/specs/format-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/format-menu-state.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// `@/store/editor` transitively imports `@/config`, which reads
+// `window.path.sep` at module load (normally injected by the preload bridge).
+// Stub it before the hoisted imports run so the store graph can load.
+vi.hoisted(() => {
+  const w = globalThis as unknown as { window?: { path?: { sep: string } } }
+  w.window ??= {}
+  w.window.path ??= { sep: '/' }
+})
+
+import { createSelectionFormatState } from '@/store/editor'
+import { updateFormatMenu } from 'main_renderer/menu/actions/format'
+
+// Mimic the Electron application menu surface `updateFormatMenu` touches:
+// `getMenuItemById('formatMenuItem')` returning an object whose
+// `submenu.items` are checkbox menu items keyed by `id`.
+const makeMenu = (ids: string[]) => {
+  const items = ids.map((id) => ({ id, checked: false }))
+  return {
+    getMenuItemById: (id: string) =>
+      id === 'formatMenuItem' ? { submenu: { items } } : undefined,
+    items
+  }
+}
+
+const FORMAT_MENU_IDS = [
+  'strongMenuItem',
+  'emphasisMenuItem',
+  'underlineMenuItem',
+  'superscriptMenuItem',
+  'subscriptMenuItem',
+  'highlightMenuItem',
+  'inlineCodeMenuItem',
+  'inlineMathMenuItem',
+  'strikeMenuItem',
+  'hyperlinkMenuItem',
+  'imageMenuItem'
+]
+
+const checkedIds = (menu: ReturnType<typeof makeMenu>) =>
+  menu.items.filter((i) => i.checked).map((i) => i.id)
+
+describe('createSelectionFormatState', () => {
+  it('keys html_tag tokens by their tag (u/sup/sub/mark), not "html_tag"', () => {
+    const state = createSelectionFormatState([
+      { type: 'html_tag', tag: 'u' },
+      { type: 'html_tag', tag: 'sup' },
+      { type: 'html_tag', tag: 'sub' },
+      { type: 'html_tag', tag: 'mark' },
+      { type: 'strong' }
+    ])
+
+    expect(state).toEqual({ u: true, sup: true, sub: true, mark: true, strong: true })
+    expect(state.html_tag).toBeUndefined()
+  })
+})
+
+describe('updateFormatMenu', () => {
+  it('checks underline/superscript/subscript/highlight when the caret is inside them', () => {
+    const menu = makeMenu(FORMAT_MENU_IDS)
+    const state = createSelectionFormatState([
+      { type: 'html_tag', tag: 'u' },
+      { type: 'html_tag', tag: 'sup' },
+      { type: 'html_tag', tag: 'sub' },
+      { type: 'html_tag', tag: 'mark' }
+    ])
+
+    updateFormatMenu(menu, state)
+
+    expect(checkedIds(menu).sort()).toEqual(
+      ['highlightMenuItem', 'subscriptMenuItem', 'superscriptMenuItem', 'underlineMenuItem'].sort()
+    )
+  })
+
+  it('still checks the existing inline formats (strong/em/...)', () => {
+    const menu = makeMenu(FORMAT_MENU_IDS)
+    const state = createSelectionFormatState([{ type: 'strong' }, { type: 'em' }])
+
+    updateFormatMenu(menu, state)
+
+    expect(checkedIds(menu).sort()).toEqual(['emphasisMenuItem', 'strongMenuItem'].sort())
+  })
+
+  it('clears checks when the selection carries no formats', () => {
+    const menu = makeMenu(FORMAT_MENU_IDS)
+    menu.items.forEach((i) => (i.checked = true))
+
+    updateFormatMenu(menu, createSelectionFormatState([]))
+
+    expect(checkedIds(menu)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

When the caret sits inside an underline, superscript, subscript, or highlight inline style, the corresponding item in the **Format** menu was never checked.

Two gaps combined to cause it. muya encodes these four styles as `html_tag` tokens whose real format key lives in the `tag` field (`u` / `sup` / `sub` / `mark`), not in `type`:

- **Renderer** (`store/editor.ts`): `createSelectionFormatState` keyed the state by `item.type`, collapsing every `html_tag` token to `state['html_tag']` and discarding the tag.
- **Main** (`menu/actions/format.ts`): `MENU_ID_FORMAT_MAP` had no entries for `underlineMenuItem` / `superscriptMenuItem` / `subscriptMenuItem` / `highlightMenuItem`, so even a correct key could not check them.

The fix keys `html_tag` tokens by their `tag` and adds the four missing menu-map entries — matching how muya's own inline format toolbar decides which icon is active (`f.type === icon.type || (f.type === 'html_tag' && f.tag === icon.type)`).

## Testing

- New `test/unit/specs/format-menu-state.spec.ts` drives muya-style tokens through `createSelectionFormatState` → `updateFormatMenu`, asserting the four styles check, existing formats still check, and an empty selection clears all checkmarks. Verified failing before the fix.
- `pnpm run test:unit` — 471 passed
- `pnpm run lint` — 0 errors
- `pnpm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)