### PR TITLE
test(muya-e2e): backfill real-DOM e2e coverage for audited gaps

### DIFF
--- a/packages/muya/e2e/tests/blocks/reference-link-image.spec.ts
+++ b/packages/muya/e2e/tests/blocks/reference-link-image.spec.ts
@@ -59,6 +59,62 @@ test.describe('reference link', () => {
         await expect(anchor).toBeVisible();
         await expect(anchor).toHaveAttribute('href', 'https://example.com');
     });
+
+    test('editing the definition URL re-resolves the link href on re-render', async ({ page }) => {
+        // `InlineRenderer.collectReferenceDefinitions()` rebuilds the labels
+        // Map from the JSON state on every render pass, and `referenceLink.ts`
+        // reads `parent.labels.get(key)` for the href. Replacing the document
+        // with an updated definition therefore re-resolves `[a][r]` against the
+        // new URL when the link block re-patches.
+        await page.evaluate(() => {
+            window.muya!.setContent('[a][r]\n\n[r]: http://example.com\n');
+        });
+
+        const anchor = page.locator(editor.referenceLink).first();
+        await expect(anchor).toBeVisible();
+        await expect(anchor).toHaveAttribute('href', 'http://example.com');
+
+        // Swap only the definition's URL; the inline `[a][r]` text is unchanged.
+        await page.evaluate(() => {
+            window.muya!.setContent('[a][r]\n\n[r]: http://updated.example.org\n');
+        });
+
+        // After re-render the anchor mounts again and resolves the new href.
+        const updated = page.locator(editor.referenceLink).first();
+        await expect(updated).toBeVisible();
+        await expect(updated).toHaveAttribute('href', 'http://updated.example.org');
+
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('[a][r]');
+        expect(md).toContain('[r]: http://updated.example.org');
+    });
+
+    test('removing the definition leaves the reference unresolved (no anchor, literal text)', async ({ page }) => {
+        // The lexer only emits a `reference_link` token when the label is
+        // present in the labels Map (lexer.ts: `labels.has(...)` guard). With a
+        // matching definition the reference resolves to `a.mu-reference-link`.
+        // Dropping the definition means `[a][r]` is never tokenized as a
+        // reference at all — it renders as literal text, no anchor, no
+        // `span.mu-reference-link` either.
+        await page.evaluate(() => {
+            window.muya!.setContent('[a][r]\n\n[r]: http://example.com\n');
+        });
+
+        await expect(page.locator(editor.referenceLink).first()).toHaveAttribute(
+            'href',
+            'http://example.com',
+        );
+
+        await page.evaluate(() => {
+            window.muya!.setContent('[a][r]\n');
+        });
+
+        // No reference-link element of any kind survives an unresolved label.
+        await expect(page.locator('.mu-reference-link')).toHaveCount(0);
+        // The raw text round-trips through getMarkdown unchanged.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('[a][r]');
+    });
 });
 
 test.describe('reference image', () => {

--- a/packages/muya/e2e/tests/diagrams/flowchart.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/flowchart.spec.ts
@@ -1,0 +1,70 @@
+import type { TState } from '@muyajs/core';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+/**
+ * flowchart.js diagram rendering. The flowchart loader (packages/core/src/
+ * utils/diagram/index.ts) imports `flowchart.js`, calls `parse(code)` and then
+ * `diagram.drawSVG(target, options)` (see block/extra/diagram/diagramPreview.ts).
+ * flowchart.js draws through Raphael, which mounts a single `<svg>` element into
+ * the `.mu-diagram-preview` target.
+ *
+ * Unlike PlantUML this is fully client-side — no network, no mock. We assert the
+ * SVG mount and the markdown round-trip (the diagram serializes back to a
+ * ```flowchart fenced block carrying the original source).
+ */
+
+const FLOWCHART_SOURCE = 'st=>start: Start\ne=>end: End\nst->e';
+
+test.describe('flowchart diagram', () => {
+    test('setContent with a flowchart diagram mounts an SVG in the preview', async ({ page }) => {
+        await page.evaluate((text) => {
+            const state: TState[] = [{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'flowchart' },
+            }];
+            window.muya!.setContent(state);
+        }, FLOWCHART_SOURCE);
+
+        // flowchart.js draws the SVG synchronously after the loader resolves the
+        // dynamic import. Wait for the `<svg>` to mount under the preview.
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+
+        // A start -> end flow yields at least a couple of shape/connector
+        // elements. Use a permissive selector so a Raphael internal change
+        // (rect vs path) doesn't regress us.
+        const markCount = await page.evaluate(() => {
+            const root = document.querySelector('.mu-diagram-preview svg');
+            if (!root)
+                return 0;
+            return root.querySelectorAll('path, rect, text').length;
+        });
+        expect(markCount).toBeGreaterThan(0);
+    });
+
+    test('flowchart round-trips through getMarkdown', async ({ page }) => {
+        await page.evaluate((text) => {
+            const state: TState[] = [{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'flowchart' },
+            }];
+            window.muya!.setContent(state);
+        }, FLOWCHART_SOURCE);
+
+        // Wait for the SVG to mount as a sync barrier before reading markdown.
+        await expect(page.locator(`${editor.diagramPreview} svg`).first())
+            .toBeVisible({ timeout: 15_000 });
+
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        // The diagram serializes as a fenced block with the `flowchart` tag,
+        // carrying the source lines we passed in.
+        expect(md).toContain('```flowchart');
+        expect(md).toContain('st=>start: Start');
+        expect(md).toContain('e=>end: End');
+        expect(md).toContain('st->e');
+        expect(md.trim().endsWith('```')).toBe(true);
+    });
+});

--- a/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
@@ -1,0 +1,123 @@
+import type { TState } from '@muyajs/core';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+/**
+ * Mermaid diagram rendering. Unlike PlantUML (which round-trips through the
+ * public plantuml.com service), mermaid renders entirely client-side: the
+ * diagram preview block (packages/core/src/block/extra/diagram/
+ * diagramPreview.ts) lazy-imports `mermaid`, calls `mermaid.parse(code)` to
+ * validate, then `mermaid.run({ nodes: [target] })` to mount an `<svg>`.
+ *
+ * No network mock is needed. The render is async (dynamic import + parse +
+ * run), so every assertion waits on an explicit DOM condition rather than a
+ * fixed sleep.
+ */
+
+const VALID_MERMAID = 'graph TD\n    A-->B';
+
+// A truncated edge (`A--->` with no target) is rejected by `mermaid.parse`,
+// which the preview block catches and surfaces as an error node instead of
+// throwing.
+const INVALID_MERMAID = 'graph TD\n    A--->';
+
+test.describe('mermaid diagram', () => {
+    test('setContent with a valid graph mounts an <svg> under the preview', async ({ page }) => {
+        await page.evaluate((text) => {
+            window.muya!.setContent([{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'mermaid' },
+            }] as TState[]);
+        }, VALID_MERMAID);
+
+        // Mermaid is async (dynamic import + parse + run); allow generous time.
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+
+        // A `graph TD; A-->B` renders two node groups plus an edge path. Mermaid
+        // populates the shapes a tick after the `<svg>` shell mounts, so poll
+        // for the geometry rather than snapshotting it once.
+        await page.waitForFunction(() => {
+            const root = document.querySelector('.mu-diagram-preview svg');
+            if (!root)
+                return false;
+            return root.querySelectorAll('path, rect, polygon, .node').length > 0;
+        }, undefined, { timeout: 15_000 });
+    });
+
+    test('mermaid diagram round-trips through getMarkdown', async ({ page }) => {
+        await page.evaluate((text) => {
+            window.muya!.setContent([{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'mermaid' },
+            }] as TState[]);
+        }, VALID_MERMAID);
+
+        // Use the SVG mount as a sync barrier before reading markdown back.
+        await expect(page.locator(`${editor.diagramPreview} svg`).first())
+            .toBeVisible({ timeout: 15_000 });
+
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```mermaid');
+        expect(md).toContain('graph TD');
+        expect(md).toContain('A-->B');
+        expect(md.trim().endsWith('```')).toBe(true);
+    });
+
+    test('invalid mermaid code surfaces an error node instead of crashing', async ({ page }) => {
+        await page.evaluate((text) => {
+            window.muya!.setContent([{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'mermaid' },
+            }] as TState[]);
+        }, INVALID_MERMAID);
+
+        // The preview block catches the parse rejection and writes a
+        // `.mu-diagram-error` node carrying the localized 'Invalid Diagram
+        // Code' label (host loads the `en` locale, so it is literal English).
+        const error = page.locator(`${editor.diagramPreview} ${editor.diagramError}`).first();
+        await expect(error).toBeVisible({ timeout: 15_000 });
+        await expect(error).toContainText('Invalid Diagram Code');
+
+        // No SVG should have mounted for a failed parse.
+        await expect(page.locator(`${editor.diagramPreview} svg`)).toHaveCount(0);
+
+        // The editor stays alive (no thrown crash): the source still round-trips.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```mermaid');
+    });
+
+    test('rebuilding with a non-default mermaidTheme still renders an SVG', async ({ page }) => {
+        // `mermaidTheme` is read fresh from `muya.options` on each preview
+        // update (diagramPreview.ts), but the only deterministic way to change
+        // it e2e is to rebuild the editor with the new option, then re-render.
+        await page.evaluate(() => {
+            window.__e2e!.rebuildMuya({ mermaidTheme: 'forest' });
+        });
+        await page.waitForFunction(
+            () => window.muya?.editor?.scrollPage != null,
+            undefined,
+            { timeout: 15_000 },
+        );
+
+        await page.evaluate((text) => {
+            window.muya!.setContent([{
+                name: 'diagram',
+                text,
+                meta: { lang: 'yaml', type: 'mermaid' },
+            }] as TState[]);
+        }, VALID_MERMAID);
+
+        await expect(page.locator(`${editor.diagramPreview} svg`).first())
+            .toBeVisible({ timeout: 15_000 });
+
+        // The diagram still serializes back to a mermaid fence under the new
+        // theme — the theme is a render-time option, not part of the source.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```mermaid');
+        expect(md).toContain('graph TD');
+    });
+});

--- a/packages/muya/e2e/tests/diagrams/sequence.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/sequence.spec.ts
@@ -1,0 +1,90 @@
+import type { TState } from '@muyajs/core';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+/**
+ * js-sequence-diagrams rendering. The sequence loader (packages/core/src/utils/
+ * diagram/sequence/index.ts) vendors `js-sequence-diagrams` wired to snap.svg:
+ * `render.parse(code)` returns a diagram whose `drawSVG(target, { theme })`
+ * appends a `<svg>` into the diagram preview. Everything is client-side — no
+ * network, no mock needed (unlike plantuml.spec.ts).
+ *
+ * The vendored renderer tags every emitted `<svg>` with the `sequence` class
+ * plus the active theme's css-class (`hand` | `simple`) — see
+ * packages/core/src/utils/diagram/sequence/sequence-diagram-snap.js
+ * (`paper_.addClass('sequence')` then `addClass(this.cssClass_)`).
+ */
+
+const SEQUENCE_SOURCE = 'A->B: hello';
+
+function sequenceState(text: string): TState[] {
+    return [{
+        name: 'diagram',
+        text,
+        meta: { lang: 'yaml', type: 'sequence' },
+    }];
+}
+
+test.describe('sequence diagram', () => {
+    test('setContent with a sequence diagram mounts an <svg> under the preview', async ({ page }) => {
+        await page.evaluate((state) => {
+            window.muya!.setContent(state);
+        }, sequenceState(SEQUENCE_SOURCE));
+
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+
+        // The vendored renderer always tags the svg with the `sequence` class.
+        await expect(svg).toHaveClass(/sequence/);
+    });
+
+    test('sequence diagram round-trips through getMarkdown', async ({ page }) => {
+        await page.evaluate((state) => {
+            window.muya!.setContent(state);
+        }, sequenceState(SEQUENCE_SOURCE));
+
+        // Wait for the svg as a sync barrier before reading markdown.
+        await expect(page.locator(`${editor.diagramPreview} svg`).first())
+            .toBeVisible({ timeout: 15_000 });
+
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```sequence');
+        expect(md).toContain('A->B: hello');
+        expect(md.trim().endsWith('```')).toBe(true);
+    });
+
+    test('default sequenceTheme is `hand` and the svg carries the hand css-class', async ({ page }) => {
+        // The host boots Muya without an explicit sequenceTheme, so the default
+        // (`hand`, per MUYA_DEFAULT_OPTIONS) is in effect.
+        const theme = await page.evaluate(() => window.muya!.options.sequenceTheme);
+        expect(theme).toBe('hand');
+
+        await page.evaluate((state) => {
+            window.muya!.setContent(state);
+        }, sequenceState(SEQUENCE_SOURCE));
+
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+        await expect(svg).toHaveClass(/\bhand\b/);
+    });
+
+    test('sequenceTheme `simple` re-renders with the simple css-class', async ({ page }) => {
+        // Rebuild Muya with the `simple` theme, then render the same diagram.
+        await page.evaluate(() => {
+            window.__e2e!.rebuildMuya({ sequenceTheme: 'simple' });
+        });
+
+        const theme = await page.evaluate(() => window.muya!.options.sequenceTheme);
+        expect(theme).toBe('simple');
+
+        await page.evaluate((state) => {
+            window.muya!.setContent(state);
+        }, sequenceState(SEQUENCE_SOURCE));
+
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+        await expect(svg).toHaveClass(/\bsimple\b/);
+        // The hand-drawn theme's class must not leak onto the simple render.
+        await expect(svg).not.toHaveClass(/\bhand\b/);
+    });
+});

--- a/packages/muya/e2e/tests/drag/table-row-column-menu.spec.ts
+++ b/packages/muya/e2e/tests/drag/table-row-column-menu.spec.ts
@@ -1,0 +1,196 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor, floats } from '../helpers/selectors';
+
+/**
+ * TableRowColumMenu (the `.mu-table-bar-tools` row/column operations popup)
+ * end-to-end coverage.
+ *
+ * Trigger contract (source of truth:
+ * `packages/core/src/ui/tableDragBar/index.ts`):
+ *   - Hovering just OUTSIDE the table — so the cursor sits in no cell but a
+ *     cell exists 20px above OR 20px to the left — reveals the drag bar.
+ *     `barType` is 'bottom' when a cell is 20px above (cursor below the
+ *     table) and 'right' when a cell is 20px to the left (cursor right of
+ *     the table).
+ *   - A QUICK click on the bar (mousedown + mouseup inside the 300ms drag
+ *     arming window) clears the drag timer. ONLY when `barType === 'right'`
+ *     does `mouseup` emit `muya-table-bar`, which shows the
+ *     `TableRowColumMenu`. A quick click on the BOTTOM bar emits nothing —
+ *     no menu opens (the column equivalent is wired through
+ *     `TableColumnToolbar`, not this popup).
+ *
+ * The 'right' menu renders Insert Row Above / Insert Row Below / Remove Row
+ * (`packages/core/src/ui/tableRowColumMenu/config.ts::toolList.right`).
+ */
+
+const TWO_BY_TWO = '| h1 | h2 |\n| --- | --- |\n| a | b |\n';
+
+async function makeTwoByTwo(page: Page) {
+    await page.evaluate((md) => {
+        window.muya!.setContent(md);
+    }, TWO_BY_TWO);
+    const table = page.locator(editor.table).first();
+    await expect(table).toBeVisible();
+    // Two rows: the header row + one body row.
+    await expect(table.locator('tr')).toHaveCount(2);
+    return table;
+}
+
+/** Read the float wrapper's opacity for a parked baseFloat (>0 === shown). */
+async function wrapperOpacity(page: Page, selector: string): Promise<number> {
+    // `.mu-table-bar-tools` lands on BOTH the float wrapper and the inner
+    // container (the TableRowColumMenu constructor adds it to floatBox too),
+    // so scope to the first match — both share the same `.mu-float-wrapper`.
+    return page.locator(selector).first().evaluate((el) => {
+        const wrapper = el.closest('.mu-float-wrapper') as HTMLElement | null;
+        if (!wrapper)
+            return 0;
+        return Number.parseFloat(wrapper.style.opacity || '0');
+    });
+}
+
+/** The TableRowColumMenu content container (avoids the wrapper double-match). */
+function menuContainer(page: Page) {
+    return page.locator(`.mu-float-container${floats.tableRowColumMenu}`);
+}
+
+async function expectShown(page: Page, selector: string) {
+    await expect.poll(async () => wrapperOpacity(page, selector), {
+        timeout: 5_000,
+        intervals: [50, 100, 250, 500],
+    }).toBeGreaterThan(0);
+}
+
+/**
+ * Hover just to the RIGHT of the table's last body row so the drag bar's
+ * mousemove handler picks `barType === 'right'`: the cursor is in no cell,
+ * but `(x - 20, y)` lands inside the rightmost cell.
+ */
+async function revealRightBar(page: Page, table: ReturnType<Page['locator']>) {
+    const lastRowLastCell = table.locator('tr').last().locator('td, th').last();
+    const box = await lastRowLastCell.boundingBox();
+    if (!box)
+        throw new Error('last-row cell has no bounding box');
+
+    const probeX = box.x + box.width + 10;
+    const probeY = box.y + box.height / 2;
+    await page.mouse.move(probeX, probeY);
+    await page.waitForTimeout(80);
+    await page.mouse.move(probeX, probeY + 1);
+
+    await expectShown(page, floats.tableDragBar);
+    return page.locator(floats.tableDragBar);
+}
+
+/**
+ * Hover just BELOW the table's first column so the handler picks
+ * `barType === 'bottom'`: the cursor is in no cell, but `(x, y - 20)`
+ * lands inside a body cell.
+ */
+async function revealBottomBar(page: Page, table: ReturnType<Page['locator']>) {
+    const firstColLastRow = table.locator('tr').last().locator('td, th').first();
+    const box = await firstColLastRow.boundingBox();
+    if (!box)
+        throw new Error('last-row first cell has no bounding box');
+
+    const probeX = box.x + box.width / 2;
+    const probeY = box.y + box.height + 10;
+    await page.mouse.move(probeX, probeY);
+    await page.waitForTimeout(80);
+    await page.mouse.move(probeX, probeY + 1);
+
+    await expectShown(page, floats.tableDragBar);
+    return page.locator(floats.tableDragBar);
+}
+
+/**
+ * Quick-click (mousedown immediately followed by mouseup, well inside the
+ * 300ms drag-arming window) on the bar's centre.
+ */
+async function quickClickBar(page: Page, bar: ReturnType<Page['locator']>) {
+    const box = await bar.boundingBox();
+    if (!box)
+        throw new Error('drag bar has no bounding box');
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.up();
+}
+
+test.describe('TableRowColumMenu (row/column bar popup)', () => {
+    test('the drag bar appears with right-orientation when hovering to the right of the table', async ({ page }) => {
+        const table = await makeTwoByTwo(page);
+        const bar = await revealRightBar(page, table);
+
+        // The render(barType) call writes `data-drag` onto the container.
+        await expect.poll(async () => bar.getAttribute('data-drag'), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe('right');
+    });
+
+    test('a quick-click on the RIGHT bar opens the row-operations menu', async ({ page }) => {
+        const table = await makeTwoByTwo(page);
+        const bar = await revealRightBar(page, table);
+        await expect.poll(async () => bar.getAttribute('data-drag')).toBe('right');
+
+        await quickClickBar(page, bar);
+
+        const menu = menuContainer(page);
+        await expectShown(page, floats.tableRowColumMenu);
+
+        // The 'right' toolList renders exactly three row operations.
+        const items = menu.locator('li.item');
+        await expect(items).toHaveCount(3);
+        await expect(menu).toContainText('Insert Row Above');
+        await expect(menu).toContainText('Insert Row Below');
+        await expect(menu).toContainText('Remove Row');
+        // It is the ROW menu, not the column menu.
+        await expect(menu).not.toContainText('Column');
+    });
+
+    test('a quick-click on the BOTTOM bar does NOT open the row/column menu', async ({ page }) => {
+        const table = await makeTwoByTwo(page);
+        const bar = await revealBottomBar(page, table);
+        await expect.poll(async () => bar.getAttribute('data-drag'), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe('bottom');
+
+        // Sanity: the popup is parked (hidden) before we click.
+        expect(await wrapperOpacity(page, floats.tableRowColumMenu)).toBe(0);
+
+        await quickClickBar(page, bar);
+
+        // `mouseup` emits `muya-table-bar` only for the 'right' bar, so the
+        // bottom bar must leave the popup parked. Give the (absent) emit a
+        // window to land, then assert it never showed.
+        await page.waitForTimeout(400);
+        expect(await wrapperOpacity(page, floats.tableRowColumMenu)).toBe(0);
+    });
+
+    test('Insert Row Below adds a body row to the table', async ({ page }) => {
+        const table = await makeTwoByTwo(page);
+        const bar = await revealRightBar(page, table);
+        await expect.poll(async () => bar.getAttribute('data-drag')).toBe('right');
+
+        await quickClickBar(page, bar);
+
+        const menu = menuContainer(page);
+        await expectShown(page, floats.tableRowColumMenu);
+
+        // `data-label` on each item is the action verb ('insert' / 'remove'),
+        // shared across the two insert rows; disambiguate by visible text.
+        await menu.locator('li.item', { hasText: 'Insert Row Below' }).click();
+
+        // Adding a row grows the table from 2 rows (header + 1 body) to 3.
+        await expect(table.locator('tr')).toHaveCount(3);
+        // The popup closes after selecting an item.
+        await expect.poll(async () => wrapperOpacity(page, floats.tableRowColumMenu), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe(0);
+    });
+});

--- a/packages/muya/e2e/tests/helpers/selectors.ts
+++ b/packages/muya/e2e/tests/helpers/selectors.ts
@@ -14,6 +14,11 @@ export const editor = {
     paragraph: '.mu-paragraph',
     atxHeading: '.mu-atx-heading',
     setextHeading: '.mu-setext-heading',
+    // A Shift+Enter soft line break inside a Format leaf renders as a
+    // `<span.mu-soft-line-break>` wrapping a literal `\n`. Source of truth:
+    // packages/muya/src/inlineRenderer/renderer/softLineBreak.ts +
+    // CLASS_NAMES.MU_SOFT_LINE_BREAK in packages/muya/src/config/index.ts.
+    softLineBreak: '.mu-soft-line-break',
     blockQuote: '.mu-block-quote',
     bulletList: '.mu-bullet-list',
     orderList: '.mu-order-list',
@@ -22,6 +27,11 @@ export const editor = {
     thematicBreak: '.mu-thematic-break',
     codeBlock: '.mu-code-block',
     fenceCode: '.mu-fence-code',
+    // The leaf node that holds the actual code text inside a code block.
+    // Prism highlight `<span class="token …">` runs are appended here.
+    // Source of truth: packages/muya/src/block/content/codeBlockContent/index.ts
+    // (classList pushes 'mu-codeblock-content').
+    codeContent: '.mu-codeblock-content',
     languageInput: '.mu-language-input',
     table: 'table',
     tableCell: '.mu-table-cell',
@@ -33,11 +43,27 @@ export const editor = {
     htmlDisabled: '.mu-disable-html-render',
     mathBlock: '.mu-math-block',
     mathRender: '.mu-math-render',
+    // Inline-math wrapper. Carries `mu-hide` while the caret sits outside the
+    // `$...$` token (KaTeX preview shown, source collapsed); the class drops
+    // when the caret is inside, revealing the editable `.mu-math-text` source.
+    inlineMath: '.mu-math',
+    inlineMathText: '.mu-math > .mu-math-text',
     katex: '.katex',
     diagramBlock: '.mu-diagram-block',
     diagramContainer: '.mu-diagram-container',
     diagramPreview: '.mu-diagram-preview',
+    // Error surface rendered into the diagram preview when the diagram
+    // renderer throws (e.g. invalid mermaid syntax). Source of truth:
+    // packages/core/src/block/extra/diagram/diagramPreview.ts (catch branch).
+    diagramError: '.mu-diagram-error',
     image: '.mu-inline-image',
+    // Inline image placeholder rendered when the image has no resolvable src
+    // (e.g. `![]()` / `![alt]()`). Source of truth:
+    // packages/muya/src/inlineRenderer/renderer/image.ts (the `else` branch
+    // appends CLASS_NAMES.MU_EMPTY_IMAGE → `mu-empty-image`). Clicking it emits
+    // `muya-image-selector` (selection/ImageSelection.ts) which opens the
+    // ImageEditTool float.
+    emptyImage: '.mu-inline-image.mu-empty-image',
     inlineFootnoteIdentifier: '.mu-inline-footnote-identifier',
     link: 'span.mu-link, a.mu-reference-link, a.mu-raw-html',
     // Frontmatter block (renders as a `<pre.mu-frontmatter>` wrapping a code block).

--- a/packages/muya/e2e/tests/inline/format-toolbar.spec.ts
+++ b/packages/muya/e2e/tests/inline/format-toolbar.spec.ts
@@ -1,14 +1,27 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
 import { getMarkdown } from '../helpers/api';
 import { editor, floats } from '../helpers/selectors';
 
-async function selectAllOfFirstParagraph(page: import('@playwright/test').Page) {
+async function selectAllOfFirstParagraph(page: Page) {
     const para = page.locator(editor.paragraph).first();
     // Triple-click to select the full paragraph text — this is the standard
     // browser gesture that fires selectionchange so the IFT pops up.
     await para.click({ clickCount: 3 });
     return para;
 }
+
+// Inline strong markers (`**`) are rendered as `span.mu-remove` sibling nodes
+// either side of the `<strong.mu-inline-rule>` run. Source of truth:
+// packages/muya/src/inlineRenderer/renderer/delEmStrongFactory.ts builds
+// `span.${className}.mu-remove` where className comes from
+// Renderer#getClassName: when the caret is OUTSIDE the token the markers get
+// `mu-hide` (collapsed); when the caret is INSIDE (checkConflicted true) they
+// get `mu-gray` (revealed). `.mu-remove` is stable across both states, so we
+// scope to it and assert the mu-hide/mu-gray toggle.
+const strongMarker = `${editor.paragraph} span.mu-remove`;
+const strongMarkerHidden = `${editor.paragraph} span.mu-remove.mu-hide`;
+const strongMarkerGray = `${editor.paragraph} span.mu-remove.mu-gray`;
 
 test.describe('inline format toolbar', () => {
     test('appears on text selection', async ({ page }) => {
@@ -32,5 +45,46 @@ test.describe('inline format toolbar', () => {
         await page.locator(`${floats.inlineFormatToolbar} li.item.em`).click();
         const md = await getMarkdown(page);
         expect(md).toMatch(/[*_]alpha[*_]/);
+    });
+
+    test('strong run renders with collapsed (mu-hide) markers when the caret is outside', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('a **bold** b'));
+        // Click at the very start of the paragraph so the caret sits OUTSIDE
+        // the strong token; the markers should collapse to `.mu-hide`.
+        await page.locator(editor.paragraph).first().click({ position: { x: 2, y: 2 } });
+
+        // The strong run itself is a live `<strong.mu-inline-rule>` node.
+        const strongRun = page.locator(`${editor.paragraph} strong.mu-inline-rule`);
+        await expect(strongRun).toHaveCount(1);
+        await expect(strongRun).toHaveText('bold');
+
+        // Two `**` marker spans, both collapsed via `.mu-hide`, none revealed.
+        await expect(page.locator(strongMarker)).toHaveCount(2);
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(2);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(0);
+
+        expect(await getMarkdown(page)).toContain('**bold**');
+    });
+
+    test('mu-hide toggles off the **markers as the caret enters the strong run, and back on as it leaves', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('a **bold** b'));
+
+        // 1) Caret outside the strong run → both markers carry `.mu-hide`.
+        await page.locator(editor.paragraph).first().click({ position: { x: 2, y: 2 } });
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(2);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(0);
+
+        // 2) Move the caret INTO the strong run by clicking the rendered word.
+        //    The markers re-render WITHOUT `.mu-hide` (they become `.mu-gray`,
+        //    i.e. revealed) — this is the toggle the inline renderer performs
+        //    via Renderer#getClassName + checkConflicted.
+        await page.locator(`${editor.paragraph} strong.mu-inline-rule`).click();
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(0);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(2);
+
+        // 3) Move the caret back OUT → `.mu-hide` returns on both markers.
+        await page.locator(editor.paragraph).first().click({ position: { x: 2, y: 2 } });
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(2);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(0);
     });
 });

--- a/packages/muya/e2e/tests/inline/shortcuts.spec.ts
+++ b/packages/muya/e2e/tests/inline/shortcuts.spec.ts
@@ -28,4 +28,15 @@ test.describe('keyboard shortcuts', () => {
         await page.keyboard.press(`${metaKey()}+e`);
         expect(await getMarkdown(page)).toContain('`codeblock`');
     });
+
+    test('Cmd/Ctrl+D applies strikethrough to the selection', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('struck text'));
+        await tripleClickFirstParagraph(page);
+        await page.keyboard.press(`${metaKey()}+d`);
+        // The `del` renderer mounts a live `<del>` element inside the paragraph.
+        const del = page.locator(`${editor.paragraph} del`).first();
+        await expect(del).toBeVisible();
+        await expect(del).toContainText('struck text');
+        expect(await getMarkdown(page)).toContain('~~struck text~~');
+    });
 });

--- a/packages/muya/e2e/tests/options/disable-html.spec.ts
+++ b/packages/muya/e2e/tests/options/disable-html.spec.ts
@@ -1,5 +1,6 @@
 import type { TState } from '@muyajs/core';
 import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
 import { editor } from '../helpers/selectors';
 
 /**
@@ -67,5 +68,92 @@ test.describe('options / disableHtml', () => {
         const preview = wrapper.locator(editor.htmlPreview);
         const injected = preview.locator('.injected');
         await expect(injected).toHaveCount(1);
+    });
+
+    /**
+     * CHARACTERIZATION — inline raw-html is NOT gated by `disableHtml`.
+     *
+     * Source of truth: `disableHtml` is read in exactly three block-level
+     * spots —
+     *   - `packages/core/src/block/commonMark/html/index.ts` (pushes the
+     *     `mu-disable-html-render` class onto the html-BLOCK wrapper),
+     *   - `packages/core/src/block/commonMark/html/htmlPreview.ts` +
+     *     `packages/core/src/utils/index.ts::sanitize` (escapes the
+     *     html-BLOCK preview),
+     *   - `packages/core/src/ui/previewToolBar/index.ts` (toolbar gating).
+     *
+     * The inline pipeline never consults it: neither
+     * `packages/core/src/inlineRenderer/lexer.ts` nor
+     * `packages/core/src/inlineRenderer/renderer/htmlTag.ts` reference
+     * `disableHtml`. So an inline `<u>…</u>` / `<b>…</b>` token inside a
+     * paragraph still renders as a LIVE element (a real `<u>`/`<b>` carrying
+     * `.mu-inline-rule.mu-raw-html`) even when `disableHtml: true`.
+     *
+     * That contradicts the intuitive expectation that `disableHtml` would
+     * also neutralize inline HTML — see `suspectedBugs`. These tests pin the
+     * actual behavior so the gap is visible if it ever changes.
+     */
+    test('disableHtml: true — inline <u> raw-html STILL renders as a live element (not source)', async ({ page }) => {
+        await page.evaluate(() => {
+            window.__e2e!.rebuildMuya({ disableHtml: true });
+            window.muya!.setContent([{
+                name: 'paragraph',
+                text: '<u>under</u>',
+            }] as TState[]);
+        });
+
+        // No block-level disable class is applied — that flag is html-BLOCK
+        // only, and this is a paragraph with an inline html_tag token.
+        await expect(page.locator(editor.htmlDisabled)).toHaveCount(0);
+        // The html-block wrapper is never created for inline html either.
+        await expect(page.locator(editor.htmlBlock)).toHaveCount(0);
+
+        // The inline raw-html renders as a live `<u>` element (NOT escaped
+        // source). The `<u>` carries the `.mu-raw-html` inline marker class.
+        const live = page.locator('u.mu-raw-html');
+        await expect(live).toHaveCount(1);
+        await expect(live).toBeVisible();
+        // The visible content of the rendered element is just the inner text,
+        // not the literal tag markup.
+        await expect(live).toHaveText('under');
+
+        // The original source is preserved on the element's `data-raw`
+        // attribute (used for round-trip / caret editing).
+        await expect(live).toHaveAttribute('data-raw', '<u>under</u>');
+
+        // Round-trips losslessly back to the raw-html source.
+        expect(await getMarkdown(page)).toBe('<u>under</u>\n');
+    });
+
+    test('disableHtml: true — inline <b> raw-html renders the same as with disableHtml: false', async ({ page }) => {
+        // disableHtml: true
+        await page.evaluate(() => {
+            window.__e2e!.rebuildMuya({ disableHtml: true });
+            window.muya!.setContent([{
+                name: 'paragraph',
+                text: '<b>strong</b>',
+            }] as TState[]);
+        });
+        const liveEnabled = page.locator('b.mu-raw-html');
+        await expect(liveEnabled).toHaveCount(1);
+        await expect(liveEnabled).toHaveText('strong');
+        const markdownEnabled = await getMarkdown(page);
+
+        // disableHtml: false (default) — identical inline outcome, proving the
+        // flag has no effect on inline html rendering.
+        await page.evaluate(() => {
+            window.__e2e!.rebuildMuya({ disableHtml: false });
+            window.muya!.setContent([{
+                name: 'paragraph',
+                text: '<b>strong</b>',
+            }] as TState[]);
+        });
+        const liveDefault = page.locator('b.mu-raw-html');
+        await expect(liveDefault).toHaveCount(1);
+        await expect(liveDefault).toHaveText('strong');
+        const markdownDefault = await getMarkdown(page);
+
+        expect(markdownEnabled).toBe(markdownDefault);
+        expect(markdownDefault).toBe('<b>strong</b>\n');
     });
 });

--- a/packages/muya/e2e/tests/typing/blockquote-and-rule.spec.ts
+++ b/packages/muya/e2e/tests/typing/blockquote-and-rule.spec.ts
@@ -1,7 +1,20 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
-import { getMarkdown } from '../helpers/api';
+import { getMarkdown, getState } from '../helpers/api';
 import { slowType } from '../helpers/keyboard';
 import { editor, floats, quickInsertItem } from '../helpers/selectors';
+
+/** A muya state node as returned by `muya.getState()`. */
+interface IStateNode {
+    name: string;
+    text?: string;
+    children?: IStateNode[];
+}
+
+/** Read the top-level document state as a typed array of blocks. */
+async function getBlocks(page: Page): Promise<IStateNode[]> {
+    return (await getState(page)) as IStateNode[];
+}
 
 test.describe('blockquote and thematic break', () => {
     test('slash menu creates a block quote', async ({ page }) => {
@@ -27,5 +40,107 @@ test.describe('blockquote and thematic break', () => {
         await page.keyboard.type('/');
         await page.locator(quickInsertItem('thematic-break')).click();
         await expect(page.locator(editor.thematicBreak).first()).toBeVisible();
+    });
+
+    test('typing "> " at the start of an empty paragraph converts to a block quote', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        // `_convertToBlockQuote` (block/base/format.ts) fires from the inline
+        // update pipeline once the text matches `(?:^|\n) {0,3}(>).+` — the
+        // trailing space after ">" satisfies the `.+`.
+        await slowType(page, '> ');
+
+        const quote = page.locator(editor.blockQuote).first();
+        await expect(quote).toBeVisible();
+
+        // The conversion seeds the quote with a single empty paragraph.
+        const blocks = await getBlocks(page);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('block-quote');
+        expect(blocks[0].children).toHaveLength(1);
+        expect(blocks[0].children![0].name).toBe('paragraph');
+
+        // Type into the freshly created quote paragraph and confirm round-trip.
+        await slowType(page, 'a');
+        await expect(quote.locator(editor.paragraph).first()).toContainText('a');
+        expect(await getMarkdown(page)).toContain('> a');
+    });
+
+    test('Enter twice inside a block quote exits into a trailing paragraph', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '> ');
+        await expect(page.locator(editor.blockQuote).first()).toBeVisible();
+        await slowType(page, 'a');
+
+        // First Enter: the quote paragraph is non-empty, so a new empty
+        // paragraph is appended *inside* the block quote. muya's enter handler
+        // re-renders synchronously and re-seats the caret, so before issuing
+        // the second Enter we wait for the live selection to settle on the new
+        // empty quote paragraph — issuing the press too eagerly drops it.
+        await page.keyboard.press('Enter');
+        await expect(page.locator(editor.blockQuote).locator(editor.paragraph)).toHaveCount(2);
+        await page.waitForFunction(() => {
+            const sel = window.muya!.editor.selection.getSelection();
+            const anchor = sel?.anchorBlock;
+            return anchor != null
+                && anchor.blockName === 'paragraph.content'
+                && anchor.text === '';
+        }, undefined, { timeout: 5000 });
+
+        // Second Enter: the now-empty quote paragraph is the last child, so
+        // `_enterInBlockQuote` lifts it out as a trailing top-level paragraph.
+        await page.keyboard.press('Enter');
+
+        // Exactly one block quote remains (the 'a' line) plus a trailing
+        // paragraph. Poll the document state so the assertion auto-retries
+        // until the synchronous re-render has fully settled.
+        await expect.poll(async () => {
+            const b = await getBlocks(page);
+            return b.map(node => node.name);
+        }).toEqual(['block-quote', 'paragraph']);
+
+        const blocks = await getBlocks(page);
+        expect(blocks[0].children).toHaveLength(1);
+        expect(blocks[0].children![0].name).toBe('paragraph');
+        expect(blocks[0].children![0].text).toBe('a');
+        expect(blocks[1].text).toBe('');
+
+        // The trailing paragraph lives outside the block quote in the DOM.
+        await expect(page.locator(editor.blockQuote)).toHaveCount(1);
+        await expect(page.locator(editor.blockQuote).locator(editor.paragraph)).toHaveCount(1);
+        await expect(page.locator(editor.paragraph)).toHaveCount(2);
+
+        // The caret has moved into the trailing paragraph content block.
+        const anchorName = await page.evaluate(
+            () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName ?? null,
+        );
+        expect(anchorName).toBe('paragraph.content');
+
+        expect(await getMarkdown(page)).toContain('> a');
+    });
+
+    test('typing "> > " nests a block quote inside a block quote', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        // First "> " makes the outer quote; the second "> " typed into its
+        // empty paragraph re-triggers the conversion and nests another quote.
+        await slowType(page, '> ');
+        await expect(page.locator(editor.blockQuote).first()).toBeVisible();
+        await slowType(page, '> ');
+
+        await expect(page.locator(editor.blockQuote)).toHaveCount(2);
+
+        const blocks = await getBlocks(page);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('block-quote');
+        expect(blocks[0].children).toHaveLength(1);
+        expect(blocks[0].children![0].name).toBe('block-quote');
+        expect(blocks[0].children![0].children).toHaveLength(1);
+        expect(blocks[0].children![0].children![0].name).toBe('paragraph');
+
+        expect(await getMarkdown(page)).toContain('> > ');
     });
 });

--- a/packages/muya/e2e/tests/typing/blockquote-and-rule.spec.ts
+++ b/packages/muya/e2e/tests/typing/blockquote-and-rule.spec.ts
@@ -83,7 +83,7 @@ test.describe('blockquote and thematic break', () => {
         await expect(page.locator(editor.blockQuote).locator(editor.paragraph)).toHaveCount(2);
         await page.waitForFunction(() => {
             const sel = window.muya!.editor.selection.getSelection();
-            const anchor = sel?.anchorBlock;
+            const anchor = sel?.anchor?.block;
             return anchor != null
                 && anchor.blockName === 'paragraph.content'
                 && anchor.text === '';
@@ -114,7 +114,7 @@ test.describe('blockquote and thematic break', () => {
 
         // The caret has moved into the trailing paragraph content block.
         const anchorName = await page.evaluate(
-            () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName ?? null,
+            () => window.muya!.editor.selection.getSelection()?.anchor?.block?.blockName ?? null,
         );
         expect(anchorName).toBe('paragraph.content');
 

--- a/packages/muya/e2e/tests/typing/code-block.spec.ts
+++ b/packages/muya/e2e/tests/typing/code-block.spec.ts
@@ -33,4 +33,37 @@ test.describe('code block', () => {
         await expect(page.locator(editor.codeBlock).first()).toBeVisible();
         expect(await getMarkdown(page)).toContain('const x = 1;');
     });
+
+    test('js code block highlights real code with Prism token spans and reflects ```js', async ({ page }) => {
+        // The `js` alias resolves to `javascript`, which muya preloads into its
+        // Prism `loadedLanguages` set
+        // (packages/muya/src/utils/prism/loadLanguage.ts), so highlighting runs
+        // synchronously on the first render — no language fetch is needed.
+        await page.evaluate(() => {
+            window.muya!.setContent('```js\nconst x = 1;\n```\n');
+        });
+        await expect(page.locator(editor.codeBlock).first()).toBeVisible();
+
+        const codeContent = page.locator(editor.codeContent).first();
+        // The code leaf carries class `mu-codeblock-content` (not the stale
+        // `.mu-fence-code`); Prism appends `<span class="token …">` runs here.
+        await expect(codeContent).toBeVisible();
+
+        const tokens = page.locator(`${editor.codeContent} .token`);
+        await expect(tokens.first()).toBeVisible();
+        // `const x = 1;` tokenizes into keyword / operator / number / punctuation.
+        await expect(tokens).toHaveCount(4);
+        await expect(
+            page.locator(`${editor.codeContent} .token.keyword`).first(),
+        ).toHaveText('const');
+
+        // The fenced wrapper records the language and the language-input shows it.
+        await expect(page.locator(editor.codeBlock).first()).toHaveClass(/mu-fenced-code/);
+        await expect(page.locator(editor.languageInput).first()).toHaveText('js');
+
+        // Round-trip: the language fence and code text survive serialization.
+        const md = await getMarkdown(page);
+        expect(md).toContain('```js');
+        expect(md).toContain('const x = 1;');
+    });
 });

--- a/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
+++ b/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
@@ -37,4 +37,65 @@ test.describe('math and diagrams', () => {
         await expect(page.locator(`${editor.diagramPreview} svg`).first())
             .toBeVisible({ timeout: 15_000 });
     });
+
+    test('inline $x^2$ renders KaTeX inside the paragraph and round-trips', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('inline $x^2$ math'));
+
+        // The inline math wrapper lives inside the paragraph (not a math
+        // block) and KaTeX renders asynchronously into .mu-math-render.
+        const mathRender = page.locator(`${editor.paragraph} ${editor.mathRender}`).first();
+        await expect(mathRender).toBeVisible();
+        await expect(page.locator(`${editor.paragraph} ${editor.katex}`).first())
+            .toBeVisible({ timeout: 10_000 });
+
+        // Exactly one inline formula was rendered.
+        await expect(page.locator(editor.katex)).toHaveCount(1);
+
+        // The source markdown round-trips losslessly through the serializer.
+        expect(await getMarkdown(page)).toContain('$x^2$');
+    });
+
+    test('clicking the rendered inline KaTeX activates the source for editing', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('inline $x^2$ math'));
+        await expect(page.locator(`${editor.paragraph} ${editor.katex}`).first())
+            .toBeVisible({ timeout: 10_000 });
+
+        const mathWrapper = page.locator(editor.inlineMath).first();
+
+        // Before clicking: the caret is outside the inline-math token, so the
+        // wrapper carries `mu-hide` — the KaTeX preview shows and the raw
+        // `$x^2$` source span is collapsed.
+        await expect(mathWrapper).toHaveClass(/mu-hide/);
+
+        // Clicking the rendered KaTeX runs `_handleClickInlineRuleRender`,
+        // which `setCursor`s across the math source range read from the
+        // preview's data-start/data-end. That re-renders the token with the
+        // caret *inside* it, dropping the `mu-hide` class and revealing the
+        // editable `.mu-math-text` source span.
+        await page.locator(`${editor.mathRender} ${editor.katex}`).first().click();
+        await expect(mathWrapper).not.toHaveClass(/mu-hide/);
+        await expect(page.locator(editor.inlineMathText).first()).toBeVisible();
+
+        // The selection now spans the math source text (the `x^2` between the
+        // `$` markers, offsets 8..11 of `inline $x^2$ math`) and is anchored
+        // in the inline paragraph content block — not collapsed and not a
+        // separate math block.
+        const selection = await page.evaluate(() => {
+            const sel = window.muya!.editor.selection.getSelection();
+            if (!sel)
+                return null;
+            return {
+                anchorOffset: sel.anchor.offset,
+                focusOffset: sel.focus.offset,
+                anchorBlockName: sel.anchorBlock.blockName,
+            };
+        });
+        expect(selection).not.toBeNull();
+        expect(selection!.anchorOffset).toBe(8);
+        expect(selection!.focusOffset).toBe(11);
+        expect(selection!.anchorBlockName).toBe('paragraph.content');
+
+        // The source still round-trips after the click activated edit mode.
+        expect(await getMarkdown(page)).toContain('$x^2$');
+    });
 });

--- a/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
+++ b/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
@@ -87,7 +87,7 @@ test.describe('math and diagrams', () => {
             return {
                 anchorOffset: sel.anchor.offset,
                 focusOffset: sel.focus.offset,
-                anchorBlockName: sel.anchorBlock.blockName,
+                anchorBlockName: sel.anchor.block.blockName,
             };
         });
         expect(selection).not.toBeNull();

--- a/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
+++ b/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
@@ -34,4 +34,85 @@ test.describe('paragraphs and headings', () => {
         await expect(page.locator(editor.setextHeading).first()).toBeVisible();
         expect(await getMarkdown(page)).toContain('Setext Title');
     });
+
+    // ATX shortcut: typing `#`..`######` + a space at the start of an empty
+    // paragraph converts it to an atx-heading of the matching level. The level
+    // is taken from the hash count (`_convertToAtxHeading` in
+    // packages/muya/src/block/base/format.ts), and the heading renders as an
+    // `h{level}` element carrying `.mu-atx-heading`.
+    for (const { hashes, level } of [
+        { hashes: '####', level: 4 },
+        { hashes: '#####', level: 5 },
+        { hashes: '######', level: 6 },
+    ]) {
+        test(`typing '${hashes} ' converts an empty paragraph to atx-heading level ${level}`, async ({ page }) => {
+            await page.evaluate(() => window.muya!.setContent(''));
+            await page.locator(editor.paragraph).first().click();
+            await slowType(page, `${hashes} Title`);
+
+            const heading = page.locator(editor.atxHeading).first();
+            await expect(heading).toBeVisible();
+            // The heading tag reflects the level (h4 / h5 / h6).
+            await expect(heading).toHaveJSProperty('tagName', `H${level}`);
+            // No paragraph remains.
+            await expect(page.locator(editor.paragraph)).toHaveCount(0);
+            // Markdown round-trips with the right number of leading hashes.
+            expect(await getMarkdown(page)).toContain(`${hashes} Title`);
+        });
+    }
+
+    // The ATX regex caps at six hashes (`#{1,6}` with a whitespace/end
+    // lookahead). Seven hashes followed by text never satisfies the lookahead,
+    // so the block stays a plain paragraph rather than becoming a heading.
+    test('typing 7 hashes does NOT convert to a heading (stays a paragraph)', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '####### x');
+
+        await expect(page.locator(editor.paragraph).first()).toBeVisible();
+        await expect(page.locator(editor.atxHeading)).toHaveCount(0);
+        expect(await getMarkdown(page)).toContain('####### x');
+    });
+
+    // Shift+Enter inserts a soft line break inside a single paragraph: the text
+    // becomes `a\nb` (one paragraph, one `.mu-soft-line-break` span), and the
+    // markdown carries the embedded newline. NOTE: the engine emits a plain
+    // soft break (`\n`), not a CommonMark hard break (`  \n` / `\\\n`) — see
+    // suspectedBugs. Backspace at the start of the second visual line removes
+    // the soft break, joining the two lines back into `ab`.
+    test('Shift+Enter inserts a soft line break, Backspace removes it', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        await slowType(page, 'a');
+        await page.keyboard.press('Shift+Enter');
+        await slowType(page, 'b');
+
+        // Stays one paragraph containing a soft-line-break span. The span wraps
+        // a bare `\n` (zero-area inline box), so assert it is attached rather
+        // than visible.
+        await expect(page.locator(editor.paragraph)).toHaveCount(1);
+        await expect(page.locator(editor.softLineBreak)).toHaveCount(1);
+        await expect(page.locator(editor.softLineBreak).first()).toBeAttached();
+        await page.waitForFunction(
+            () => window.muya!.getMarkdown() === 'a\nb\n',
+            undefined,
+            { timeout: 5000 },
+        );
+        expect(await getMarkdown(page)).toBe('a\nb\n');
+
+        // Move the caret to the start of the second visual line (before `b`) and
+        // Backspace to delete the soft break, rejoining the lines into `ab`.
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('Backspace');
+
+        await page.waitForFunction(
+            () => window.muya!.getMarkdown() === 'ab\n',
+            undefined,
+            { timeout: 5000 },
+        );
+        expect(await getMarkdown(page)).toBe('ab\n');
+        await expect(page.locator(editor.paragraph)).toHaveCount(1);
+        await expect(page.locator(editor.softLineBreak)).toHaveCount(0);
+    });
 });

--- a/packages/muya/e2e/tests/typing/table.spec.ts
+++ b/packages/muya/e2e/tests/typing/table.spec.ts
@@ -3,6 +3,31 @@ import { getMarkdown } from '../helpers/api';
 import { slowType } from '../helpers/keyboard';
 import { editor, floats, quickInsertItem, tablePickerCell } from '../helpers/selectors';
 
+/**
+ * Seed a 2x2 GFM table directly via `setContent` (header row + one body row,
+ * two columns). Driving the table through markdown is far steadier than
+ * typing `| .. |` + Enter under headless, and lets cell-editing tests start
+ * from a known shape. muya renders `<figure.mu-table><table.mu-table-inner>`
+ * with NO `<thead>`/`<tbody>` — every cell is a `<td.mu-table-cell>` whose
+ * editable leaf carries `.mu-table-cell-content`.
+ *
+ * The first body cell is left EMPTY on purpose so cell-editing tests can type
+ * into a clean cell. Clearing a seeded cell with Backspace inside the cell is
+ * unsafe — TableCellContent.backspaceHandler at offset 0 can replace the whole
+ * table — so editing tests must start from an empty cell rather than delete.
+ */
+async function makeTwoByTwoTable(page: import('@playwright/test').Page) {
+    await page.evaluate(() => {
+        window.muya!.setContent('| h1 | h2 |\n| --- | --- |\n|  | b |\n');
+    });
+    const table = page.locator(editor.table).first();
+    await expect(table).toBeVisible();
+    // Two rows (header + body), two columns each.
+    await expect(table.locator('tr')).toHaveCount(2);
+    await expect(table.locator('tr').first().locator('td')).toHaveCount(2);
+    return table;
+}
+
 test.describe('table', () => {
     test('typing `| a | b |` + Enter converts paragraph to a table', async ({ page }) => {
         await page.evaluate(() => window.muya!.setContent(''));
@@ -62,5 +87,119 @@ test.describe('table', () => {
         await expect(firstBodyCell).toContainText('cell-text');
         const md = await getMarkdown(page);
         expect(md).toContain('cell-text');
+    });
+
+    test('typing `**b**` in a cell renders an inline strong run and round-trips to markdown', async ({ page }) => {
+        const table = await makeTwoByTwoTable(page);
+
+        // Edit the (empty) first body cell. The cell content leaf is a
+        // `Format` block, so the inline `**...**` tokenizer applies.
+        const bodyCell = table.locator('tr').nth(1).locator('td').first();
+        const cellContent = bodyCell.locator('.mu-table-cell-content');
+        await cellContent.click();
+        await slowType(page, '**b**');
+
+        // The strong run renders as a live `<strong>` element inside the cell
+        // (see inlineRenderer/renderer/delEmStrongFactory.ts — it emits
+        // `h('strong.mu-inline-rule', ...)`).
+        const strong = bodyCell.locator('strong');
+        await expect(strong).toHaveCount(1);
+        // Characterization: while the caret is still between the live `**`
+        // markers, the trailing pair is absorbed into the strong content, so
+        // the rendered text reads `b**` (not a bare `b`). Assert what actually
+        // renders — the run carries the `b`.
+        await expect(strong).toContainText('b');
+
+        // getMarkdown serialises the strong run back into the body cell. Same
+        // marker-absorption quirk shows up here as `**b****`, so assert the
+        // strong opener rather than an exact `**b**`.
+        await expect.poll(() => getMarkdown(page)).toContain('**b');
+    });
+
+    test('a block-level shortcut (`# `) typed in a cell stays cell text (no heading conversion)', async ({ page }) => {
+        const table = await makeTwoByTwoTable(page);
+
+        // The `# `→atx-heading shortcut is owned by ParagraphContent's
+        // re-parse path; TableCellContent extends `Format` directly and never
+        // runs it, so the hashes remain literal cell text.
+        const bodyCell = table.locator('tr').nth(1).locator('td').first();
+        const cellContent = bodyCell.locator('.mu-table-cell-content');
+        await cellContent.click();
+        await slowType(page, '# x');
+
+        // No atx-heading appears, and the table is still a table.
+        await expect(page.locator(editor.atxHeading)).toHaveCount(0);
+        await expect(table).toBeVisible();
+        // The literal text lives in the cell.
+        await expect(cellContent).toContainText('# x');
+
+        // The active selection is still inside a table cell content block —
+        // the shortcut did NOT escape the cell.
+        const anchorBlockName = await page.evaluate(
+            () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName,
+        );
+        expect(anchorBlockName).toBe('table.cell.content');
+
+        // The markdown still holds the literal hashes inside the GFM table row,
+        // not as a heading.
+        const md = await getMarkdown(page);
+        expect(md).toContain('# x');
+        expect(md).toContain('|');
+    });
+
+    test('clicking the table figure dead-zone places the caret in the last cell', async ({ page }) => {
+        const table = await makeTwoByTwoTable(page);
+
+        // `editor.table` resolves the inner `<table.mu-table-inner>`. The
+        // dead-zone target is its `<figure.mu-table>` parent, which has
+        // `padding: 0.5em 0` (top/bottom only). Table#_listenDomEvent only
+        // fires its caret-to-last-cell handler when `event.target` IS the
+        // figure node — i.e. a click in that top/bottom padding band, not on
+        // any `<td>`.
+        const figureBox = await table.evaluate((tableEl) => {
+            const figure = tableEl.closest('figure.mu-table') as HTMLElement | null;
+            if (!figure)
+                throw new Error('table figure (.mu-table) not found');
+            const r = figure.getBoundingClientRect();
+            const inner = tableEl.getBoundingClientRect();
+            return {
+                x: r.x,
+                width: r.width,
+                figureBottom: r.bottom,
+                innerBottom: inner.bottom,
+            };
+        });
+
+        // Click in the bottom padding band of the figure (below the inner
+        // table, still inside the figure), targeting the last cell.
+        const clickX = figureBox.x + figureBox.width / 2;
+        const padGap = figureBox.figureBottom - figureBox.innerBottom;
+        // Guard: the padding band must exist for this click to land on the
+        // figure rather than the inner table.
+        expect(padGap).toBeGreaterThan(1);
+        const clickY = figureBox.innerBottom + padGap / 2;
+        await page.mouse.click(clickX, clickY);
+
+        // The caret is now in a table cell content block. Read the live
+        // selection's anchor block name (set by Table's mousedown handler via
+        // `lastContentInDescendant().setCursor(...)`).
+        await expect.poll(
+            () => page.evaluate(
+                () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName ?? null,
+            ),
+        ).toBe('table.cell.content');
+
+        // And it is specifically the LAST cell of the table (last row, last
+        // column) — `lastContentInDescendant`.
+        const inLastCell = await page.evaluate(() => {
+            const anchorBlock = window.muya!.editor.selection.getSelection()?.anchorBlock;
+            if (!anchorBlock)
+                return false;
+            const cellEl = (anchorBlock.domNode as HTMLElement | undefined)?.closest('td.mu-table-cell');
+            const figure = cellEl?.closest('figure.mu-table');
+            const cells = figure ? [...figure.querySelectorAll('td.mu-table-cell')] : [];
+            return cellEl != null && cells.length > 0 && cells[cells.length - 1] === cellEl;
+        });
+        expect(inLastCell).toBe(true);
     });
 });

--- a/packages/muya/e2e/tests/typing/table.spec.ts
+++ b/packages/muya/e2e/tests/typing/table.spec.ts
@@ -136,7 +136,7 @@ test.describe('table', () => {
         // The active selection is still inside a table cell content block —
         // the shortcut did NOT escape the cell.
         const anchorBlockName = await page.evaluate(
-            () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName,
+            () => window.muya!.editor.selection.getSelection()?.anchor?.block?.blockName,
         );
         expect(anchorBlockName).toBe('table.cell.content');
 
@@ -185,14 +185,14 @@ test.describe('table', () => {
         // `lastContentInDescendant().setCursor(...)`).
         await expect.poll(
             () => page.evaluate(
-                () => window.muya!.editor.selection.getSelection()?.anchorBlock?.blockName ?? null,
+                () => window.muya!.editor.selection.getSelection()?.anchor?.block?.blockName ?? null,
             ),
         ).toBe('table.cell.content');
 
         // And it is specifically the LAST cell of the table (last row, last
         // column) — `lastContentInDescendant`.
         const inLastCell = await page.evaluate(() => {
-            const anchorBlock = window.muya!.editor.selection.getSelection()?.anchorBlock;
+            const anchorBlock = window.muya!.editor.selection.getSelection()?.anchor?.block;
             if (!anchorBlock)
                 return false;
             const cellEl = (anchorBlock.domNode as HTMLElement | undefined)?.closest('td.mu-table-cell');

--- a/packages/muya/e2e/tests/ui/image-tools.spec.ts
+++ b/packages/muya/e2e/tests/ui/image-tools.spec.ts
@@ -1,5 +1,32 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
 import { editor, floats } from '../helpers/selectors';
+
+/**
+ * Read the inline `opacity` the float's `.mu-float-wrapper` carries.
+ *
+ * baseFloat hides a float by leaving the wrapper at the CSS default
+ * (`opacity: 0`, off-screen at `-9999px`) and shows it by setting an inline
+ * `opacity: 1` + an on-screen position once `computePosition` resolves
+ * (see ui/baseFloat/index.ts `show`/`hide`). Playwright's `toBeVisible`
+ * ignores `opacity`, so a hidden float still reports visible — the inline
+ * opacity is the reliable shown/hidden signal (same trick as
+ * ui/paragraph-front.spec.ts).
+ */
+async function floatOpacity(page: Page, selector: string): Promise<number> {
+    return page.locator(selector).evaluate((el) => {
+        const wrapper = el.closest('.mu-float-wrapper') as HTMLElement | null;
+        return Number.parseFloat(wrapper?.style.opacity || '0');
+    });
+}
+
+/** The on-screen top the wrapper is positioned at once shown (px). */
+async function floatTop(page: Page, selector: string): Promise<string> {
+    return page.locator(selector).evaluate((el) => {
+        const wrapper = el.closest('.mu-float-wrapper') as HTMLElement | null;
+        return wrapper?.style.top || '';
+    });
+}
 
 test.describe('image tools', () => {
     test('setContent with an image renders an inline image element', async ({ page }) => {
@@ -12,5 +39,82 @@ test.describe('image tools', () => {
     test('image-selector (edit tool) and image-toolbar float roots are registered', async ({ page }) => {
         await expect(page.locator(floats.imageEditTool)).toHaveCount(1);
         await expect(page.locator(floats.imageToolbar)).toHaveCount(1);
+    });
+
+    test('an empty image (`![]()`) renders the empty-image placeholder', async ({ page }) => {
+        // With no resolvable src the inline image renderer takes its `else`
+        // branch and tags the wrapper with `mu-empty-image`
+        // (inlineRenderer/renderer/image.ts). The placeholder still carries the
+        // raw markdown on `data-raw` and an empty `.mu-image-container`.
+        await page.evaluate(() => {
+            window.muya!.setContent('![]()');
+        });
+
+        const placeholder = page.locator(editor.emptyImage).first();
+        await expect(placeholder).toBeVisible();
+        await expect(placeholder).toHaveAttribute('data-raw', '![]()');
+        // No real <img> is mounted for an empty image.
+        await expect(page.locator(`${editor.image} img`)).toHaveCount(0);
+
+        // The empty image round-trips losslessly through the serializer.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toBe('![]()\n');
+    });
+
+    test('clicking the empty-image placeholder opens the image edit tool', async ({ page }) => {
+        await page.evaluate(() => {
+            window.muya!.setContent('![]()');
+        });
+
+        const placeholder = page.locator(editor.emptyImage).first();
+        await expect(placeholder).toBeVisible();
+
+        // Before the click the edit-tool float is hidden — its wrapper sits at
+        // the CSS default opacity 0 (no inline opacity has been written yet).
+        expect(await floatOpacity(page, floats.imageEditTool)).toBe(0);
+
+        // Clicking an empty-image wrapper fires `muya-image-selector`
+        // (selection/ImageSelection.ts) which the ImageEditTool subscribes to
+        // and shows itself. `show()` writes inline opacity 1 once
+        // `computePosition` resolves.
+        await placeholder.click();
+
+        await expect.poll(
+            async () => floatOpacity(page, floats.imageEditTool),
+            { timeout: 3_000 },
+        ).toBeGreaterThan(0);
+
+        // And it is positioned on-screen (not parked at the -9999px hide spot).
+        const top = await floatTop(page, floats.imageEditTool);
+        expect(top).not.toBe('-9999px');
+        expect(top).not.toBe('');
+
+        // The shown tool is the link/embed editor: it renders the src input and
+        // the Embed button (imageEditTool `_renderLinkBody`).
+        const tool = page.locator(floats.imageEditTool);
+        await expect(tool.locator('input.src')).toHaveCount(1);
+        await expect(tool.locator('button.role-button.link')).toBeVisible();
+    });
+
+    test('an image with alt but no src is still treated as an empty placeholder', async ({ page }) => {
+        // `![alt]()` has an alt but no resolvable src, so the renderer still
+        // takes the empty-image branch. This is the same gate the click handler
+        // checks (MU_EMPTY_IMAGE), so the edit tool opens on click too.
+        await page.evaluate(() => {
+            window.muya!.setContent('![alt]()');
+        });
+
+        const placeholder = page.locator(editor.emptyImage).first();
+        await expect(placeholder).toBeVisible();
+        await expect(placeholder).toHaveAttribute('data-raw', '![alt]()');
+
+        expect(await floatOpacity(page, floats.imageEditTool)).toBe(0);
+
+        await placeholder.click();
+
+        await expect.poll(
+            async () => floatOpacity(page, floats.imageEditTool),
+            { timeout: 3_000 },
+        ).toBeGreaterThan(0);
     });
 });

--- a/packages/muya/e2e/tests/ui/paragraph-front.spec.ts
+++ b/packages/muya/e2e/tests/ui/paragraph-front.spec.ts
@@ -1,5 +1,43 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
 import { editor, floats } from '../helpers/selectors';
+
+/**
+ * Hover the first paragraph so the `ParagraphFrontButton` positions its
+ * handle over it (mousemove is throttled at 300 ms, so move twice with a tick
+ * in between to guarantee the handler observes the latest cursor location —
+ * same trick as drag/paragraph-reorder.spec.ts), then quick-click the handle.
+ *
+ * `ParagraphFrontButton`'s click handler emits the `muya-front-menu` event
+ * carrying the hovered block; `ParagraphFrontMenu` subscribes and (after a
+ * 0 ms timeout) shows + renders the menu. Resolving once the first
+ * `.turn-into-item` is visible proves the menu rendered its submenu.
+ */
+async function openFrontMenu(page: Page): Promise<void> {
+    const para = page.locator(editor.paragraph).first();
+    const box = await para.boundingBox();
+    if (!box)
+        throw new Error('paragraph has no bounding box');
+
+    await page.mouse.move(box.x + 10, box.y + box.height / 2);
+    await page.waitForTimeout(50);
+    await page.mouse.move(box.x + 12, box.y + box.height / 2);
+
+    const wrapper = page.locator(floats.paragraphFrontButton);
+    await expect.poll(async () => wrapper.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        return r.width > 0
+            && r.height > 0
+            && Number.parseFloat((el as HTMLElement).style.opacity || '0') > 0;
+    }), { timeout: 3_000 }).toBe(true);
+
+    await page.locator(floats.paragraphFrontButtonInner).click();
+
+    await expect(
+        page.locator(`${floats.paragraphFrontMenu} .turn-into-item`).first(),
+    ).toBeVisible({ timeout: 3_000 });
+}
 
 test.describe('paragraph front button + menu', () => {
     test('front-menu float root mounts after editor init', async ({ page }) => {
@@ -32,5 +70,75 @@ test.describe('paragraph front button + menu', () => {
                 return r.width > 0 && r.height > 0;
             });
         }, { timeout: 3_000 }).toBe(true);
+    });
+});
+
+test.describe('paragraph front menu — Turn Into', () => {
+    test('Turn Into → Code Block converts an empty paragraph and round-trips', async ({ page }) => {
+        // `canTurnIntoMenu` only offers code-block / diagram targets when the
+        // paragraph is EMPTY (a non-empty paragraph is limited to
+        // heading/quote/list — covered by the gating test below). Start from a
+        // single empty paragraph so the Code Block entry is present.
+        await page.evaluate(() => window.muya!.setContent([{ name: 'paragraph', text: '' }]));
+        await openFrontMenu(page);
+
+        // Submenu item selector is `div.turn-into-item.<label>` (label
+        // `code-block`).
+        await page
+            .locator(`${floats.paragraphFrontMenu} .turn-into-item.code-block`)
+            .click();
+
+        // The paragraph is replaced in place by a fenced code block
+        // (`mu-code-block` — block/commonMark/codeBlock sets this classList),
+        // wrapping the `.mu-codeblock-content` editor surface. NB: this engine
+        // does not emit `.mu-fence-code` (editor.fenceCode is a legacy alias).
+        await expect(page.locator(editor.codeBlock).first()).toBeVisible({ timeout: 3_000 });
+        await expect(
+            page.locator(`${editor.codeBlock} ${editor.codeContent}`).first(),
+        ).toBeVisible();
+        // replaceBlockByLabel swaps the block out, so no paragraph survives.
+        await expect(page.locator(editor.paragraph)).toHaveCount(0);
+
+        // Empty fenced code block round-trips to a bare ``` fence pair.
+        const md = await getMarkdown(page);
+        expect(md).toBe('```\n\n```\n');
+    });
+
+    test('Turn Into → Mermaid converts an empty paragraph to a diagram block and round-trips', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent([{ name: 'paragraph', text: '' }]));
+        await openFrontMenu(page);
+
+        // Label is `diagram mermaid`; the space becomes two classes
+        // (`turn-into-item diagram mermaid`).
+        await page
+            .locator(`${floats.paragraphFrontMenu} .turn-into-item.diagram.mermaid`)
+            .click();
+
+        // Diagram block mounts its container + preview surface
+        // (block/extra/diagram sets `mu-diagram-block`).
+        await expect(page.locator(editor.diagramBlock).first()).toBeVisible({ timeout: 3_000 });
+        await expect(page.locator(editor.diagramContainer).first()).toBeVisible();
+        await expect(page.locator(editor.diagramPreview).first()).toBeVisible();
+        await expect(page.locator(editor.paragraph)).toHaveCount(0);
+
+        // Empty mermaid diagram round-trips to a ```mermaid fence.
+        const md = await getMarkdown(page);
+        expect(md).toBe('```mermaid\n\n```\n');
+    });
+
+    test('Turn Into menu gates code-block/diagram to EMPTY paragraphs only', async ({ page }) => {
+        // A non-empty paragraph's Turn-Into submenu is restricted by
+        // `canTurnIntoMenu`'s PARAGRAPH_TURN_INTO_REG to
+        // paragraph/heading/quote/lists — code-block and diagram entries are
+        // absent. This is the gating contract that justifies starting the two
+        // conversion tests above from an empty paragraph.
+        await page.evaluate(() => window.muya!.setContent('hello world'));
+        await openFrontMenu(page);
+
+        const menu = floats.paragraphFrontMenu;
+        await expect(page.locator(`${menu} .turn-into-item.code-block`)).toHaveCount(0);
+        await expect(page.locator(`${menu} .turn-into-item.diagram.mermaid`)).toHaveCount(0);
+        // Block-quote IS an allowed target for a non-empty paragraph.
+        await expect(page.locator(`${menu} .turn-into-item.block-quote`)).toHaveCount(1);
     });
 });

--- a/packages/muya/e2e/tests/ui/slash-menu.spec.ts
+++ b/packages/muya/e2e/tests/ui/slash-menu.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
 import { slowType } from '../helpers/keyboard';
 import { editor, floats, quickInsertItem } from '../helpers/selectors';
 
@@ -26,5 +27,78 @@ test.describe('slash quick-insert menu', () => {
         await page.keyboard.type('/');
         await page.locator(quickInsertItem('atx-heading 2')).click();
         await expect(page.locator(editor.atxHeading).first()).toBeVisible();
+    });
+
+    // EXTEND item 1a — Enter-select inserts a block (keyboard, not click).
+    // Typing `/` then narrowing with `quote` filters the menu so `block-quote`
+    // becomes the active item (fuse top match); BaseScrollFloat's keydown
+    // handler maps Enter -> selectItem(activeItem), which runs
+    // replaceBlockByLabel and converts the active paragraph in place.
+    test('narrowing then pressing Enter converts the paragraph to the active block', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.type('/');
+        await expect(page.locator(floats.quickInsert)).toBeVisible();
+        await slowType(page, 'quote');
+        // Wait until the fuse-filtered top match (Quote Block) is the active item.
+        await page.waitForFunction(() => {
+            const active = document.querySelector('.mu-quick-insert .item.active');
+            return active?.getAttribute('data-label') === 'block-quote';
+        });
+        await page.keyboard.press('Enter');
+        // The active paragraph converts to a block-quote in place.
+        await expect(page.locator(editor.blockQuote).first()).toBeVisible();
+        // Markdown serialization is async after the in-place replace — poll it.
+        await expect.poll(() => getMarkdown(page)).toMatch(/^\s*>/);
+    });
+
+    // EXTEND item 1b — front-matter is top-only gated.
+    // `checkCanInsertFrontMatter` requires `frontMatter` (on by default) AND
+    // the trigger block to have no previous sibling under the scroll page;
+    // `search()` splices the "Front Matter" entry out otherwise. So the entry
+    // is present on the document's first block and absent on a lower block.
+    test('front-matter entry is available on the first block', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.type('/');
+        await expect(page.locator(floats.quickInsert)).toBeVisible();
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.mu-quick-insert');
+            return !!el && el.querySelectorAll('.item').length > 0;
+        });
+        await expect(page.locator(quickInsertItem('frontmatter'))).toBeVisible();
+    });
+
+    test('front-matter entry is absent on a non-first block', async ({ page }) => {
+        // Heading + Enter yields an empty paragraph as the SECOND block, whose
+        // parent has a previous sibling (the heading) — front-matter gating off.
+        await page.evaluate(() => window.muya!.setContent('# heading'));
+        await page.locator(editor.atxHeading).first().click();
+        await page.keyboard.press('End');
+        await page.keyboard.press('Enter');
+        await page.keyboard.type('/');
+        await expect(page.locator(floats.quickInsert)).toBeVisible();
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.mu-quick-insert');
+            return !!el && el.querySelectorAll('.item').length > 0;
+        });
+        // Other entries still render (sanity), but front-matter is spliced out.
+        await expect(page.locator(quickInsertItem('paragraph'))).toBeVisible();
+        await expect(page.locator(quickInsertItem('frontmatter'))).toHaveCount(0);
+    });
+
+    // EXTEND item 2 — the full-width Chinese ideographic comma `、` is wired as
+    // an alternate trigger alongside `/` (checkQuickInsert: /^[/、]\S*$/).
+    test('typing the full-width `、` opens the quick-insert menu', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.insertText('、');
+        await expect(page.locator(floats.quickInsert)).toBeVisible();
+        await page.waitForFunction(() => {
+            const el = document.querySelector('.mu-quick-insert');
+            return !!el && el.querySelectorAll('.item').length > 0;
+        });
+        // The menu offers the same entries as the `/` trigger.
+        await expect(page.locator(quickInsertItem('atx-heading 1'))).toBeVisible();
     });
 });


### PR DESCRIPTION
## What

Backfills **muya e2e coverage** (`packages/muya/e2e`, Playwright + Chromium) for real-keystroke / real-DOM behaviors flagged in the coverage-gap audit and confirmed open against current code. **Test-only** — no engine source changed (only e2e specs + shared selector constants).

Third PR in the audit-driven test backfill, after #4508 (muya engine-unit) and #4509 (desktop-unit). Per-package split: this is the muya e2e tier.

## Coverage added (6 commits, ~45 tests across 16 files + selectors)

- **Diagrams (new)** — mermaid / flowchart / js-sequence client-side SVG mount, mermaid invalid-code error surface, sequenceTheme class, markdown round-trips.
- **Typing & conversions** — ATX shortcuts H1–H6 (+ 7-hash non-convert), blockquote `> ` shortcut + Enter-exit, fenced code + Prism `.token` highlight, table-cell editing.
- **Inline format & math** — strong marker `.mu-hide`/`.mu-gray` toggling on caret enter/leave, strikethrough shortcut + live `<del>`, inline KaTeX render + click-to-edit + round-trip.
- **Quick-insert / front menu / image tools** — slash-menu Enter-select conversion + front-matter top-only gating + full-width `、` trigger, paragraph front-menu "Turn Into" (code/diagram, empty-only), empty-image placeholder click → image edit tool.
- **Table tools / references / disable-html** — table right-bar quick-click row menu (+ bottom-bar no-popup), reference link/image re-resolution after editing the definition, `disableHtml` suppressing inline raw HTML.

## Behavior findings (characterized as passing tests, not fixed here)

1. **Shift+Enter emits a soft `\n`, not a hard break.** State becomes `{name:'paragraph', text:'a\nb'}` → markdown `a\nb\n`. It round-trips losslessly through muya's own serializer, but a strict CommonMark consumer collapses a bare `\n` to a space, so the visual line break would be lost. (A hard break would need `a  \nb` or `a\\\nb`.)
2. **Typing `**b**` into an empty table cell absorbs the closing markers** — the rendered `<strong>` reads `b**` and `getMarkdown()` serializes `**b****`. The strong element renders and round-trips, but the marker absorption looks like a tokenizer/cursor quirk when typing the closing pair with the caret between them.
3. **Dead selector constant** — `editor.fenceCode` (`.mu-fence-code`) in `helpers/selectors.ts` matches nothing in `@muyajs/core` (code blocks render `.mu-fenced-code` / `.mu-codeblock-content`). Left in place; added the correct `codeContent` constant alongside. Candidate for cleanup.

## Verification

- The 16 changed specs: **79 passed, exit 0, clean** (`playwright test … --project=chromium`).
- Full muya e2e suite: **168 passed** (the run's non-zero exit is two pre-existing perf/stability workers not exiting on teardown — unrelated to these specs; the suite passes in CI).
- e2e specs are `tsc`-clean (remaining `tsc` errors are pre-existing engine-`src` type-laxness, not exercised by CI's Playwright transpile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
