### PR TITLE
fix: paragraph menu / command palette parity (focus, list unwrap, shortcut symbols)

### DIFF
--- a/packages/desktop/src/renderer/src/components/commandPalette/index.vue
+++ b/packages/desktop/src/renderer/src/components/commandPalette/index.vue
@@ -444,7 +444,18 @@ ul.commands li span.shortcut {
   line-height: 20px;
 }
 ul.commands li span.shortcut > kbd {
-  margin-left: 2px;
+  display: inline-block;
+  margin-left: 4px;
+  padding: 1px 7px;
+  min-width: 10px;
+  text-align: center;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--editorColor);
+  background: var(--floatBgColor);
+  border: 1px solid var(--floatBorderColor);
+  border-radius: 4px;
 }
 
 .fade-enter-active,

--- a/packages/desktop/src/renderer/src/store/commandCenter.ts
+++ b/packages/desktop/src/renderer/src/store/commandCenter.ts
@@ -2,6 +2,8 @@ import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import log from 'electron-log'
 import bus from '../bus'
+import { isOsx } from '@/util'
+import { acceleratorToTokens } from '@/util/accelerator'
 
 import staticCommands, {
   RootCommand,
@@ -87,10 +89,7 @@ const executeCommand = (root: Root, commandId: string): void => {
 
 const normalizeAccelerator = (acc: string): string[] => {
   try {
-    return acc
-      .replace(/cmdorctrl|cmd/i, 'Cmd')
-      .replace(/ctrl/i, 'Ctrl')
-      .split('+')
+    return acceleratorToTokens(acc, isOsx)
   } catch {
     return [acc]
   }

--- a/packages/desktop/src/renderer/src/util/accelerator.ts
+++ b/packages/desktop/src/renderer/src/util/accelerator.ts
@@ -1,0 +1,41 @@
+// Turn an Electron accelerator string (e.g. "Command+Shift+T") into the
+// per-key tokens the command palette renders. On macOS modifiers become the
+// native symbols (⌘ ⇧ ⌥ ⌃) so the palette matches the muya front menu and the
+// system menus; elsewhere they stay readable words.
+
+const MAC_SYMBOLS: Record<string, string> = {
+  cmdorctrl: '⌘',
+  commandorcontrol: '⌘',
+  command: '⌘',
+  cmd: '⌘',
+  meta: '⌘',
+  super: '⌘',
+  control: '⌃',
+  ctrl: '⌃',
+  shift: '⇧',
+  option: '⌥',
+  alt: '⌥'
+}
+
+const OTHER_WORDS: Record<string, string> = {
+  cmdorctrl: 'Ctrl',
+  commandorcontrol: 'Ctrl',
+  command: 'Ctrl',
+  cmd: 'Ctrl',
+  control: 'Ctrl',
+  ctrl: 'Ctrl',
+  meta: 'Win',
+  super: 'Win',
+  shift: 'Shift',
+  option: 'Alt',
+  alt: 'Alt'
+}
+
+export const acceleratorToTokens = (accelerator: string, isOsx: boolean): string[] => {
+  const map = isOsx ? MAC_SYMBOLS : OTHER_WORDS
+  return accelerator
+    .split('+')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => map[part.toLowerCase()] ?? part)
+}

--- a/packages/desktop/test/unit/specs/accelerator.spec.ts
+++ b/packages/desktop/test/unit/specs/accelerator.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { acceleratorToTokens } from '@/util/accelerator'
+
+describe('acceleratorToTokens', () => {
+  it('maps modifiers to macOS symbols', () => {
+    expect(acceleratorToTokens('Command+Shift+T', true)).toEqual(['⌘', '⇧', 'T'])
+    expect(acceleratorToTokens('Command+Option+C', true)).toEqual(['⌘', '⌥', 'C'])
+    expect(acceleratorToTokens('Command+1', true)).toEqual(['⌘', '1'])
+    expect(acceleratorToTokens('CmdOrCtrl+Shift+P', true)).toEqual(['⌘', '⇧', 'P'])
+  })
+
+  it('keeps the trailing key untouched', () => {
+    expect(acceleratorToTokens('Command+=', true)).toEqual(['⌘', '='])
+    expect(acceleratorToTokens('Command+Option+-', true)).toEqual(['⌘', '⌥', '-'])
+  })
+
+  it('maps modifiers to words off macOS', () => {
+    expect(acceleratorToTokens('Ctrl+Shift+T', false)).toEqual(['Ctrl', 'Shift', 'T'])
+    expect(acceleratorToTokens('CmdOrCtrl+Alt+P', false)).toEqual(['Ctrl', 'Alt', 'P'])
+  })
+})

--- a/packages/muya/src/__tests__/focus.spec.ts
+++ b/packages/muya/src/__tests__/focus.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../muya';
+
+// Focusing the editor must return the caret to where the user left it, not
+// jump to the top of the document. The command palette blurs the editor
+// (clearing activeContentBlock) and then re-focuses it before running a
+// command; if focus() relocated to the first block, palette-only commands
+// such as "Reset Paragraph" would operate on the wrong block.
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('editor.focus()', () => {
+    it('restores the last cursor block after a blur instead of jumping to the first block', () => {
+        const muya = bootMuya('first\n\nsecond\n\nthird\n');
+        const last = muya.editor.scrollPage!.lastContentInDescendant() as Content;
+        last.setCursor(0, 0, true);
+        expect(muya.editor.activeContentBlock).toBe(last);
+
+        muya.blur();
+        expect(muya.editor.activeContentBlock).toBeNull();
+
+        muya.focus();
+        expect(muya.editor.activeContentBlock).toBe(last);
+    });
+
+    it('falls back to the first block when there is no live prior selection', () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant() as Content;
+
+        muya.focus();
+        expect(muya.editor.activeContentBlock).toBe(first);
+    });
+});

--- a/packages/muya/src/__tests__/resetToParagraph.spec.ts
+++ b/packages/muya/src/__tests__/resetToParagraph.spec.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import type Content from '../block/base/content';
+import type Parent from '../block/base/parent';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+import { ParagraphFrontMenu } from '../ui/paragraphFrontMenu';
+
+// Resetting a list/blockquote to paragraphs must preserve every item/line.
+// `resetToParagraph` is the shared engine path used both by the command
+// palette/menu `reset-to-paragraph` command and by the paragraph front menu
+// when the user clicks the already-active list type (toggle the list off).
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstOutmostBlock(muya: Muya): Parent {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as Content;
+    return content.outMostBlock as Parent;
+}
+
+describe('muya.resetToParagraph(block)', () => {
+    it('unwraps a bullet list into separate paragraphs, preserving every item', async () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const list = firstOutmostBlock(muya);
+        expect(list.blockName).toBe('bullet-list');
+
+        muya.resetToParagraph(list);
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(3);
+            expect(state.every(b => b.name === 'paragraph')).toBe(true);
+        });
+        const md = muya.getMarkdown();
+        expect(md).toContain('one');
+        expect(md).toContain('two');
+        expect(md).toContain('three');
+    });
+
+    it('unwraps a blockquote into separate paragraphs', async () => {
+        const muya = bootMuya('> line one\n>\n> line two\n');
+        const quote = firstOutmostBlock(muya);
+        expect(quote.blockName).toBe('block-quote');
+
+        muya.resetToParagraph(quote);
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(2);
+            expect(state.every(b => b.name === 'paragraph')).toBe(true);
+        });
+    });
+});
+
+describe('paragraph front menu — clicking the active list type unwraps the list', () => {
+    it('bullet list -> bullet-list item unwraps into paragraphs', async () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const list = firstOutmostBlock(muya);
+        expect(list.blockName).toBe('bullet-list');
+
+        const menu = new ParagraphFrontMenu(muya, {});
+        (menu as unknown as { _block: Parent })._block = list;
+        menu.selectItem(new Event('click'), { label: 'bullet-list' });
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(3);
+            expect(state.every(b => b.name === 'paragraph')).toBe(true);
+        });
+    });
+});

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -143,8 +143,25 @@ export class Editor {
     }
 
     focus() {
-    // TODO: the cursor maybe passed by muya options.cursor, and no need to find the first leaf block.
-        const firstLeafBlock = this.scrollPage?.firstContentInDescendant();
+        const { selection, scrollPage } = this;
+        const { anchorBlock, anchorPath, anchor, focus } = selection;
+
+        // Restore the user's last caret when it is still in the tree, so a
+        // focus() triggered after a blur (e.g. the command palette) keeps
+        // block-level commands operating on the block the user was editing
+        // rather than the first block of the document.
+        if (
+            anchorBlock
+            && anchor
+            && focus
+            && scrollPage?.queryBlock(anchorPath) === anchorBlock
+        ) {
+            anchorBlock.setCursor(anchor.offset, focus.offset, true);
+            return;
+        }
+
+        // TODO: the cursor maybe passed by muya options.cursor, and no need to find the first leaf block.
+        const firstLeafBlock = scrollPage?.firstContentInDescendant();
 
         if (firstLeafBlock == null)
             return;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -889,7 +889,7 @@ export class Muya {
         // form; structured containers (lists/blockquote) unwrap to preserve
         // every child, tables are left untouched.
         if (type === 'reset-to-paragraph') {
-            this._resetToParagraph(block);
+            this.resetToParagraph(block);
             return;
         }
 
@@ -947,8 +947,14 @@ export class Muya {
         });
     }
 
-    /** Return the block at the cursor to plain paragraph form. */
-    private _resetToParagraph(block: Parent) {
+    /**
+     * Return a block to plain paragraph form: lists and blockquotes unwrap to
+     * preserve every child, tables are left untouched, and everything else is
+     * replaced by a paragraph carrying its leading text. Public so the
+     * paragraph front menu can reset the block it targets (not just the cursor
+     * block).
+     */
+    resetToParagraph(block: Parent) {
         if (block.blockName === 'table')
             return;
 

--- a/packages/muya/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/muya/src/ui/paragraphFrontMenu/index.ts
@@ -276,8 +276,16 @@ export class ParagraphFrontMenu extends BaseFloat {
                 case 'bullet-list':
                     // fall through
                 case 'task-list': {
-                    if (!isAnyListState(oldState) || block.blockName === label)
+                    if (!isAnyListState(oldState))
                         break;
+
+                    // Clicking the active list type toggles the list off,
+                    // unwrapping every item back into plain paragraphs (matches
+                    // the command-palette/menu `reset-to-paragraph` behaviour).
+                    if (block.blockName === label) {
+                        muya.resetToParagraph(block);
+                        break;
+                    }
 
                     // The conversion between order/bullet/task lists re-shapes both
                     // the parent `meta` and each item's `meta` (only task-list-items


### PR DESCRIPTION
Restores three pre-refactor behaviours around the paragraph menu and command palette that regressed in the muyajs → @muyajs/core migration. Refs #4429.

## Problems & fixes

### A. Command palette "Reset Paragraph" did nothing
`editor.focus()` always moved the caret to the **first** content block. The command palette blurs the editor (clearing `activeContentBlock`) and re-focuses it before dispatching, so palette commands targeted block #1. This was hidden for commands with keyboard shortcuts / native menu items (they never go through the blur+focus round-trip), but **Reset Paragraph has no keybinding and is palette-only**, so it always no-oped.

`focus()` now restores the user's last caret when its block is still in the tree, falling back to the first block.

### B. Command palette shortcut style differed
Keybindings are stored as Electron word-forms (`Command`/`Option`); `normalizeAccelerator` left them unmapped, so the palette showed literal "Command"/"Option" instead of symbols. A new pure `acceleratorToTokens(acc, isOsx)` maps modifiers to native symbols (`⌘ ⇧ ⌥ ⌃`) on macOS and readable words elsewhere.

### C. Front-menu list item didn't unpack a list
Clicking the active list type in the paragraph front menu was a no-op; legacy muyajs unwrapped the list back into paragraphs. The engine unwrap is promoted to a public `Muya.resetToParagraph(block)` and the front menu now calls it, sharing one code path with the menu/palette `reset-to-paragraph` command.

## Tests
- `packages/muya/src/__tests__/focus.spec.ts` — focus restores the last cursor, falls back to first block
- `packages/muya/src/__tests__/resetToParagraph.spec.ts` — `resetToParagraph` unwraps lists/blockquotes; front-menu active-type click unwraps
- `packages/desktop/test/unit/specs/accelerator.spec.ts` — modifier→symbol/word mapping

## Verification
- muya: 758 unit tests pass, `lint:types` clean, lint 0 errors, no circular deps
- desktop: 470 unit tests pass, typecheck clean, lint 0 errors

Not yet verified by launching the Electron app — logic is covered at the unit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)