### PR TITLE
fix(website): register the missing end-user docs pages

### DIFF
--- a/packages/website/src/lib/docs-nav.ts
+++ b/packages/website/src/lib/docs-nav.ts
@@ -32,6 +32,7 @@ export const DOC_TABS: DocTab[] = [
         pages: [
           { slug: ['introduction'], title: 'Introduction', file: 'README.md', hint: 'Overview & getting started' },
           { slug: ['installation'], title: 'Installation', file: 'end-user/INSTALLATION.md', hint: 'Download & install on every platform' },
+          { slug: ['linux'], title: 'Linux notes', file: 'end-user/LINUX.md', hint: 'Distro-specific install tips & quirks' },
           { slug: ['basics'], title: 'Basics', file: 'end-user/BASICS.md', hint: 'The interface, files & tabs' },
           { slug: ['editing'], title: 'Editing in depth', file: 'end-user/EDITING.md', hint: 'Shortcuts, format bar & find/replace' },
           { slug: ['spelling'], title: 'Spelling', file: 'end-user/SPELLING.md', hint: 'Spell checker & dictionaries' },
@@ -43,6 +44,9 @@ export const DOC_TABS: DocTab[] = [
         pages: [
           { slug: ['preferences'], title: 'Preferences', file: 'end-user/PREFERENCES.md', hint: 'App settings reference' },
           { slug: ['key-bindings'], title: 'Key bindings', file: 'end-user/KEYBINDINGS.md', hint: 'Default & custom shortcuts' },
+          { slug: ['key-bindings-macos'], title: 'Key bindings (macOS)', file: 'end-user/KEYBINDINGS_OSX.md', hint: 'Default shortcuts on macOS' },
+          { slug: ['key-bindings-linux'], title: 'Key bindings (Linux)', file: 'end-user/KEYBINDINGS_LINUX.md', hint: 'Default shortcuts on Linux' },
+          { slug: ['key-bindings-windows'], title: 'Key bindings (Windows)', file: 'end-user/KEYBINDINGS_WINDOWS.md', hint: 'Default shortcuts on Windows' },
           { slug: ['application-data-directory'], title: 'Application data directory', file: 'end-user/APPLICATION_DATA_DIRECTORY.md', hint: 'Where MarkText stores user data' },
           { slug: ['environment-variables'], title: 'Environment variables', file: 'end-user/ENVIRONMENT.md', hint: 'Runtime environment overrides' },
           { slug: ['cli'], title: 'Command line interface', file: 'end-user/CLI.md', hint: 'Flags, switches, exit codes' }


### PR DESCRIPTION
## What

Four `end-user/*.md` docs exist in `packages/website/content/docs` but were never registered in `docs-nav.ts`, so they had **no route on the site** (`/docs/*` → 404). Worse, already-published pages link to them with relative `.md` paths, which `markdown.ts` left untouched — so those links render as dead `*.md` hrefs:

| Unregistered doc | Linked from (live page) | Was |
|---|---|---|
| `KEYBINDINGS_OSX.md` | `/docs/key-bindings` → "Key bindings for macOS" | 🔴 broken |
| `KEYBINDINGS_LINUX.md` | `/docs/key-bindings` → "Key bindings for Linux" | 🔴 broken |
| `KEYBINDINGS_WINDOWS.md` | `/docs/key-bindings` → "Key bindings for Windows" | 🔴 broken |
| `LINUX.md` | `/docs/installation` → "Linux notes" | 🔴 broken |

## Change

Register all four in `docs-nav.ts`:
- **Linux notes** (`LINUX.md`) → Quick start, after Installation → `/docs/linux`
- **Key bindings (macOS / Linux / Windows)** → Configuration, after Key bindings → `/docs/key-bindings-{macos,linux,windows}`

Once registered, `markdown.ts`'s `file → slug` map rewrites the relative links on `/docs/key-bindings` and `/docs/installation` to the new routes, so the previously-broken links resolve. The three platform pages' own links back to `KEYBINDINGS.md` already resolve (it's registered). The website build + dead-link check validate all of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
