### PR TITLE
fix(desktop): point in-app docs links at marktext.me

### DIFF
--- a/packages/desktop/src/renderer/src/components/exportSettings/index.vue
+++ b/packages/desktop/src/renderer/src/components/exportSettings/index.vue
@@ -163,7 +163,7 @@
           </div>
           <cur-select
             :description="t('exportSettings.theme.theme')"
-            more="https://github.com/marktext/marktext/blob/develop/docs/EXPORT_THEMES.md"
+            more="https://marktext.me/docs/export-themes"
             :value="theme"
             :options="themeList"
             :on-change="(value: unknown) => onSelectChange('theme', value)"

--- a/packages/desktop/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/image/components/folderSetting/index.vue
@@ -28,7 +28,7 @@
       <template #head>
         <bool
           :description="t('preferences.image.folderSetting.preferRelative')"
-          more="https://github.com/marktext/marktext/blob/develop/docs/end-user/IMAGES.md"
+          more="https://marktext.me/docs/images"
           :bool="imagePreferRelativeDirectory"
           :on-change="(value) => onSelectChange('imagePreferRelativeDirectory', value)"
         />

--- a/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
@@ -8,7 +8,7 @@
           class="link"
           :title="t('preferences.keybindings.online')"
           :aria-label="t('preferences.keybindings.online')"
-          @click="openKeybindingWiki"
+          @click="openKeybindingDocs"
         ><LinkIcon
           :size="14"
           class="link-icon"
@@ -167,7 +167,7 @@ onUnmounted(() => {
   keybindingConfigurator.value = null
 })
 
-const openKeybindingWiki = (): void => {
+const openKeybindingDocs = (): void => {
   window.electron.shell.openExternal(
     'https://marktext.me/docs/key-bindings'
   )

--- a/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
@@ -169,7 +169,7 @@ onUnmounted(() => {
 
 const openKeybindingWiki = (): void => {
   window.electron.shell.openExternal(
-    'https://github.com/marktext/marktext/blob/develop/docs/end-user/KEYBINDINGS.md'
+    'https://marktext.me/docs/key-bindings'
   )
 }
 

--- a/packages/website/src/lib/docs-nav.ts
+++ b/packages/website/src/lib/docs-nav.ts
@@ -54,6 +54,7 @@ export const DOC_TABS: DocTab[] = [
           { slug: ['export'], title: 'Export a document', file: 'end-user/EXPORT.md', hint: 'PDF, HTML, image export' },
           { slug: ['themes'], title: 'Themes', file: 'end-user/THEMES.md', hint: 'Built-in & custom UI themes' },
           { slug: ['export-themes'], title: 'Themes for exporting', file: 'end-user/EXPORT_THEMES.md', hint: 'Style your exported HTML' },
+          { slug: ['images'], title: 'Image support', file: 'end-user/IMAGES.md', hint: 'Copy images to a local folder' },
           { slug: ['image-uploader'], title: 'Image uploader configuration', file: 'end-user/IMAGE_UPLOADER_CONFIGRATION.md', hint: 'Cloud image hosts' }
         ]
       },


### PR DESCRIPTION
## What

Three in-app "learn more" links still pointed at `docs/*.md` files inside the GitHub repo. Those docs were relocated into the website package (`packages/website/content/docs`), so the links now **404**. This repoints them at the published docs on marktext.me.

| Where (Desktop) | Old (dead) link | New link |
|---|---|---|
| Export settings → theme — `exportSettings/index.vue` | `.../blob/develop/docs/EXPORT_THEMES.md` | `https://marktext.me/docs/export-themes` |
| Preferences → Keybindings — `keybindings/index.vue` | `.../blob/develop/docs/end-user/KEYBINDINGS.md` | `https://marktext.me/docs/key-bindings` |
| Preferences → Image, "prefer relative folder" — `folderSetting/index.vue` | `.../blob/develop/docs/end-user/IMAGES.md` | `https://marktext.me/docs/images` |

## Website docs registration

`IMAGES.md` already existed under `packages/website/content/docs/end-user/` but was **not** registered in `docs-nav.ts`, so `/docs/images` would 404 (the docs route uses `dynamicParams = false` + `generateStaticParams` over `ALL_PAGES`). It's now registered under the **Export & themes** group so the new link resolves and the page is reachable from the sidebar/search. The entry mirrors the existing siblings exactly.

## Intentionally not changed

Other GitHub links in the app are not documentation and stay as-is: releases/changelog, sponsors, discussions, issues, view source, LICENSE, and the bug-report issue composer. The Help menu's "Markdown Reference" and the command-palette docs entries were already migrated to marktext.me in earlier work.

## Notes

- Desktop edits are string-literal swaps; the website edit is one `docs-nav` entry. Relying on CI for lint + typecheck.
- The `keybindings` slug on the site is `key-bindings` (hyphenated) — used the registered slug, not a guessed `keybindings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
