### PR TITLE
refactor(muya): rework the selection type surface

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,14 +6,21 @@
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "cSpell.words": [
+    "commonmark",
     "contenteditable",
+    "execall",
     "frontmatter",
     "Häusler",
     "hfelix",
     "Jocs",
+    "katex",
+    "laynezh",
     "marktext",
     "muya",
+    "Setext",
     "snabbdom",
-    "Tkaixiang"
+    "snapsvg",
+    "Tkaixiang",
+    "webfontloader"
   ]
 }

--- a/packages/muya/e2e/tests/editing/selection.spec.ts
+++ b/packages/muya/e2e/tests/editing/selection.spec.ts
@@ -17,8 +17,8 @@ test.describe('selection', () => {
             const sel = window.muya!.editor.selection.getSelection();
             if (!sel)
                 return false;
-            const { anchorBlock, focusBlock } = sel;
-            return anchorBlock !== focusBlock;
+            const { anchor, focus } = sel;
+            return anchor.block !== focus.block;
         });
         expect(hasMultiBlockSelection).toBe(true);
     });

--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -101,7 +101,7 @@ describe('muya.createTable()', () => {
         const sel = muya.editor.selection.getSelection();
         expect(sel).not.toBeNull();
         // The caret lands on a table-cell content block.
-        expect(sel!.anchorBlock.blockName).toBe('table.cell.content');
+        expect(sel!.anchor.block.blockName).toBe('table.cell.content');
     });
 
     it('is a no-op when there is no current block', () => {
@@ -242,7 +242,7 @@ describe('muya.setCursor()', () => {
         await vi.waitFor(() => {
             const sel = muya.editor.selection.getSelection();
             expect(sel).not.toBeNull();
-            expect(sel!.anchorBlock).toBe(first);
+            expect(sel!.anchor.block).toBe(first);
             expect(sel!.anchor.offset).toBe(3);
         });
     });
@@ -257,7 +257,7 @@ describe('muya.setCursor()', () => {
         });
         await vi.waitFor(() => {
             const sel = muya.editor.selection.getSelection();
-            expect(sel!.anchorBlock).toBe(first);
+            expect(sel!.anchor.block).toBe(first);
             expect(sel!.anchor.offset).toBe(2);
         });
     });
@@ -275,7 +275,7 @@ describe('muya.setCursor()', () => {
         });
         await vi.waitFor(() => {
             const sel = muya.editor.selection.getSelection();
-            expect(sel!.anchorBlock).toBe(secondContent);
+            expect(sel!.anchor.block).toBe(secondContent);
             expect(sel!.anchor.offset).toBe(1);
         });
     });

--- a/packages/muya/src/__tests__/getCursorOffset.spec.ts
+++ b/packages/muya/src/__tests__/getCursorOffset.spec.ts
@@ -87,12 +87,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
         const muya = bootMuya('hello world\n');
         const block = muya.editor.scrollPage!.firstContentInDescendant()!;
         const selection: ISelection = {
-            anchor: { offset: 0 },
-            focus: { offset: 5 },
-            anchorBlock: block,
-            anchorPath: [0, 'text'],
-            focusBlock: block,
-            focusPath: [0, 'text'],
+            anchor: { offset: 0, block, path: [0, 'text'] },
+            focus: { offset: 5, block, path: [0, 'text'] },
             isCollapsed: false,
             isSelectionInSameBlock: true,
             direction: 'forward',
@@ -111,12 +107,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
         const muya = bootMuya('hello world\n');
         const block = muya.editor.scrollPage!.firstContentInDescendant()!;
         const selection: ISelection = {
-            anchor: { offset: 9 }, // after "hello wor"
-            focus: { offset: 2 }, //  after "he"
-            anchorBlock: block,
-            anchorPath: [0, 'text'],
-            focusBlock: block,
-            focusPath: [0, 'text'],
+            anchor: { offset: 9, block, path: [0, 'text'] }, // after "hello wor"
+            focus: { offset: 2, block, path: [0, 'text'] }, //  after "he"
             isCollapsed: false,
             isSelectionInSameBlock: true,
             direction: 'backward',

--- a/packages/muya/src/__tests__/historySerialization.spec.ts
+++ b/packages/muya/src/__tests__/historySerialization.spec.ts
@@ -93,7 +93,7 @@ describe('muya history serialization api', () => {
         if (recorded.selection) {
             expect(recorded.selection).not.toHaveProperty('anchorBlock');
             expect(recorded.selection).not.toHaveProperty('focusBlock');
-            expect(Array.isArray(recorded.selection.anchorPath)).toBe(true);
+            expect(Array.isArray(recorded.selection.anchor.path)).toBe(true);
         }
     });
 

--- a/packages/muya/src/__tests__/localeRefresh.spec.ts
+++ b/packages/muya/src/__tests__/localeRefresh.spec.ts
@@ -108,7 +108,7 @@ describe('muya.locale() refreshes rendered hints (Phase G — G8)', () => {
         const sel = muya.editor.selection.getSelection();
         expect(sel).not.toBeNull();
         expect(sel!.anchor.offset).toBe(5);
-        expect(sel!.anchorBlock.text).toBe('hello world');
+        expect(sel!.anchor.block.text).toBe('hello world');
     });
 
     it('is a no-op-safe re-render when the tree is not yet mounted', () => {

--- a/packages/muya/src/__tests__/replaceContent.spec.ts
+++ b/packages/muya/src/__tests__/replaceContent.spec.ts
@@ -214,7 +214,7 @@ describe('muya replaceContent — single undo boundary', () => {
 
         // @ts-expect-error — reach into the private stack for assertions.
         const storedSel = muya.editor.history._stack.undo[0].selection;
-        const pathLenBefore = storedSel?.anchorPath?.length ?? 0;
+        const pathLenBefore = storedSel?.anchor.path?.length ?? 0;
         expect(pathLenBefore).toBeGreaterThan(0);
 
         // Two full undo/redo cycles — each replay resolves the caret from paths.
@@ -237,7 +237,7 @@ describe('muya replaceContent — single undo boundary', () => {
         // @ts-expect-error — private stack read.
         const after = muya.editor.history._stack;
         const finalSel = after.redo[0]?.selection ?? after.undo[0]?.selection;
-        expect(finalSel?.anchorPath?.length ?? 0).toBeGreaterThan(0);
+        expect(finalSel?.anchor.path?.length ?? 0).toBeGreaterThan(0);
     });
 
     it('does not coalesce a later edit into the replacement boundary', async () => {
@@ -356,7 +356,7 @@ describe('muya replaceContent — single undo boundary', () => {
         muya.editor.activeContentBlock = second;
         second.setCursor(1, 1, true);
         const recordSelection = muya.getSelection();
-        const recordPath = recordSelection?.anchorPath;
+        const recordPath = recordSelection?.anchor.path;
         expect(recordPath?.length ?? 0).toBeGreaterThan(0);
 
         // Move the LIVE caret to the FIRST block — this is what an unguarded
@@ -364,7 +364,7 @@ describe('muya replaceContent — single undo boundary', () => {
         const first = muya.editor.scrollPage!.firstContentInDescendant()!;
         muya.editor.activeContentBlock = first;
         first.setCursor(0, 0, true);
-        const livePath = muya.getSelection()?.anchorPath;
+        const livePath = muya.getSelection()?.anchor.path;
         expect(livePath).not.toEqual(recordPath);
 
         muya.replaceContent('first\n\nsecond\n\nthird\n', recordSelection);
@@ -373,7 +373,7 @@ describe('muya replaceContent — single undo boundary', () => {
         // not the live DOM caret (first block).
         // @ts-expect-error — reach into the private stack for assertions.
         const storedSel = muya.editor.history._stack.undo[0].selection;
-        expect(storedSel?.anchorPath).toEqual(recordPath);
+        expect(storedSel?.anchor.path).toEqual(recordPath);
     });
 
     it('accepts a state array as well as markdown', async () => {

--- a/packages/muya/src/__tests__/setCursorByOffset.spec.ts
+++ b/packages/muya/src/__tests__/setCursorByOffset.spec.ts
@@ -53,7 +53,7 @@ describe('muya.setCursorByOffset() (PG2)', () => {
             const sel = muya.editor.selection.getSelection();
             expect(sel).not.toBeNull();
             // The caret lands inside the "third para here" block.
-            expect(sel!.anchorBlock.text).toBe('third para here');
+            expect(sel!.anchor.block.text).toBe('third para here');
             expect(sel!.anchor.offset).toBe(6);
         });
         // The document content is left clean (no sentinel residue).
@@ -72,7 +72,7 @@ describe('muya.setCursorByOffset() (PG2)', () => {
             const sel = muya.editor.selection.getSelection();
             // This engine keeps the `# ` marker in the heading content block's
             // text, so the caret lands at offset 4 of "# Title".
-            expect(sel!.anchorBlock.text).toBe('# Title');
+            expect(sel!.anchor.block.text).toBe('# Title');
             expect(sel!.anchor.offset).toBe(4);
         });
     });

--- a/packages/muya/src/__tests__/updateParagraph.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.spec.ts
@@ -169,12 +169,8 @@ describe('muya.updateParagraph()', () => {
         // range, so the real menu scenario (getSelection returns the range) is
         // stubbed here; the assertions below exercise the path re-resolution.
         const liveSelection = {
-            anchor: { offset: 0 },
-            focus: { offset: 1 },
-            anchorBlock: first,
-            anchorPath: first.path,
-            focusBlock: third,
-            focusPath: third.path,
+            anchor: { offset: 0, block: first, path: first.path },
+            focus: { offset: 1, block: third, path: third.path },
             isCollapsed: false,
             isSelectionInSameBlock: false,
             direction: 'forward',

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -296,15 +296,13 @@ class Content extends TreeNode {
         const {
             anchor,
             focus,
-            anchorBlock,
-            focusBlock,
             isCollapsed,
             isSelectionInSameBlock, // This is always be true.
             direction,
             type,
         } = selection;
 
-        if (anchorBlock !== this || focusBlock !== this)
+        if (anchor.block !== this || focus.block !== this)
             return null;
 
         return {

--- a/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
@@ -64,7 +64,7 @@ function makeClipboard(
         get: () => ({
             getSelection: () => ({
                 isSelectionInSameBlock: true,
-                anchorBlock,
+                anchor: { block: anchorBlock },
             }),
         }),
     });

--- a/packages/muya/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -36,10 +36,8 @@ function selectionOver(
     const block = { text, blockName } as unknown as Content;
     return {
         isSelectionInSameBlock: true,
-        anchor: { offset: begin },
-        focus: { offset: end },
-        anchorBlock: block,
-        focusBlock: block,
+        anchor: { offset: begin, block, path: [] },
+        focus: { offset: end, block, path: [] },
     };
 }
 

--- a/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
@@ -68,7 +68,7 @@ function makeClipboard(options: Record<string, unknown>, anchorBlock: Content) {
         get: () => ({
             getSelection: () => ({
                 isSelectionInSameBlock: true,
-                anchorBlock,
+                anchor: { block: anchorBlock },
             }),
         }),
     });

--- a/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
@@ -124,7 +124,7 @@ function makeClipboard(
     } as unknown as Muya);
     Object.defineProperty(clipboard, 'selection', {
         get: () => ({
-            getSelection: () => ({ isSelectionInSameBlock: true, anchorBlock }),
+            getSelection: () => ({ isSelectionInSameBlock: true, anchor: { block: anchorBlock } }),
             table: tableStub,
         }),
     });

--- a/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
@@ -48,7 +48,7 @@ function makeClipboard(options: Record<string, unknown>, anchorBlock: Content) {
         get: () => ({
             getSelection: () => ({
                 isSelectionInSameBlock: true,
-                anchorBlock,
+                anchor: { block: anchorBlock },
             }),
         }),
     });

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -81,12 +81,8 @@ function stubSelection(
     const aPath = a.path;
     const fPath = f.path;
     muya.editor.selection.getSelection = () => ({
-        anchor: { offset: aOff },
-        focus: { offset: fOff },
-        anchorBlock: a,
-        anchorPath: aPath,
-        focusBlock: f,
-        focusPath: fPath,
+        anchor: { offset: aOff, block: a, path: aPath },
+        focus: { offset: fOff, block: f, path: fPath },
         isCollapsed: false,
         isSelectionInSameBlock: a === f,
         direction,

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -107,7 +107,9 @@ function resolveSelectionOrder(
     clipboard: Clipboard,
     selection: ISelection,
 ): Nullable<ICopyOrder> {
-    const { anchor, anchorBlock, focus, focusBlock } = selection;
+    const { anchor, focus } = selection;
+    const anchorBlock = anchor.block;
+    const focusBlock = focus.block;
     const anchorOutMostBlock = anchorBlock.outMostBlock!;
     const focusOutMostBlock = focusBlock.outMostBlock!;
     const anchorOutMostBlockOffset = clipboard.scrollPage?.offset(anchorOutMostBlock);
@@ -257,8 +259,9 @@ export function getClipboardData(clipboard: Clipboard): IClipboardPayload {
     if (selection == null)
         return { html: '', text: '' };
 
-    const { isSelectionInSameBlock, anchor, anchorBlock, focus, focusBlock }
-        = selection;
+    const { isSelectionInSameBlock, anchor, focus } = selection;
+    const anchorBlock = anchor.block;
+    const focusBlock = focus.block;
 
     if (anchorBlock == null || focusBlock == null)
         return { html: '', text: '' };

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -322,11 +322,11 @@ export function cutSelection(clipboard: Clipboard): void {
     const {
         isSelectionInSameBlock,
         anchor,
-        anchorBlock,
         focus,
-        focusBlock,
         direction,
     } = selection;
+    const anchorBlock = anchor.block;
+    const focusBlock = focus.block;
 
     // Handler `cut` event in the same block.
     if (isSelectionInSameBlock) {

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -219,7 +219,8 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
     if (!selection)
         return;
 
-    const { isSelectionInSameBlock, anchorBlock } = selection;
+    const { isSelectionInSameBlock, anchor } = selection;
+    const anchorBlock = anchor.block;
 
     if (!anchorBlock)
         return;

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -86,8 +86,9 @@ export class Editor {
         const { domNode } = this.muya;
 
         const eventHandler = (event: Event) => {
-            const { anchorBlock, isSelectionInSameBlock }
-                = this.selection.getSelection() ?? {};
+            const selectionResult = this.selection.getSelection();
+            const anchorBlock = selectionResult?.anchor.block;
+            const isSelectionInSameBlock = selectionResult?.isSelectionInSameBlock;
             // Fix issue that language input can not get focus when it's empty(Firefox only)
             if (
                 event.type === 'click'
@@ -385,10 +386,10 @@ export class Editor {
         if (!selection)
             return;
 
-        const { anchorPath, anchor, focus, isSelectionInSameBlock } = selection;
+        const { anchor, focus, isSelectionInSameBlock } = selection;
         // `ScrollPage.queryBlock` consumes the path array in place (`path.shift`),
         // so query against a copy and leave the caller's selection untouched.
-        const cursorBlock = this.scrollPage?.queryBlock([...anchorPath]);
+        const cursorBlock = this.scrollPage?.queryBlock([...anchor.path]);
 
         const begin = Math.min(anchor.offset, focus.offset);
         const end = Math.max(anchor.offset, focus.offset);
@@ -418,9 +419,16 @@ export class Editor {
         // paths so `_setCursor`'s `queryBlock(path)` fallback can't drain the
         // caller's arrays — notably the selection object stored in the undo stack.
         this.selection.setSelection({
-            ...selection,
-            anchorPath: [...selection.anchorPath],
-            focusPath: [...selection.focusPath],
+            anchor,
+            focus,
+            anchorBlock: anchor.block,
+            anchorPath: [...anchor.path],
+            focusBlock: focus.block,
+            focusPath: [...focus.path],
+            isCollapsed: selection.isCollapsed,
+            isSelectionInSameBlock,
+            direction: selection.direction,
+            type: selection.type,
         });
     }
 

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -1,6 +1,6 @@
 import type { JSONOpList } from 'ot-json1';
 import type { Muya } from '../muya';
-import type { IHistorySelection } from '../selection/types';
+import type { IAnchorFocusInfo, IHistorySelection } from '../selection/types';
 import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import * as json1 from 'ot-json1';
@@ -33,16 +33,16 @@ interface IStack {
     redo: IOperation[];
 }
 
-// A JSON-serializable view of an ISelection. The live `anchorBlock` /
-// `focusBlock` references are dropped — they are an in-memory optimization
-// only. `Selection._setCursor` re-resolves the target block from
-// `anchorPath` / `focusPath` via `scrollPage.queryBlock(path)` when no block
-// instance is present, so a path-only selection restores the caret losslessly.
+// A JSON-serializable view of an ISelection. The live endpoint `block`
+// references are dropped — they are an in-memory optimization only.
+// `Selection._setCursor` re-resolves the target block from each endpoint's
+// `path` via `scrollPage.queryBlock(path)` when no block instance is present,
+// so a path-only selection restores the caret losslessly.
+type ISerializableAnchorFocusInfo = Pick<IAnchorFocusInfo, 'offset' | 'path'>;
+
 interface ISerializableSelection {
-    anchor: IHistorySelection['anchor'];
-    focus: IHistorySelection['focus'];
-    anchorPath: IHistorySelection['anchorPath'];
-    focusPath: IHistorySelection['focusPath'];
+    anchor: ISerializableAnchorFocusInfo;
+    focus: ISerializableAnchorFocusInfo;
     isCollapsed: IHistorySelection['isCollapsed'];
     isSelectionInSameBlock: IHistorySelection['isSelectionInSameBlock'];
     direction: IHistorySelection['direction'];
@@ -215,10 +215,8 @@ class History {
             return selection;
 
         return {
-            anchor: deepClone(selection.anchor),
-            focus: deepClone(selection.focus),
-            anchorPath: deepClone(selection.anchorPath),
-            focusPath: deepClone(selection.focusPath),
+            anchor: { offset: selection.anchor.offset, path: deepClone(selection.anchor.path) },
+            focus: { offset: selection.focus.offset, path: deepClone(selection.focus.path) },
             isCollapsed: selection.isCollapsed,
             isSelectionInSameBlock: selection.isSelectionInSameBlock,
             direction: selection.direction,
@@ -229,9 +227,9 @@ class History {
     // Rebuild a selection without live block references. The block instances
     // are intentionally omitted: the only consumers of a restored selection
     // are `editor.updateContents` and `selection._setCursor`, both of which
-    // re-resolve the target block from `anchorPath` / `focusPath` via
+    // re-resolve the target block from each endpoint's `path` via
     // `scrollPage.queryBlock` when no block instance is present. The return
-    // type is `IHistorySelection`, whose `anchorBlock` / `focusBlock` are
+    // type is `IHistorySelection`, whose endpoint `block` references are
     // optional, so the missing block fields are part of the contract rather
     // than an unsound cast over fabricated `ContentBlock` instances.
     private _fromSerializableSelection(
@@ -241,10 +239,8 @@ class History {
             return selection;
 
         return {
-            anchor: deepClone(selection.anchor),
-            focus: deepClone(selection.focus),
-            anchorPath: deepClone(selection.anchorPath),
-            focusPath: deepClone(selection.focusPath),
+            anchor: { offset: selection.anchor.offset, path: deepClone(selection.anchor.path) },
+            focus: { offset: selection.focus.offset, path: deepClone(selection.focus.path) },
             isCollapsed: selection.isCollapsed,
             isSelectionInSameBlock: selection.isSelectionInSameBlock,
             direction: selection.direction,

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -355,7 +355,7 @@ export class Muya {
         if (selection && selection.isSelectionInSameBlock) {
             const begin = Math.min(selection.anchor.offset, selection.focus.offset);
             const end = Math.max(selection.anchor.offset, selection.focus.offset);
-            const cursorBlock = this.editor.scrollPage?.queryBlock(selection.anchorPath);
+            const cursorBlock = this.editor.scrollPage?.queryBlock(selection.anchor.path);
             if (cursorBlock && cursorBlock.isContent())
                 cursorBlock.setCursor(begin, end, true);
         }
@@ -414,15 +414,8 @@ export class Muya {
         if (!sel)
             return;
 
-        const {
-            anchor,
-            focus,
-            anchorBlock,
-            anchorPath,
-            focusBlock,
-            focusPath,
-            isSelectionInSameBlock,
-        } = sel;
+        const { anchor, focus, isSelectionInSameBlock } = sel;
+        const anchorBlock = anchor.block;
 
         if (!isSelectionInSameBlock || !(anchorBlock instanceof Format))
             return;
@@ -433,9 +426,9 @@ export class Muya {
             anchor,
             focus,
             anchorBlock,
-            anchorPath,
-            focusBlock,
-            focusPath,
+            anchorPath: anchor.path,
+            focusBlock: focus.block,
+            focusPath: focus.path,
         });
 
         anchorBlock.format(type);
@@ -1096,8 +1089,8 @@ export class Muya {
         const live = sel.getSelection();
         const anchor = live?.anchor ?? sel.anchor;
         const focus = live?.focus ?? sel.focus;
-        const anchorPath = live?.anchorPath ?? sel.anchorPath;
-        const focusPath = live?.focusPath ?? sel.focusPath;
+        const anchorPath = live?.anchor.path ?? sel.anchorPath;
+        const focusPath = live?.focus.path ?? sel.focusPath;
         if (!anchor || !focus || !anchorPath?.length || !focusPath?.length)
             return null;
 

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -6,6 +6,7 @@ import { BLOCK_DOM_PROPERTY, CLASS_NAMES } from '../config';
 import { isHTMLElement, isKeyboardEvent } from '../utils';
 import { getImageInfo, getImageSrc } from '../utils/image';
 import { findContentDOM } from './dom';
+import { SelectionType } from './types';
 
 class ImageSelection {
     selected: IImageSelectionData | null = null;
@@ -56,7 +57,7 @@ class ImageSelection {
             event.preventDefault();
             const { block, ...imageInfo } = selected;
             block.deleteImage(imageInfo);
-            this._selection.activate('text');
+            this._selection.activate(SelectionType.Text);
         }
     };
 

--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -261,7 +261,7 @@ class TableRectSelection {
 
     /**
      * The selected rectangle as an `ITableState` sub-table, or `null` when there
-     * is no frozen selection. The clipboard serialises this to GFM markdown.
+     * is no frozen selection. The clipboard serializes this to GFM markdown.
      */
     getStateForCopy(): Nullable<ITableState> {
         if (!this.hasSelection)

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -1,6 +1,8 @@
 import type Content from '../block/base/content';
 import type Format from '../block/base/format';
+import type { TBlockPath } from '../block/types';
 import type { Muya } from '../muya';
+import type { Nullable } from '../types';
 import type Selection from './index';
 import type { ICursor, INodeOffset, ISelection } from './types';
 import { BLOCK_DOM_PROPERTY } from '../config';
@@ -16,15 +18,17 @@ import {
     getNodeAndOffset,
     getOffsetOfParagraph,
 } from './dom';
+import { SelectionType } from './types';
 
 class TextSelection {
-    public doc: Document = document;
-    public anchorPath: (string | number)[] = [];
-    public anchorBlock: Content | null = null;
-    public focusPath: (string | number)[] = [];
-    public focusBlock: Content | null = null;
-    public anchor: INodeOffset | null = null;
-    public focus: INodeOffset | null = null;
+    public anchorPath: TBlockPath = [];
+    public anchorBlock: Nullable<Content> = null;
+    public focusPath: TBlockPath = [];
+    public focusBlock: Nullable<Content> = null;
+    public anchor: Nullable<INodeOffset> = null;
+    public focus: Nullable<INodeOffset> = null;
+
+    private _doc: Document = document;
 
     private _selectInfo: {
         isSelect: boolean;
@@ -45,16 +49,16 @@ class TextSelection {
     get isCollapsed() {
         const { anchorBlock, focusBlock, anchor, focus } = this;
 
-        if (anchor === null || focus === null)
+        if (anchor == null || focus == null)
             return false;
 
         return anchorBlock === focusBlock && anchor.offset === focus.offset;
     }
 
     get isSelectionInSameBlock() {
-        const { anchorBlock, focusBlock, anchor } = this;
+        const { anchorBlock, focusBlock, anchor, focus } = this;
 
-        if (anchor === null || focus === null)
+        if (anchor == null || focus == null)
             return false;
 
         return anchorBlock === focusBlock;
@@ -69,7 +73,7 @@ class TextSelection {
             isSelectionInSameBlock,
             isCollapsed,
         } = this;
-        if (anchor === null || focus === null || !anchorBlock || !focusBlock)
+        if (anchor == null || focus == null || !anchorBlock || !focusBlock)
             return 'none';
 
         if (isCollapsed)
@@ -117,13 +121,13 @@ class TextSelection {
         };
 
         this.setSelection(cursor);
-        const activeEle = this.doc.activeElement;
+        const activeEle = this._doc.activeElement;
         if (isHTMLElement(activeEle) && activeEle.classList.contains('mu-content'))
             activeEle.blur();
     }
 
     getSelection(): ISelection | null {
-        const selection = document.getSelection();
+        const selection = this._doc.getSelection();
 
         if (!selection)
             return null;
@@ -146,19 +150,18 @@ class TextSelection {
         // crashing — the caller treats null the same as "no selection".
         if (!anchorBlock || !focusBlock)
             return null;
+
         const anchorPath = anchorBlock.path;
         const focusPath = focusBlock.path;
 
-        const aOffset
-            = getOffsetOfParagraph(anchorNode, anchorDomNode) + anchorOffset;
+        const aOffset = getOffsetOfParagraph(anchorNode, anchorDomNode) + anchorOffset;
         const fOffset = getOffsetOfParagraph(focusNode, focusDomNode) + focusOffset;
         const anchor = { offset: aOffset };
         const focus = { offset: fOffset };
 
-        const isCollapsed
-            = anchorBlock === focusBlock && anchor.offset === focus.offset;
-
+        const isCollapsed = anchorBlock === focusBlock && anchor.offset === focus.offset;
         const isSelectionInSameBlock = anchorBlock === focusBlock;
+
         let direction: string;
 
         if (isSelectionInSameBlock) {
@@ -174,12 +177,8 @@ class TextSelection {
         const type = isCollapsed ? 'Caret' : 'Range';
 
         return {
-            anchor,
-            focus,
-            anchorBlock,
-            anchorPath,
-            focusBlock,
-            focusPath,
+            anchor: { offset: anchor.offset, block: anchorBlock, path: anchorPath },
+            focus: { offset: focus.offset, block: focusBlock, path: focusPath },
             isCollapsed,
             isSelectionInSameBlock,
             direction,
@@ -203,7 +202,7 @@ class TextSelection {
         this.anchorPath = anchorPath ?? path ?? [];
         this.focusBlock = focusBlock ?? block ?? null;
         this.focusPath = focusPath ?? path ?? [];
-        this._setCursor();
+        this._updateSelection();
 
         const {
             isCollapsed,
@@ -243,8 +242,7 @@ class TextSelection {
             isSelectionInSameBlock,
             direction,
             type,
-            kind: 'text',
-            selection: this,
+            kind: SelectionType.Text,
             selectedImage: this._selection.image,
             cursorCoords,
             formats,
@@ -289,18 +287,14 @@ class TextSelection {
             if (!selection)
                 return;
 
-            const {
-                anchor,
-                focus,
-                anchorBlock,
-                focusBlock,
-                isSelectionInSameBlock,
-            } = selection;
+            const { anchor, focus, isSelectionInSameBlock } = selection;
 
             if (isSelectionInSameBlock) {
                 return;
             }
 
+            const anchorBlock = anchor.block;
+            const focusBlock = focus.block;
             const newSelection = {
                 anchor,
                 focus,
@@ -324,7 +318,7 @@ class TextSelection {
     }
 
     private _selectRange(range: Range) {
-        const selection = this.doc.getSelection();
+        const selection = this._doc.getSelection();
 
         if (selection) {
             selection.removeAllRanges();
@@ -338,7 +332,7 @@ class TextSelection {
         endNode?: Node,
         endOffset?: number,
     ) {
-        const range = this.doc.createRange();
+        const range = this._doc.createRange();
         range.setStart(startNode, startOffset);
         if (endNode && typeof endOffset === 'number')
             range.setEnd(endNode, endOffset);
@@ -351,12 +345,12 @@ class TextSelection {
     }
 
     private _setFocus(focusNode: Node, focusOffset: number) {
-        const selection = this.doc.getSelection();
+        const selection = this._doc.getSelection();
         if (selection)
             selection.extend(focusNode, focusOffset);
     }
 
-    private _setCursor() {
+    private _updateSelection() {
         const {
             anchor,
             focus,
@@ -368,7 +362,8 @@ class TextSelection {
         } = this;
 
         if (!anchor || !focus) {
-            const selection = this.doc.getSelection();
+            const selection = this._doc.getSelection();
+
             if (selection)
                 selection.removeAllRanges();
 

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -1,7 +1,7 @@
 import type Table from '../block/gfm/table';
 import type TableBodyCell from '../block/gfm/table/cell';
 import type { Muya } from '../muya';
-import type { ICursor, IImageSelectionData, ISelection, SelectionType } from './types';
+import type { ICursor, IImageSelectionData, ISelection } from './types';
 import {
     getCursorCoords,
     getCursorYOffset,
@@ -10,6 +10,7 @@ import {
 import ImageSelection from './ImageSelection';
 import TableRectSelection from './TableRectSelection';
 import TextSelection from './TextSelection';
+import { SelectionType } from './types';
 
 class Selection {
     static getCursorYOffset(paragraph: HTMLElement) {
@@ -37,16 +38,16 @@ class Selection {
 
     get type(): SelectionType {
         if (this._image.selected)
-            return 'image';
+            return SelectionType.Image;
         if (this._table.hasSelection)
-            return 'table';
-        return 'text';
+            return SelectionType.Table;
+        return SelectionType.Text;
     }
 
     get current(): TextSelection | TableRectSelection | ImageSelection {
         switch (this.type) {
-            case 'image': return this._image;
-            case 'table': return this._table;
+            case SelectionType.Image: return this._image;
+            case SelectionType.Table: return this._table;
             default: return this._text;
         }
     }
@@ -90,21 +91,20 @@ class Selection {
     selectImage(data: IImageSelectionData): void {
         this._image.selected = data;
         this.muya.editor.activeContentBlock = null;
-        this.activate('image');
+        this.activate(SelectionType.Image);
     }
 
     activate(type: SelectionType): void {
-        if (type !== 'text')
+        if (type !== SelectionType.Text)
             this._text.collapse();
-        if (type !== 'table')
+        if (type !== SelectionType.Table)
             this._table.clear();
-        if (type !== 'image')
+        if (type !== SelectionType.Image)
             this._image.clear();
 
-        if (type !== 'text') {
+        if (type !== SelectionType.Text) {
             this.muya.eventCenter.emit('selection-change', {
                 kind: type,
-                selection: this.current,
             });
         }
     }
@@ -128,30 +128,25 @@ class Selection {
     }
 
     selectAll(): void {
-        const { anchor, focus, isSelectionInSameBlock, anchorBlock, focusBlock, anchorPath }
-            = this._text;
+        const { anchor, focus, isSelectionInSameBlock, anchorBlock, focusBlock, anchorPath } = this._text;
         const tableSelection = this._table;
 
-        // Table escalation:
-        //   whole table frozen → clear + select the whole document.
-        //   single cell frozen → select the whole table.
         if (tableSelection.isWholeTableSelected()) {
             tableSelection.clear();
             this._text.selectAllContent();
             return;
         }
+
         if (tableSelection.isSingleCellSelected()) {
             const cellBlock = anchorBlock?.closestBlock('table.cell') as TableBodyCell | null;
             const table = cellBlock?.table ?? null;
+
             if (table) {
                 tableSelection.selectTable(table);
                 return;
             }
         }
 
-        // Caret / range inside table cells. A 1x1 selection freezes that cell;
-        // a range across two cells of the same table selects the whole table;
-        // a range across two different tables is a no-op (no document select).
         if (
             anchorBlock?.blockName === 'table.cell.content'
             && focusBlock?.blockName === 'table.cell.content'
@@ -205,6 +200,7 @@ class Selection {
             });
             return;
         }
+
         this._text.selectAllContent();
     }
 }

--- a/packages/muya/src/selection/offsetCursor.ts
+++ b/packages/muya/src/selection/offsetCursor.ts
@@ -140,7 +140,7 @@ export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
     let focusOffset = focus.offset;
 
     // When both sentinels live in the same block, the second one's recorded
-    // offset is shifted by the first sentinel's length. Normalise so both
+    // offset is shifted by the first sentinel's length. Normalize so both
     // offsets are expressed against the sentinel-free text.
     if (anchor.block === focus.block) {
         if (anchorOffset <= focusOffset)
@@ -216,7 +216,8 @@ export function injectStateSentinels(
     state: TState[],
     selection: ISelection,
 ): TState[] | null {
-    const { anchorPath, focusPath } = selection;
+    const anchorPath = selection.anchor.path;
+    const focusPath = selection.focus.path;
     const anchorOffset = selection.anchor.offset;
     const focusOffset = selection.focus.offset;
 

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -1,5 +1,6 @@
 import type ContentBlock from '../block/base/content';
 import type Format from '../block/base/format';
+import type { TBlockPath } from '../block/types';
 import type { ImageToken } from '../inlineRenderer/types';
 
 export interface INodeOffset {
@@ -11,46 +12,60 @@ export interface ICursor {
     start?: INodeOffset | null;
     end?: INodeOffset | null;
     block?: ContentBlock;
-    path?: (string | number)[];
+    path?: TBlockPath;
     // The same as TSelection
     anchor?: INodeOffset | null;
     focus?: INodeOffset | null;
     anchorBlock?: ContentBlock;
-    anchorPath?: (string | number)[];
+    anchorPath?: TBlockPath;
     focusBlock?: ContentBlock;
-    focusPath?: (string | number)[];
+    focusPath?: TBlockPath;
     isCollapsed?: boolean;
     isSelectionInSameBlock?: boolean;
     direction?: string;
     type?: string;
 }
 
+// One endpoint of a selection: the offset plus the live block reference and its
+// json path. `block` is an in-memory optimization re-resolved from `path` on
+// apply, so the history variant below makes it optional.
+export interface IAnchorFocusInfo {
+    offset: number;
+    block: ContentBlock;
+    path: TBlockPath;
+}
+
 // Only used for selection.getSelection return type.
 export interface ISelection {
-    anchor: INodeOffset;
-    focus: INodeOffset;
-    anchorBlock: ContentBlock;
-    anchorPath: (string | number)[];
-    focusBlock: ContentBlock;
-    focusPath: (string | number)[];
+    anchor: IAnchorFocusInfo;
+    focus: IAnchorFocusInfo;
     isCollapsed: boolean;
     isSelectionInSameBlock: boolean;
     direction: string;
     type: string;
 }
 
-// An `ISelection` whose live `anchorBlock` / `focusBlock` references are
-// optional. The history stacks store selections that may have lost their block
-// instances after a serialize/restore round-trip (those references are an
-// in-memory optimization re-resolved from `anchorPath` / `focusPath` on apply).
-// A full `ISelection` is assignable to this type, so live selections captured
-// via `getSelection()` still fit without any cast.
-export type IHistorySelection = Omit<ISelection, 'anchorBlock' | 'focusBlock'> & {
-    anchorBlock?: ContentBlock;
-    focusBlock?: ContentBlock;
+// An endpoint whose live `block` reference is optional — used by the history
+// stacks, whose selections may have lost their block instances after a
+// serialize/restore round-trip (the reference is re-resolved from `path` on
+// apply).
+export type IHistoryAnchorFocusInfo = Omit<IAnchorFocusInfo, 'block'> & {
+    block?: ContentBlock;
 };
 
-export type SelectionType = 'text' | 'table' | 'image';
+// An `ISelection` whose endpoints' live `block` references are optional. A full
+// `ISelection` is assignable to this type, so live selections captured via
+// `getSelection()` still fit without any cast.
+export type IHistorySelection = Omit<ISelection, 'anchor' | 'focus'> & {
+    anchor: IHistoryAnchorFocusInfo;
+    focus: IHistoryAnchorFocusInfo;
+};
+
+export enum SelectionType {
+    Text = 'text',
+    Table = 'table',
+    Image = 'image',
+}
 
 export interface IImageSelectionData {
     token: ImageToken;

--- a/packages/muya/src/ui/inlineFormatToolbar/index.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/index.ts
@@ -130,7 +130,8 @@ export class InlineFormatToolbar extends BaseFloat {
         if (!selection)
             return;
 
-        const { anchorBlock, isSelectionInSameBlock } = selection;
+        const { anchor, isSelectionInSameBlock } = selection;
+        const anchorBlock = anchor.block;
 
         if (!isSelectionInSameBlock)
             return;
@@ -254,8 +255,8 @@ export class InlineFormatToolbar extends BaseFloat {
 
         // Restore selection before formatting
         selection.setSelection({
-            anchor,
-            focus,
+            anchor: anchor ?? null,
+            focus: focus ?? null,
             anchorBlock: anchorBlock!,
             anchorPath,
             focusBlock: focusBlock!,

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
@@ -91,8 +91,9 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
         });
 
         const handleKeydown = (event: Event) => {
-            const { anchorBlock, isSelectionInSameBlock }
-                = editor.selection.getSelection() ?? {};
+            const selectionResult = editor.selection.getSelection();
+            const anchorBlock = selectionResult?.anchor.block;
+            const isSelectionInSameBlock = selectionResult?.isSelectionInSameBlock;
             if (isSelectionInSameBlock && anchorBlock instanceof ParagraphContent) {
                 if (anchorBlock.text)
                     return;


### PR DESCRIPTION
## Summary

Reworks the type surface of the muya selection module. These sub-changes are physically intertwined in the same files/hunks (notably `selection/types.ts` and `selection/index.ts`), so they ship as one cohesive refactor rather than artificially split commits that wouldn't compile in isolation.

- **`SelectionType` → string enum.** Converts the `'text' | 'table' | 'image'` union to a string enum and routes every comparison/assignment through the enum members. String-enum members equal their string value at runtime, so the `kind` field emitted on `selection-change` events still serializes to `'text'`/`'table'`/`'image'` for the desktop renderer and any plugin consumers.
- **Nested `ISelection`.** Block + path now live under each endpoint via `IAnchorFocusInfo` (`{ offset, block, path }`), with `IHistoryAnchorFocusInfo` for the serialize/restore history variant whose `block` is optional. Every `getSelection()` consumer moves to `anchor.block` / `anchor.path`. The flat `ICursor` input contract for `setSelection()` is **unchanged**, so the few places that build a cursor from a selection map the fields explicitly.
- **Drop dead event field.** Removes the unused `selection` field from the `selection-change` payload — no in-repo listener reads it.
- **Type-error fix.** Coerces the facade's nullable `anchor`/`focus` (`Nullable<INodeOffset>` includes `void`) when restoring the selection in the inline format toolbar.
- **Minor.** Adopts the `TBlockPath` alias for `ICursor` paths and tidies `selectAll()`.

A separate preceding commit (`chore`) grows the cSpell dictionary and fixes a comment typo.

## Test plan

- `pnpm -C packages/muya exec tsc --noEmit` — clean.
- `pnpm -C packages/muya lint` — no errors (only pre-existing complexity warnings).
- `pnpm -C packages/muya test` — **760/760 pass** (unit specs updated for the nested shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)