### PR TITLE
test(desktop): backfill renderer/main unit coverage for audited gaps

### DIFF
--- a/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `@/store/editor` transitively imports `@/config`, which reads
+// `window.path.sep` at module load (normally injected by the preload bridge).
+// It also reaches `window.electron.clipboard` / `window.electron.ipcRenderer`
+// at runtime. Stub the surfaces before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: {
+        clipboard: { writeText: (s: string) => void }
+        ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void }
+      }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+// The notification service touches the DOM / template HTML; stub it so we can
+// observe `notify` without rendering a toast.
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+import bus from '@/bus'
+import notice from '@/services/notification'
+
+describe('useEditorStore FORMAT_LINK_CLICK (anchor links)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('emits scroll-to-header with the matching block slug for an in-doc anchor', () => {
+    const store = useEditorStore()
+    store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FORMAT_LINK_CLICK({ data: { href: '#installation' }, dirname: '' })
+
+    expect(emitSpy).toHaveBeenCalledWith('scroll-to-header', 'uid-1')
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for an anchor that matches no TOC github-slug', () => {
+    const store = useEditorStore()
+    store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FORMAT_LINK_CLICK({ data: { href: '#nope' }, dirname: '' })
+
+    expect(emitSpy).not.toHaveBeenCalled()
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('ignores a bare "#" (empty anchor slug) without emit or IPC', () => {
+    const store = useEditorStore()
+    store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FORMAT_LINK_CLICK({ data: { href: '#' }, dirname: '' })
+
+    expect(emitSpy).not.toHaveBeenCalled()
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('forwards a non-anchor link to the main process over IPC', () => {
+    const store = useEditorStore()
+    store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    const payload = { data: { href: 'http://x' }, dirname: '/docs' }
+    store.FORMAT_LINK_CLICK(payload)
+
+    expect(emitSpy).not.toHaveBeenCalledWith('scroll-to-header', expect.anything())
+    expect(sendSpy).toHaveBeenCalledWith('mt::format-link-click', {
+      data: { href: 'http://x' },
+      dirname: '/docs'
+    })
+  })
+})
+
+describe('useEditorStore copyGithubSlug', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('copies "#<githubSlug>" of the matched block id to the clipboard and notifies', () => {
+    const store = useEditorStore()
+    store.listToc = [{ slug: 'uid-1', githubSlug: 'getting-started', lvl: 2 }]
+
+    const writeSpy = vi.spyOn(window.electron.clipboard, 'writeText')
+
+    store.copyGithubSlug('uid-1')
+
+    expect(writeSpy).toHaveBeenCalledWith('#getting-started')
+    expect(notice.notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing (no clipboard write, no notify) when the id is not in the TOC', () => {
+    const store = useEditorStore()
+    store.listToc = [{ slug: 'uid-1', githubSlug: 'getting-started', lvl: 2 }]
+
+    const writeSpy = vi.spyOn(window.electron.clipboard, 'writeText')
+
+    store.copyGithubSlug('missing')
+
+    expect(writeSpy).not.toHaveBeenCalled()
+    expect(notice.notify).not.toHaveBeenCalled()
+  })
+})

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// `@/util/pdf` (imported transitively for `getHtmlToc`) and the export wrapper
+// reach `window.path` / `window.fileUtils` / `window.marktext` via the preload
+// bridge. Stub the surfaces the modules touch before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; join?: (...parts: string[]) => string }
+      fileUtils?: unknown
+      marktext?: unknown
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', join: (...parts: string[]) => parts.join('/') }
+})
+
+import { exportStyledHTML } from '@/util/exportHtml'
+import { getHtmlToc, type TocEntry } from '@/util/pdf'
+
+// `exportStyledHTML(muya, markdown, options)` renders through the real
+// `@muyajs/core` `MarkdownToHtml` engine (which runs in jsdom). The first arg is
+// a Muya instance, but the engine treats it as optional — the export path only
+// reads a few `muya.options.*` flags with `??` defaults — so the desktop wrapper
+// works with a bare `null` here, matching the engine's own parity suite which
+// calls `new MarkdownToHtml(md).generate(...)` with no muya.
+const NO_MUYA = null as unknown as Parameters<typeof exportStyledHTML>[0]
+
+describe('exportStyledHTML — wrapper parity', () => {
+  it('emits a self-contained document: inline <style> blocks, no CDN <link>', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi\n\ntext', {})
+
+    // The engine inlines github-markdown-css / katex / prism as <style> blocks
+    // by default (inlineStyles: true) instead of CDN <link rel="stylesheet">
+    // tags — so a saved file renders offline / behind CSP.
+    expect(out).toContain('<style>')
+    expect(out).not.toMatch(/<link[^>]+rel="stylesheet"[^>]+href="https:\/\//)
+    expect(out).not.toMatch(/href="https:\/\/cdnjs\.cloudflare\.com/)
+  })
+
+  it('wraps the rendered body in exactly one <article class="markdown-body"> with the rendered <h1>', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi\n\ntext', {})
+
+    expect((out.match(/<article class="markdown-body">/g) || []).length).toBe(1)
+    // Heading rendered, and the engine injects a github-compatible slug id.
+    expect(out).toMatch(/<h1[^>]*\sid="hi"[^>]*>Hi<\/h1>/)
+    expect(out).toContain('<p>text</p>')
+  })
+
+  it('cleanly replaces <body> exactly once (no duplicate <body>)', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi\n\ntext', {})
+
+    expect((out.match(/<body>/g) || []).length).toBe(1)
+    expect((out.match(/<\/body>/g) || []).length).toBe(1)
+    const body = /<body>([\s\S]*)<\/body>/.exec(out)![1]
+    expect(body).toContain('<article class="markdown-body">')
+    expect(body).not.toContain('<body>')
+  })
+})
+
+describe('exportStyledHTML — [TOC] expansion and slug matching', () => {
+  // Mirror what `muya.getTOC()` returns ({ lvl, content } per heading, content
+  // being the RAW markdown heading text). `getHtmlToc` re-slugs `content`; the
+  // engine slugs each heading's rendered textContent — both via the SAME
+  // `generateGithubSlug`, so for plain-text headings the anchors line up.
+  const MD = [
+    '# Getting Started',
+    '',
+    '[TOC]',
+    '',
+    '## Installation',
+    '',
+    'first',
+    '',
+    '## Installation',
+    '',
+    'second',
+    '',
+    '## Use **bold** and [a link](http://x)'
+  ].join('\n')
+
+  const TOC: TocEntry[] = [
+    { lvl: 1, content: 'Getting Started' },
+    { lvl: 2, content: 'Installation' },
+    { lvl: 2, content: 'Installation' },
+    { lvl: 2, content: 'Use **bold** and [a link](http://x)' }
+  ]
+
+  it('replaces the rendered <p>[TOC]</p> with the toc list', async() => {
+    const toc = getHtmlToc(TOC, {})
+    const out = await exportStyledHTML(NO_MUYA, MD, { toc })
+
+    expect(out).toContain('toc-container')
+    expect(out).toContain('Table of Contents')
+    // The literal [TOC] paragraph is gone — replaced by the toc list.
+    expect(out).not.toMatch(/<p>\s*\[TOC\]\s*<\/p>/i)
+  })
+
+  it('dedups repeated headings: two "Installation" → installation / installation-1, with matching anchors', async() => {
+    const toc = getHtmlToc(TOC, {})
+    const out = await exportStyledHTML(NO_MUYA, MD, { toc })
+
+    // Engine-written heading ids in document order.
+    const ids = [...out.matchAll(/<h[1-6][^>]*\sid="([^"]+)"/g)].map((m) => m[1])
+    expect(ids).toEqual([
+      'getting-started',
+      'installation',
+      'installation-1',
+      'use-bold-and-a-link'
+    ])
+
+    // The two plain-text anchors resolve to real heading ids.
+    expect(out).toContain('href="#installation"')
+    expect(out).toContain('href="#installation-1"')
+    expect(ids).toContain('installation')
+    expect(ids).toContain('installation-1')
+  })
+
+  it('SLUG DIVERGENCE: a heading with inline markup produces a TOC anchor that does NOT match the heading id', async() => {
+    const toc = getHtmlToc(TOC, {})
+    const out = await exportStyledHTML(NO_MUYA, MD, { toc })
+
+    const hrefs = [...out.matchAll(/href="#([^"]+)"/g)].map((m) => m[1])
+    const ids = [...out.matchAll(/<h[1-6][^>]*\sid="([^"]+)"/g)].map((m) => m[1])
+
+    // getHtmlToc slugs the RAW markdown content "Use **bold** and [a link](http://x)"
+    // → "use-bold-and-a-linkhttpx" (only `*[]():/` etc. stripped as non-\w, so
+    // the "httpx" of "http://x" survives). The engine slugs the heading's
+    // rendered textContent "Use bold and a link" → "use-bold-and-a-link". The
+    // two diverge, so this anchor is a DEAD link in the exported document.
+    expect(hrefs).toContain('use-bold-and-a-linkhttpx')
+    expect(ids).toContain('use-bold-and-a-link')
+    expect(ids).not.toContain('use-bold-and-a-linkhttpx')
+    expect(hrefs).not.toContain('use-bold-and-a-link')
+  })
+
+  it('does not inject the toc when the document has no [TOC] marker', async() => {
+    const toc = getHtmlToc(TOC, {})
+    const out = await exportStyledHTML(NO_MUYA, '# Getting Started\n\n## Installation\n', {
+      toc
+    })
+
+    expect(out).not.toContain('toc-container')
+  })
+})
+
+describe('exportStyledHTML — header/footer assembly', () => {
+  it('type:2 + headerFooterStyled:true → styled page table with all parts', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', {
+      header: { type: 2, left: 'L', center: 'C', right: 'R' },
+      footer: { type: 2, center: 'FC' },
+      headerFooterStyled: true
+    })
+
+    expect(out).toContain('page-container')
+    // type !== 1 → no 'single'; headerFooterStyled === true → ' styled'.
+    expect(out).toMatch(/class="page-header\s+styled"/)
+    expect(out).toContain('header-content-left')
+    expect(out).toContain('header-content-right')
+    expect(out).toMatch(/<div class="header-content">C<\/div>/)
+    // A hidden footer placeholder row inside the table, plus a fixed real footer.
+    expect(out).toContain('page-footer-fake')
+    expect(out).toMatch(/class="page-footer\s+styled"/)
+    expect(out).toMatch(/<div class="footer-content">FC<\/div>/)
+  })
+
+  it('type:1 + headerFooterStyled:false → single + simple', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', {
+      header: { type: 1, center: 'C' },
+      headerFooterStyled: false
+    })
+
+    expect(out).toContain('page-container')
+    // type === 1 → 'single'; headerFooterStyled === false → ' simple'.
+    expect(out).toMatch(/page-header[^"]*single/)
+    expect(out).toMatch(/page-header[^"]*simple/)
+  })
+
+  it('no header/footer → no page-container table', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', {})
+
+    expect(out).not.toContain('page-container')
+    expect(out).not.toContain('page-footer')
+    // Body is just the plain article.
+    const body = /<body>([\s\S]*)<\/body>/.exec(out)![1]
+    expect(body.trim()).toMatch(/^<article class="markdown-body">/)
+  })
+
+  it('a footer alone still builds the page table (real footer + fake footer row)', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', {
+      footer: { type: 2, center: 'only-footer' }
+    })
+
+    expect(out).toContain('page-container')
+    expect(out).toContain('page-footer-fake')
+    // No type and no headerFooterStyled → bare `page-footer` class (sanitize
+    // collapses the trailing space the template leaves behind).
+    expect(out).toMatch(/class="page-footer"/)
+    expect(out).toContain('only-footer')
+  })
+})
+
+describe('exportStyledHTML — relative image paths', () => {
+  it('preserves a relative img src (not stripped by sanitize)', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '![alt](./a.png)', {})
+
+    expect(out).toMatch(/<img[^>]+src="\.\/a\.png"/)
+    expect(out).toContain('alt="alt"')
+  })
+})

--- a/packages/desktop/test/unit/specs/format-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/format-menu-state.spec.ts
@@ -11,6 +11,14 @@ vi.hoisted(() => {
 
 import { createSelectionFormatState } from '@/store/editor'
 import { updateFormatMenu } from 'main_renderer/menu/actions/format'
+// The toolbar config is a deep subpath of @muyajs/core that vite resolves at
+// runtime but whose types are not exposed via the package `exports` map.
+// @ts-expect-error deep @muyajs/core subpath resolves at runtime (vite) but exposes no types
+import inlineFormatIcons from '@muyajs/core/ui/inlineFormatToolbar/config'
+import keybindingsWindows from 'main_renderer/keyboard/keybindingsWindows'
+import keybindingsLinux from 'main_renderer/keyboard/keybindingsLinux'
+
+interface IInlineFormatIcon { type: string, shortcut?: string }
 
 // Mimic the Electron application menu surface `updateFormatMenu` touches:
 // `getMenuItemById('formatMenuItem')` returning an object whose
@@ -89,5 +97,96 @@ describe('updateFormatMenu', () => {
     updateFormatMenu(menu, createSelectionFormatState([]))
 
     expect(checkedIds(menu)).toEqual([])
+  })
+})
+
+// Two surfaces advertise inline-format shortcuts to the user:
+//  - the desktop Format menu accelerators (keybindings*.ts → menu/templates/format.ts)
+//  - the muya InlineFormatToolbar (`@muyajs/core` config.ts → tooltip badge)
+// They are NOT derived from a single source, so they can drift. The test env is
+// non-osx (jsdom userAgent has no "Mac"), so the toolbar config renders with the
+// `Ctrl` COMMAND_KEY — line it up against the non-osx (Windows/Linux) keybindings.
+describe('Format-menu accelerators vs muya inlineFormatToolbar shortcuts', () => {
+  // muya toolbar `type` → desktop keybinding id (menu item accelerator source).
+  const TYPE_TO_KEYBINDING: Readonly<Record<string, string>> = {
+    strong: 'format.strong',
+    em: 'format.emphasis',
+    u: 'format.underline',
+    del: 'format.strike',
+    mark: 'format.highlight',
+    inline_code: 'format.inline-code',
+    inline_math: 'format.inline-math',
+    link: 'format.hyperlink',
+    image: 'format.image',
+    clear: 'format.clear-format'
+  }
+
+  // Canonical form so display notation (`⇧+Ctrl+H`, `⌘`) and Electron accelerator
+  // notation (`Ctrl+Shift+H`, `Command`) compare equal: sorted modifier set + key.
+  const normalizeShortcut = (raw: string | undefined | null): string => {
+    if (!raw) return ''
+    const mods = new Set<string>()
+    let key = ''
+    for (const part of raw.split('+').map((p) => p.trim()).filter(Boolean)) {
+      const lower = part.toLowerCase()
+      if (lower === 'ctrl' || lower === 'control' || lower === '⌃') mods.add('ctrl')
+      else if (lower === 'cmd' || lower === 'command' || lower === '⌘') mods.add('cmd')
+      else if (lower === 'cmdorctrl' || lower === 'commandorcontrol') mods.add('cmdorctrl')
+      else if (lower === 'shift' || lower === '⇧') mods.add('shift')
+      else if (lower === 'alt' || lower === 'option' || lower === '⌥') mods.add('alt')
+      else key = lower
+    }
+    return [...[...mods].sort(), `KEY=${key}`].join('+')
+  }
+
+  const toolbarShortcutOf = (type: string): string | undefined =>
+    (inlineFormatIcons as IInlineFormatIcon[]).find((i) => i.type === type)?.shortcut
+
+  it('confirms the test env is the non-osx (Ctrl) variant', () => {
+    // The toolbar config picks COMMAND_KEY from `isOsx`; jsdom is non-osx here.
+    expect(toolbarShortcutOf('strong')).toBe('Ctrl+B')
+  })
+
+  // strong/em are the requested reconcilable mapping, plus the rest of the set
+  // that agrees once notation is normalized.
+  const RECONCILABLE = ['strong', 'em', 'u', 'del', 'mark', 'link', 'image', 'clear'] as const
+
+  it.each(RECONCILABLE)(
+    'toolbar shortcut for "%s" matches the Format-menu accelerator (Windows + Linux)',
+    (type) => {
+      const kbId = TYPE_TO_KEYBINDING[type]
+      const toolbar = normalizeShortcut(toolbarShortcutOf(type))
+      expect(toolbar).not.toBe('')
+      expect(normalizeShortcut(keybindingsWindows.get(kbId))).toBe(toolbar)
+      expect(normalizeShortcut(keybindingsLinux.get(kbId))).toBe(toolbar)
+    }
+  )
+
+  // CHARACTERIZATION of a real drift (see suspectedBugs): the @muyajs/core toolbar
+  // advertises Ctrl+E / ⇧+Ctrl+E for inline code / inline math, but the Format
+  // menu binds Ctrl+` (Win) / Ctrl+Y (Linux) and Ctrl+Shift+M respectively.
+  it('inlineCode shortcut DIVERGES between toolbar and menu accelerator', () => {
+    const toolbar = normalizeShortcut(toolbarShortcutOf('inline_code'))
+    expect(toolbar).toBe(normalizeShortcut('Ctrl+E'))
+    expect(normalizeShortcut(keybindingsWindows.get('format.inline-code'))).toBe(
+      normalizeShortcut('Ctrl+`')
+    )
+    expect(normalizeShortcut(keybindingsLinux.get('format.inline-code'))).toBe(
+      normalizeShortcut('Ctrl+Y')
+    )
+    expect(normalizeShortcut(keybindingsWindows.get('format.inline-code'))).not.toBe(toolbar)
+    expect(normalizeShortcut(keybindingsLinux.get('format.inline-code'))).not.toBe(toolbar)
+  })
+
+  it('inlineMath shortcut DIVERGES between toolbar and menu accelerator', () => {
+    const toolbar = normalizeShortcut(toolbarShortcutOf('inline_math'))
+    expect(toolbar).toBe(normalizeShortcut('Shift+Ctrl+E'))
+    expect(normalizeShortcut(keybindingsWindows.get('format.inline-math'))).toBe(
+      normalizeShortcut('Ctrl+Shift+M')
+    )
+    expect(normalizeShortcut(keybindingsLinux.get('format.inline-math'))).toBe(
+      normalizeShortcut('Ctrl+Shift+M')
+    )
+    expect(normalizeShortcut(keybindingsWindows.get('format.inline-math'))).not.toBe(toolbar)
   })
 })

--- a/packages/desktop/test/unit/specs/image-path-autocomplete.spec.ts
+++ b/packages/desktop/test/unit/specs/image-path-autocomplete.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { searchFilesAndDir, watchers } from 'main_renderer/utils/imagePathAutoComplement'
+
+// `searchFilesAndDir` is a main-process helper backed by real Node `fs`:
+// it reads a directory, keeps only sub-directories + image files, fuzzy
+// filters by `key`, caches the result and starts an `fs.watch` watcher.
+// Each test gets a fresh disposable temp dir so the module-level cache never
+// crosses test boundaries, and every watcher is torn down afterwards.
+
+const seedDir = (): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mt-img-ac-'))
+  fs.writeFileSync(path.join(dir, 'a.png'), '')
+  fs.writeFileSync(path.join(dir, 'b.jpg'), '')
+  fs.writeFileSync(path.join(dir, 'notes.txt'), '')
+  fs.mkdirSync(path.join(dir, 'images'))
+  return dir
+}
+
+let tmpDirs: string[] = []
+
+beforeEach(() => {
+  tmpDirs = []
+})
+
+afterEach(() => {
+  for (const [dir, watcher] of watchers) {
+    watcher.close()
+    watchers.delete(dir)
+  }
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('searchFilesAndDir', () => {
+  it('returns image files as "image", sub-directories as "directory", and excludes non-image files', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    const result = await searchFilesAndDir(dir, '')
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { file: 'a.png', type: 'image' },
+        { file: 'b.jpg', type: 'image' },
+        { file: 'images', type: 'directory' }
+      ])
+    )
+    expect(result).toHaveLength(3)
+    expect(result.some((e) => e.file === 'notes.txt')).toBe(false)
+    expect(result.find((e) => e.file === 'images')?.type).toBe('directory')
+  })
+
+  it('starts watching the directory it scans', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    await searchFilesAndDir(dir, '')
+
+    expect(watchers.has(dir)).toBe(true)
+  })
+
+  it('fuzzy-filters entries by key (every match contains the typed character)', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    const result = await searchFilesAndDir(dir, 'a')
+
+    // fuzzaldrin matches every candidate whose name contains the subsequence
+    // 'a': both "a.png" and "images" qualify, while "b.jpg" is dropped.
+    expect(result.map((e) => e.file).sort()).toEqual(['a.png', 'images'])
+  })
+
+  it('narrows to a single image when the key is specific enough', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    const result = await searchFilesAndDir(dir, 'a.p')
+
+    expect(result).toEqual([{ file: 'a.png', type: 'image' }])
+  })
+
+  it('serves a repeated lookup of the same directory from the cache', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    await searchFilesAndDir(dir, '')
+    // Mutate the directory on disk; the cached result must be returned as-is.
+    fs.writeFileSync(path.join(dir, 'c.gif'), '')
+
+    const cached = await searchFilesAndDir(dir, '')
+
+    expect(cached.map((e) => e.file).sort()).toEqual(['a.png', 'b.jpg', 'images'])
+    expect(cached.some((e) => e.file === 'c.gif')).toBe(false)
+  })
+
+  it('rejects when the directory cannot be read', async() => {
+    const missing = path.join(os.tmpdir(), 'mt-img-ac-does-not-exist-xyz')
+
+    await expect(searchFilesAndDir(missing, '')).rejects.toBeTruthy()
+  })
+})

--- a/packages/desktop/test/unit/specs/listen-for-main.spec.ts
+++ b/packages/desktop/test/unit/specs/listen-for-main.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `listenForMain` pulls in the layout store, which transitively imports the
+// preferences store and `@/config` (the latter reads `window.path.sep` at
+// module load). Stub the contextBridge surfaces before the hoisted imports run
+// so the store graph can load.
+vi.hoisted(() => {
+  const w = globalThis as unknown as { window?: { path?: { sep: string } } }
+  w.window ??= {}
+  w.window.path ??= { sep: '/' }
+})
+
+import { useListenForMainStore } from '@/store/listenForMain'
+import { useLayoutStore } from '@/store/layout'
+
+// `EDITOR_EDIT_ACTION('findInFolder')` routes through `layoutStore.SET_LAYOUT`,
+// which (because `showSideBar` is defined) reads `window.marktext.env`,
+// fires `window.electron.ipcRenderer.send`, and persists the sidebar
+// visibility preference (another `ipcRenderer.send`). The renderer i18n module
+// (pulled in via the preferences store) also reads `window.electron.ipcRenderer`
+// at import time. Provide spies for all of it.
+const win = window as unknown as {
+  electron?: { ipcRenderer: { on: Mock; send: Mock; invoke: Mock } }
+  marktext?: { env: { windowId: number } }
+}
+
+describe('listenForMain store EDITOR_EDIT_ACTION', () => {
+  beforeEach(() => {
+    win.electron = {
+      ipcRenderer: {
+        on: vi.fn(),
+        send: vi.fn(),
+        invoke: vi.fn(() => Promise.resolve(false))
+      }
+    }
+    win.marktext = { env: { windowId: 1 } }
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    delete win.electron
+    delete win.marktext
+    vi.clearAllMocks()
+  })
+
+  it("opens the search side panel for 'findInFolder'", () => {
+    const layoutStore = useLayoutStore()
+    expect(layoutStore.rightColumn).toBe('files')
+    expect(layoutStore.showSideBar).toBe(false)
+
+    useListenForMainStore().EDITOR_EDIT_ACTION('findInFolder')
+
+    expect(layoutStore.rightColumn).toBe('search')
+    expect(layoutStore.showSideBar).toBe(true)
+  })
+
+  it('does not mutate the layout for a non-findInFolder action', () => {
+    const layoutStore = useLayoutStore()
+    layoutStore.$patch({ rightColumn: 'files', showSideBar: false })
+
+    useListenForMainStore().EDITOR_EDIT_ACTION('insertParagraph')
+
+    expect(layoutStore.rightColumn).toBe('files')
+    expect(layoutStore.showSideBar).toBe(false)
+  })
+})

--- a/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
+++ b/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
@@ -47,4 +47,35 @@ describe('moveImageToFolder relative-directory persistence', () => {
     expect(path.isAbsolute(result)).toBe(false)
     expect(result.startsWith('assets/')).toBe(true)
   })
+
+  it('returns the absolute hashed path for a local path string when isRelative is false', async() => {
+    const source = '/Users/someone/pictures/pic.png'
+    const result = await moveImageToFolder(docPath, source, assetsDir, false, docPath)
+    // copy still lands inside the assets dir...
+    expect(copy).toHaveBeenCalledTimes(1)
+    expect(copy.mock.calls[0][1].startsWith(assetsDir)).toBe(true)
+    // ...and with isRelative=false the returned reference is the absolute
+    // hashed destination path (the second arg passed to copy).
+    expect(path.isAbsolute(result)).toBe(true)
+    expect(result).toBe(copy.mock.calls[0][1])
+    expect(result.startsWith(`${assetsDir}${path.sep}`)).toBe(true)
+  })
+
+  it('short-circuits without copying when the image already lives in outputDir', async() => {
+    // The resolved imagePath equals path.join(outputDir, basename) so
+    // noHashPath === imagePath and the copy step is skipped.
+    const inPlace = path.join(assetsDir, 'already.png')
+    const result = await moveImageToFolder(docPath, inPlace, assetsDir, false, docPath)
+    expect(copy).not.toHaveBeenCalled()
+    // The original absolute path is returned unchanged (isRelative=false).
+    expect(result).toBe(inPlace)
+  })
+
+  it('short-circuits to a relative reference when isRelative is set and the image is in outputDir', async() => {
+    const inPlace = path.join(assetsDir, 'already.png')
+    const result = await moveImageToFolder(docPath, inPlace, assetsDir, true, docPath)
+    expect(copy).not.toHaveBeenCalled()
+    expect(path.isAbsolute(result)).toBe(false)
+    expect(result.startsWith('assets/')).toBe(true)
+  })
 })

--- a/packages/desktop/test/unit/specs/pdf.spec.ts
+++ b/packages/desktop/test/unit/specs/pdf.spec.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// `@/util/pdf` reads `window.path.join` and (for disk themes)
+// `window.marktext.paths` / `window.fileUtils` at call time, all normally
+// injected by the preload bridge. Stub the surface before the hoisted imports
+// run so the module graph can load. Per-test overrides below swap the
+// `window.fileUtils` behavior via `vi.resetModules()` + dynamic import.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string, join: (...parts: string[]) => string }
+      marktext?: { paths: { userDataPath: string } }
+      fileUtils?: { isFile: (p: string) => Promise<boolean>, readFile: (p: string) => Promise<unknown> }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', join: (...parts: string[]) => parts.join('/') }
+  w.window.marktext ??= { paths: { userDataPath: '/userData' } }
+  w.window.fileUtils ??= { isFile: async() => false, readFile: async() => '' }
+})
+
+// NOTE: `academic.theme.css?inline` / `liber.theme.css?inline` resolve to an
+// EMPTY string under vitest (no CSS `?inline` transform is configured), so the
+// academic/liber branch contributes no CSS in this environment. We therefore
+// characterize the branch *dispatch* (academic/liber take the inline path and
+// never touch `window.fileUtils`/`window.marktext`, unlike a disk theme name)
+// rather than asserting a theme-specific selector token, which is unavailable
+// here. See suspectedBugs / notes.
+
+const loadPdf = async() => {
+  return import('@/util/pdf')
+}
+
+describe('getCssForOptions', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    const w = globalThis as unknown as {
+      window: {
+        marktext: { paths: { userDataPath: string } }
+        fileUtils: { isFile: (p: string) => Promise<boolean>, readFile: (p: string) => Promise<unknown> }
+      }
+    }
+    w.window.marktext = { paths: { userDataPath: '/userData' } }
+    w.window.fileUtils = { isFile: async() => false, readFile: async() => '' }
+  })
+
+  it('academic/liber take the inline-theme branch (no disk access required)', async() => {
+    const { getCssForOptions } = await loadPdf()
+    // Remove the disk surfaces entirely: if academic/liber tried a disk read
+    // these would throw. They must not.
+    const w = globalThis as unknown as { window: Record<string, unknown> }
+    delete w.window.marktext
+    delete w.window.fileUtils
+
+    await expect(getCssForOptions({ theme: 'academic' })).resolves.toBeTypeOf('string')
+    await expect(getCssForOptions({ theme: 'liber' })).resolves.toBeTypeOf('string')
+  })
+
+  it('appends no theme CSS for theme:"default" (disk lookup misses) or {}', async() => {
+    const { getCssForOptions } = await loadPdf()
+    // 'default' is NOT special-cased: it falls into the disk branch, which
+    // reads window.marktext.paths + window.fileUtils.isFile (→ false here).
+    const def = await getCssForOptions({ theme: 'default' })
+    const empty = await getCssForOptions({})
+
+    // Both produce the same base stylesheet (no theme block appended).
+    expect(def).toBe(empty)
+    expect(def).not.toContain('Georgia')
+    expect(def).toContain('.markdown-body{')
+  })
+
+  it('reads a custom theme name from disk via window.fileUtils', async() => {
+    const isFile = vi.fn(async() => true)
+    const readFile = vi.fn(async() => '.custom{}')
+    const w = globalThis as unknown as {
+      window: { fileUtils: { isFile: typeof isFile, readFile: typeof readFile } }
+    }
+    w.window.fileUtils = { isFile, readFile }
+
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ theme: 'mytheme' })
+
+    expect(css).toContain('.custom{}')
+    expect(isFile).toHaveBeenCalledWith('/userData/themes/export/mytheme')
+  })
+
+  it('omits the disk theme CSS when the theme file is absent', async() => {
+    const w = globalThis as unknown as {
+      window: { fileUtils: { isFile: () => Promise<boolean>, readFile: () => Promise<unknown> } }
+    }
+    w.window.fileUtils = { isFile: async() => false, readFile: async() => '.custom{}' }
+
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ theme: 'mytheme' })
+
+    expect(css).not.toContain('.custom{}')
+  })
+
+  it('round-trips a disk theme containing CSS child-combinator (>) selectors', async() => {
+    // The whole stylesheet is escapeHTML → sanitize → unescapeHTML'd, so a `>`
+    // in a theme selector must survive the round-trip unmangled.
+    const w = globalThis as unknown as {
+      window: { fileUtils: { isFile: () => Promise<boolean>, readFile: () => Promise<string> } }
+    }
+    w.window.fileUtils = { isFile: async() => true, readFile: async() => '.a > .b{color:red}' }
+
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ theme: 'mytheme' })
+
+    expect(css).toContain('.a > .b{color:red}')
+  })
+
+  it('emits font-family/size/line-height rules into .markdown-body', async() => {
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ fontFamily: 'Foo', fontSize: 14, lineHeight: 1.6 })
+
+    expect(css).toContain('font-family:"Foo"')
+    expect(css).toContain('font-size:14px;')
+    expect(css).toContain('line-height:1.6;')
+    // The font-family also seeds the header/footer container.
+    expect(css).toContain('.hf-container{font-family:"Foo"')
+  })
+
+  it('adds heading auto-numbering CSS when autoNumberingHeadings is set', async() => {
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ autoNumberingHeadings: true })
+
+    expect(css).toContain('counter-reset')
+    expect(css).toContain('h2:before')
+  })
+
+  it('hides front matter when showFrontMatter is false, not when true', async() => {
+    const { getCssForOptions } = await loadPdf()
+    const hidden = await getCssForOptions({ showFrontMatter: false })
+    const shown = await getCssForOptions({ showFrontMatter: true })
+
+    expect(hidden).toContain('pre.front-matter{display:none')
+    expect(shown).not.toContain('pre.front-matter{display:none')
+  })
+
+  it('emits header/footer font-size rules when headerFooterFontSize is set', async() => {
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({ headerFooterFontSize: 9 })
+
+    expect(css).toContain('font-size: 9px;')
+    expect(css).toContain('.page-header .hf-container')
+  })
+
+  it('wraps printable CSS in an @media print @page block by default', async() => {
+    const { getCssForOptions } = await loadPdf()
+    const printable = await getCssForOptions({})
+    const styledHtml = await getCssForOptions({ type: 'styledHtml' })
+
+    expect(printable).toContain('@media print{@page{')
+    // type === 'styledHtml' is the only non-printable mode.
+    expect(styledHtml).not.toContain('@media print')
+  })
+})
+
+describe('getHtmlToc', () => {
+  it('renders a "Table of Contents" title and excludes the top H1 by default', async() => {
+    const { getHtmlToc } = await loadPdf()
+    const toc = [
+      { lvl: 1, content: 'Top' },
+      { lvl: 2, content: 'Sub' }
+    ]
+    const html = getHtmlToc(toc, {})
+
+    expect(html).toContain('class="toc-title"')
+    expect(html).toContain('Table of Contents')
+    // Top H1 is dropped, its sub-heading is kept.
+    expect(html).not.toContain('href="#top"')
+    expect(html).toContain('href="#sub"')
+  })
+
+  it('includes the top heading and honors a custom tocTitle', async() => {
+    const { getHtmlToc } = await loadPdf()
+    const toc = [
+      { lvl: 1, content: 'Top' },
+      { lvl: 2, content: 'Sub' }
+    ]
+    const html = getHtmlToc(toc, { tocTitle: 'Contents', tocIncludeTopHeading: true })
+
+    expect(html).toContain('Contents')
+    expect(html).toContain('href="#top"')
+    expect(html).toContain('href="#sub"')
+  })
+
+  it('clones its input — repeated calls are stable (the helper shifts internally)', async() => {
+    const { getHtmlToc } = await loadPdf()
+    const toc = [
+      { lvl: 1, content: 'Top' },
+      { lvl: 2, content: 'Sub' }
+    ]
+    const first = getHtmlToc(toc, { tocIncludeTopHeading: true })
+    const second = getHtmlToc(toc, { tocIncludeTopHeading: true })
+
+    expect(second).toBe(first)
+    // The caller's array is untouched (no shift leaked out).
+    expect(toc).toHaveLength(2)
+    expect(toc[0]).toEqual({ lvl: 1, content: 'Top' })
+  })
+
+  it('dedups identical heading slugs in document order with -N suffixes', async() => {
+    const { getHtmlToc } = await loadPdf()
+    const toc = [
+      { lvl: 2, content: 'Installation' },
+      { lvl: 2, content: 'Installation' }
+    ]
+    const html = getHtmlToc(toc, { tocIncludeTopHeading: true })
+
+    expect(html).toContain('href="#installation"')
+    expect(html).toContain('href="#installation-1"')
+  })
+
+  it('returns an empty string when the TOC has no qualifying entries', async() => {
+    const { getHtmlToc } = await loadPdf()
+    // A lone top-level H1 is shifted away by the default (exclude-top) path,
+    // leaving nothing to render.
+    expect(getHtmlToc([{ lvl: 1, content: 'Only' }], {})).toBe('')
+    expect(getHtmlToc([], {})).toBe('')
+  })
+})

--- a/packages/desktop/test/unit/specs/selection-menus.spec.ts
+++ b/packages/desktop/test/unit/specs/selection-menus.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+
+import { updateSelectionMenus } from 'main_renderer/menu/actions/paragraph'
+
+// Real paragraph submenu ids (see src/main/menu/templates/paragraph.ts). The
+// source reads the paragraph entry via getMenuItemById('paragraphMenuEntry').
+const PARAGRAPH_MENU_IDS = [
+  'heading1MenuItem',
+  'heading2MenuItem',
+  'heading3MenuItem',
+  'heading4MenuItem',
+  'heading5MenuItem',
+  'heading6MenuItem',
+  'upgradeHeadingMenuItem',
+  'degradeHeadingMenuItem',
+  'tableMenuItem',
+  'codeFencesMenuItem',
+  'quoteBlockMenuItem',
+  'mathBlockMenuItem',
+  'htmlBlockMenuItem',
+  'orderListMenuItem',
+  'bulletListMenuItem',
+  'taskListMenuItem',
+  'looseListItemMenuItem',
+  'paragraphMenuItem',
+  'horizontalLineMenuItem',
+  'frontMatterMenuItem'
+]
+
+// Real format submenu ids (see src/main/menu/templates/format.ts).
+const FORMAT_MENU_IDS = [
+  'strongMenuItem',
+  'emphasisMenuItem',
+  'underlineMenuItem',
+  'superscriptMenuItem',
+  'subscriptMenuItem',
+  'highlightMenuItem',
+  'inlineCodeMenuItem',
+  'inlineMathMenuItem',
+  'strikeMenuItem',
+  'hyperlinkMenuItem',
+  'imageMenuItem'
+]
+
+// `updateSelectionMenus` enables/disables (and re-checks) menu items via a
+// loosely-typed Electron application menu surface: `getMenuItemById(id)`
+// returns an object whose `submenu.items` are menu items keyed by `id`.
+const makeMenu = () => {
+  const paragraphItems = PARAGRAPH_MENU_IDS.map((id) => ({ id, enabled: true, checked: false }))
+  const formatItems = FORMAT_MENU_IDS.map((id) => ({ id, enabled: true, checked: false }))
+  return {
+    paragraphItems,
+    formatItems,
+    getMenuItemById: (id: string) => {
+      if (id === 'paragraphMenuEntry') return { submenu: { items: paragraphItems } }
+      if (id === 'formatMenuItem') return { submenu: { items: formatItems } }
+      return undefined
+    }
+  }
+}
+
+type FakeMenu = ReturnType<typeof makeMenu>
+
+const enabledIds = (items: FakeMenu['paragraphItems']) =>
+  items.filter((i) => i.enabled).map((i) => i.id)
+
+const disabledIds = (items: FakeMenu['paragraphItems']) =>
+  items.filter((i) => !i.enabled).map((i) => i.id)
+
+// The set the source disables for multiline selections (DISABLE_LABELS).
+const DISABLE_LABELS = [
+  'heading1MenuItem',
+  'heading2MenuItem',
+  'heading3MenuItem',
+  'heading4MenuItem',
+  'heading5MenuItem',
+  'heading6MenuItem',
+  'upgradeHeadingMenuItem',
+  'degradeHeadingMenuItem',
+  'tableMenuItem',
+  'hyperlinkMenuItem',
+  'imageMenuItem'
+]
+
+describe('updateSelectionMenus', () => {
+  it('disables every Paragraph submenu item when the selection is disabled (table/multi-block)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: {}, isDisabled: true })
+
+    expect(enabledIds(menu.paragraphItems)).toEqual([])
+    expect(menu.paragraphItems.every((i) => i.enabled === false)).toBe(true)
+  })
+
+  it('leaves the Format submenu fully enabled for a disabled selection (it is reset first)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: {}, isDisabled: true })
+
+    expect(menu.formatItems.every((i) => i.enabled === true)).toBe(true)
+  })
+
+  it('disables hyperlink/image (Format) and heading/table (Paragraph) for a multiline selection', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: {}, isMultiline: true })
+
+    // Format menu: only the DISABLE_LABELS entries it owns are disabled.
+    const formatItem = (id: string) => menu.formatItems.find((i) => i.id === id)!
+    expect(formatItem('hyperlinkMenuItem').enabled).toBe(false)
+    expect(formatItem('imageMenuItem').enabled).toBe(false)
+    expect(formatItem('strongMenuItem').enabled).toBe(true)
+    expect(formatItem('emphasisMenuItem').enabled).toBe(true)
+
+    // Paragraph menu: the DISABLE_LABELS heading/table entries are disabled.
+    const paraDisabled = disabledIds(menu.paragraphItems)
+    const expectedParaDisabled = DISABLE_LABELS.filter((id) => PARAGRAPH_MENU_IDS.includes(id))
+    // Plus the loose-list-item is disabled because affiliation has no ul/ol.
+    expect(paraDisabled.sort()).toEqual(
+      [...expectedParaDisabled, 'looseListItemMenuItem'].sort()
+    )
+  })
+
+  it('disables every Format submenu item for code content and re-enables codeFences (Paragraph)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, {
+      affiliation: { code: true },
+      isCodeFences: true,
+      isCodeContent: true
+    })
+
+    // Every format item is disabled inside code content.
+    expect(menu.formatItems.every((i) => i.enabled === false)).toBe(true)
+
+    // Paragraph submenu is disabled wholesale by isCodeFences...
+    const paraItem = (id: string) => menu.paragraphItems.find((i) => i.id === id)!
+    expect(paraItem('paragraphMenuItem').enabled).toBe(false)
+    expect(paraItem('heading1MenuItem').enabled).toBe(false)
+    // ...except codeFencesMenuItem is re-enabled because affiliation has a code element.
+    expect(paraItem('codeFencesMenuItem').enabled).toBe(true)
+  })
+
+  it('disables loose-list-item when the affiliation has neither ul nor ol', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: { p: true } })
+
+    const loose = menu.paragraphItems.find((i) => i.id === 'looseListItemMenuItem')!
+    expect(loose.enabled).toBe(false)
+  })
+
+  it('keeps loose-list-item enabled when the affiliation is a list (ul/ol)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: { ul: true } })
+
+    const loose = menu.paragraphItems.find((i) => i.id === 'looseListItemMenuItem')!
+    expect(loose.enabled).toBe(true)
+  })
+
+  it('checks the matching paragraph item via the affiliation -> menu id map', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu, { affiliation: { h1: true } })
+
+    const checked = menu.paragraphItems.filter((i) => i.checked).map((i) => i.id)
+    expect(checked).toEqual(['heading1MenuItem'])
+  })
+})

--- a/packages/desktop/test/unit/specs/spellchecker-switch-language.spec.ts
+++ b/packages/desktop/test/unit/specs/spellchecker-switch-language.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+
+// The renderer SpellChecker reads `isOsx` from `@/util` (a top-level import
+// binding) and reaches Electron through `window.electron.ipcRenderer.invoke`.
+// We mock `@/util` per test to flip the platform branch, and stub the
+// contextBridge `window.electron` surface the class touches.
+const win = window as unknown as {
+  electron?: { ipcRenderer: { invoke: Mock } }
+}
+
+const loadSpellChecker = async(isOsx: boolean) => {
+  vi.resetModules()
+  vi.doMock('@/util', () => ({ isOsx }))
+  return (await import('../../../src/renderer/src/spellchecker/index')).SpellChecker
+}
+
+describe('renderer SpellChecker.switchLanguage', () => {
+  let invoke: Mock
+
+  beforeEach(() => {
+    invoke = vi.fn(() => Promise.resolve(true))
+    win.electron = { ipcRenderer: { invoke } }
+  })
+
+  afterEach(() => {
+    delete win.electron
+    vi.doUnmock('@/util')
+  })
+
+  it('invokes the IPC channel once and records the new language (non-macOS, enabled)', async() => {
+    const SpellChecker = await loadSpellChecker(false)
+    const checker = new SpellChecker(true, 'en-US')
+
+    const result = await checker.switchLanguage('de-DE')
+
+    expect(result).toBe(true)
+    expect(invoke).toHaveBeenCalledTimes(1)
+    expect(invoke).toHaveBeenCalledWith('mt::spellchecker-switch-language', 'de-DE')
+    expect(checker.lang).toBe('de-DE')
+    expect(checker.currentSpellcheckerLanguage).toBe('de-DE')
+  })
+
+  it('short-circuits to true on macOS without touching IPC', async() => {
+    const SpellChecker = await loadSpellChecker(true)
+    const checker = new SpellChecker(true, 'en-US')
+
+    const result = await checker.switchLanguage('de-DE')
+
+    expect(result).toBe(true)
+    expect(invoke).not.toHaveBeenCalled()
+    // The OS spell checker auto-detects language, so the stored language is
+    // left untouched.
+    expect(checker.currentSpellcheckerLanguage).toBe('en-US')
+  })
+
+  it('returns false without IPC when the spell checker is disabled (non-macOS)', async() => {
+    const SpellChecker = await loadSpellChecker(false)
+    const checker = new SpellChecker(false, 'en-US')
+
+    const result = await checker.switchLanguage('de-DE')
+
+    expect(result).toBe(false)
+    expect(invoke).not.toHaveBeenCalled()
+    expect(checker.currentSpellcheckerLanguage).toBe('en-US')
+  })
+
+  it('throws on an empty language when enabled (non-macOS) and never invokes IPC', async() => {
+    const SpellChecker = await loadSpellChecker(false)
+    const checker = new SpellChecker(true, 'en-US')
+
+    await expect(checker.switchLanguage('')).rejects.toThrow(
+      'Expected non-empty language for spell checker.'
+    )
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Backfills **desktop renderer/main unit-test coverage** (`packages/desktop`) for behaviors flagged untested in a coverage-gap audit, after re-verifying each gap against the **current** code. **Test-only change** — no app source was modified.

Companion to #4508 (muya engine tests); split per-package.

## Coverage added (4 commits, 66 tests across 9 files)

- **Menu state** — `updateSelectionMenus` disable matrix (table / multiline / code-fence / loose-list) and Format-menu ↔ toolbar shortcut parity.
- **Export / PDF** — `exportStyledHTML` (inline-CSS survival, `[TOC]` expansion, header/footer table assembly, relative `<img>` preservation) and `getCssForOptions` / `getHtmlToc` option branches.
- **Renderer store / IPC** — find-in-folder layout action, in-document anchor-link click + copy-heading-anchor, spellchecker language-switch IPC contract.
- **Image utils** — `searchFilesAndDir` fuzzy results + path cache, `moveImageToFolder` absolute-path + already-in-output-dir branches.

## Behavior findings (characterized as passing tests, not fixed here)

1. **Dead `[TOC]` anchors for headings with inline markup.** `getHtmlToc`/`assignHeadingSlugs` (`util/pdf.ts`) slugs the **raw markdown** heading content, while the engine (`markdownToHtml._injectHeadingIds`) slugs the **rendered** `textContent`. A heading like `## Use **bold** and [a link](http://x)` yields `href="#use-bold-and-a-linkhttpx"` vs `id="use-bold-and-a-link"` → the TOC link is dead. Plain-text headings (incl. the dedup chain) resolve fine.
2. **Inline code/math shortcut drift.** The @muyajs/core inline toolbar advertises `Ctrl+E` / `⇧+Ctrl+E`, but the Format menu binds `Ctrl+`` (Win) / `Ctrl+Y` (Linux) and `Ctrl+Shift+M`. The two surfaces aren't derived from one source, so they drift silently. The other 8 inline types reconcile.
3. **`pdf.ts` `theme:'default'`** is not special-cased; it falls into the disk-theme branch and dereferences `window.marktext.paths`, which would throw if that surface is absent.
4. **Dead `image-uploaded` bus listener.** `editor.vue` registers `bus.on('image-uploaded', …)` but nothing in the repo emits it; the deletion-URL notification path is unreachable. (The real upload flow runs inline via `await uploadImage(...)`.)

## Not unit-testable without a small source refactor (3 audited gaps deferred)

These live entirely inside Vue SFC `<script setup>` closures with no exports, so they can't be reached without extracting a pure helper (not done here, to keep this test-only):

- **`sourceCode.vue` `handleImageAction`** (image-action → source rewrite). Note: it also has an apparent **off-by-one** — `lines.findIndex(l => l.indexOf(id) > 0)` skips an image whose `![id](…)` starts at column 0 — worth a fix when extracted.
- **`editor.vue` `handleUploadedImage` / `insertImage`** (the dead-listener path above).
- **`editor.vue` table dialog** — row/col clamping (1–30 × 1–20) is enforced only by Element Plus `:min`/`:max` in the template; there is no JS clamp to unit-test.

## Verification

- `pnpm -C packages/desktop exec vitest run` → **14 files / 540 tests pass**
- `pnpm -C packages/desktop run typecheck` (vue-tsc --noEmit) → clean
- root `eslint` on changed files → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
