### PR TITLE
test(muya): backfill engine-unit coverage for audited gaps

### DIFF
--- a/packages/muya/src/__tests__/localeCompleteness.spec.ts
+++ b/packages/muya/src/__tests__/localeCompleteness.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { de, en, es, fr, ja, ko, pt, zhCN, zhTW } from '../locales';
+
+// CHARACTERIZATION: every shipped locale must carry the exact same translation
+// keys as the canonical `en` locale (no missing/extra keys), and expose a
+// `name` tag identifying it. Missing keys would surface untranslated strings;
+// extra keys are dead weight. `en` is the source of truth.
+
+const nonEnLocales: Array<[string, typeof en]> = [
+    ['de', de],
+    ['es', es],
+    ['fr', fr],
+    ['ja', ja],
+    ['ko', ko],
+    ['pt', pt],
+    ['zh-CN', zhCN],
+    ['zh-TW', zhTW],
+];
+
+describe('locale completeness', () => {
+    const enKeys = Object.keys(en.resource).sort();
+
+    it('en exposes a non-empty resource map and the expected name', () => {
+        expect(en.name).toBe('en');
+        expect(enKeys.length).toBeGreaterThan(0);
+    });
+
+    it('ships exactly nine built-in locales (en + 8 translations)', () => {
+        expect(nonEnLocales).toHaveLength(8);
+    });
+
+    describe('key parity with en', () => {
+        for (const [tag, locale] of nonEnLocales) {
+            it(`${tag} has the same resource keys as en (no missing/extra)`, () => {
+                expect(Object.keys(locale.resource).sort()).toEqual(enKeys);
+            });
+        }
+    });
+
+    describe('locale name tags', () => {
+        const expected: Record<string, string> = {
+            'de': 'de',
+            'es': 'es',
+            'fr': 'fr',
+            'ja': 'ja',
+            'ko': 'ko',
+            'pt': 'pt',
+            'zh-CN': 'zh-CN',
+            'zh-TW': 'zh-TW',
+        };
+        for (const [tag, locale] of nonEnLocales) {
+            it(`${tag} reports the expected name tag`, () => {
+                expect(locale.name).toBe(expected[tag]);
+            });
+        }
+    });
+
+    describe('every resource value is a non-empty string', () => {
+        for (const [tag, locale] of [['en', en] as [string, typeof en], ...nonEnLocales]) {
+            it(`${tag} has only non-empty string values`, () => {
+                for (const value of Object.values(locale.resource)) {
+                    expect(typeof value).toBe('string');
+                    expect((value as string).length).toBeGreaterThan(0);
+                }
+            });
+        }
+    });
+});

--- a/packages/muya/src/__tests__/setOptions.spec.ts
+++ b/packages/muya/src/__tests__/setOptions.spec.ts
@@ -100,3 +100,98 @@ describe('muya runtime options', () => {
         expect(muya.getMarkdown()).toBe(before);
     });
 });
+
+// Render-affecting options: the inline renderer (`InlineRenderer.tokenizer`)
+// reads `muya.options` live on every render pass, so superSubScript governs
+// whether `^x^` / `~x~` are tokenized into <sup>/<sub> or left as literal
+// text. The serialized markdown is identical either way (the markers stay in
+// the source); the option only changes the rendered DOM, so these are asserted
+// against the rendered tree, not getMarkdown().
+describe('muya render-affecting options', () => {
+    function bootMuyaWith(markdown: string, options: Record<string, unknown>): Muya {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+        muya.init();
+        bootedHosts.push(muya.domNode);
+        return muya;
+    }
+
+    it('superSubScript:false renders literal ^sup^ (no <sup> element)', async () => {
+        const muya = bootMuyaWith('^sup^\n', { superSubScript: false });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+        expect(muya.domNode.querySelectorAll('sup').length).toBe(0);
+        expect(muya.domNode.textContent).toContain('^sup^');
+        // The source markdown is unchanged — the option only governs rendering.
+        expect(muya.getMarkdown()).toBe('^sup^\n');
+    });
+
+    it('superSubScript:true renders a <sup> element for ^sup^', async () => {
+        const muya = bootMuyaWith('^sup^\n', { superSubScript: true });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+        expect(muya.domNode.querySelectorAll('sup').length).toBe(1);
+        // The marker is preserved in the serialized markdown regardless.
+        expect(muya.getMarkdown()).toBe('^sup^\n');
+    });
+
+    it('setOptions superSubScript with forceRender toggles the <sup> live', async () => {
+        const muya = bootMuyaWith('^sup^\n', { superSubScript: true });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('sup').length).toBe(1);
+
+        muya.setOptions({ superSubScript: false }, true);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('sup').length).toBe(0);
+        expect(muya.domNode.textContent).toContain('^sup^');
+
+        muya.setOptions({ superSubScript: true }, true);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('sup').length).toBe(1);
+    });
+
+    it('frontmatterType:false drives the option onto muya.options', () => {
+        const muya = bootMuyaWith('body\n', {});
+        muya.setOptions({ frontmatterType: '+' });
+        expect(muya.options.frontmatterType).toBe('+');
+    });
+
+    // CHARACTERIZATION: setOptions({ frontmatterType }, forceRender) does NOT
+    // retroactively rewrite an existing frontmatter block's fences. The
+    // serializer (`serializeFrontMatter`) keys off the BLOCK's own
+    // `meta.lang`/`meta.style` (baked in at parse time), and `_forceRender`
+    // rebuilds the tree from the unchanged state, so a YAML (`---`) block stays
+    // YAML even after switching the option to TOML (`+`). The option only
+    // affects NEWLY inserted frontmatter (`insertFrontMatterAtStart`).
+    it('setOptions({frontmatterType}, true) does NOT rewrite existing frontmatter fences', async () => {
+        const muya = bootMuyaWith('---\ntitle: hi\n---\n\nbody\n', {});
+        const before = muya.getMarkdown();
+        expect((muya.getState()[0] as { meta: { lang: string } }).meta.lang).toBe('yaml');
+
+        muya.setOptions({ frontmatterType: '+' }, true);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+        // The fences are still `---` (yaml), NOT `+++` (toml) — the existing
+        // block's meta is unchanged by the option switch.
+        expect(muya.getMarkdown()).toBe(before);
+        expect(muya.getMarkdown().startsWith('---\n')).toBe(true);
+        expect((muya.getState()[0] as { meta: { lang: string } }).meta.lang).toBe('yaml');
+    });
+
+    it('frontmatterType set via setOptions applies to NEWLY inserted frontmatter', async () => {
+        const muya = bootMuyaWith('body\n', {});
+        muya.setOptions({ frontmatterType: '+' });
+        // Place the cursor so updateParagraph has a target block.
+        muya.editor.activeContentBlock = muya.editor.scrollPage!.firstContentInDescendant()!;
+        muya.updateParagraph('front-matter');
+
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('frontmatter');
+        });
+
+        // The freshly inserted block follows the updated option: TOML `+++`.
+        expect((muya.getState()[0] as { meta: { lang: string } }).meta.lang).toBe('toml');
+        expect(muya.getMarkdown().startsWith('+++\n')).toBe(true);
+    });
+});

--- a/packages/muya/src/__tests__/updateParagraph.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.spec.ts
@@ -99,6 +99,36 @@ describe('muya.updateParagraph()', () => {
         });
     });
 
+    // Promote clamp: H1 is the top heading level, so `upgrade heading` on an
+    // H1 is a no-op (the level stays 1) — _changeHeadingLevel returns early
+    // when `level === 1`.
+    it('upgrade heading on h1 is a no-op (stays level 1)', async () => {
+        const muya = bootMuya('# one\n');
+        placeCursorOnFirstBlock(muya);
+        expect(firstBlock(muya).name).toBe('atx-heading');
+        expect(firstBlock(muya).meta.level).toBe(1);
+        muya.updateParagraph('upgrade heading');
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(firstBlock(muya).name).toBe('atx-heading');
+        expect(firstBlock(muya).meta.level).toBe(1);
+        expect(muya.getMarkdown()).toContain('# one');
+    });
+
+    // Demote clamp: degrading an H6 drops past the heading floor, so the block
+    // becomes a plain paragraph (newLevel === 0 -> 'paragraph' label).
+    it('degrade heading on h6 turns it into a paragraph', async () => {
+        const muya = bootMuya('###### six\n');
+        placeCursorOnFirstBlock(muya);
+        expect(firstBlock(muya).name).toBe('atx-heading');
+        expect(firstBlock(muya).meta.level).toBe(6);
+        muya.updateParagraph('degrade heading');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('paragraph');
+        });
+        expect(muya.getMarkdown()).toContain('six');
+        expect(muya.getMarkdown()).not.toContain('# six');
+    });
+
     it('turns a paragraph into a blockquote', async () => {
         const muya = bootMuya('quote me\n');
         placeCursorOnFirstBlock(muya);
@@ -234,6 +264,37 @@ describe('muya.updateParagraph()', () => {
         await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
         expect(firstBlock(muya).name).toBe('paragraph');
         expect(muya.getMarkdown()).toContain('keep me');
+    });
+
+    // HR positive path: an empty paragraph passes the content guard, so `hr`
+    // replaces it with a thematic-break AND inserts a fresh trailing paragraph
+    // so the user is never stranded on the un-editable rule. The cursor lands
+    // in that trailing paragraph.
+    it('converts an empty paragraph to an hr, leaving a trailing paragraph with the cursor', async () => {
+        const muya = bootMuya('');
+        const first = placeCursorOnFirstBlock(muya);
+        expect(firstBlock(muya).name).toBe('paragraph');
+        expect(first.text).toBe('');
+
+        muya.updateParagraph('hr');
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(2);
+            expect(state[0].name).toBe('thematic-break');
+            expect(state[1].name).toBe('paragraph');
+        });
+
+        const state = muya.getState();
+        // The trailing paragraph is empty and ready for input.
+        expect((state[1] as { text: string }).text).toBe('');
+
+        // The cursor moved off the original paragraph into the trailing one:
+        // the active content block is the trailing paragraph's leaf.
+        const active = muya.editor.activeContentBlock;
+        expect(active).not.toBeNull();
+        const trailing = muya.editor.scrollPage!.lastContentInDescendant();
+        expect(active).toBe(trailing);
     });
 
     // G4 regression: the plain 'paragraph' menu item must not collapse a list /

--- a/packages/muya/src/block/base/__tests__/autoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/autoPair.spec.ts
@@ -266,3 +266,38 @@ describe('autoPair — bbea7eca skip when preInputChar is alphanumeric', () => {
         expect(needRender).toBe(false);
     });
 });
+
+// ── option toggles disable the individual auto-pair behaviours ────────────
+// Each of `autoPairBracket`, `autoPairMarkdownSyntax`, `autoPairQuote`
+// gates exactly one branch in `autoPair`. When the option is `false` the
+// branch must NOT fire: the typed character is left as-is with no inserted
+// closer and `needRender` stays `false`. These pin the per-option opt-out
+// so a future refactor can't silently re-enable a disabled behaviour.
+describe('autoPair — per-option opt-out', () => {
+    it('does not pair `(` when autoPairBracket is false', () => {
+        const fakeThis = makeFakeThis('foo', 3, { autoPairBracket: false });
+        const event = makeInputEvent('insertText', '(');
+        const { text, needRender } = invokeAutoPair(fakeThis, event, 'foo(', 4);
+
+        expect(text).toBe('foo(');
+        expect(needRender).toBe(false);
+    });
+
+    it('does not pair `*` after a space when autoPairMarkdownSyntax is false', () => {
+        const fakeThis = makeFakeThis('foo ', 4, { autoPairMarkdownSyntax: false });
+        const event = makeInputEvent('insertText', '*');
+        const { text, needRender } = invokeAutoPair(fakeThis, event, 'foo *', 5);
+
+        expect(text).toBe('foo *');
+        expect(needRender).toBe(false);
+    });
+
+    it('does not pair `"` when autoPairQuote is false', () => {
+        const fakeThis = makeFakeThis('foo', 3, { autoPairQuote: false });
+        const event = makeInputEvent('insertText', '"');
+        const { text, needRender } = invokeAutoPair(fakeThis, event, 'foo"', 4);
+
+        expect(text).toBe('foo"');
+        expect(needRender).toBe(false);
+    });
+});

--- a/packages/muya/src/block/base/__tests__/formatBackspace.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatBackspace.spec.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+
+// Coverage for `Format.backspaceHandler` — the Firefox-compatibility fix for
+// muya#113 (https://github.com/marktext/muya/issues/113). When the collapsed
+// caret rests on an inline-syntax marker boundary, a raw contenteditable
+// Backspace would delete one marker character and leave the rendered run with
+// an unbalanced / duplicated marker. `backspaceHandler` intercepts that case:
+// it re-tokenizes `this.text`, trims ONE character off the matched token's raw
+// markdown, regenerates the text, and steps the caret back by one — removing a
+// single marker char with no dangling or doubled markers.
+//
+// Offsets here are in RAW markdown-text coordinates: the active content block
+// renders its markdown source (markers visible), so `setCursor`/`getCursor`
+// round-trip against the same string the handler scans. For `'foo **strong**'`
+// the tokenizer yields a `'foo '` text token (range 0..4) and a `'**strong**'`
+// strong token (range 4..14); the handler matches a token by
+// `range.end === offset` (caret just past the token's close) or
+// `range.start + 1 === offset` (caret one char into the token's open).
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    // The DOM selection is document-global; a range left pointing into the
+    // just-removed host would corrupt the next test's `setCursor`.
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Rest a collapsed caret at `offset` (RAW markdown coordinates) inside the
+// first content block and mark it active, the way a click lands the caret
+// before a Backspace.
+function caretInFirstBlock(muya: Muya, offset: number): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(offset, offset, true);
+    return content;
+}
+
+function pressBackspace(content: Format): Event {
+    const event = new Event('keydown', { cancelable: true });
+    content.backspaceHandler(event);
+    return event;
+}
+
+describe('format.backspaceHandler — closing-marker boundary (muya#113)', () => {
+    it('just-outside the closing `**`: removes one marker char, no doubled markers', () => {
+        // Caret at offset 14, immediately after the whole `**strong**` close.
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 14);
+        const event = pressBackspace(content);
+
+        // Exactly one `*` of the closing pair is gone — not the whole pair, not
+        // a content char. `strong` and the opening `**` survive intact.
+        expect(content.text).toBe('foo **strong*');
+        // No dangling / duplicated markers: the original balanced `**…**` is now
+        // a clean single trailing `*`, never `***` or an untouched `**…**`.
+        expect(content.text).not.toContain('***');
+        expect(content.text).not.toContain('strong**');
+        // Caret steps back by one to sit on the boundary it just edited.
+        expect(content.getCursor()!.start.offset).toBe(13);
+        // The handler owns this Backspace, so the native delete is suppressed.
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('just-inside the closing `**` (between `strong` and the close): no-op, defers to default', () => {
+        // Caret at offset 12, between the `strong` text and its closing `**`.
+        // Neither token boundary rule matches, so the handler leaves the markers
+        // alone and lets the default contenteditable Backspace run.
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 12);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(12);
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('between the two `*` of the closing marker: still a no-op', () => {
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 13);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(13);
+        expect(event.defaultPrevented).toBe(false);
+    });
+});
+
+describe('format.backspaceHandler — opening-marker boundary (muya#113)', () => {
+    it('just-inside the opening `**`: removes one marker char, no doubled markers', () => {
+        // Caret at offset 5, one char into the opening `**` (between the pair).
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 5);
+        const event = pressBackspace(content);
+
+        // One `*` of the opening pair is removed; the closing `**` is untouched.
+        expect(content.text).toBe('foo *strong**');
+        expect(content.text).not.toContain('***');
+        expect(content.getCursor()!.start.offset).toBe(4);
+        expect(event.defaultPrevented).toBe(true);
+    });
+});
+
+describe('format.backspaceHandler — single-char `*` em markers (muya#113)', () => {
+    it('just-outside the closing `*`: removes the single closing marker', () => {
+        // `foo *em*` — caret at offset 8, just past the closing `*`.
+        const content = caretInFirstBlock(bootMuya('foo *em*\n'), 8);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo *em');
+        expect(content.getCursor()!.start.offset).toBe(7);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('just-inside the opening `*`: removes the single opening marker', () => {
+        // `foo *em*` — caret at offset 5, one char into the opening `*`.
+        const content = caretInFirstBlock(bootMuya('foo *em*\n'), 5);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo em*');
+        expect(content.getCursor()!.start.offset).toBe(4);
+        expect(event.defaultPrevented).toBe(true);
+    });
+});
+
+describe('format.backspaceHandler — plain-text boundaries (no markers involved)', () => {
+    it('caret at start of text (offset 0): no-op, defers to default', () => {
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 0);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(0);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret one char into leading text: trims that text char, markers untouched', () => {
+        // Offset 1 matches the `'foo '` text token's `range.start + 1`, so the
+        // leading `f` is dropped and the inline-format markers are left alone.
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 1);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('oo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(0);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret mid-run, off any marker boundary (offset 6): no-op, defers to default', () => {
+        // Offset 6 is the first char of `strong`; it matches no token boundary
+        // (`range.end` 4/14, `range.start + 1` 1/5), so the handler leaves the
+        // text untouched and lets the default Backspace delete the char.
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 6);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('foo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(6);
+        expect(event.defaultPrevented).toBe(false);
+    });
+});

--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -3,6 +3,7 @@
 import type Format from '../format';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../../muya';
+import { InlineFormatToolbar } from '../../../ui/inlineFormatToolbar';
 
 // Coverage for the PUBLIC `Format.format()` toggle-OFF and `clear` paths over a
 // real engine boot. `formatCursor.spec.ts` pins the apply-side `_addFormat`
@@ -58,6 +59,32 @@ function caretInFirstBlock(muya: Muya, offset: number): Format {
     return content;
 }
 
+// Drive `format()` over a NON-collapsed selection (`start..end`), the way
+// dragging across a word before pressing Ctrl+B wraps the run. `format()` reads
+// the live range through `this.getCursor()`, but happy-dom's `Selection` does
+// not track range offsets — `document.getSelection()` always collapses to 0, so
+// a real `setCursor(0, 3)` round-trips back as `{start:0,end:0}`. Stub the
+// block's `getCursor` for this one call so the real `format()` / `_addFormat` /
+// `generator` text surgery runs against the intended range; everything below it
+// (the marker wrapping, the offset bookkeeping, the markdown serialization) is
+// the genuine engine code path.
+function selectInFirstBlock(muya: Muya, start: number, end: number): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(start, start, true);
+    (content as unknown as { getCursor: () => unknown }).getCursor = () => ({
+        start: { offset: start },
+        end: { offset: end },
+        anchor: { offset: start },
+        focus: { offset: end },
+        isCollapsed: start === end,
+        isSelectionInSameBlock: true,
+        direction: 'forward',
+        type: start === end ? 'Caret' : 'Range',
+    });
+    return content;
+}
+
 describe('format.format() toggle-off with the caret inside the formatted run', () => {
     it('strong: `**word**` un-bolds to plain `word`', () => {
         const content = caretInFirstBlock(bootMuya('**word**\n'), 2);
@@ -100,6 +127,47 @@ describe('format.format() toggle-off with the caret inside the formatted run', (
     });
 });
 
+describe('format.format() apply-ON over a non-collapsed selection', () => {
+    it('strong: selecting `abc` and applying wraps it in `**…**`', async () => {
+        const muya = bootMuya('abc\n');
+        selectInFirstBlock(muya, 0, 3).format('strong');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('**abc**');
+        });
+    });
+
+    it('em: selecting `abc` and applying wraps it in `*…*`', async () => {
+        const muya = bootMuya('abc\n');
+        selectInFirstBlock(muya, 0, 3).format('em');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('*abc*');
+        });
+    });
+
+    it('u: selecting `abc` and applying wraps it in `<u>…</u>`', async () => {
+        const muya = bootMuya('abc\n');
+        selectInFirstBlock(muya, 0, 3).format('u');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('<u>abc</u>');
+        });
+    });
+
+    it('del: selecting `abc` and applying wraps it in `~~…~~`', async () => {
+        const muya = bootMuya('abc\n');
+        selectInFirstBlock(muya, 0, 3).format('del');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('~~abc~~');
+        });
+    });
+
+    it('also rewrites the live block text, not only the serialized state', () => {
+        const muya = bootMuya('abc\n');
+        const content = selectInFirstBlock(muya, 0, 3);
+        content.format('strong');
+        expect(content.text).toBe('**abc**');
+    });
+});
+
 describe('format.format(\'clear\') with the caret inside the run', () => {
     it('strips a strong run to plain text', () => {
         const content = caretInFirstBlock(bootMuya('**word**\n'), 2);
@@ -120,5 +188,99 @@ describe('format.format(\'clear\') with the caret inside the run', () => {
         content.format('clear');
         expect(content.text).toBe('Anthropic');
         expect(content.text).not.toContain('](');
+    });
+});
+
+// The inline-format toolbar (the "format picker") is what calls
+// `content.format('link')` when the user clicks the link button. The toolbar's
+// `_selectItem` collapses the picker after a link/image (you can't keep the
+// floating buttons up while the cursor jumps into the new `[](…)` URL slot).
+// `format()` itself emits NOTHING — the collapse lives in the toolbar — so this
+// drives the real `_selectItem` link branch on a real booted block and pins the
+// hide.
+//
+// Reading the toolbar's private `_selectItem` off the prototype (the
+// linkTools.spec.ts technique): the only collaborators it touches are
+// `this.muya.editor.selection`, `this._block.format(type)` and `this.hide()`.
+interface IFormatToolbarInternals {
+    _block: Format | null;
+    status: boolean;
+    hide: () => void;
+    _selectItem: (event: Event, item: { type: string; icon: string }) => void;
+}
+
+function makeFakeEvent(): Event {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+    } as unknown as Event;
+}
+
+describe('format picker collapses after link creation', () => {
+    it('selecting the link button runs content.format(\'link\') and hides the picker', () => {
+        const muya = bootMuya('abc\n');
+        const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+        muya.editor.activeContentBlock = content as never;
+        content.setCursor(0, 0, true);
+
+        const toolbar = new InlineFormatToolbar(muya);
+        const internals = toolbar as unknown as IFormatToolbarInternals;
+        internals._block = content;
+        // `_selectItem` only collapses (`hide()`) once the float is shown.
+        internals.status = true;
+        const hideSpy = vi.spyOn(internals, 'hide');
+
+        // A non-collapsed range so `format('link')` actually wraps `abc`.
+        (content as unknown as { getCursor: () => unknown }).getCursor = () => ({
+            start: { offset: 0 },
+            end: { offset: 3 },
+            anchor: { offset: 0 },
+            focus: { offset: 3 },
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+            direction: 'forward',
+            type: 'Range',
+        });
+
+        internals._selectItem(makeFakeEvent(), { type: 'link', icon: '' });
+
+        // The real `format('link')` rewrote the run into a markdown link.
+        expect(content.text).toBe('[abc]()');
+        // ...and the picker collapsed (link/image branch → `this.hide()`).
+        expect(hideSpy).toHaveBeenCalledTimes(1);
+
+        toolbar.destroy();
+    });
+
+    it('a non-link format (strong) re-renders the picker instead of hiding it', () => {
+        const muya = bootMuya('abc\n');
+        const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+        muya.editor.activeContentBlock = content as never;
+        content.setCursor(0, 0, true);
+
+        const toolbar = new InlineFormatToolbar(muya);
+        const internals = toolbar as unknown as IFormatToolbarInternals;
+        internals._block = content;
+        internals.status = true;
+        const hideSpy = vi.spyOn(internals, 'hide');
+
+        (content as unknown as { getCursor: () => unknown }).getCursor = () => ({
+            start: { offset: 0 },
+            end: { offset: 3 },
+            anchor: { offset: 0 },
+            focus: { offset: 3 },
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+            direction: 'forward',
+            type: 'Range',
+        });
+
+        internals._selectItem(makeFakeEvent(), { type: 'strong', icon: '' });
+
+        expect(content.text).toBe('**abc**');
+        // Non-link/image formats keep the picker up (re-render branch).
+        expect(hideSpy).not.toHaveBeenCalled();
+
+        toolbar.destroy();
     });
 });

--- a/packages/muya/src/block/commonMark/codeBlock/__tests__/lineNumbersGutter.spec.ts
+++ b/packages/muya/src/block/commonMark/codeBlock/__tests__/lineNumbersGutter.spec.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// Characterization coverage for the code-block line-numbers gutter
+// (option: codeBlockLineNumbers, marktext a028a7c2). The gutter lives in two
+// places that must stay in sync:
+//   - CodeBlock (the <pre>, class `mu-code-block`) adds the `mu-line-numbers`
+//     class purely from the option.
+//   - Code.createCopyNode() only creates the `.mu-line-numbers-rows` wrapper
+//     when the option is on AND the host is a real `code-block` (not
+//     frontmatter / math / diagram / html). CodeBlock.create then MOVES that
+//     wrapper into the <pre> so the gutter is not clipped by `.mu-code`.
+// Spans are filled lazily on CodeBlockContent.update() via syncLineNumbersSpans
+// (one span per visible row, trailing-newline row included). State and the
+// reposition pass flush on requestAnimationFrame.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function nextFrame(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+const THREE_LINE_FENCE = '```js\nconst a = 1\nconst b = 2\nconst c = 3\n```\n';
+
+describe('code-block line-numbers gutter', () => {
+    describe('when codeBlockLineNumbers is true', () => {
+        it('adds the mu-line-numbers class to the code-block <pre>', () => {
+            const muya = bootMuya(THREE_LINE_FENCE, { codeBlockLineNumbers: true });
+            const pre = muya.domNode.querySelector<HTMLElement>('pre.mu-code-block');
+            expect(pre).not.toBeNull();
+            expect(pre!.tagName).toBe('PRE');
+            expect(pre!.classList.contains('mu-line-numbers')).toBe(true);
+        });
+
+        it('creates a single .mu-line-numbers-rows wrapper inside the <pre>', () => {
+            const muya = bootMuya(THREE_LINE_FENCE, { codeBlockLineNumbers: true });
+            const root = muya.domNode;
+            const wrappers = root.querySelectorAll('.mu-line-numbers-rows');
+            expect(wrappers.length).toBe(1);
+
+            const wrapper = wrappers[0] as HTMLElement;
+            // CodeBlock.create lifts the wrapper out of `.mu-code` into the <pre>.
+            expect(wrapper.parentElement!.tagName).toBe('PRE');
+            expect(wrapper.parentElement!.classList.contains('mu-code-block')).toBe(true);
+            expect(wrapper.getAttribute('contenteditable')).toBe('false');
+            expect(wrapper.getAttribute('aria-hidden')).toBe('true');
+        });
+
+        it('fills the wrapper with one span per visible row after the rAF flush', async () => {
+            const muya = bootMuya(THREE_LINE_FENCE, { codeBlockLineNumbers: true });
+            const wrapper = muya.domNode.querySelector<HTMLElement>('.mu-line-numbers-rows')!;
+            await nextFrame();
+            await nextFrame();
+            expect(wrapper.childElementCount).toBe(3);
+            expect(wrapper.querySelectorAll('span').length).toBe(3);
+        });
+
+        it('renders one span per line for a single-line block', async () => {
+            const muya = bootMuya('```js\nsolo\n```\n', { codeBlockLineNumbers: true });
+            const wrapper = muya.domNode.querySelector<HTMLElement>('.mu-line-numbers-rows')!;
+            await nextFrame();
+            await nextFrame();
+            expect(wrapper.childElementCount).toBe(1);
+        });
+    });
+
+    describe('when codeBlockLineNumbers is false', () => {
+        it('does not add the mu-line-numbers class to the <pre>', () => {
+            const muya = bootMuya(THREE_LINE_FENCE, { codeBlockLineNumbers: false });
+            const pre = muya.domNode.querySelector<HTMLElement>('pre.mu-code-block');
+            expect(pre).not.toBeNull();
+            expect(pre!.classList.contains('mu-line-numbers')).toBe(false);
+        });
+
+        it('does not create a .mu-line-numbers-rows wrapper', () => {
+            const muya = bootMuya(THREE_LINE_FENCE, { codeBlockLineNumbers: false });
+            expect(muya.domNode.querySelectorAll('.mu-line-numbers-rows').length).toBe(0);
+        });
+
+        it('defaults to off (option omitted behaves like false)', () => {
+            const muya = bootMuya(THREE_LINE_FENCE);
+            const pre = muya.domNode.querySelector<HTMLElement>('pre.mu-code-block');
+            expect(pre!.classList.contains('mu-line-numbers')).toBe(false);
+            expect(muya.domNode.querySelectorAll('.mu-line-numbers-rows').length).toBe(0);
+        });
+    });
+
+    describe('the gutter is exclusive to real code blocks', () => {
+        it('does not gutter a math block even with the option on', () => {
+            const muya = bootMuya('$$\na + b\nc + d\n$$\n', { codeBlockLineNumbers: true });
+            const root = muya.domNode;
+            const mathBlock = root.querySelector<HTMLElement>('.mu-math-block');
+            expect(mathBlock).not.toBeNull();
+            expect(mathBlock!.classList.contains('mu-line-numbers')).toBe(false);
+            // The math container reuses Code with _withLineNumbers=false, so no
+            // gutter class and no rows wrapper anywhere in the surface.
+            expect(root.querySelectorAll('.mu-line-numbers').length).toBe(0);
+            expect(root.querySelectorAll('.mu-line-numbers-rows').length).toBe(0);
+        });
+
+        it('does not gutter front matter even with the option on', () => {
+            const muya = bootMuya('---\ntitle: x\nlang: en\n---\n\nbody\n', { codeBlockLineNumbers: true });
+            const root = muya.domNode;
+            const frontmatter = root.querySelector<HTMLElement>('pre.mu-frontmatter');
+            expect(frontmatter).not.toBeNull();
+            expect(frontmatter!.classList.contains('mu-line-numbers')).toBe(false);
+            expect(root.querySelectorAll('.mu-line-numbers').length).toBe(0);
+            expect(root.querySelectorAll('.mu-line-numbers-rows').length).toBe(0);
+        });
+
+        it('does not gutter a diagram block even with the option on', () => {
+            const muya = bootMuya('```mermaid\ngraph TD\nA-->B\n```\n', { codeBlockLineNumbers: true });
+            const root = muya.domNode;
+            const diagram = root.querySelector<HTMLElement>('pre.mu-diagram-container');
+            expect(diagram).not.toBeNull();
+            expect(diagram!.classList.contains('mu-line-numbers')).toBe(false);
+            expect(root.querySelectorAll('.mu-line-numbers').length).toBe(0);
+            expect(root.querySelectorAll('.mu-line-numbers-rows').length).toBe(0);
+        });
+    });
+});

--- a/packages/muya/src/block/content/codeBlockContent/__tests__/enterBackspaceHandler.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/enterBackspaceHandler.spec.ts
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// CHARACTERIZATION — codeBlockContent enter / backspace handlers.
+//
+// `CodeBlockContent` (src/block/content/codeBlockContent/index.ts) owns three
+// keystroke paths that the migration audit flagged as untested:
+//   - backspaceHandler at offset 0 converts the whole code block back into a
+//     plain paragraph (data-loss guard — the code text must survive verbatim);
+//   - the plain enterHandler inserts `\n` plus the line indent (and, when the
+//     caret sits between an auto-indent pair, an extra tabSize block);
+//   - Shift+Enter jumps OUT of the code block, appending a trailing paragraph
+//     when there is no following content.
+//
+// We boot a real Muya so the json1 op / selection plumbing matches a live
+// keystroke, then drive the handler off the resolved content block the way the
+// keydown listener does (the handler reads `getCursor()` + `this.text`).
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Resolve the single `codeblock.content` leaf, the way a click on the code
+// block resolves the active content block.
+function codeContent(muya: Muya): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'codeblock.content')
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error('codeblock.content block not found');
+    return target;
+}
+
+function keyEvent(over: Partial<KeyboardEvent> = {}): KeyboardEvent {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Enter',
+        shiftKey: false,
+        ...over,
+    } as unknown as KeyboardEvent;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('codeBlockContent.backspaceHandler — offset-0 converts to paragraph', () => {
+    it('replaces the code block with a paragraph whose text equals the code text', async () => {
+        const muya = bootMuya('```js\nconst a = 1\n```\n');
+        const content = codeContent(muya);
+        muya.editor.activeContentBlock = content;
+        content.setCursor(0, 0, true);
+
+        const original = content.text;
+        const event = keyEvent({ key: 'Backspace' });
+        content.backspaceHandler(event);
+
+        await flush();
+        const state = muya.getState();
+        expect(state[0].name).toBe('paragraph');
+        // Data-loss guard: the code text survives verbatim into the paragraph.
+        expect((state[0] as { text: string }).text).toBe(original);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('lands the caret at offset 0 of the new paragraph', async () => {
+        const muya = bootMuya('```js\nhello\n```\n');
+        const content = codeContent(muya);
+        muya.editor.activeContentBlock = content;
+        content.setCursor(0, 0, true);
+
+        content.backspaceHandler(keyEvent({ key: 'Backspace' }));
+
+        await flush();
+        const newContent = muya.editor.activeContentBlock!;
+        const cursor = newContent.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+        expect(cursor!.end.offset).toBe(0);
+    });
+
+    it('does NOT convert to a paragraph when the cursor is past offset 0', async () => {
+        const muya = bootMuya('```js\nfoo\n```\n');
+        const content = codeContent(muya);
+        muya.editor.activeContentBlock = content;
+        // Caret one in from the start — the offset-0 conversion branch must not fire.
+        content.setCursor(1, 1, true);
+
+        const event = keyEvent({ key: 'Backspace' });
+        content.backspaceHandler(event);
+
+        await flush();
+        const state = muya.getState();
+        // The block stays a code-block: the offset-0 paragraph conversion guard
+        // only triggers when start === end === 0.
+        expect(state[0].name).toBe('code-block');
+    });
+});
+
+describe('codeBlockContent.enterHandler — plain Enter inserts newline + indent', () => {
+    it('keeps the 2-space indent and advances the caret by 1 + indent.length', () => {
+        const muya = bootMuya('```js\nfoo\n```\n');
+        const content = codeContent(muya);
+        // Drive the indent logic on a known single-line text without depending
+        // on the parser-produced text shape: the handler reads `this.text` and
+        // the caret offset, then rewrites `this.text` in place.
+        content.text = '  foo';
+        muya.editor.activeContentBlock = content;
+        content.setCursor(5, 5, true);
+
+        const event = keyEvent({ key: 'Enter' });
+        content.enterHandler(event);
+
+        // indent = leading whitespace `  `; no auto-indent pair at the caret.
+        expect(content.text).toBe('  foo\n  ');
+        const cursor = content.getCursor()!;
+        // offset = start(5) + 1 (newline) + indent.length(2)
+        expect(cursor.start.offset).toBe(8);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('adds an extra tabSize block when the caret sits inside an auto-indent pair', () => {
+        const muya = bootMuya('```js\nfoo\n```\n');
+        const content = codeContent(muya);
+        // Caret between `{` and `}` → checkAutoIndent true; default tabSize 4.
+        content.text = '{}';
+        muya.editor.activeContentBlock = content;
+        content.setCursor(1, 1, true);
+
+        content.enterHandler(keyEvent({ key: 'Enter' }));
+
+        // `{` + \n + (indent + 4 spaces) + \n + (indent) + `}`; indent is '' here.
+        expect(content.text).toBe('{\n    \n}');
+        const cursor = content.getCursor()!;
+        // offset = start(1) + 1 + indent.length(0) + tabSize(4)
+        expect(cursor.start.offset).toBe(6);
+        expect(muya.options.tabSize).toBe(4);
+    });
+});
+
+describe('codeBlockContent.enterHandler — Shift+Enter jumps out of the code block', () => {
+    it('appends a trailing paragraph and moves the caret to it when nothing follows', async () => {
+        // A doc that is ONLY a fenced code block — no following content block.
+        const muya = bootMuya('```js\ncode\n```');
+        const content = codeContent(muya);
+        muya.editor.activeContentBlock = content;
+        content.setCursor(content.text.length, content.text.length, true);
+
+        const before = muya.getState().length;
+        const event = keyEvent({ key: 'Enter', shiftKey: true });
+        content.enterHandler(event);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(before + 1);
+        expect(state[state.length - 1].name).toBe('paragraph');
+        // Caret moved to the new trailing paragraph at offset 0.
+        const active = muya.editor.activeContentBlock!;
+        expect(active.blockName).toBe('paragraph.content');
+        expect(active.getCursor()!.start.offset).toBe(0);
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('moves the caret to the following block when one already exists (no new block)', async () => {
+        const muya = bootMuya('```js\ncode\n```\n\nafter\n');
+        const content = codeContent(muya);
+        muya.editor.activeContentBlock = content;
+        content.setCursor(content.text.length, content.text.length, true);
+
+        const before = muya.getState().length;
+        content.enterHandler(keyEvent({ key: 'Enter', shiftKey: true }));
+
+        await flush();
+        const state = muya.getState();
+        // Reuses the existing next content block — no paragraph is appended.
+        expect(state.length).toBe(before);
+        const active = muya.editor.activeContentBlock!;
+        expect(active.text).toBe('after');
+    });
+});

--- a/packages/muya/src/block/content/langInputContent/__tests__/handlers.spec.ts
+++ b/packages/muya/src/block/content/langInputContent/__tests__/handlers.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import LangInputContent from '../index';
+
+// `LangInputContent.enterHandler` / `backspaceHandler` only touch a small,
+// structurally-typed slice of the block surface:
+//   - enterHandler reads `this.parent` and calls
+//     `parent.lastContentInDescendant()?.setCursor(0, 0)` plus
+//     `event.preventDefault()` / `event.stopPropagation()`.
+//   - backspaceHandler reads `this.getCursor()` (start/end offsets) and
+//     `this.text`, then either calls `this.updateLanguage('')` (Firefox
+//     single-char compat branch) or walks to `this.previousContentInContext()`.
+// So — like autoPair.spec.ts — we drive the prototype methods off a fake
+// `this` and avoid the full Muya/DOM bootstrap.
+
+function makeFakeEvent() {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+    } as unknown as Event;
+}
+
+describe('langInputContent.enterHandler', () => {
+    it('preventDefault + stopPropagation and moves caret to parent.lastContentInDescendant(0,0)', () => {
+        const lastContent = { setCursor: vi.fn() };
+        const fakeThis = {
+            parent: {
+                lastContentInDescendant: vi.fn(() => lastContent),
+            },
+        };
+        const event = makeFakeEvent();
+
+        LangInputContent.prototype.enterHandler.call(
+            fakeThis as unknown as LangInputContent,
+            event,
+        );
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(fakeThis.parent.lastContentInDescendant).toHaveBeenCalledTimes(1);
+        expect(lastContent.setCursor).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('does not throw when parent.lastContentInDescendant() returns null', () => {
+        const fakeThis = {
+            parent: {
+                lastContentInDescendant: vi.fn(() => null),
+            },
+        };
+        const event = makeFakeEvent();
+
+        expect(() =>
+            LangInputContent.prototype.enterHandler.call(
+                fakeThis as unknown as LangInputContent,
+                event,
+            ),
+        ).not.toThrow();
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('langInputContent.backspaceHandler', () => {
+    it('firefox single-char branch: cursor {1,1} with text length 1 → preventDefault + updateLanguage("")', () => {
+        const fakeThis = {
+            text: 'a',
+            getCursor: vi.fn(() => ({
+                start: { offset: 1 },
+                end: { offset: 1 },
+            })),
+            updateLanguage: vi.fn(),
+            previousContentInContext: vi.fn(() => null),
+        };
+        const event = makeFakeEvent();
+
+        LangInputContent.prototype.backspaceHandler.call(
+            fakeThis as unknown as LangInputContent,
+            event,
+        );
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(fakeThis.updateLanguage).toHaveBeenCalledWith('');
+        // The {1,1} branch does not also enter the {0,0} branch.
+        expect(fakeThis.previousContentInContext).not.toHaveBeenCalled();
+    });
+
+    it('cursor {0,0} with a previousContentInContext → caret to that block end, preventDefault', () => {
+        const previousBlock = {
+            text: 'previous',
+            setCursor: vi.fn(),
+        };
+        const fakeThis = {
+            text: 'js',
+            getCursor: vi.fn(() => ({
+                start: { offset: 0 },
+                end: { offset: 0 },
+            })),
+            updateLanguage: vi.fn(),
+            previousContentInContext: vi.fn(() => previousBlock),
+        };
+        const event = makeFakeEvent();
+
+        LangInputContent.prototype.backspaceHandler.call(
+            fakeThis as unknown as LangInputContent,
+            event,
+        );
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        const offset = previousBlock.text.length;
+        expect(previousBlock.setCursor).toHaveBeenCalledWith(offset, offset, true);
+        // The {0,0} branch must not trigger the single-char updateLanguage path.
+        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+    });
+
+    it('cursor {0,0} with NO previousContentInContext → preventDefault, no caret move, no throw', () => {
+        const fakeThis = {
+            text: 'js',
+            getCursor: vi.fn(() => ({
+                start: { offset: 0 },
+                end: { offset: 0 },
+            })),
+            updateLanguage: vi.fn(),
+            previousContentInContext: vi.fn(() => null),
+        };
+        const event = makeFakeEvent();
+
+        expect(() =>
+            LangInputContent.prototype.backspaceHandler.call(
+                fakeThis as unknown as LangInputContent,
+                event,
+            ),
+        ).not.toThrow();
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(fakeThis.previousContentInContext).toHaveBeenCalledTimes(1);
+        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+    });
+
+    it('cursor in the middle (e.g. {1,1} text length > 1) → neither branch fires, no preventDefault', () => {
+        const fakeThis = {
+            text: 'java',
+            getCursor: vi.fn(() => ({
+                start: { offset: 1 },
+                end: { offset: 1 },
+            })),
+            updateLanguage: vi.fn(),
+            previousContentInContext: vi.fn(() => null),
+        };
+        const event = makeFakeEvent();
+
+        LangInputContent.prototype.backspaceHandler.call(
+            fakeThis as unknown as LangInputContent,
+            event,
+        );
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+        expect(fakeThis.previousContentInContext).not.toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/deleteMerge.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/deleteMerge.spec.ts
@@ -120,3 +120,30 @@ describe('forward Delete at end-of-paragraph — merge with next block', () => {
         expect(cursor!.start.offset).toBe(5);
     });
 });
+
+describe('forward Delete at end of a code block — no merge', () => {
+    it('leaves the state unchanged (codeBlockContent has no merging deleteHandler)', async () => {
+        const muya = bootMuya('```js\nx\n```\n');
+        const before = JSON.stringify(muya.getState());
+        const code = contentByText(muya, 'x');
+
+        deleteAtEnd(muya, code);
+
+        await flush();
+        const after = JSON.stringify(muya.getState());
+        expect(after).toBe(before);
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('code-block');
+    });
+
+    it('preventDefaults at end-of-text but performs no model merge', () => {
+        const muya = bootMuya('```js\nx\n```\n');
+        const code = contentByText(muya, 'x');
+
+        const event = deleteAtEnd(muya, code);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(code.text).toBe('x');
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/enterConvert.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/enterConvert.spec.ts
@@ -1,0 +1,260 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// ENTER-CONVERT GUARD — pressing Enter on a top-level paragraph whose text is a
+// block-conversion trigger replaces the paragraph with the matching block.
+//
+// `ParagraphContent.enterHandler` routes a plain (non-shift) Enter on a
+// top-level paragraph through `_enterConvert`. That method inspects `this.text`:
+//   - `$$`            -> math-block
+//   - ```` ```lang ```` -> fenced code-block with meta.lang
+//   - `<tag>` (non-void html) -> html-block `<tag>\n\n</tag>`
+//   - `| ... |` with even backlash counts -> table (see tableConversion.spec)
+// Anything else (including VOID html tags like `<br>` and pipe rows with an odd
+// escaped pipe) falls through to `Format.enterHandler`, which just splits the
+// paragraph — the block STAYS a paragraph. These characterization tests drive
+// the handler the way the keydown listener does and assert the document state
+// after the json1 op flushes on the next frame.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Find the leaf `.content` block whose rendered text matches `text`, the way a
+// click resolves the active content block.
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+// Replace the paragraph content's text with a conversion trigger, render it,
+// land the caret at the end, then route a plain Enter through the handler the
+// way the keydown listener does.
+function enterWithText(muya: Muya, content: Content, text: string): { preventDefault: ReturnType<typeof vi.fn> } {
+    muya.editor.activeContentBlock = content;
+    content.text = text;
+    content.update();
+    const offset = content.text.length;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        shiftKey: false,
+        key: 'Enter',
+    } as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+    content.enterHandler(event);
+    return event;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('enter on `$$` — converts to a math-block', () => {
+    it('replaces the paragraph with a single math-block', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '$$');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('math-block');
+    });
+
+    it('seeds the math-block with empty text', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '$$');
+
+        await flush();
+        const state = muya.getState();
+        expect((state[0] as { text: string }).text).toBe('');
+    });
+
+    it('calls preventDefault so the browser cannot insert a native newline', () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        const event = enterWithText(muya, content, '$$');
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});
+
+describe('enter on ```` ```js ```` — converts to a fenced code-block', () => {
+    it('replaces the paragraph with a single code-block', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('code-block');
+    });
+
+    it('records meta.lang === "js" and meta.type === "fenced"', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState();
+        const meta = (state[0] as { meta: { lang: string; type: string } }).meta;
+        expect(meta.lang).toBe('js');
+        expect(meta.type).toBe('fenced');
+    });
+
+    it('seeds the code-block with empty text', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState();
+        expect((state[0] as { text: string }).text).toBe('');
+    });
+});
+
+describe('enter on `<div>` — converts to an html-block', () => {
+    it('replaces the paragraph with a single html-block', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '<div>');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('html-block');
+    });
+
+    it('seeds the html-block text with the open/close tag pair', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '<div>');
+
+        await flush();
+        const state = muya.getState();
+        expect((state[0] as { text: string }).text).toBe('<div>\n\n</div>');
+    });
+
+    it('lands the caret at offset tagName.length + 3 inside the html-block', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '<div>');
+
+        await flush();
+        const htmlContent = contentByText(muya, '<div>\n\n</div>');
+        const cursor = htmlContent.getCursor();
+        expect(cursor).not.toBeNull();
+        // tagName 'div' length 3 + 3 === 6.
+        expect(cursor!.start.offset).toBe(6);
+    });
+});
+
+describe('enter on `<br>` (VOID html tag) — NOT converted', () => {
+    it('keeps the block a paragraph (no html-block) — it just splits', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '<br>');
+
+        await flush();
+        const state = muya.getState();
+        // Fell through to Format.enterHandler: the paragraph split into two
+        // paragraphs (no html-block conversion).
+        expect(state.length).toBe(2);
+        expect(state.every(block => block.name === 'paragraph')).toBe(true);
+        expect(state.some(block => block.name === 'html-block')).toBe(false);
+    });
+
+    it('keeps the `<br>` text on the first paragraph (cursor was at end)', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '<br>');
+
+        await flush();
+        const state = muya.getState();
+        expect((state[0] as { text: string }).text).toBe('<br>');
+    });
+});
+
+describe('enter on `|a\\|b|c|` (odd escaped pipe) — NOT converted', () => {
+    it('keeps the block a paragraph (no table) — it just splits', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '|a\\|b|c|');
+
+        await flush();
+        const state = muya.getState();
+        // Odd escaped pipe fails the isLengthEven guard: fell through to
+        // Format.enterHandler, splitting the paragraph (no table conversion).
+        expect(state.length).toBe(2);
+        expect(state.every(block => block.name === 'paragraph')).toBe(true);
+        expect(state.some(block => block.name === 'table')).toBe(false);
+    });
+
+    it('keeps the pipe-row text on the first paragraph (cursor was at end)', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '|a\\|b|c|');
+
+        await flush();
+        const state = muya.getState();
+        expect((state[0] as { text: string }).text).toBe('|a\\|b|c|');
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/enterHandler.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/enterHandler.spec.ts
@@ -1,0 +1,192 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// ENTER-SPLIT GUARD — pressing Enter mid-paragraph splits the block in two.
+//
+// `ParagraphContent.enterHandler` routes a plain (non-shift) Enter on a
+// top-level paragraph through `_enterConvert`, which — when the text is not a
+// block-conversion trigger — falls through to `Format.enterHandler`. That base
+// handler keeps the text BEFORE the caret on the original block, moves the text
+// AFTER the caret onto a freshly inserted sibling paragraph, and drops the
+// caret at offset 0 of the new block. These characterization tests drive the
+// handler the way the keydown listener does and assert the resulting document
+// state after the json1 op flushes on the next frame.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Find the leaf `.content` block whose rendered text matches `text`, the way a
+// click resolves the active content block.
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+// Land the caret at `offset` of the given content block (active block + cursor),
+// then route an Enter through its handler the way the keydown listener does.
+function enterAt(muya: Muya, content: Content, offset: number): { preventDefault: ReturnType<typeof vi.fn> } {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        shiftKey: false,
+        key: 'Enter',
+    } as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+    content.enterHandler(event);
+    return event;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// `getState()` returns a discriminated `TState` union; only some variants carry
+// `text`. The blocks asserted here are paragraphs, so narrow to read it.
+function blockText(state: ReturnType<Muya['getState']>, index: number): string {
+    return (state[index] as { text: string }).text;
+}
+
+describe('enter mid-paragraph — split into two paragraphs', () => {
+    it('keeps `hello` on the first block and moves ` world` onto the new block', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, 5);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(2);
+        expect(state[0].name).toBe('paragraph');
+        expect(state[1].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('hello');
+        expect(blockText(state, 1)).toBe(' world');
+    });
+
+    it('lands the caret at offset 0 of the new (second) block', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, 5);
+
+        await flush();
+        const newBlock = contentByText(muya, ' world');
+        const cursor = newBlock.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+
+    it('calls preventDefault so the browser cannot also insert a native newline', () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        const event = enterAt(muya, content, 5);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});
+
+describe('enter at offset 0 — all text moves to the new block', () => {
+    it('leaves the first block empty and carries the whole text onto the second', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, 0);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(2);
+        expect(state[0].name).toBe('paragraph');
+        expect(state[1].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('');
+        expect(blockText(state, 1)).toBe('hello world');
+    });
+
+    it('lands the caret at offset 0 of the new block holding the text', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, 0);
+
+        await flush();
+        const newBlock = contentByText(muya, 'hello world');
+        const cursor = newBlock.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+});
+
+describe('enter at end-of-text — appends an empty paragraph with the caret in it', () => {
+    it('keeps the full text on the first block and adds an empty second block', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, content.text.length);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(2);
+        expect(state[0].name).toBe('paragraph');
+        expect(state[1].name).toBe('paragraph');
+        expect(blockText(state, 0)).toBe('hello world');
+        expect(blockText(state, 1)).toBe('');
+    });
+
+    it('lands the caret at offset 0 of the new empty block', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = contentByText(muya, 'hello world');
+
+        enterAt(muya, content, content.text.length);
+
+        await flush();
+        const state = muya.getState();
+        expect(blockText(state, 1)).toBe('');
+        const empty = contentByText(muya, '');
+        const cursor = empty.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/insertTabAndIndent.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/insertTabAndIndent.spec.ts
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// Characterization of ParagraphContent.tabHandler's three plain-Tab branches
+// (src/block/content/paragraphContent/index.ts):
+//   1. insertTab()           — a normal paragraph gains `tabSize` non-breaking
+//                              spaces (U+00A0) at the caret and the caret
+//                              advances by that width.
+//   2. _indentListItem() / _unindentListItem() — Tab nests a list item under
+//      its predecessor; Shift+Tab lifts it back out.
+//   3. _checkCursorAtEndFormat() — with the caret just inside a closing inline
+//      marker (e.g. the `**` of strong) Tab jumps the caret PAST the marker and
+//      leaves the text unchanged.
+//
+// Real Muya is booted (mirroring deleteMerge.spec.ts / backspaceUnwrap.spec.ts):
+// the caret is landed via content.setCursor, the handler is invoked the way the
+// keydown listener routes it, and state/markdown/cursor are read after the
+// json1 op flushes on the next animation frame.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+// A non-breaking space — the character insertTab repeats `tabSize` times.
+const NBSP = String.fromCharCode(160);
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Find the leaf `.content` block whose rendered text matches `text`, the way a
+// click resolves the active content block.
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+// Land the caret at [start, end] of the given content block (active block +
+// cursor), then route a Tab through its handler the way the keydown listener
+// does.
+function tabAt(muya: Muya, content: Content, offset: number, shiftKey = false): void {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Tab',
+        shiftKey,
+    } as unknown as KeyboardEvent;
+    content.tabHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+function blockText(state: ReturnType<Muya['getState']>, index: number): string {
+    return (state[index] as { text: string }).text;
+}
+
+describe('paragraphContent.tabHandler — insertTab in a plain paragraph', () => {
+    it('inserts `tabSize` non-breaking spaces and advances the caret by that width (default 4)', async () => {
+        const muya = bootMuya('hello\n');
+        expect(muya.options.tabSize).toBe(4);
+        const content = contentByText(muya, 'hello');
+
+        tabAt(muya, content, 5);
+
+        await flush();
+        const text = blockText(muya.getState(), 0);
+        // `hello` + four U+00A0 spaces.
+        expect(text).toBe(`hello${NBSP.repeat(4)}`);
+        expect(text.length).toBe(9);
+        // The inserted run is non-breaking spaces, not ordinary spaces.
+        expect([...text.slice(5)].every(ch => ch.charCodeAt(0) === 160)).toBe(true);
+
+        const cursor = content.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(9);
+    });
+
+    it('honors a custom tabSize of 2 (narrower insert, caret advances by 2)', async () => {
+        const muya = bootMuya('hello\n', { tabSize: 2 });
+        expect(muya.options.tabSize).toBe(2);
+        const content = contentByText(muya, 'hello');
+
+        tabAt(muya, content, 5);
+
+        await flush();
+        const text = blockText(muya.getState(), 0);
+        expect(text).toBe(`hello${NBSP.repeat(2)}`);
+        expect(text.length).toBe(7);
+
+        const cursor = content.getCursor();
+        expect(cursor!.start.offset).toBe(7);
+    });
+
+    it('the tabSize-2 insert is strictly narrower than the tabSize-4 insert', async () => {
+        // Only one DOM selection exists at a time, so capture each instance's
+        // caret offset immediately after driving it, before booting the other.
+        const wide = bootMuya('x\n');
+        const wideContent = contentByText(wide, 'x');
+        tabAt(wide, wideContent, 1);
+        await flush();
+        const wideLen = blockText(wide.getState(), 0).length;
+        const wideCaret = wideContent.getCursor()!.start.offset;
+
+        const narrow = bootMuya('x\n', { tabSize: 2 });
+        const narrowContent = contentByText(narrow, 'x');
+        tabAt(narrow, narrowContent, 1);
+        await flush();
+        const narrowLen = blockText(narrow.getState(), 0).length;
+        const narrowCaret = narrowContent.getCursor()!.start.offset;
+
+        // 1 ('x') + 4 vs 1 ('x') + 2.
+        expect(wideLen).toBe(5);
+        expect(narrowLen).toBe(3);
+        expect(narrowLen).toBeLessThan(wideLen);
+        expect(wideCaret).toBe(5);
+        expect(narrowCaret).toBe(3);
+    });
+});
+
+describe('paragraphContent.tabHandler — indent / unindent a list item', () => {
+    it('tab nests the second item under the first (2-space markdown indent)', async () => {
+        const muya = bootMuya('- a\n- b\n');
+        expect(muya.getMarkdown()).toBe('- a\n- b\n');
+        const b = contentByText(muya, 'b');
+
+        tabAt(muya, b, 0);
+
+        await flush();
+        // `b` is now a nested bullet list under `a`'s list item.
+        expect(muya.getMarkdown()).toBe('- a\n  - b\n');
+        // The whole document stays a single bullet list — nothing dropped.
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('bullet-list');
+    });
+
+    it('shift+Tab lifts the nested item back out to the top level', async () => {
+        const muya = bootMuya('- a\n- b\n');
+        const b = contentByText(muya, 'b');
+
+        tabAt(muya, b, 0);
+        await flush();
+        expect(muya.getMarkdown()).toBe('- a\n  - b\n');
+
+        const nestedB = contentByText(muya, 'b');
+        tabAt(muya, nestedB, 0, true);
+        await flush();
+
+        expect(muya.getMarkdown()).toBe('- a\n- b\n');
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('bullet-list');
+    });
+});
+
+describe('paragraphContent.tabHandler — jump past a closing inline marker', () => {
+    it('tab just inside a closing `**` moves the caret past the marker with no text change', async () => {
+        const muya = bootMuya('**bold**\n');
+        const content = contentByText(muya, '**bold**');
+        // Content text carries the raw markers: `**bold**` (length 8); the
+        // closing `**` occupies offsets 6..8, so "just inside" is offset 6.
+        expect(content.text).toBe('**bold**');
+
+        tabAt(muya, content, 6);
+
+        await flush();
+        // No text was inserted — the caret only jumped past the closing marker.
+        expect(blockText(muya.getState(), 0)).toBe('**bold**');
+        const cursor = content.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(8);
+    });
+
+    it('tab at the true end of the paragraph still inserts a tab (no marker to jump)', async () => {
+        const muya = bootMuya('**bold**\n');
+        const content = contentByText(muya, '**bold**');
+
+        tabAt(muya, content, 8);
+
+        await flush();
+        const text = blockText(muya.getState(), 0);
+        // Caret was past the closing marker, so insertTab runs.
+        expect(text).toBe(`**bold**${NBSP.repeat(4)}`);
+        expect(content.getCursor()!.start.offset).toBe(12);
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/tableConversion.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/tableConversion.spec.ts
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import type Table from '../../../gfm/table';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// Enter-to-table conversion in a plain paragraph.
+//
+// When a paragraph's text looks like a GFM pipe-table header — `| a | b |` —
+// pressing Enter converts the paragraph into a real table block (header row +
+// one empty body row) and drops the caret into the FIRST BODY cell. The guard
+// for this is the `TABLE_BLOCK_REG` + `isLengthEven` pair in `_enterConvert`:
+// an ODD number of escaped pipes (e.g. `| a \| b |`) means the row isn't a
+// genuine column boundary, so the paragraph must stay a paragraph. These tests
+// drive the paragraph content's `enterHandler` the way the keydown dispatcher
+// does and assert the converted shape + caret landing.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// The first content leaf of the document — for these specs always the single
+// booted paragraph's content block.
+function firstContent(muya: Muya): Content {
+    return muya.editor.scrollPage!.firstContentInDescendant() as Content;
+}
+
+function findTable(muya: Muya): Table | null {
+    let table: Table | null = null;
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'table')
+            table = block as unknown as Table;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return table;
+}
+
+// Set the paragraph's text, land the caret at its end, then route a (non-shift)
+// Enter through its handler exactly like the keydown listener does.
+function enterWithText(muya: Muya, text: string): Content {
+    const content = firstContent(muya);
+    content.text = text;
+    muya.editor.activeContentBlock = content;
+    const offset = content.text.length;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Enter',
+        shiftKey: false,
+    } as unknown as KeyboardEvent;
+    content.enterHandler(event);
+    return content;
+}
+
+describe('paragraphContent.enterHandler — pipe-table conversion', () => {
+    it('converts `| a | b |` into a 2-column table', async () => {
+        const muya = bootMuya('placeholder');
+
+        enterWithText(muya, '| a | b |');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('table');
+
+        const table = findTable(muya);
+        expect(table).not.toBeNull();
+        expect(table!.columnCount).toBe(2);
+        // Header row + one empty body row.
+        expect(table!.rowCount).toBe(2);
+    });
+
+    it('lands the caret in the first BODY cell (row 1, column 0)', async () => {
+        const muya = bootMuya('placeholder');
+
+        enterWithText(muya, '| a | b |');
+
+        await flush();
+        const anchorBlock = muya.editor.selection.anchorBlock;
+        expect(anchorBlock).not.toBeNull();
+        // Caret is in a table cell content leaf.
+        expect(anchorBlock!.blockName).toBe('table.cell.content');
+
+        // The owning cell sits in the SECOND row (the empty body row, index 1)
+        // at the first column.
+        const cell = anchorBlock!.closestBlock('table.cell') as {
+            rowOffset: number;
+            columnOffset: number;
+        } | null;
+        expect(cell).not.toBeNull();
+        expect(cell!.rowOffset).toBe(1);
+        expect(cell!.columnOffset).toBe(0);
+    });
+
+    it('keeps the header text in the first row\'s cells', async () => {
+        const muya = bootMuya('placeholder');
+
+        enterWithText(muya, '| a | b |');
+
+        await flush();
+        const table = findTable(muya)!;
+        const tableState = table.getState();
+        const headerRow = tableState.children[0];
+        expect(headerRow.children.length).toBe(2);
+        // parseTableHeader keeps the surrounding spaces from the cell text.
+        expect(headerRow.children[0].text).toBe(' a ');
+        expect(headerRow.children[1].text).toBe(' b ');
+        // The body row is empty.
+        const bodyRow = tableState.children[1];
+        expect(bodyRow.children.every(c => c.text === '')).toBe(true);
+    });
+
+    it('converts `| a | b | c |` into a 3-column table', async () => {
+        const muya = bootMuya('placeholder');
+
+        enterWithText(muya, '| a | b | c |');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('table');
+
+        const table = findTable(muya)!;
+        expect(table.columnCount).toBe(3);
+        expect(table.rowCount).toBe(2);
+    });
+
+    it('does NOT convert `| a \\| b |` (odd/escaped pipe) — stays a paragraph', async () => {
+        const muya = bootMuya('placeholder');
+
+        const content = enterWithText(muya, '| a \\| b |');
+
+        await flush();
+        const state = muya.getState();
+        // The odd escaped pipe fails the isLengthEven guard, so the table
+        // branch is skipped and the default super.enterHandler splits the
+        // paragraph instead (no table is created).
+        expect(findTable(muya)).toBeNull();
+        expect(state.every(block => block.name === 'paragraph')).toBe(true);
+        // The original content leaf survives as a paragraph content block.
+        expect(content.blockName).toBe('paragraph.content');
+    });
+});

--- a/packages/muya/src/block/content/tableCell/__tests__/arrowHandler.spec.ts
+++ b/packages/muya/src/block/content/tableCell/__tests__/arrowHandler.spec.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// ArrowUp / ArrowDown navigation inside a table cell — `TableCellContent.arrowHandler`.
+//
+// The migration audit flagged the vertical-navigation branches as untested:
+//   - ArrowDown from a header cell jumps to the SAME column of the next row
+//     (same-column offset preservation is load-bearing).
+//   - ArrowDown from the last body row with no following block appends a
+//     trailing paragraph and lands the caret there at offset 0.
+//   - ArrowUp from a header cell with a preceding block jumps the caret to the
+//     END of that block's last content.
+// Each branch is driven through a real boot so cell-resolution and caret
+// placement run exactly as an Arrow keystroke would.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Collect the table cell content blocks in document order.
+function tableCells(muya: Muya): Content[] {
+    const out: Content[] = [];
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'table.cell.content')
+            out.push(block as unknown as Content);
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return out;
+}
+
+function arrowAtStart(muya: Muya, cell: Content, key: 'ArrowUp' | 'ArrowDown'): void {
+    muya.editor.activeContentBlock = cell;
+    cell.setCursor(0, 0, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key,
+    } as unknown as KeyboardEvent;
+    cell.arrowHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('tableCellContent arrow navigation', () => {
+    it('arrowDown from a header cell lands the caret in the same column of the body row', async () => {
+        // Cells in document order: [ab, cd] (header), [ef, gh] (body).
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        expect(cells.length).toBe(4);
+
+        // ArrowDown from header column 0 (`ab`).
+        arrowAtStart(muya, cells[0], 'ArrowDown');
+        await flush();
+
+        // The caret should now be in the body cell of the SAME column (`ef`).
+        const bodyCol0 = cells[2];
+        expect(bodyCol0.text).toBe('ef');
+        const cursor = bodyCol0.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+
+    it('arrowDown preserves the column index when moving down (column 1)', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+
+        // ArrowDown from header column 1 (`cd`).
+        arrowAtStart(muya, cells[1], 'ArrowDown');
+        await flush();
+
+        // The caret should be in the body cell of column 1 (`gh`), not column 0.
+        const bodyCol1 = cells[3];
+        expect(bodyCol1.text).toBe('gh');
+        const cursor = bodyCol1.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+
+        // The other body cell did not receive the caret.
+        expect(cells[2].getCursor()).toBeNull();
+    });
+
+    it('arrowDown from the last body cell with no following block appends a trailing paragraph and lands the caret there', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        expect(cells.length).toBe(4);
+
+        // ArrowDown from the last body cell (`gh`), nothing after the table.
+        arrowAtStart(muya, cells[3], 'ArrowDown');
+        await flush();
+
+        // A trailing paragraph was appended after the table.
+        const state = muya.getState();
+        expect(state.length).toBe(2);
+        expect(state[0].name).toBe('table');
+        expect(state[1].name).toBe('paragraph');
+        expect((state[1] as { text: string }).text).toBe('');
+
+        // The caret lands in the new paragraph at offset 0.
+        const appended = muya.editor.scrollPage!.lastContentInDescendant() as Content;
+        expect(appended.constructor.name).toBe('ParagraphContent');
+        const cursor = appended.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+
+    it('arrowUp from a header cell with a preceding paragraph jumps the caret to the END of that paragraph', async () => {
+        // A paragraph `intro` precedes the table.
+        const muya = bootMuya('intro\n\n| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        expect(cells.length).toBe(4);
+
+        // ArrowUp from header column 0 (`ab`).
+        arrowAtStart(muya, cells[0], 'ArrowUp');
+        await flush();
+
+        // The caret moved to the END of the preceding paragraph (`intro`).
+        const first = muya.editor.scrollPage!.firstContentInDescendant() as Content;
+        expect(first.text).toBe('intro');
+        const cursor = first.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe('intro'.length);
+        expect(cursor!.end.offset).toBe('intro'.length);
+    });
+
+    it('arrowUp from a body cell lands the caret in the same column of the header row', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+
+        // ArrowUp from body column 1 (`gh`).
+        arrowAtStart(muya, cells[3], 'ArrowUp');
+        await flush();
+
+        // The caret moves to the END of the header cell of the SAME column (`cd`).
+        const headerCol1 = cells[1];
+        expect(headerCol1.text).toBe('cd');
+        const cursor = headerCol1.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe('cd'.length);
+    });
+});

--- a/packages/muya/src/block/content/tableCell/__tests__/enterHandler.spec.ts
+++ b/packages/muya/src/block/content/tableCell/__tests__/enterHandler.spec.ts
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isOsx } from '../../../../config';
+import { Muya } from '../../../../muya';
+
+// `TableCellContent.enterHandler` dispatches to one of three branches based on
+// the keyboard modifiers it reads off the event:
+//   - Shift+Enter  → `shiftEnter`   : inserts a literal `<br/>` at the caret.
+//   - Cmd/Ctrl+Enter → `commandEnter`: inserts a new row after the current one.
+//   - plain Enter  → `normalEnter`  : moves the caret to the next row's first
+//                     cell, or appends a trailing paragraph when at the table's
+//                     last row with nothing following.
+// `isOsx` is resolved at import time from the userAgent. Under happy-dom the
+// userAgent is "...X11; Darwin arm64..." which does NOT match /Mac/, so
+// `isOsx === false` here and the command branch is reached via `ctrlKey`, not
+// `metaKey`. We assert the ACTUAL behavior in this environment.
+//
+// Driven through a real boot (mirroring backspaceSafety.spec.ts) so cell
+// resolution, row insertion, and caret placement run exactly as a real
+// keystroke would.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Collect the table cell content blocks in document order.
+function tableCells(muya: Muya): Content[] {
+    const out: Content[] = [];
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'table.cell.content')
+            out.push(block as unknown as Content);
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return out;
+}
+
+function makeEnterEvent(
+    modifiers: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean } = {},
+): KeyboardEvent {
+    return {
+        key: 'Enter',
+        shiftKey: modifiers.shiftKey ?? false,
+        metaKey: modifiers.metaKey ?? false,
+        ctrlKey: modifiers.ctrlKey ?? false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+}
+
+function enterAt(
+    muya: Muya,
+    cell: Content,
+    offset: number,
+    modifiers?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean },
+): void {
+    muya.editor.activeContentBlock = cell;
+    cell.setCursor(offset, offset, true);
+    cell.enterHandler(makeEnterEvent(modifiers));
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('tableCellContent.enterHandler', () => {
+    it('sanity-checks the happy-dom isOsx assumption', () => {
+        // The command branch in this env is reached via ctrlKey, not metaKey.
+        expect(isOsx).toBe(false);
+    });
+
+    it('shift+Enter inserts a literal <br/> at the caret and advances it by 5', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        expect(cells.length).toBe(4);
+
+        const cell = cells[0]; // header cell `ab`
+        // Caret in the middle of `ab` (offset 1).
+        enterAt(muya, cell, 1, { shiftKey: true });
+
+        await flush();
+        expect(cell.text).toContain('<br/>');
+        // `a` + `<br/>` + `b`
+        expect(cell.text).toBe('a<br/>b');
+
+        const cursor = cell.getCursor();
+        expect(cursor).not.toBeNull();
+        // Caret advances by `<br/>`.length (5) from the original offset 1.
+        expect(cursor!.start.offset).toBe(1 + '<br/>'.length);
+        expect(cursor!.start.offset).toBe(6);
+    });
+
+    it('plain Enter in a header cell moves the caret to the next row, same column', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        // cells: [0]=ab (header c0), [1]=cd (header c1), [2]=ef (body c0), [3]=gh (body c1)
+
+        enterAt(muya, cells[0], 0);
+
+        await flush();
+        // Table is intact.
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('table');
+
+        // Caret moved to the FIRST cell of the next row (the body row's c0 = `ef`).
+        const target = cells[2];
+        const cursor = target.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+        expect(target.text).toBe('ef');
+    });
+
+    it('plain Enter in a last-row cell with nothing after appends a trailing paragraph and moves the caret there', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        // Last-row first cell is `ef` (cells[2]); the row's last content is `gh`.
+        // Nothing follows the table in the document, so a trailing paragraph is
+        // appended.
+        enterAt(muya, cells[2], 0);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(2);
+        expect(state[0].name).toBe('table');
+        expect(state[1].name).toBe('paragraph');
+        expect((state[1] as { text: string }).text).toBe('');
+
+        // Caret is in the newly appended trailing paragraph.
+        const newCells = tableCells(muya);
+        const trailing = muya.editor.scrollPage!.lastContentInDescendant()!;
+        expect(newCells.includes(trailing as unknown as Content)).toBe(false);
+        const cursor = (trailing as unknown as Content).getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+
+    it('ctrl+Enter (command branch when !isOsx) inserts a new row, rowCount + 1', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        const table = (cells[0] as unknown as { table: { rowCount: number } }).table;
+        const beforeRowCount = table.rowCount;
+        expect(beforeRowCount).toBe(2);
+
+        enterAt(muya, cells[0], 0, { ctrlKey: true });
+
+        await flush();
+        expect(table.rowCount).toBe(beforeRowCount + 1);
+        expect(table.rowCount).toBe(3);
+
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('table');
+        // The table state now carries 3 rows.
+        expect((state[0] as { children: unknown[] }).children.length).toBe(3);
+    });
+
+    it('metaKey+Enter does NOT take the command branch under happy-dom (isOsx false) and behaves as plain Enter', async () => {
+        const muya = bootMuya('| ab | cd |\n| --- | --- |\n| ef | gh |\n');
+        const cells = tableCells(muya);
+        const table = (cells[0] as unknown as { table: { rowCount: number } }).table;
+        const beforeRowCount = table.rowCount;
+
+        // metaKey alone, ctrlKey false: because isOsx === false, this falls
+        // through to normalEnter rather than commandEnter, so no row is added.
+        enterAt(muya, cells[0], 0, { metaKey: true });
+
+        await flush();
+        expect(table.rowCount).toBe(beforeRowCount);
+
+        // Caret moved to the next row's first cell (normalEnter behavior).
+        const target = cells[2];
+        const cursor = target.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+    });
+});

--- a/packages/muya/src/block/extra/diagram/__tests__/diagramPreview.spec.ts
+++ b/packages/muya/src/block/extra/diagram/__tests__/diagramPreview.spec.ts
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../../muya';
+import type { IDiagramMeta, IDiagramState } from '../../../../state/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CLASS_NAMES } from '../../../../config';
+import I18n from '../../../../i18n';
+import { en } from '../../../../locales/en';
+import { zhCN } from '../../../../locales/zh-CN';
+import DiagramPreview from '../diagramPreview';
+
+// The diagram renderer (`utils/diagram` default export) dynamically imports
+// heavy renderer packages (mermaid / vega / flowchart) that don't load under
+// happy-dom. We mock it so:
+//   - the "valid" path never runs (we only characterize empty + error states),
+//   - the "invalid" path can throw a controlled message we assert is sanitized.
+const loadRendererMock = vi.fn();
+vi.mock('../../../../utils/diagram', () => ({
+    default: (...args: unknown[]) => loadRendererMock(...args),
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+    loadRendererMock.mockReset();
+});
+
+// Build a structurally-typed fake `Muya` carrying only what DiagramPreview
+// touches: an `i18n` with `.t(key)` and `options` with the diagram themes.
+function makeFakeMuya(locale = en): { muya: Muya; i18n: I18n } {
+    const muya = {
+        options: {
+            mermaidTheme: 'default',
+            vegaTheme: 'default',
+            sequenceTheme: 'hand',
+        },
+    } as unknown as Muya;
+    const i18n = new I18n(muya, locale);
+    (muya as unknown as { i18n: I18n }).i18n = i18n;
+    return { muya, i18n };
+}
+
+function makeState(text: string, type: IDiagramMeta['type'] = 'mermaid'): IDiagramState {
+    return {
+        name: 'diagram',
+        text,
+        meta: { lang: 'yaml', type },
+    };
+}
+
+// DiagramPreview's constructor fires `update()` unawaited. To get a
+// deterministic DOM, construct it, then await our own `update()` call.
+function makePreview(text: string, type: IDiagramMeta['type'] = 'mermaid', locale = en) {
+    const { muya, i18n } = makeFakeMuya(locale);
+    const preview = new DiagramPreview(muya, makeState(text, type));
+    bootedHosts.push(preview.domNode!);
+    return { preview, muya, i18n };
+}
+
+describe('diagramPreview — empty state', () => {
+    it('renders the empty-state class + localized "Empty Diagram" for empty code', async () => {
+        const { preview } = makePreview('');
+        await preview.update('');
+
+        const html = preview.domNode!.innerHTML;
+        expect(html).toContain(`class="${CLASS_NAMES.MU_EMPTY}"`);
+        expect(CLASS_NAMES.MU_EMPTY).toBe('mu-empty');
+        expect(html).toContain('Empty Diagram');
+    });
+
+    it('localizes the empty-state label via i18n (zh-CN)', async () => {
+        const { preview } = makePreview('', 'mermaid', zhCN);
+        await preview.update('');
+
+        const html = preview.domNode!.innerHTML;
+        expect(html).toContain(`class="${CLASS_NAMES.MU_EMPTY}"`);
+        expect(html).toContain('空图表');
+    });
+});
+
+describe('diagramPreview — invalid / error state', () => {
+    it('renders the error class + localized "Invalid Diagram Code" when the renderer throws', async () => {
+        loadRendererMock.mockRejectedValue(new Error('Unknown diagram name mermaid'));
+        const { preview } = makePreview('graph TD; A-->B');
+        await preview.update('graph TD; A-->B');
+
+        const html = preview.domNode!.innerHTML;
+        expect(html).toContain('class="mu-diagram-error"');
+        expect(html).toContain('Invalid Diagram Code');
+        expect(html).toContain('class="mu-diagram-error-detail"');
+        expect(html).toContain('Unknown diagram name mermaid');
+    });
+
+    it('sanitizes the error detail (escapes embedded HTML so no raw tag survives)', async () => {
+        loadRendererMock.mockRejectedValue(new Error('boom <img src=x onerror=alert(1)>'));
+        const { preview } = makePreview('graph TD; A-->B');
+        await preview.update('graph TD; A-->B');
+
+        const detail = preview.domNode!.querySelector('.mu-diagram-error-detail')!;
+        expect(detail).not.toBeNull();
+        // No live <img> element should be parsed into the DOM — the tag was escaped.
+        expect(detail.querySelector('img')).toBeNull();
+        expect(preview.domNode!.querySelector('img')).toBeNull();
+        // The escaped text is still present as text content.
+        expect(detail.textContent).toContain('boom');
+    });
+
+    it('localizes the error label via i18n (zh-CN)', async () => {
+        loadRendererMock.mockRejectedValue(new Error('nope'));
+        const { preview } = makePreview('graph TD; A-->B', 'mermaid', zhCN);
+        await preview.update('graph TD; A-->B');
+
+        const html = preview.domNode!.innerHTML;
+        expect(html).toContain('class="mu-diagram-error"');
+        expect(html).toContain('图表渲染失败');
+    });
+});
+
+describe('diagramPreview — clickHandler routing', () => {
+    it('preventDefault + stopPropagation + setCursor(0,0) on the parent first content', () => {
+        const { preview } = makePreview('');
+        const setCursor = vi.fn();
+        const cursorBlock = { setCursor };
+        const parent = {
+            firstContentInDescendant: vi.fn(() => cursorBlock),
+        };
+        // parent is typed as Parent | null; the fake only implements what
+        // clickHandler calls.
+        preview.parent = parent as unknown as DiagramPreview['parent'];
+
+        const event = {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as unknown as Event;
+
+        preview.clickHandler(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(parent.firstContentInDescendant).toHaveBeenCalledTimes(1);
+        expect(setCursor).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('still preventDefault/stopPropagation but does not throw when parent is null', () => {
+        const { preview } = makePreview('');
+        preview.parent = null;
+
+        const event = {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as unknown as Event;
+
+        expect(() => preview.clickHandler(event)).not.toThrow();
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when parent has no content (firstContentInDescendant returns null)', () => {
+        const { preview } = makePreview('');
+        const parent = {
+            firstContentInDescendant: vi.fn(() => null),
+        };
+        preview.parent = parent as unknown as DiagramPreview['parent'];
+
+        const event = {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        } as unknown as Event;
+
+        expect(() => preview.clickHandler(event)).not.toThrow();
+        expect(parent.firstContentInDescendant).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/muya/src/block/gfm/table/__tests__/alignColumn.spec.ts
+++ b/packages/muya/src/block/gfm/table/__tests__/alignColumn.spec.ts
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// Coverage for `Table.alignColumn`. The migration audit noted the insert /
+// remove row-column paths are unit-tested (insertRowColumn.spec.ts /
+// removeRowColumn.spec.ts) but the per-column alignment API the floating
+// table toolbar drives had no direct test. `alignColumn(offset, value)`
+// toggles a column between the requested alignment and 'none', writes both
+// the cell `meta.align` (state) and the `data-align` DOM attribute, and
+// dispatches an OT op so the serialized delimiter row reflects the change.
+// These tests boot a real table and assert the resulting per-cell state,
+// dataset, and round-tripped delimiter so a regression that drops the toggle
+// or the DOM/state sync is caught.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// eslint-disable-next-line ts/no-explicit-any
+function findTable(muya: Muya): any {
+    // eslint-disable-next-line ts/no-explicit-any
+    let table: any = null;
+    // eslint-disable-next-line ts/no-explicit-any
+    const visit = (block: any) => {
+        if (block.constructor?.blockName === 'table')
+            table = block;
+        // eslint-disable-next-line ts/no-explicit-any
+        block.children?.forEach((c: any) => visit(c));
+    };
+    visit(muya.editor.scrollPage);
+    if (!table)
+        throw new Error('no table found');
+    return table;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// Collect every cell in a given column (header + body) off the live block tree.
+/* eslint-disable ts/no-explicit-any */
+function cellsInColumn(table: any, column: number): any[] {
+    const inner = table.firstChild;
+    const cells: any[] = [];
+    inner.forEach((row: any) => {
+        cells.push(row.find(column));
+    });
+    return cells;
+}
+/* eslint-enable ts/no-explicit-any */
+
+// A plain 2-column table with no explicit alignment — both columns parse as
+// align 'none'.
+const PLAIN_TABLE = '| a | b |\n| --- | --- |\n| 1 | 2 |\n';
+
+describe('table.alignColumn', () => {
+    it('sets meta.align and the data-align attribute on every cell in the column', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'center');
+
+        await flush();
+        for (const cell of cellsInColumn(table, 0)) {
+            expect(cell.meta.align).toBe('center');
+            expect(cell.align).toBe('center');
+            expect(cell.domNode.dataset.align).toBe('center');
+        }
+        // Column 1 is untouched.
+        for (const cell of cellsInColumn(table, 1))
+            expect(cell.meta.align).toBe('none');
+    });
+
+    it('reflects the requested alignment in the getState() per-cell meta', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'center');
+
+        await flush();
+        const state = table.getState();
+        for (const row of state.children)
+            expect(row.children[0].meta.align).toBe('center');
+    });
+
+    it('serializes a center-aligned column as a :---: delimiter', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'center');
+
+        await flush();
+        const md = muya.getMarkdown();
+        expect(md).toContain(':---:');
+    });
+
+    it('toggles the column back to none when alignColumn is called twice with the same value', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'center');
+        await flush();
+        expect(md(muya)).toContain(':---:');
+
+        // Calling again with the same value toggles back to 'none'.
+        table.alignColumn(0, 'center');
+        await flush();
+
+        for (const cell of cellsInColumn(table, 0)) {
+            expect(cell.meta.align).toBe('none');
+            expect(cell.domNode.dataset.align).toBe('none');
+        }
+        // The center delimiter is gone; the default un-aligned delimiter row
+        // (only dashes, no colons) is serialized.
+        expect(md(muya)).not.toContain(':---:');
+        expect(md(muya)).toContain('---');
+    });
+
+    it('serializes a right-aligned column as a ---: delimiter', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(1, 'right');
+
+        await flush();
+        for (const cell of cellsInColumn(table, 1))
+            expect(cell.meta.align).toBe('right');
+
+        const markdown = muya.getMarkdown();
+        expect(markdown).toContain('---:');
+        // Column 0 stays unaligned, so no left/center markers appear.
+        expect(markdown).not.toContain(':---:');
+    });
+
+    it('serializes a left-aligned column as a :--- delimiter', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'left');
+
+        await flush();
+        for (const cell of cellsInColumn(table, 0))
+            expect(cell.meta.align).toBe('left');
+
+        expect(muya.getMarkdown()).toContain(':---');
+    });
+
+    it('switches directly between non-none alignments without toggling off', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+
+        table.alignColumn(0, 'center');
+        await flush();
+        // A different value than the current one — should set it, not toggle.
+        table.alignColumn(0, 'right');
+        await flush();
+
+        for (const cell of cellsInColumn(table, 0))
+            expect(cell.meta.align).toBe('right');
+    });
+
+    it('is a no-op for an out-of-range column offset', async () => {
+        const muya = bootMuya(PLAIN_TABLE);
+        const table = findTable(muya);
+        expect(table.columnCount).toBe(2);
+
+        table.alignColumn(5, 'center');
+
+        await flush();
+        // Nothing changed: both columns stay 'none'.
+        for (let col = 0; col < table.columnCount; col++) {
+            for (const cell of cellsInColumn(table, col))
+                expect(cell.meta.align).toBe('none');
+        }
+    });
+});
+
+function md(muya: Muya): string {
+    return muya.getMarkdown();
+}

--- a/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/__tests__/parityAutoCheck.spec.ts
@@ -134,4 +134,44 @@ describe('parity PG3: autoCheck task-list cascade', () => {
             });
         },
     );
+
+    it(
+        'PG3: autoCheck:false leaves descendants untouched when the parent toggles',
+        async () => {
+            const muya = bootMuya(NESTED_TASKS, { autoCheck: false });
+            const [parent] = taskItems(muya);
+            expect(checkedFlags(muya)).toEqual([false, false, false]);
+
+            // The DOM click handler invokes `update(checked, 'user')`. With
+            // `autoCheck` disabled, the cascade guard (`source !== 'api' &&
+            // this.muya.options.autoCheck`) is false, so only the toggled item
+            // changes — descendants stay unchecked.
+            checkboxOf(parent).update(true, 'user');
+
+            await vi.waitFor(() => {
+                expect(checkedFlags(muya)).toEqual([true, false, false]);
+            });
+        },
+    );
+
+    it(
+        'PG3: a checked task item serializes as "- [x]"',
+        async () => {
+            const muya = bootMuya(NESTED_TASKS, { autoCheck: false });
+            const [parent] = taskItems(muya);
+
+            checkboxOf(parent).update(true, 'user');
+
+            await vi.waitFor(() => {
+                expect(checkedFlags(muya)).toEqual([true, false, false]);
+            });
+
+            const markdown = muya.getMarkdown();
+            // The checked parent emits the GFM checked marker; the unchecked
+            // children keep the empty marker.
+            expect(markdown).toContain('- [x] parent');
+            expect(markdown).toContain('- [ ] child1');
+            expect(markdown).toContain('- [ ] child2');
+        },
+    );
 });

--- a/packages/muya/src/search/__tests__/search.spec.ts
+++ b/packages/muya/src/search/__tests__/search.spec.ts
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+// Coverage for the Search module (src/search/index.ts) — the find/replace
+// engine the desktop "Find in document" / "Find and replace" surfaces drive.
+// The module lives at muya.editor.searchModule and exposes search(value, opts),
+// find('previous'|'next'), and replace(value, {isSingle, isRegexp}). Each match
+// renders a highlight span into the live DOM: the active match gets
+// `span.mu-highlight`, every other match gets `span.mu-selection`
+// (Renderer.getHighlightClassName). block.update() patches the inline DOM
+// synchronously, so the spans are queryable right after the call.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function placeCursorOnFirstBlock(muya: Muya): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    return first;
+}
+
+function highlightCount(muya: Muya): number {
+    return muya.domNode.querySelectorAll('span.mu-highlight').length;
+}
+
+function selectionCount(muya: Muya): number {
+    return muya.domNode.querySelectorAll('span.mu-selection').length;
+}
+
+describe('search.search()', () => {
+    it('collects every match and highlights the first (one mu-highlight, rest mu-selection)', () => {
+        const muya = bootMuya('apple banana apple cherry\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('apple');
+
+        expect(search.matches.length).toBe(2);
+        expect(search.index).toBe(0);
+        // First match active, second selected.
+        expect(search.matches[0].start).toBe(0);
+        expect(search.matches[1].start).toBe(13);
+
+        // Active match -> span.mu-highlight, the remaining match -> span.mu-selection.
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(search.matches.length - 1);
+        expect(selectionCount(muya)).toBe(1);
+    });
+
+    it('clears highlights when searching for an empty value', () => {
+        const muya = bootMuya('apple banana apple cherry\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('apple');
+        expect(highlightCount(muya)).toBe(1);
+
+        search.search('');
+        expect(search.matches.length).toBe(0);
+        expect(search.index).toBe(-1);
+        expect(highlightCount(muya)).toBe(0);
+        expect(selectionCount(muya)).toBe(0);
+    });
+});
+
+describe('search.find() — cursor navigation across matches', () => {
+    it('wraps forward 0 -> 1 -> 2 -> 0 and backward 0 -> 2, moving the active mu-highlight', () => {
+        const muya = bootMuya('x and x and x\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('x');
+        expect(search.matches.length).toBe(3);
+        expect(search.index).toBe(0);
+        // Exactly one active highlight, the other two are selections.
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(2);
+
+        // next three times wraps forward: 1, 2, 0
+        search.find('next');
+        expect(search.index).toBe(1);
+        search.find('next');
+        expect(search.index).toBe(2);
+        search.find('next');
+        expect(search.index).toBe(0);
+
+        // The single active highlight follows the index.
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(2);
+
+        // previous from index 0 wraps backward to the last match (2).
+        search.find('previous');
+        expect(search.index).toBe(2);
+        expect(highlightCount(muya)).toBe(1);
+        expect(selectionCount(muya)).toBe(2);
+    });
+});
+
+describe('search.replace() — replace all across multiple blocks', () => {
+    it('replaces every occurrence of the needle in every block (replace-all flush)', async () => {
+        const muya = bootMuya('x foo x foo end\n\n# foo here\n\n- foo\n');
+        placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('foo');
+        // Two in the paragraph, one in the heading, one in the list item.
+        expect(search.matches.length).toBe(4);
+
+        search.replace('BAR', { isSingle: false, isRegexp: false });
+
+        // block.text writes are batched into the json state on the next rAF, so
+        // wait for getMarkdown (which serializes the json state) to settle.
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).not.toContain('foo');
+        });
+
+        const md = muya.getMarkdown();
+        // Paragraph with two occurrences plus trailing text survives intact.
+        expect(md).toContain('x BAR x BAR end');
+        // Heading block.
+        expect(md).toContain('# BAR here');
+        // List item block.
+        expect(md).toContain('- BAR');
+
+        // A fresh search for the old needle finds nothing.
+        search.search('foo');
+        expect(search.matches.length).toBe(0);
+    });
+});

--- a/packages/muya/src/selection/__tests__/selectionChange.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectionChange.spec.ts
@@ -85,4 +85,32 @@ describe('selection-change payload', () => {
         const formats = payload!.formats as Array<{ type: string }>;
         expect(formats.some(f => f.type === 'strong')).toBe(true);
     });
+
+    it('reports BOTH strong and em when the cursor is inside overlapping markers', () => {
+        // `**_x_**` nests an emphasis token inside a strong token. With the
+        // selection inside the shared `x`, `getFormatsInRange` recurses into the
+        // strong token's children and surfaces both inline formats so the
+        // desktop toolbar lights up bold AND italic at once.
+        const muya = bootMuya('**_x_**\n');
+        const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+
+        let payload: Record<string, unknown> | null = null;
+        muya.on('selection-change', (p: unknown) => {
+            payload = p as Record<string, unknown>;
+        });
+
+        // Text is `**_x_**`: `**_` is offsets 0-3, the `x` is offset 3-4, the
+        // closing `_**` is 4-7. Select just the `x` (3..4) — inside both ranges.
+        muya.editor.selection.setSelection({
+            anchor: { offset: 3 },
+            focus: { offset: 4 },
+            block: first,
+            path: first.path,
+        });
+
+        expect(payload).not.toBeNull();
+        const formats = (payload!.formats as Array<{ type: string }>).map(f => f.type);
+        expect(formats).toContain('strong');
+        expect(formats).toContain('em');
+    });
 });

--- a/packages/muya/src/state/__tests__/blockSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/blockSerialization.spec.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
 import { MarkdownToState } from '../markdownToState';
 import ExportMarkdown from '../stateToMarkdown';
 
@@ -16,6 +18,47 @@ function roundTrip(md: string): string {
         frontMatter: true,
     }).generate(md);
     return new ExportMarkdown({ listIndentation: 1 }).generate(states);
+}
+
+function parse(md: string) {
+    return new MarkdownToState({
+        footnote: false,
+        math: true,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: true,
+    }).generate(md);
+}
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Walk up from the first content leaf to the enclosing `code-block` parent
+// (the block that owns the `lang` setter and the `meta.type` field).
+// eslint-disable-next-line ts/no-explicit-any
+function findCodeBlock(muya: Muya): any {
+    // eslint-disable-next-line ts/no-explicit-any
+    let node: any = muya.editor.scrollPage!.firstContentInDescendant();
+    while (node && node.blockName !== 'code-block')
+        node = node.parent;
+    return node;
 }
 
 describe('stateToMarkdown — heading round-trip', () => {
@@ -163,6 +206,106 @@ describe('stateToMarkdown — table edge cases', () => {
 | 1   |     |
 `;
         expect(roundTrip(md)).toBe(md);
+    });
+});
+
+describe('markdownToState — indented code block', () => {
+    it('parses a 4-space-indented block as a code-block with meta.type "indented"', () => {
+        const states = parse('    code\n');
+
+        expect(states.length).toBe(1);
+        const state = states[0];
+        expect(state.name).toBe('code-block');
+        // `meta` only exists on the code-block state; narrow before reading it.
+        if (state.name !== 'code-block')
+            throw new Error('expected a code-block state');
+        expect(state.meta.type).toBe('indented');
+        // Indented blocks carry no info string, so the language is empty.
+        expect(state.meta.lang).toBe('');
+        expect(state.text).toBe('code');
+    });
+
+    it('round-trips an indented code block back to 4-space-indented markdown', () => {
+        // The serializer prefixes every line of a non-fenced code block with
+        // exactly four spaces (serializeCodeBlock, `type !== 'fenced'` branch).
+        const md = '    code\n';
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('round-trips a multi-line indented code block preserving each line indent', () => {
+        const md = '    line one\n    line two\n';
+        expect(roundTrip(md)).toBe(md);
+    });
+});
+
+describe('codeBlock — setting lang promotes an indented block to fenced', () => {
+    it('flips meta.type indented -> fenced and updates the live block lang', async () => {
+        const muya = bootMuya('    code\n');
+        const codeBlock = findCodeBlock(muya);
+        expect(codeBlock).toBeTruthy();
+        expect(codeBlock.meta.type).toBe('indented');
+
+        codeBlock.lang = 'js';
+
+        // The live block object reflects both the new type and language
+        // synchronously (the setter mutates `this.meta` directly).
+        expect(codeBlock.meta.type).toBe('fenced');
+        expect(codeBlock.meta.lang).toBe('js');
+
+        // The `meta.type` change is dispatched as an OT op, so it reaches the
+        // serialized JSON state after the rAF flush.
+        await vi.waitFor(() => {
+            const state = muya.getState()[0];
+            expect(state.name).toBe('code-block');
+            if (state.name !== 'code-block')
+                throw new Error('expected a code-block state');
+            expect(state.meta.type).toBe('fenced');
+        });
+    });
+
+    it('swaps the DOM class from mu-indented-code to mu-fenced-code', () => {
+        const muya = bootMuya('    code\n');
+        const codeBlock = findCodeBlock(muya);
+        const node = codeBlock.domNode as HTMLElement;
+        expect(node.classList.contains('mu-indented-code')).toBe(true);
+        expect(node.classList.contains('mu-fenced-code')).toBe(false);
+
+        codeBlock.lang = 'js';
+
+        expect(node.classList.contains('mu-indented-code')).toBe(false);
+        expect(node.classList.contains('mu-fenced-code')).toBe(true);
+    });
+
+    it('emits a fenced block from getMarkdown (CHARACTERIZATION: drops the language tag — see suspectedBugs)', async () => {
+        const muya = bootMuya('    code\n');
+        const codeBlock = findCodeBlock(muya);
+
+        codeBlock.lang = 'js';
+
+        // The setter dispatches an OT op ONLY for `meta.type`, never for
+        // `meta.lang`. So the serialized JSON state ends up `fenced` but with
+        // an EMPTY language: getMarkdown opens a bare ``` fence and the `js`
+        // info string is lost. This pins the actual current behaviour.
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('```');
+            expect(md).toContain('code');
+        });
+
+        const md = muya.getMarkdown();
+        // No longer the indented 4-space form.
+        expect(md.startsWith('    ')).toBe(false);
+        // Bug: the language tag never reaches the serializer.
+        expect(md).not.toContain('```js');
+        expect(md).toBe('```\ncode\n```\n');
+
+        // The JSON state confirms the language was dropped while the live
+        // block still holds it.
+        const state = muya.getState()[0];
+        if (state.name !== 'code-block')
+            throw new Error('expected a code-block state');
+        expect(state.meta.lang).toBe('');
+        expect(codeBlock.meta.lang).toBe('js');
     });
 });
 

--- a/packages/muya/src/state/__tests__/listMarkerOption.spec.ts
+++ b/packages/muya/src/state/__tests__/listMarkerOption.spec.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+// Characterization coverage for the list-marker / ordered-delimiter Muya
+// options as they thread through `replaceBlockByLabel` (the path
+// `updateParagraph` drives) into the serialized markdown. The marker the
+// list is created with lives in the list block's `meta` and is emitted
+// verbatim by stateToMarkdown, so booting Muya with `bulletListMarker` /
+// `orderListDelimiter` and creating a list through `updateParagraph` lets us
+// pin the produced markdown. State flushes on rAF, so assertions wait via
+// vi.waitFor.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Partial<ConstructorParameters<typeof Muya>[1]> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function placeCursorOnFirstBlock(muya: Muya): Content {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    return first;
+}
+
+// eslint-disable-next-line ts/no-explicit-any
+function firstBlock(muya: Muya): any {
+    return muya.getState()[0];
+}
+
+describe('list marker option — bulletListMarker', () => {
+    it('default bullet list uses "- " marker', async () => {
+        const muya = bootMuya('item\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('bullet-list');
+            expect(firstBlock(muya).meta.marker).toBe('-');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('- ')).toBe(true);
+    });
+
+    it('{bulletListMarker:"*"} emits "* " markers', async () => {
+        const muya = bootMuya('item\n', { bulletListMarker: '*' });
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('bullet-list');
+            expect(firstBlock(muya).meta.marker).toBe('*');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('* ')).toBe(true);
+        expect(lines[0].startsWith('- ')).toBe(false);
+    });
+
+    it('{bulletListMarker:"+"} emits "+ " markers', async () => {
+        const muya = bootMuya('item\n', { bulletListMarker: '+' });
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('bullet-list');
+            expect(firstBlock(muya).meta.marker).toBe('+');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('+ ')).toBe(true);
+    });
+});
+
+describe('list marker option — orderListDelimiter', () => {
+    it('default ordered list uses "1. " delimiter', async () => {
+        const muya = bootMuya('item\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ol-order');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('order-list');
+            expect(firstBlock(muya).meta.delimiter).toBe('.');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('1. ')).toBe(true);
+    });
+
+    it('{orderListDelimiter:")"} emits "1) " not "1. "', async () => {
+        const muya = bootMuya('item\n', { orderListDelimiter: ')' });
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ol-order');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('order-list');
+            expect(firstBlock(muya).meta.delimiter).toBe(')');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('1) ')).toBe(true);
+        expect(lines[0].startsWith('1. ')).toBe(false);
+    });
+
+    it('{orderListDelimiter:")"} carries to the ol-bullet command label too', async () => {
+        const muya = bootMuya('item\n', { orderListDelimiter: ')' });
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ol-bullet');
+        await vi.waitFor(() => {
+            expect(firstBlock(muya).name).toBe('order-list');
+            expect(firstBlock(muya).meta.delimiter).toBe(')');
+        });
+        const lines = muya.getMarkdown().split('\n').filter(l => l.trim() !== '');
+        expect(lines[0].startsWith('1) ')).toBe(true);
+    });
+});

--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -1,3 +1,4 @@
+import type { IBulletListState, IOrderListState, TState } from '../types';
 import { describe, expect, it } from 'vitest';
 import { MarkdownToState } from '../markdownToState';
 import ExportMarkdown from '../stateToMarkdown';
@@ -265,5 +266,116 @@ sep
             1. foo
 `;
         expect(roundTrip(md, 'dfm')).toBe(md);
+    });
+});
+
+// stateToMarkdown reads `loose` straight off the list meta. In a real boot
+// that flag is seeded from `muya.options.preferLooseListItem` at list
+// creation time (see block/base/format.ts `_convertToList`); here we drive the
+// serializer directly with both flag values to lock in the exact spacing the
+// option controls. A loose list separates every item with a blank line; a
+// tight list does not.
+describe('stateToMarkdown — list looseness (preferLooseListItem)', () => {
+    function serialize(states: TState[]): string {
+        return new ExportMarkdown({ listIndentation: 1 }).generate(states);
+    }
+
+    function bulletList(loose: boolean): IBulletListState {
+        return {
+            name: 'bullet-list',
+            meta: { marker: '-', loose },
+            children: [
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'foo' }] },
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'bar' }] },
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'baz' }] },
+            ],
+        };
+    }
+
+    it('inserts blank lines between items when loose is true', () => {
+        expect(serialize([bulletList(true)])).toBe('- foo\n\n- bar\n\n- baz\n');
+    });
+
+    it('keeps items adjacent (no blank lines) when loose is false', () => {
+        expect(serialize([bulletList(false)])).toBe('- foo\n- bar\n- baz\n');
+    });
+
+    it('list meta.loose carries the preferLooseListItem flag verbatim', () => {
+        // The serializer is the only consumer of meta.loose; assert the round
+        // contract by parsing a canonical loose list and reading the flag back.
+        const looseStates = new MarkdownToState({
+            footnote: false,
+            math: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+        }).generate('- foo\n\n- bar\n');
+        const list = looseStates[0] as IBulletListState;
+        expect(list.name).toBe('bullet-list');
+        expect(list.meta.loose).toBe(true);
+
+        const tightStates = new MarkdownToState({
+            footnote: false,
+            math: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+        }).generate('- foo\n- bar\n');
+        const tightList = tightStates[0] as IBulletListState;
+        expect(tightList.meta.loose).toBe(false);
+    });
+});
+
+// Ordered-list start number is preserved through the markdown round-trip, and
+// the per-item number is computed by incrementing `meta.start` (see
+// stateToMarkdown.ts `serializeListItem`). The delimiter (`.` or `)`) likewise
+// comes from `meta.delimiter`, which a real boot seeds from
+// `muya.options.orderListDelimiter`.
+describe('stateToMarkdown — ordered list start + delimiter', () => {
+    function serialize(states: TState[]): string {
+        return new ExportMarkdown({ listIndentation: 1 }).generate(states);
+    }
+
+    it('keeps a non-1 start number through the round-trip', () => {
+        // The parser stores start=3; the serializer renders 3., 4. (start + i).
+        expect(roundTrip('3. one\n4. two\n')).toBe('3. one\n4. two\n');
+    });
+
+    it('parses the start number into order-list meta.start', () => {
+        const states = new MarkdownToState({
+            footnote: false,
+            math: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+        }).generate('3. one\n4. two\n');
+        const list = states[0] as IOrderListState;
+        expect(list.name).toBe('order-list');
+        expect(list.meta.start).toBe(3);
+        expect(list.meta.delimiter).toBe('.');
+    });
+
+    it('emits the configured delimiter (")") for an ordered list', () => {
+        const states: IOrderListState[] = [{
+            name: 'order-list',
+            meta: { start: 1, loose: false, delimiter: ')' },
+            children: [
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'one' }] },
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'two' }] },
+            ],
+        }];
+        expect(serialize(states)).toBe('1) one\n2) two\n');
+    });
+
+    it('combines a non-1 start with the ")" delimiter', () => {
+        const states: IOrderListState[] = [{
+            name: 'order-list',
+            meta: { start: 5, loose: false, delimiter: ')' },
+            children: [
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'one' }] },
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'two' }] },
+            ],
+        }];
+        expect(serialize(states)).toBe('5) one\n6) two\n');
     });
 });

--- a/packages/muya/src/state/__tests__/markdownToState.spec.ts
+++ b/packages/muya/src/state/__tests__/markdownToState.spec.ts
@@ -13,7 +13,10 @@ interface IStateLike {
     children?: IStateLike[];
 }
 
-function generate(markdown: string, options: Partial<{ footnote: boolean }> = {}): IStateLike[] {
+function generate(
+    markdown: string,
+    options: Partial<{ footnote: boolean; trimUnnecessaryCodeBlockEmptyLines: boolean }> = {},
+): IStateLike[] {
     return new MarkdownToState({
         footnote: false,
         math: false,
@@ -229,5 +232,133 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         const level2 = level1Nested!.children![0];
         const level2Nested = level2.children!.find(c => c.name === 'task-list');
         expect(level2Nested, 'level 2 should contain level 3 nested, not as sibling').toBeDefined();
+    });
+});
+
+// Fix #1265: the `trimUnnecessaryCodeBlockEmptyLines` option strips leading
+// and trailing blank lines from a fenced code block's text while leaving
+// interior blanks alone. The option threads only through MarkdownToState
+// (it rewrites the code-block `text` at parse time); ExportMarkdown simply
+// serialises whatever text the state carries, so the round-trip reflects the
+// parse-time decision.
+describe('markdownToState — trimUnnecessaryCodeBlockEmptyLines (#1265)', () => {
+    const fenced = '```js\n\n\ncode\n\n\n```\n';
+
+    it('retains surrounding blank lines when the option is false', () => {
+        const states = generate(fenced, { trimUnnecessaryCodeBlockEmptyLines: false });
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('code-block');
+        expect(states[0].meta).toEqual({ type: 'fenced', lang: 'js' });
+        // marked already drops one of the three blanks on each side; the
+        // option being OFF leaves the remaining surrounding blanks intact.
+        expect(states[0].text).toBe('\n\ncode\n\n');
+    });
+
+    it('strips leading/trailing blank lines when the option is true', () => {
+        const states = generate(fenced, { trimUnnecessaryCodeBlockEmptyLines: true });
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('code-block');
+        expect(states[0].text).toBe('code');
+    });
+
+    it('keeps interior blank lines while trimming the surrounding ones', () => {
+        const md = '```js\n\n\na\n\nb\n\n\n```\n';
+        const trimmed = generate(md, { trimUnnecessaryCodeBlockEmptyLines: true });
+        expect(trimmed[0].text).toBe('a\n\nb');
+        const kept = generate(md, { trimUnnecessaryCodeBlockEmptyLines: false });
+        expect(kept[0].text).toBe('\n\na\n\nb\n\n');
+    });
+
+    it('honours the option through a stateToMarkdown round-trip', () => {
+        const exporter = () => new ExportMarkdown({ listIndentation: 1 });
+        const trimmedStates = generate(fenced, { trimUnnecessaryCodeBlockEmptyLines: true });
+        const trimmedMd = exporter().generate(
+            trimmedStates as unknown as Parameters<ExportMarkdown['generate']>[0],
+        );
+        expect(trimmedMd).toBe('```js\ncode\n```\n');
+
+        const keptStates = generate(fenced, { trimUnnecessaryCodeBlockEmptyLines: false });
+        const keptMd = exporter().generate(
+            keptStates as unknown as Parameters<ExportMarkdown['generate']>[0],
+        );
+        expect(keptMd).toBe('```js\n\n\ncode\n\n\n```\n');
+    });
+});
+
+// Setext headings (`text\n===` / `text\n---`) are a distinct state node
+// (`setext-heading`) from atx headings, and a bare `---` / `***` / `___`
+// line is a thematic break — not a heading underline.
+describe('markdownToState — setext heading vs thematic break', () => {
+    it('parses `text\\n---` as a single level-2 setext-heading', () => {
+        const states = generate('text\n---\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('setext-heading');
+        expect(states[0].meta!.level).toBe(2);
+        expect(states[0].text).toBe('text');
+    });
+
+    it('parses `text\\n===` as a single level-1 setext-heading', () => {
+        const states = generate('text\n===\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('setext-heading');
+        expect(states[0].meta!.level).toBe(1);
+        expect(states[0].text).toBe('text');
+    });
+
+    it('parses a bare `---` line as a single thematic-break', () => {
+        const states = generate('---\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('thematic-break');
+    });
+});
+
+// Thematic-break markers: `---`, `***`, `___` all produce a thematic-break;
+// a mixed `-*-` line is not a valid HR and stays a paragraph.
+describe('markdownToState — thematic break markers', () => {
+    it('parses `---` as a thematic-break', () => {
+        const states = generate('---\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('thematic-break');
+        expect(states[0].text).toBe('---');
+    });
+
+    it('parses `***` as a thematic-break', () => {
+        const states = generate('***\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('thematic-break');
+        expect(states[0].text).toBe('***');
+    });
+
+    it('parses `___` as a thematic-break', () => {
+        const states = generate('___\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('thematic-break');
+        expect(states[0].text).toBe('___');
+    });
+
+    it('does not parse `-*-` (mixed markers) as a thematic-break', () => {
+        const states = generate('-*-\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('paragraph');
+        expect(states[0].text).toBe('-*-');
+    });
+});
+
+// HTML blocks: a lone `<img>` is lowered to a paragraph (isSingleImage
+// branch, anticipating a future image state node), while other HTML is an
+// `html-block` state.
+describe('markdownToState — HTML block vs single-image paragraph', () => {
+    it('lowers a lone `<img>` tag to a paragraph (isSingleImage branch)', () => {
+        const states = generate('<img src="x">\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('paragraph');
+        expect(states[0].text).toBe('<img src="x">');
+    });
+
+    it('keeps other HTML as an html-block state', () => {
+        const states = generate('<div>x</div>\n');
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('html-block');
+        expect(states[0].text).toBe('<div>x</div>');
     });
 });

--- a/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
+++ b/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
@@ -1,5 +1,6 @@
 import type { ITableCellState, ITableRowState, ITableState } from '../types';
 import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
 import ExportMarkdown from '../stateToMarkdown';
 
 function cell(text: string, align = 'none'): ITableCellState {
@@ -70,5 +71,74 @@ describe('serializeTable — row width mismatch', () => {
         expect(md).toContain('| b');
         expect(md).toContain('| 1');
         expect(md).toContain('| 2');
+    });
+});
+
+// `align` lives on every cell's `meta.align` ('none' | 'left' | 'center' |
+// 'right'). The serializer renders the delimiter row from the *header* row's
+// cell aligns: left → ':---', center → ':---:', right → '---:', none → '---'.
+function gen(markdown: string): TStateForExport {
+    return new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(markdown) as unknown as TStateForExport;
+}
+
+type TStateForExport = Parameters<ExportMarkdown['generate']>[0];
+
+describe('serializeTable — column alignment', () => {
+    it('renders the delimiter row from per-column align', () => {
+        const state = table([
+            row([cell('a', 'left'), cell('b', 'center'), cell('c', 'right')]),
+            row([cell('1'), cell('2'), cell('3')]),
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+        const delimiterRow = md.split('\n')[1];
+
+        // left → leading colon, no trailing colon.
+        expect(delimiterRow).toContain(':---');
+        // center → leading and trailing colon.
+        expect(delimiterRow).toContain(':---:');
+        // right → trailing colon only.
+        expect(delimiterRow).toContain('---:');
+    });
+
+    it('the header row drives the delimiter, not body rows', () => {
+        const state = table([
+            row([cell('a', 'center'), cell('b', 'none')]),
+            // body-row aligns are ignored by the serializer.
+            row([cell('1', 'right'), cell('2', 'left')]),
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+        const delimiterRow = md.split('\n')[1];
+
+        expect(delimiterRow).toContain(':---:');
+        // The 'none' column has no colons in its delimiter cell; the dashes
+        // are wrapped with a leading and trailing space ('| --- |').
+        expect(delimiterRow).toBe('|:---:| --- |');
+    });
+
+    it('round-trips a left/center/right table to a byte-stable delimiter row', () => {
+        const md
+            = '| a | b | c |\n| :--- | :---: | ---: |\n| 1 | 2 | 3 |\n';
+
+        const firstPass = new ExportMarkdown().generate(gen(md));
+        const secondPass = new ExportMarkdown().generate(gen(firstPass));
+
+        // The parsed aligns survive serialization with the expected markers.
+        const delimiterRow = firstPass.split('\n')[1];
+        expect(delimiterRow).toBe('|:--- |:---:| ---:|');
+        expect(delimiterRow).toContain(':---');
+        expect(delimiterRow).toContain(':---:');
+        expect(delimiterRow).toContain('---:');
+
+        // Re-parsing the serialized output and serializing again is byte-stable.
+        expect(secondPass).toBe(firstPass);
+        expect(secondPass.split('\n')[1]).toBe(delimiterRow);
     });
 });

--- a/packages/muya/src/ui/emojiSelector/__tests__/emojiSelector.spec.ts
+++ b/packages/muya/src/ui/emojiSelector/__tests__/emojiSelector.spec.ts
@@ -1,0 +1,212 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmojiSelector } from '..';
+import EventCenter from '../../../event';
+import { en } from '../../../locales/en';
+import { zhCN } from '../../../locales/zh-CN';
+
+// Integration-shaped tests for the EmojiSelector floating autocomplete UI.
+//
+// The selector is a BaseScrollFloat subclass driven entirely by the
+// `muya-emoji-picker` event (emitted from Format.checkInlineUpdate / the
+// `:alias` typing path). We mock the slice of Muya the selector touches
+// (eventCenter, domNode, i18n, ui) and run BaseFloat/BaseScrollFloat for real
+// so the snabbdom render path is exercised end-to-end in happy-dom.
+
+function makeFakeMuya(t: (s: string) => string = (s: string) => s): { muya: Muya; eventCenter: EventCenter } {
+    const eventCenter = new EventCenter();
+    const editorDomNode = document.createElement('div');
+    const editorWrapper = document.createElement('div');
+    editorWrapper.appendChild(editorDomNode);
+    document.body.appendChild(editorWrapper);
+
+    const shownFloat = new Set();
+    // Mirror Ui.listen so `status` flips when the float shows/hides.
+    eventCenter.subscribe('muya-float', (tool: unknown, status: boolean) => {
+        status ? shownFloat.add(tool) : shownFloat.delete(tool);
+    });
+
+    const muya = {
+        domNode: editorDomNode,
+        eventCenter,
+        i18n: { t },
+        ui: { shownFloat },
+        options: {},
+    } as unknown as Muya;
+
+    return { muya, eventCenter };
+}
+
+function stubReference(): HTMLElement {
+    const span = document.createElement('span');
+    // BaseFloat computes position off the reference; happy-dom has no layout,
+    // so a stubbed rect keeps autoUpdate from throwing.
+    span.getBoundingClientRect = () =>
+        ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => '' }) as DOMRect;
+    document.body.appendChild(span);
+    return span;
+}
+
+// Build an I18n-shaped stub from a real locale resource map so the category
+// title rendering asserts against the actual shipped translations.
+function localeT(resource: Record<string, string>): (s: string) => string {
+    return (key: string) => resource[key] || key;
+}
+
+const selectors: EmojiSelector[] = [];
+
+afterEach(() => {
+    while (selectors.length)
+        selectors.pop()!.destroy();
+    vi.restoreAllMocks();
+});
+
+describe('emojiSelector — plugin shape', () => {
+    it('exposes a stable static pluginName so Muya.use registers it under "emojiPicker"', () => {
+        expect(EmojiSelector.pluginName).toBe('emojiPicker');
+    });
+});
+
+describe('emojiSelector — render on muya-emoji-picker event', () => {
+    let muya: Muya;
+    let eventCenter: EventCenter;
+    let selector: EmojiSelector;
+
+    beforeEach(() => {
+        ({ muya, eventCenter } = makeFakeMuya());
+        selector = new EmojiSelector(muya);
+        selectors.push(selector);
+    });
+
+    it('searches matches, marks the first item active, and shows the float', () => {
+        const reference = stubReference();
+        const setEmoji = vi.fn();
+
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji } });
+
+        expect(selector.renderArray.length).toBeGreaterThan(0);
+        expect(selector.activeItem).toBe(selector.renderArray[0]);
+        expect(selector.status).toBe(true);
+    });
+
+    it('groups results under category sections and renders one .item per emoji with a span', () => {
+        const reference = stubReference();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji: vi.fn() } });
+
+        const sections = selector.floatBox!.querySelectorAll('section');
+        expect(sections.length).toBeGreaterThan(0);
+        const items = selector.floatBox!.querySelectorAll('div.item');
+        expect(items.length).toBe(selector.renderArray.length);
+        // First rendered item carries the active class.
+        const activeItems = selector.floatBox!.querySelectorAll('div.item.active');
+        expect(activeItems.length).toBe(1);
+        // Each item embeds the emoji glyph in a child span and tags its alias.
+        const first = items[0] as HTMLElement;
+        expect(first.querySelector('span')).not.toBeNull();
+        expect(first.dataset.label).toBe(selector.activeItem!.aliases[0]);
+    });
+
+    it('hides (no show) when emojiText is empty', () => {
+        const reference = stubReference();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: '', block: { setEmoji: vi.fn() } });
+
+        expect(selector.status).toBe(false);
+        expect(selector.renderArray.length).toBe(0);
+    });
+
+    it('hides when the search yields no matches', () => {
+        const reference = stubReference();
+        eventCenter.emit('muya-emoji-picker', {
+            reference,
+            emojiText: 'zzzzznotanemojizzzzz',
+            block: { setEmoji: vi.fn() },
+        });
+
+        expect(selector.status).toBe(false);
+    });
+});
+
+describe('emojiSelector — selection', () => {
+    let muya: Muya;
+    let eventCenter: EventCenter;
+    let selector: EmojiSelector;
+
+    beforeEach(() => {
+        ({ muya, eventCenter } = makeFakeMuya());
+        selector = new EmojiSelector(muya);
+        selectors.push(selector);
+    });
+
+    it('selectItem calls block.setEmoji with the item\'s first alias', () => {
+        const reference = stubReference();
+        const setEmoji = vi.fn();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji } });
+
+        const item = selector.renderArray[0];
+        selector.selectItem(item);
+
+        expect(setEmoji).toHaveBeenCalledTimes(1);
+        expect(setEmoji).toHaveBeenCalledWith(item.aliases[0]);
+    });
+
+    it('clicking a rendered item fires setEmoji with that item\'s alias', () => {
+        const reference = stubReference();
+        const setEmoji = vi.fn();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji } });
+
+        const items = selector.floatBox!.querySelectorAll('div.item');
+        const second = (items[1] ?? items[0]) as HTMLElement;
+        const expectedAlias = second.dataset.label!;
+        second.click();
+
+        expect(setEmoji).toHaveBeenCalledTimes(1);
+        expect(setEmoji).toHaveBeenCalledWith(expectedAlias);
+    });
+
+    it('step("next") advances activeItem and selecting it routes through setEmoji', () => {
+        const reference = stubReference();
+        const setEmoji = vi.fn();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji } });
+
+        const first = selector.renderArray[0];
+        selector.step('next');
+        expect(selector.activeItem).toBe(selector.renderArray[1] ?? first);
+
+        selector.selectItem(selector.activeItem);
+        expect(setEmoji).toHaveBeenCalledWith(selector.activeItem!.aliases[0]);
+    });
+});
+
+describe('emojiSelector — localized category titles', () => {
+    it('renders the en category title verbatim', () => {
+        const { muya, eventCenter } = makeFakeMuya(localeT(en.resource));
+        const selector = new EmojiSelector(muya);
+        selectors.push(selector);
+
+        const reference = stubReference();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji: vi.fn() } });
+
+        const titles = [...selector.floatBox!.querySelectorAll('section .title')].map(t => t.textContent);
+        const category = selector.renderArray[0].category;
+        expect(titles).toContain((en.resource as Record<string, string>)[category]);
+    });
+
+    it('renders the zh-CN translation for a matched category via i18n.t', () => {
+        const { muya, eventCenter } = makeFakeMuya(localeT(zhCN.resource));
+        const selector = new EmojiSelector(muya);
+        selectors.push(selector);
+
+        const reference = stubReference();
+        eventCenter.emit('muya-emoji-picker', { reference, emojiText: 'smile', block: { setEmoji: vi.fn() } });
+
+        const category = selector.renderArray[0].category;
+        const translated = (zhCN.resource as Record<string, string>)[category];
+        // The matched emoji lives in a category that zh-CN actually translates.
+        expect(translated).toBeTruthy();
+        expect(translated).not.toBe(category);
+
+        const titles = [...selector.floatBox!.querySelectorAll('section .title')].map(t => t.textContent);
+        expect(titles).toContain(translated);
+    });
+});

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import type ParagraphContent from '../../../block/content/paragraphContent';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { zhCN } from '../../../locales';
+import { Muya } from '../../../muya';
+import { ParagraphQuickInsertMenu } from '../index';
+
+// Characterization of `ParagraphQuickInsertMenu.search()` + `render()`:
+//   • `search('')` returns the full MENU_CONFIG (frontmatter included when the
+//     cursor block can host front matter — an empty paragraph at the document
+//     start with `frontMatter: true`).
+//   • `search(localizedFragment)` fuzzy-matches (fuse.js) over each child's
+//     `i18nTitle` (i18n.t(title)) and `title`, keeps only sections that have a
+//     match, sets `child.i18nTitle`, and sorts the surviving sections by their
+//     best child score (ascending = best first).
+//   • `search('zzzzz')` yields `renderData === []` and `render()` paints a
+//     `.no-result` node carrying the localized "No result".
+//
+// We boot a real Muya with the zh-CN locale (mirrors localeRefresh.spec /
+// updateParagraph.spec), construct the menu directly, and point `menu.block` at
+// the booted empty paragraph's content leaf — exactly what `listen()` does when
+// the `/` trigger fires.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {
+        markdown,
+        locale: zhCN,
+    } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Boot the editor over a single empty paragraph and hand back the menu with its
+// `block` already pointed at the paragraph's content leaf.
+function bootMenu(): { muya: Muya; menu: ParagraphQuickInsertMenu } {
+    const muya = bootMuya('\n');
+    const menu = new ParagraphQuickInsertMenu(muya);
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    menu.block = first as unknown as ParagraphContent;
+
+    return { muya, menu };
+}
+
+describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () => {
+    it('search("") returns the full menu config (frontmatter included on an empty doc-start paragraph)', () => {
+        const { menu } = bootMenu();
+
+        menu.search('');
+
+        const sectionNames = menu.renderData.map(d => d.name);
+        expect(sectionNames).toEqual([
+            'basic blocks',
+            'headers',
+            'advanced blocks',
+            'list blocks',
+            'diagrams',
+        ]);
+
+        // An empty paragraph at the document start with frontMatter:true can host
+        // front matter, so the basic-blocks section keeps its frontmatter entry.
+        const basic = menu.renderData.find(d => d.name === 'basic blocks')!;
+        expect(basic.children.map(c => c.label)).toEqual([
+            'paragraph',
+            'thematic-break',
+            'frontmatter',
+        ]);
+    });
+
+    it('search(localized fragment) keeps only sections whose i18nTitle matched', () => {
+        const { menu } = bootMenu();
+
+        // '代码块' is the zh-CN translation of 'Code Block'.
+        menu.search('代码');
+
+        expect(menu.renderData.map(d => d.name)).toEqual(['advanced blocks']);
+        const matched = menu.renderData[0].children;
+        expect(matched.map(c => c.label)).toEqual(['code-block']);
+        // search() stamps the localized title onto the matched child.
+        expect(matched[0].i18nTitle).toBe('代码块');
+        // fuse.js attaches a score to every match.
+        expect(typeof matched[0].score).toBe('number');
+    });
+
+    it('an exact localized title match scores ~0 and surfaces as the section', () => {
+        const { menu } = bootMenu();
+
+        // '表格' is the zh-CN translation of 'Table Block'.
+        menu.search('表格');
+
+        // 'table' (advanced blocks) is the exact match and sorts first.
+        expect(menu.renderData[0].name).toBe('advanced blocks');
+        const best = menu.renderData[0].children[0];
+        expect(best.label).toBe('table');
+        expect(best.i18nTitle).toBe('表格');
+        expect(best.score).toBeLessThan(0.001);
+    });
+
+    it('a multi-section match is sorted by best child score (best section first)', () => {
+        const { menu } = bootMenu();
+
+        // The character '表' appears in '表格' (Table Block, advanced blocks) and
+        // in '任务列表'/etc. (list blocks), so two sections match.
+        menu.search('表');
+
+        expect(menu.renderData.length).toBeGreaterThan(1);
+        // 'advanced blocks' (table, best score) sorts ahead of 'list blocks'.
+        expect(menu.renderData[0].name).toBe('advanced blocks');
+        expect(menu.renderData[0].children[0].label).toBe('table');
+
+        // Sections are ordered by ascending best-child score.
+        const bestScores = menu.renderData.map(d => d.children[0].score!);
+        const sorted = [...bestScores].sort((a, b) => a - b);
+        expect(bestScores).toEqual(sorted);
+    });
+
+    it('search("zzzzz") yields empty renderData', () => {
+        const { menu } = bootMenu();
+
+        menu.search('zzzzz');
+
+        expect(menu.renderData).toEqual([]);
+        expect(menu.renderArray).toEqual([]);
+    });
+});
+
+describe('paragraphQuickInsertMenu render() — DOM output', () => {
+    it('a no-match search paints a single localized .no-result node', () => {
+        const { menu } = bootMenu();
+
+        // search() calls render() internally; the no-result node lands in the DOM.
+        menu.search('zzzzz');
+
+        const noResult = menu.scrollElement!.querySelector('.no-result');
+        expect(noResult).not.toBeNull();
+        // '无结果' is the zh-CN translation of 'No result'.
+        expect(noResult!.textContent).toBe('无结果');
+        // No section is rendered when there is no result.
+        expect(menu.scrollElement!.querySelectorAll('section').length).toBe(0);
+    });
+
+    it('a match renders one <section> per matched group with exactly one .item.active', () => {
+        const { menu } = bootMenu();
+
+        menu.search('表');
+
+        const sections = menu.scrollElement!.querySelectorAll('section');
+        expect(sections.length).toBe(menu.renderData.length);
+
+        // The first child of the first (best) section is the active item.
+        expect(menu.activeItem!.label).toBe('table');
+        const active = menu.scrollElement!.querySelectorAll('.item.active');
+        expect(active.length).toBe(1);
+        expect((active[0] as HTMLElement).dataset.label).toBe('table');
+    });
+
+    it('renderArray is the flattened children of every matched section', () => {
+        const { menu } = bootMenu();
+
+        menu.search('列表');
+
+        const flattened = menu.renderData.flatMap(d => d.children);
+        expect(menu.renderArray).toEqual(flattened);
+        // activeItem defaults to the first flattened child.
+        expect(menu.activeItem).toBe(menu.renderArray[0]);
+    });
+});

--- a/packages/muya/src/utils/__tests__/search.spec.ts
+++ b/packages/muya/src/utils/__tests__/search.spec.ts
@@ -1,6 +1,6 @@
 import type { IMatch } from '../../search/types';
 import { describe, expect, it } from 'vitest';
-import { buildRegexValue } from '../search';
+import { buildRegexValue, matchString } from '../search';
 
 // Defensive coverage for the search helpers migrated from marktext.
 //
@@ -50,5 +50,79 @@ describe('buildRegexValue — marktext 4c517b16 group expansion', () => {
     it('returns the value verbatim when there are no $N tokens', () => {
         const value = buildRegexValue(makeMatch('foo', ['x']), 'plain replacement');
         expect(value).toBe('plain replacement');
+    });
+});
+
+// `matchString` is the search engine's lexer: it turns the user-facing
+// search options (case sensitivity / whole word / regexp) into a global
+// RegExp and returns the `execall` match shape `{ match, subMatches, index }`.
+// Pin the option matrix so a refactor of the regex assembly in
+// `utils/search.ts` can't silently change which substrings are found.
+describe('matchString — search option matrix', () => {
+    describe('isCaseSensitive', () => {
+        it('matches every casing when false (3 matches, indices 0/4/8)', () => {
+            const matches = matchString('Foo foo FOO', 'foo', { isCaseSensitive: false });
+            expect(matches).toHaveLength(3);
+            expect(matches.map(m => m.index)).toEqual([0, 4, 8]);
+            expect(matches.map(m => m.match)).toEqual(['Foo', 'foo', 'FOO']);
+        });
+
+        it('matches only the exact-case occurrence when true (1 match at the lowercase foo)', () => {
+            const matches = matchString('Foo foo FOO', 'foo', { isCaseSensitive: true });
+            expect(matches).toHaveLength(1);
+            expect(matches[0].index).toBe(4);
+            expect(matches[0].match).toBe('foo');
+        });
+    });
+
+    describe('isWholeWord', () => {
+        it('matches every substring occurrence when false (3 matches)', () => {
+            const matches = matchString('cat category scatter', 'cat', { isWholeWord: false });
+            expect(matches).toHaveLength(3);
+            expect(matches.map(m => m.index)).toEqual([0, 4, 14]);
+        });
+
+        it('matches only the standalone word when true (1 match)', () => {
+            const matches = matchString('cat category scatter', 'cat', { isWholeWord: true });
+            expect(matches).toHaveLength(1);
+            expect(matches[0].index).toBe(0);
+            expect(matches[0].match).toBe('cat');
+        });
+
+        it('combines isWholeWord with isCaseSensitive', () => {
+            const matches = matchString('Cat cat scatter', 'cat', {
+                isWholeWord: true,
+                isCaseSensitive: true,
+            });
+            // 'Cat' (index 0) is excluded by case sensitivity, 'scatter' by the
+            // word boundary — only the standalone lowercase 'cat' survives.
+            expect(matches).toHaveLength(1);
+            expect(matches[0].index).toBe(4);
+            expect(matches[0].match).toBe('cat');
+        });
+    });
+
+    describe('isRegexp', () => {
+        it('treats the value as a RegExp when true', () => {
+            const matches = matchString('2026-05-20', '\\d{4}', { isRegexp: true });
+            expect(matches).toHaveLength(1);
+            expect(matches[0].match).toBe('2026');
+            expect(matches[0].index).toBe(0);
+        });
+
+        it('returns [] for an invalid pattern instead of throwing', () => {
+            // A bare '(' is an invalid RegExp; matchString swallows the
+            // SyntaxError and returns an empty result.
+            expect(() => matchString('abc', '(', { isRegexp: true })).not.toThrow();
+            expect(matchString('abc', '(', { isRegexp: true })).toEqual([]);
+        });
+
+        it('populates subMatches from capture groups', () => {
+            const matches = matchString('2026-05-20', '(\\d{2})-(\\d{2})', { isRegexp: true });
+            expect(matches).toHaveLength(1);
+            expect(matches[0].match).toBe('26-05');
+            expect(matches[0].index).toBe(2);
+            expect(matches[0].subMatches).toEqual(['26', '05']);
+        });
     });
 });

--- a/packages/muya/src/utils/__tests__/wordCount.spec.ts
+++ b/packages/muya/src/utils/__tests__/wordCount.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { wordCount } from '../index';
+
+// Characterization of the current wordCount algorithm in src/utils/index.ts.
+// It returns { word, paragraph, character, all }:
+//  - paragraph: count of non-empty chunks split on two-or-more newlines.
+//  - word: number of CJK chars (一-龥) + number of whitespace tokens
+//    in the CJK-stripped string.
+//  - character: total length of those non-CJK tokens + number of CJK chars
+//    (i.e. excludes whitespace between tokens).
+//  - all: the raw markdown string length.
+describe('wordCount', () => {
+    it('counts plain ASCII words', () => {
+        expect(wordCount('hello world')).toEqual({
+            word: 2,
+            character: 10,
+            paragraph: 1,
+            all: 11,
+        });
+    });
+
+    it('counts each CJK character as its own word', () => {
+        const result = wordCount('你好 world');
+        expect(result.word).toBe(3);
+        expect(result.character).toBe(7);
+        expect(result.paragraph).toBe(1);
+        expect(result.all).toBe(8);
+    });
+
+    it('splits paragraphs on blank lines', () => {
+        const result = wordCount('a\n\nb\n\nc');
+        expect(result.paragraph).toBe(3);
+        expect(result.word).toBe(3);
+        expect(result.character).toBe(3);
+        expect(result.all).toBe(7);
+    });
+
+    it('returns all zeros for the empty string', () => {
+        expect(wordCount('')).toEqual({
+            word: 0,
+            character: 0,
+            paragraph: 0,
+            all: 0,
+        });
+    });
+});


### PR DESCRIPTION
## What

Backfills **engine-unit test coverage** (`packages/muya`, `@muyajs/core`) for behaviors identified as untested in a coverage-gap audit. Each gap was re-verified against the **current** code first — a large fraction of the original list was already covered by specs added during the muyajs → @muyajs/core migration, so this PR only adds tests for genuinely-open, automatable gaps.

**Test-only change** — no engine source was modified.

## Coverage added (7 commits, ~210 new assertions across 30 files)

- **Search** — `matchString` case-sensitivity / whole-word / regexp (incl. invalid-pattern no-throw and capture groups); new `Search` module spec for live match counting, `.mu-highlight`/`.mu-selection` classes, next/previous wraparound, and cross-block replace-all.
- **State serialization / parsing** — code-block empty-line trimming, setext / thematic-break / HTML-block parsing, table alignment round-trip (`:---` / `:---:` / `---:`), bullet-marker & order-delimiter & loose-item options, ordered-list start preservation.
- **Content-block key handlers** — paragraph Enter split + syntax-line conversions (fence / `$$` / table / `<tag>`, with escaped-pipe and void-tag guards), Tab insert/indent/format-skip, code-block Enter/Shift-Enter/backspace-to-paragraph, lang-input Enter/Backspace, table-cell Enter (soft break / row nav / new row) and arrow navigation.
- **Inline format & selection** — bold/italic/underline/strike serialize round-trips, link-apply hides the format picker, backspace around inline markers (muya#113), `getFormatsInRange` overlapping strong+em.
- **Option wiring** — autoPair bracket/markdown/quote OFF branches, autoCheck OFF (no cascade), `codeBlockLineNumbers` gutter assembly + non-code suppression, `superSubScript`-off literal rendering, `frontmatterType`.
- **Table / diagram / menus** — column alignment toggling, diagram preview empty/invalid/click-routing, heading promote/demote clamp + HR insertion.
- **Utils & UI** — `wordCount` (CJK + paragraph counting), built-in locale key-set completeness across all shipped languages, quick-insert fuzzy search via `i18nTitle` + no-result, emoji selector render/select/localized categories.

## Behavior findings (characterized as passing tests, not fixed here)

1. **Indented → fenced loses the language tag.** Promoting an indented code block to fenced (`CodeBlock set lang`) mutates the live block and dispatches a `meta.type` OT op but **never a `meta.lang` op**, so `getMarkdown()` / JSON state emit a bare ```` ``` ```` fence with `lang: ''` even though the live block shows `lang: 'js'`. The user's chosen language is dropped on save. Tests assert the current (buggy) behavior so a future fix flips them deliberately.
2. **`frontmatterType` is not retroactive.** `setOptions({ frontmatterType }, true)` does not rewrite an existing frontmatter block's fences (serialization keys off the block's own parse-time `meta.lang`/`style`); the option only governs newly-inserted frontmatter. Tests document both behaviors. Whether (1) and the retroactive case are bugs to fix is a product call — flagged for follow-up.

## Verification

- `pnpm -C packages/muya test` → **115 files / 964 tests pass**
- `pnpm -C packages/muya lint:types` (tsc --noEmit) → clean
- `pnpm -C packages/muya exec eslint` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
