### PR TITLE
fix(website): point self-referential doc links at the published docs

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -238,7 +238,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - **Main Project**: [MarkText Editor](https://github.com/marktext/marktext)
 - **Website**: [https://marktext.me](https://marktext.me)
-- **Documentation**: [MarkText Docs](https://github.com/marktext/marktext/tree/develop/docs)
+- **Documentation**: [MarkText Docs](https://marktext.me/docs)
 
 ## 💖 Sponsors
 

--- a/packages/website/content/docs/end-user/FAQ.md
+++ b/packages/website/content/docs/end-user/FAQ.md
@@ -18,11 +18,11 @@ MarkText is a pure markdown editor without feature such as knowledge management 
 
 ### Where can I find documentation?
 
-Documentation is currently under development.
+The full documentation is available on the MarkText website:
 
-- [End-user documentation](https://github.com/marktext/marktext/blob/develop/docs/README.md)
+- [End-user documentation](../README.md)
 
-- [Developer documentation](https://github.com/marktext/marktext/blob/develop/docs/dev/README.md)
+- [Developer documentation](../dev/README.md)
 
 ### Can I run a portable version of MarkText?
 


### PR DESCRIPTION
## What

Two spots in the website package still linked to `docs/*.md` under the GitHub repo. Those docs were relocated **into this package** (`packages/website/content/docs`) and are published on marktext.me, so the old links point at a `docs/` tree that no longer holds them.

| File | Old link | New link |
|---|---|---|
| `packages/website/README.md` | `github.com/marktext/marktext/tree/develop/docs` | `https://marktext.me/docs` |
| `content/docs/end-user/FAQ.md` — End-user documentation | `.../blob/develop/docs/README.md` | `../README.md` → `/docs/introduction` |
| `content/docs/end-user/FAQ.md` — Developer documentation | `.../blob/develop/docs/dev/README.md` | `../dev/README.md` → `/docs/dev/overview` |

The FAQ links use **relative content paths** (the in-content convention): `markdown.ts` rewrites them to the published slugs on the site, and they still resolve when `FAQ.md` is viewed on GitHub. The website build + dead-link check validate them.

Also dropped the now-stale *"Documentation is currently under development"* line above those FAQ links — the docs are live.

The GitHub links in FAQ that are **not** docs (source code, LICENSE) are intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
