### PR TITLE
fix(i18n): reconcile desktop & muya locale keys after the muya engine refactor

### DIFF
--- a/packages/desktop/src/renderer/src/commands/index.ts
+++ b/packages/desktop/src/renderer/src/commands/index.ts
@@ -723,17 +723,17 @@ export const getCommandsWithDescriptions = async(): Promise<CommandDescriptor[]>
         for (const subcommand of subcommands) {
           const { value } = subcommand
           if (value === 'light') {
-            subcommand.description = t('theme.cadmiumLight')
+            subcommand.description = t('menu.theme.cadmiumLight')
           } else if (value === 'dark') {
-            subcommand.description = t('theme.dark')
+            subcommand.description = t('menu.theme.dark')
           } else if (value === 'graphite') {
-            subcommand.description = t('theme.graphiteLight')
+            subcommand.description = t('menu.theme.graphiteLight')
           } else if (value === 'material-dark') {
-            subcommand.description = t('theme.materialDark')
+            subcommand.description = t('menu.theme.materialDark')
           } else if (value === 'one-dark') {
-            subcommand.description = t('theme.oneDark')
+            subcommand.description = t('menu.theme.oneDark')
           } else if (value === 'ulysses') {
-            subcommand.description = t('theme.ulyssesLight')
+            subcommand.description = t('menu.theme.ulyssesLight')
           }
         }
       }

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "Datei",
-      "new": "Neu",
       "newTab": "Neuer Tab",
       "newWindow": "Neues Fenster",
-      "open": "Öffnen",
       "openFile": "Datei öffnen...",
       "openFolder": "Ordner öffnen...",
       "openRecent": "Zuletzt verwendet",
@@ -25,9 +23,6 @@
       "exportPdf": "Als PDF exportieren",
       "import": "Importieren",
       "print": "Drucken",
-      "recent": "Zuletzt verwendete Dateien",
-      "close": "Schließen",
-      "closeAll": "Alle schließen",
       "closeTab": "Tab schließen",
       "closeWindow": "Fenster schließen",
       "quit": "Beenden",
@@ -70,26 +65,19 @@
       "demoteHeading": "Überschrift herabstufen",
       "table": "Tabelle",
       "codeFences": "Code-Blöcke",
-      "codeBlock": "Code-Block",
       "quoteBlock": "Zitat-Block",
       "mathBlock": "Mathematik-Block",
       "htmlBlock": "HTML-Block",
-      "quote": "Zitat",
       "orderedList": "Nummerierte Liste",
       "bulletList": "Aufzählungsliste",
-      "unorderedList": "Ungeordnete Liste",
       "taskList": "Aufgabenliste",
       "looseListItem": "Lockeres Listenelement",
-      "paragraphItem": "Absatzelement",
       "horizontalRule": "Horizontale Linie",
       "frontMatter": "Front Matter"
     },
     "window": {
       "title": "Fenster",
-      "window": "Fenster",
       "minimize": "Minimieren",
-      "close": "Schließen",
-      "zoom": "Zoom",
       "zoomIn": "Vergrößern",
       "zoomOut": "Verkleinern",
       "fullScreen": "Vollbild",
@@ -106,20 +94,16 @@
       "followUs": "Folgen Sie uns",
       "support": "MarkText unterstützen",
       "license": "Lizenz",
-      "checkForUpdates": "Nach Updates suchen",
-      "aboutMarkText": "Über MarkText",
       "about": "Über",
       "checkUpdates": "Updates prüfen"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "Über MarkText",
       "checkUpdates": "Nach Updates suchen...",
       "preferences": "Einstellungen",
       "services": "Dienste",
       "hide": "MarkText ausblenden",
-      "hideMarkText": "MarkText ausblenden",
       "hideOthers": "Andere ausblenden",
       "showAll": "Alle anzeigen",
       "quit": "MarkText beenden"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Seitenleiste umschalten",
       "toggleTabbar": "Tab-Leiste umschalten",
       "commandPalette": "Befehlspalette",
-      "sourceCode": "Quellcode-Modus",
       "sourceCodeMode": "Quellcode-Modus",
-      "typewriter": "Schreibmaschinen-Modus",
       "typewriterMode": "Schreibmaschinen-Modus",
-      "focus": "Fokus-Modus",
       "focusMode": "Fokus-Modus",
-      "showTabBar": "Tab-Leiste anzeigen",
-      "toc": "Inhaltsverzeichnis",
       "toggleTableOfContents": "Inhaltsverzeichnis umschalten",
       "reloadImages": "Bilder neu laden",
       "showDeveloperTools": "Entwicklertools anzeigen",
@@ -148,35 +127,18 @@
       "italic": "Kursiv",
       "underline": "Unterstrichen",
       "strikethrough": "Durchgestrichen",
-      "code": "Inline-Code",
-      "codeBlock": "Code-Block",
-      "quote": "Zitat",
-      "unorderedList": "Ungeordnete Liste",
-      "orderedList": "Nummerierte Liste",
-      "taskList": "Aufgabenliste",
-      "table": "Tabelle",
-      "link": "Link",
       "image": "Bild",
-      "heading1": "Überschrift 1",
-      "heading2": "Überschrift 2",
-      "heading3": "Überschrift 3",
-      "heading4": "Überschrift 4",
-      "heading5": "Überschrift 5",
-      "heading6": "Überschrift 6",
       "superscript": "Hochgestellt",
       "subscript": "Tiefgestellt",
       "highlight": "Hervorhebung",
       "inlineCode": "Inline-Code",
       "inlineMath": "Inline-Mathematik",
       "hyperlink": "Hyperlink",
-      "clearFormatting": "Formatierung löschen",
       "clearFormat": "Format löschen"
     },
     "theme": {
       "theme": "Design (&T)",
-      "light": "Hell",
       "dark": "Dunkel",
-      "auto": "Automatisch",
       "followThemDisabled": "Themenauswahl deaktiviert, wenn dem Systemdesign gefolgt wird",
       "lightThemes": "— Helle Designs —",
       "darkThemes": "— Dunkle Designs —",
@@ -375,13 +337,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Tabellengröße ändern",
-    "alignLeft": "Links ausrichten",
-    "alignCenter": "Zentriert ausrichten",
-    "alignRight": "Rechts ausrichten",
-    "deleteTable": "Tabelle löschen"
-  },
   "recent": {
     "noTabsOpen": "Sie haben keine Tabs geöffnet.",
     "newFile": "Neue Datei"
@@ -394,7 +349,6 @@
     "title": "Einstellungen",
     "search": {
       "placeholder": "In Einstellungen suchen...",
-      "optionalValues": "optionale Werte",
       "categories": {
         "general": "Allgemein",
         "editor": "Editor",
@@ -499,7 +453,6 @@
         "titleBarStyle": {
           "title": "Titelleistenstil",
           "custom": "Benutzerdefiniert",
-          "titleBarStyle": "Titelleistenstil",
           "native": "Nativ"
         },
         "requiresRestart": "Erfordert Neustart",
@@ -632,53 +585,19 @@
         "relativeFolderName": "Name des relativen Ordners",
         "filenameNote": "Der Dateiname wird automatisch generiert."
       },
-      "imageInsertAction": {
-        "title": "Bildeinfügungsaktion",
-        "folder": "In Ordner hochladen",
-        "path": "In Pfad kopieren",
-        "upload": "In die Cloud hochladen",
-        "copyToFolder": "In Ordner kopieren",
-        "uploadToServer": "Auf Server hochladen"
-      },
-      "imageFolderPath": {
-        "title": "Bilderordnerpfad",
-        "description": "Bilderordnerpfad",
-        "selectFolder": "Ordner auswählen",
-        "relativePath": "Relativer Pfad",
-        "absolutePath": "Absoluter Pfad"
-      },
-      "cloudPictureBed": {
-        "title": "Cloud-Bildspeicher",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Relatives Verzeichnis bevorzugen",
-        "description": "Bevorzugtes relatives Verzeichnis für Bilder"
-      },
       "uploader": {
         "title": "Bild-Uploader",
         "currentUploader": "Aktueller Uploader: {name}",
         "picgoNotInstalled": "PicGo nicht installiert",
-        "picgoDetectionStatus": "PicGo-Erkennungsstatus",
         "picgoInstalled": "PicGo installiert",
         "picgoDetectionFailed": "PicGo-Erkennung fehlgeschlagen",
         "debugInfo": "Debug-Informationen",
-        "installCommand": "Installationsbefehl",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "chooseInstallMethod": "Installationsmethode wählen:",
         "retestPicgo": "Erneut testen",
-        "detecting": "Erkennung läuft...",
         "lastDetectionTime": "Letzte Erkennungszeit",
-        "detectionStatus": "Erkennungsstatus",
         "usageGuide": {
           "title": "PicGo Grundlegende Anleitung",
           "step1": "Uploader konfigurieren",
@@ -689,13 +608,6 @@
           "step3Description": "Verwenden Sie den folgenden Befehl, um die aktuelle Konfiguration anzuzeigen:",
           "documentation": "Vollständige Dokumentation anzeigen"
         },
-        "configureUploader": "Uploader konfigurieren",
-        "configureDescription": "Verwenden Sie den folgenden Befehl, um den PicGo-Uploader zu konfigurieren:",
-        "uploadImage": "Bilder hochladen",
-        "uploadDescription": "Verwenden Sie den folgenden Befehl, um Bilder hochzuladen:",
-        "viewConfig": "Konfiguration anzeigen",
-        "viewConfigDescription": "Verwenden Sie den folgenden Befehl, um die aktuelle Konfiguration anzuzeigen:",
-        "viewDocumentation": "Vollständige Dokumentation anzeigen",
         "scriptDescription": "Skriptbeschreibung",
         "scriptLocation": "Skriptort",
         "save": "Speichern",
@@ -708,7 +620,6 @@
         "pleaseInstall": "Bitte installieren",
         "scriptPath": "Skriptpfad",
         "picgoDetection": "PicGo-Erkennung",
-        "autoDetection": "Automatische Erkennung",
         "lastSuccessTime": "Letzte erfolgreiche Zeit",
         "neverDetected": "Nie erkannt",
         "neverSuccessful": "Nie erfolgreich"
@@ -717,44 +628,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "Listenelement",
-        "preferLooseListItem": "Lockere Listenelemente bevorzugen",
-        "bulletListMarker": "Aufzählungszeichen",
-        "orderListDelimiter": "Nummerierte Liste Trennzeichen",
-        "listIndentation": {
-          "title": "Listeneinrückung",
-          "dfm": "Standard-Format-Modus",
-          "tab": "Tab",
-          "oneSpace": "Ein Leerzeichen",
-          "twoSpaces": "Zwei Leerzeichen",
-          "threeSpaces": "Drei Leerzeichen",
-          "fourSpaces": "Vier Leerzeichen"
-        }
-      },
-      "heading": {
-        "title": "Überschrift",
-        "preferHeadingStyle": "Bevorzugter Überschriftenstil"
-      },
-      "frontmatter": {
-        "title": "Front Matter",
-        "frontmatterType": "Front Matter Typ"
-      },
       "extensions": {
         "title": "Erweiterungen",
         "superSubScript": "Hoch-/Tiefgestellt",
         "footnote": "Fußnote",
-        "isHtmlEnabled": "HTML aktiviert",
-        "isGitlabCompatibilityEnabled": "GitLab-Kompatibilität",
-        "sequenceTheme": "Sequenz-Design",
-        "superscript": "Hochgestellt",
-        "subscript": "Tiefgestellt",
-        "frontMatter": "Front Matter",
-        "math": "Mathematik",
-        "diagram": "Diagramm",
         "footnoteNotes": "Fußnoten",
         "frontmatterType": {
-          "frontmatterType": "Front Matter Typ",
           "jsonBrace": "JSON-Klammer",
           "jsonSemicolon": "JSON-Semikolon",
           "title": "Front Matter Typ"
@@ -762,12 +641,6 @@
       },
       "diagrams": {
         "title": "Diagramme",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "Flussdiagramm",
-        "sequence": "Sequenz",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Sequenz-Design",
           "handDrawn": "Handgezeichnet",
@@ -776,11 +649,6 @@
         "plantumlServer": {
           "title": "PlantUML-Server-URL"
         }
-      },
-      "math": {
-        "title": "Mathematik",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -811,28 +679,13 @@
         "title": "Listen"
       }
     },
-    "spelling": {
-      "title": "Rechtschreibung",
-      "enabled": "Rechtschreibprüfung aktivieren",
-      "autoDetectLanguage": "Sprache automatisch erkennen",
-      "language": "Sprache",
-      "noSuggestions": "Keine Vorschläge",
-      "spellcheckerEnabled": "Rechtschreibprüfung aktiviert",
-      "spellcheckerNoUnderline": "Keine Unterstreichung für falsch geschriebene Wörter",
-      "spellcheckerLanguage": "Rechtschreibprüfungssprache"
-    },
     "theme": {
       "title": "Design",
-      "theme": "Design",
       "followSystemTheme": "Systemdesign folgen",
       "modeThemes": "Design-Auswahl",
       "lightModeTheme": "Helles Modus-Design",
       "darkModeTheme": "Dunkles Modus-Design",
       "customCss": "Benutzerdefiniertes CSS",
-      "codeBlockTheme": {
-        "title": "Code-Block-Design",
-        "description": "Design für Code-Blöcke"
-      },
       "importCustomThemes": "Benutzerdefinierte Designs importieren",
       "importTheme": "Design importieren",
       "openFolder": "Ordner öffnen",
@@ -841,13 +694,6 @@
     "keybindings": {
       "title": "Tastenkürzel",
       "description": "Tastenkürzel anpassen",
-      "searchPlaceholder": "Tastenkürzel suchen",
-      "command": "Befehl",
-      "keybinding": "Tastenkürzel",
-      "reset": "Zurücksetzen",
-      "resetAll": "Alle zurücksetzen",
-      "edit": "Bearbeiten",
-      "cancel": "Abbrechen",
       "save": "Speichern",
       "restoreDefaults": "Standardwerte wiederherstellen",
       "debugOptions": "Debug-Optionen",
@@ -921,9 +767,7 @@
       "exportFile": "Datei exportieren",
       "exportFilePdf": "Als PDF exportieren",
       "zoom": "Zoom",
-      "checkUpdate": "Nach Updates suchen",
-      "lineEnding": "Zeilenende",
-      "close": "Schließen"
+      "checkUpdate": "Nach Updates suchen"
     },
     "edit": {
       "undo": "Rückgängig",
@@ -943,8 +787,7 @@
       "findPrevious": "Rückwärts suchen",
       "replace": "Ersetzen",
       "findInFolder": "Im Ordner suchen",
-      "screenshot": "Screenshot",
-      "mathBlock": "Mathe-Block"
+      "screenshot": "Screenshot"
     },
     "paragraph": {
       "heading1": "Überschrift 1",
@@ -1010,8 +853,6 @@
       "reloadImages": "Bilder neu laden",
       "textDirection": "Textrichtung",
       "actualSize": "Tatsächliche Größe",
-      "zoomIn": "Vergrößern",
-      "zoomOut": "Verkleinern",
       "devToggleDeveloperTools": "Entwicklertools umschalten"
     },
     "tabs": {
@@ -1033,10 +874,6 @@
     "docs": {
       "userGuide": "Benutzerhandbuch",
       "markdownSyntax": "Markdown-Syntax"
-    },
-    "utils": {
-      "noUpdateResourceFile": "Keine Update-Ressourcendatei",
-      "todoUpdateCheck": "Update-Überprüfung"
     },
     "spellchecker": {
       "switchLanguage": "Sprache wechseln"
@@ -1083,25 +920,6 @@
       "anchorLinkCopied": "Anker-Link kopiert",
       "tabNotFound": "Tab nicht gefunden",
       "tocItemNotFound": "Inhaltsverzeichnis {key} nicht gefunden",
-      "highlightStart": "[Hervorhebung Start]",
-      "highlightEnd": "[Hervorhebung Ende]",
-      "typeAtToInsert": "/ eingeben zum Einfügen",
-      "inputFootnoteDefinition": "Fußnotendefinition eingeben...",
-      "inputYamlFrontMatter": "YAML Front Matter eingeben...",
-      "inputLanguageIdentifier": "Sprachkennung eingeben...",
-      "inputMathematicalFormula": "Mathematische Formel eingeben...",
-      "fence": "Zaun",
-      "indent": "Einrückung",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Klicken um Bild hinzuzufügen",
-      "loadImageFailed": "Bild konnte nicht geladen werden",
       "errorLoadingTabTitle": "Fehler beim Laden des Tabs",
       "errorLoadingTabMessage": "Beim Laden der Dateiänderung ist ein Fehler aufgetreten, da der Tab nicht gefunden werden kann.",
       "mixedLineEndingsNormalized": "„{name}“ enthält gemischte Zeilenenden, die automatisch zu {lineEnding} normalisiert wurden.",
@@ -1118,204 +936,7 @@
     "failedToRemoveWord": "Wort konnte nicht aus dem Wörterbuch entfernt werden",
     "unexpectedError": "Unerwarteter Rechtschreibprüfungsfehler"
   },
-  "quickInsert": {
-    "basicBlock": "Grundblock",
-    "header": "Kopfzeile",
-    "advancedBlock": "Erweiterter Block",
-    "listBlock": "Listenblock",
-    "diagram": "Diagramm",
-    "paragraph": {
-      "title": "Absatz",
-      "subtitle": "Textinhalt eingeben"
-    },
-    "horizontalLine": {
-      "title": "Horizontale Linie",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Front Matter",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Überschrift 1",
-      "subtitle": "# Überschrift"
-    },
-    "header2": {
-      "title": "Überschrift 2",
-      "subtitle": "## Überschrift"
-    },
-    "header3": {
-      "title": "Überschrift 3",
-      "subtitle": "### Überschrift"
-    },
-    "header4": {
-      "title": "Überschrift 4",
-      "subtitle": "#### Überschrift"
-    },
-    "header5": {
-      "title": "Überschrift 5",
-      "subtitle": "##### Überschrift"
-    },
-    "header6": {
-      "title": "Überschrift 6",
-      "subtitle": "###### Überschrift"
-    },
-    "tableBlock": {
-      "title": "Tabellenblock",
-      "subtitle": "｜ Kopfzeile ｜ Kopfzeile ｜"
-    },
-    "mathFormula": {
-      "title": "Mathematische Formel",
-      "subtitle": "$$ Formel $$"
-    },
-    "htmlBlock": {
-      "title": "HTML-Block",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Code-Block",
-      "subtitle": "``` Code ```"
-    },
-    "quoteBlock": {
-      "title": "Zitat-Block",
-      "subtitle": "> Zitatinhalt"
-    },
-    "orderedList": {
-      "title": "Nummerierte Liste",
-      "subtitle": "1. Listenelement"
-    },
-    "bulletList": {
-      "title": "Aufzählungsliste",
-      "subtitle": "- Listenelement"
-    },
-    "todoList": {
-      "title": "Aufgabenliste",
-      "subtitle": "- [ ] Aufgabenelement"
-    },
-    "vegaChart": {
-      "title": "Vega-Lite-Diagramm",
-      "subtitle": "Datenvisualisierungsdiagramm"
-    },
-    "flowChart": {
-      "title": "Flussdiagramm",
-      "subtitle": "Flussdiagramm"
-    },
-    "sequenceChart": {
-      "title": "Sequenzdiagramm",
-      "subtitle": "Sequenzdiagramm"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML-Diagramm",
-      "subtitle": "UML-Diagramm"
-    },
-    "mermaid": {
-      "title": "Mermaid-Diagramm",
-      "subtitle": "Mermaid-Diagramm",
-      "gantt": {
-        "title": "Gantt-Diagramm"
-      },
-      "pie": {
-        "title": "Kreisdiagramm"
-      },
-      "flowchart": {
-        "title": "Flussdiagramm"
-      },
-      "sequence": {
-        "title": "Sequenzdiagramm"
-      },
-      "class": {
-        "title": "Klassendiagramm"
-      },
-      "state": {
-        "title": "Zustandsdiagramm",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "User Journey"
-      },
-      "git": {
-        "title": "Git-Diagramm"
-      },
-      "er": {
-        "title": "ER-Diagramm"
-      },
-      "requirement": {
-        "title": "Anforderungsdiagramm"
-      }
-    },
-    "taskList": {
-      "title": "Aufgabenliste"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite Diagramm"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML-Diagramm"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid-Diagramm"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Duplizieren",
-    "turnInto": "Umwandeln in",
-    "newParagraph": "Neuer Absatz",
-    "delete": "Löschen",
-    "paragraph": "Absatz",
-    "table": "Tabelle",
-    "html": "HTML",
-    "mathblock": "Mathe-Block",
-    "pre": "Code-Block",
-    "frontMatter": "Front Matter",
-    "ulTask": "Aufgabenliste",
-    "ulBullet": "Aufzählungsliste",
-    "olOrder": "Nummerierte Liste",
-    "blockquote": "Blockzitat",
-    "heading1": "Überschrift 1",
-    "heading2": "Überschrift 2",
-    "heading3": "Überschrift 3",
-    "heading4": "Überschrift 4",
-    "heading5": "Überschrift 5",
-    "heading6": "Überschrift 6",
-    "hr": "Horizontale Linie"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Auswählen",
-          "embedLink": "Link einbetten"
-        },
-        "select": {
-          "chooseButton": "Bild wählen",
-          "tip": "Wählen Sie ein Bild von Ihrem Computer."
-        },
-        "inputs": {
-          "alt": "Alternativtext",
-          "src": "Bildlink oder lokaler Pfad",
-          "title": "Bildtitel"
-        },
-        "embedButton": "Bild einbetten",
-        "hint": {
-          "prefix": "Webbild oder lokalen Pfad einfügen. Modus wechseln",
-          "simple": "einfacher Modus",
-          "full": "vollständiger Modus"
-        }
-      },
-      "toolbar": {
-        "edit": "Bild bearbeiten",
-        "inline": "Inline-Bild",
-        "alignLeft": "Linksbündig",
-        "alignCenter": "Zentrieren",
-        "alignRight": "Rechtsbündig",
-        "delete": "Bild entfernen"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "YAML Front Matter eingeben...",
-      "languageIdentifier": "Sprachbezeichner eingeben...",
-      "mathFormula": "Mathematische Formel eingeben..."
-    },
     "export": {
       "error": "Export-Fehler",
       "errorExporting": "Fehler beim Exportieren der {type}-Datei",
@@ -1338,65 +959,11 @@
       "imageStructureDeletedComment": "Bildstruktur-gelöscht-Kommentar"
     },
     "spellcheck": {
-      "enabled": "Rechtschreibprüfung aktiviert",
-      "disabled": "Rechtschreibprüfung deaktiviert",
-      "enabledError": "Fehler beim Aktivieren der Rechtschreibprüfung",
       "disabledError": "Fehler beim Deaktivieren der Rechtschreibprüfung",
       "errorSwitchingLanguage": "Fehler beim Wechseln der Rechtschreibprüfungssprache {languageCode}",
       "languageMissing": "Rechtschreibprüfungssprache fehlt {languageCode}",
       "switchError": "Rechtschreibprüfung-Wechselfehler für {languageCode}, {error}",
       "title": "Rechtschreibprüfung"
-    },
-    "table": "Tabelle",
-    "resizeTable": "Tabellengröße ändern",
-    "left": "links",
-    "alignLeft": "Links ausrichten",
-    "center": "zentriert",
-    "alignCenter": "Zentriert ausrichten",
-    "right": "rechts",
-    "alignRight": "Rechts ausrichten",
-    "delete": "löschen",
-    "deleteTable": "Tabelle löschen",
-    "insertRowAbove": "Zeile oberhalb einfügen",
-    "insertRowBelow": "Zeile unterhalb einfügen",
-    "removeRow": "Zeile entfernen",
-    "insertColumnLeft": "Spalte links einfügen",
-    "insertColumnRight": "Spalte rechts einfügen",
-    "removeColumn": "Spalte entfernen",
-    "copyContent": "Inhalt kopieren",
-    "emptyMathFormula": "< Leere mathematische Formel >",
-    "invalidMathFormula": "< Ungültige mathematische Formel >",
-    "emptyMermaidBlock": "< Leerer Mermaid-Block >",
-    "loading": "Lädt...",
-    "emptyDiagramBlock": "< Leerer Diagramm-Block >",
-    "emptyHtmlBlock": "< Leerer HTML-Block >",
-    "onlyTopBlockCanRenderIcon": "Nur der oberste Block kann das vordere Symbol rendern.",
-    "unhandledFunctionType": "Unbehandelter Funktionstyp: {functionType}",
-    "highlight-start": "[Hervorhebung Start]",
-    "highlight-end": "[Hervorhebung Ende]",
-    "type-at-to-insert": "Geben Sie / ein, um einzufügen",
-    "input-footnote-definition": "Fußnotendefinition eingeben",
-    "input-yaml-front-matter": "YAML-Front-Matter eingeben",
-    "input-language-identifier": "Sprachkennung eingeben",
-    "input-mathematical-formula": "Mathematische Formel eingeben",
-    "fence": "Zaun",
-    "indent": "Einrückung",
-    "front-matter-delimiter": "Front-Matter-Trennzeichen",
-    "math-delimiter": "Mathe-Trennzeichen",
-    "mermaid-start": "Mermaid Start",
-    "flowchart-start": "Flussdiagramm Start",
-    "sequence-start": "Sequenz Start",
-    "plantuml-start": "PlantUML Start",
-    "vega-lite-start": "Vega-Lite Start",
-    "click-to-add-image": "Klicken Sie, um ein Bild hinzuzufügen",
-    "load-image-failed": "Bild laden fehlgeschlagen"
-  },
-  "edit": {
-    "undo": "Rückgängig",
-    "redo": "Wiederholen",
-    "cut": "Ausschneiden",
-    "copy": "Kopieren",
-    "paste": "Einfügen",
-    "selectAll": "Alles auswählen"
+    }
   }
 }

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -364,7 +364,7 @@
       "items": {
         "autoSave": "Den bearbeiteten Inhalt automatisch speichern",
         "autoSaveDelay": "Die Zeit in ms nach einer Änderung, bis die Datei gespeichert wird",
-        "autoNormalizeLineEndings": "Zeilenenden beim Öffnen automatisch zu LF normalisieren und optional nachgestellte neue Zeilen",
+        "autoNormalizeLineEndings": "Zeilenenden beim Öffnen von Dateien automatisch normalisieren. Wenn deaktiviert, werden Dateien unverändert geöffnet.",
         "titleBarStyle": "Der Titelleisten-Stil (nur Windows und Linux-System)",
         "openFilesInNewWindow": "Dateien in einem neuen Fenster öffnen",
         "openFolderInNewWindow": "Ordner über Menü in einem neuen Fenster öffnen",
@@ -413,7 +413,6 @@
         "followSystemTheme": "Systemdesign folgen",
         "lightModeTheme": "Design, das verwendet werden soll, wenn sich das System im hellen Modus befindet",
         "darkModeTheme": "Design, das verwendet werden soll, wenn sich das System im dunklen Modus befindet",
-        "customCss": "Benutzerdefiniertes CSS für das aktuelle Theme",
         "spellcheckerEnabled": "Ob Rechtschreibprüfung aktiviert ist",
         "spellcheckerNoUnderline": "Rechtschreibfehler nicht unterstreichen",
         "spellcheckerLanguage": "Die Rechtschreibprüfungs-Sprache",
@@ -421,15 +420,8 @@
         "imagePreferRelativeDirectory": "Ob das relative Bildverzeichnis bevorzugt werden soll",
         "imageRelativeDirectoryBase": "Wohin relative Bilder kopiert werden",
         "imageRelativeDirectoryName": "Der relative Bildordner-Name",
-        "sideBarVisibility": "Ob die Seitenleiste sichtbar ist",
-        "tabBarVisibility": "Ob die Tabs angezeigt werden",
-        "sourceCodeModeEnabled": "Ob der Quellcode-Modus standardmäßig aktiviert ist",
-        "searchExclusions": "Liste der Glob-Muster, die von der Suche ausgeschlossen werden sollen",
-        "searchMaxFileSize": "Die maximale Dateigröße (<maxFileSize><suffix>). Suffixe von K, M oder G sind erlaubt, wenn kein Suffix angegeben ist, wird die Zahl als Bytes behandelt",
-        "searchIncludeHidden": "Ob in versteckten Dateien und Verzeichnissen gesucht werden soll",
-        "searchNoIgnore": "Ob Ignore-Dateien wie .gitignore ignoriert werden sollen",
-        "searchFollowSymlinks": "Ob symbolische Links verfolgt werden sollen",
-        "watcherUsePolling": "Ob Polling verwendet werden soll. Polling kann zu hoher CPU-Auslastung führen, ist aber notwendig, um Dateien über ein Netzwerk zu überwachen"
+        "fileSortOrder": "Sortierreihenfolge für Dateien in geöffneten Ordnern: aufsteigend oder absteigend.",
+        "openedFilesInSidebar": "Ob geöffnete Dateien in der Seitenleiste angezeigt werden sollen."
       }
     },
     "categories": {

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "File",
-      "new": "New",
       "newTab": "New Tab",
       "newWindow": "New Window",
-      "open": "Open",
       "openFile": "Open File...",
       "openFolder": "Open Folder...",
       "openRecent": "Open Recent",
@@ -25,9 +23,6 @@
       "exportPdf": "Export as PDF",
       "import": "Import",
       "print": "Print",
-      "recent": "Recent Files",
-      "close": "Close",
-      "closeAll": "Close All",
       "closeTab": "Close Tab",
       "closeWindow": "Close Window",
       "quit": "Quit",
@@ -70,26 +65,19 @@
       "demoteHeading": "Demote Heading",
       "table": "Table",
       "codeFences": "Code Fences",
-      "codeBlock": "Code Block",
       "quoteBlock": "Quote Block",
       "mathBlock": "Math Block",
       "htmlBlock": "HTML Block",
-      "quote": "Quote",
       "orderedList": "Ordered List",
       "bulletList": "Bullet List",
-      "unorderedList": "Unordered List",
       "taskList": "Task List",
       "looseListItem": "Loose List Item",
-      "paragraphItem": "Paragraph Item",
       "horizontalRule": "Horizontal Rule",
       "frontMatter": "Front Matter"
     },
     "window": {
       "title": "Window",
-      "window": "Window",
       "minimize": "Minimize",
-      "close": "Close",
-      "zoom": "Zoom",
       "zoomIn": "Zoom In",
       "zoomOut": "Zoom Out",
       "fullScreen": "Full Screen",
@@ -106,20 +94,16 @@
       "followUs": "Follow Us",
       "support": "Support MarkText",
       "license": "License",
-      "checkForUpdates": "Check for Updates",
-      "aboutMarkText": "About MarkText",
       "about": "About",
       "checkUpdates": "Check for Updates"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "About MarkText",
       "checkUpdates": "Check for Updates...",
       "preferences": "Preferences",
       "services": "Services",
       "hide": "Hide MarkText",
-      "hideMarkText": "Hide MarkText",
       "hideOthers": "Hide Others",
       "showAll": "Show All",
       "quit": "Quit MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Toggle Sidebar",
       "toggleTabbar": "Toggle Tabbar",
       "commandPalette": "Command Palette",
-      "sourceCode": "Source Code Mode",
       "sourceCodeMode": "Source Code Mode",
-      "typewriter": "Typewriter Mode",
       "typewriterMode": "Typewriter Mode",
-      "focus": "Focus Mode",
       "focusMode": "Focus Mode",
-      "showTabBar": "Show Tab Bar",
-      "toc": "Table of Contents",
       "toggleTableOfContents": "Toggle Table of Contents",
       "reloadImages": "Reload Images",
       "showDeveloperTools": "Show Developer Tools",
@@ -148,35 +127,18 @@
       "italic": "Italic",
       "underline": "Underline",
       "strikethrough": "Strikethrough",
-      "code": "Inline Code",
-      "codeBlock": "Code Block",
-      "quote": "Quote",
-      "unorderedList": "Unordered List",
-      "orderedList": "Ordered List",
-      "taskList": "Task List",
-      "table": "Table",
-      "link": "Link",
       "image": "Image",
-      "heading1": "Heading 1",
-      "heading2": "Heading 2",
-      "heading3": "Heading 3",
-      "heading4": "Heading 4",
-      "heading5": "Heading 5",
-      "heading6": "Heading 6",
       "superscript": "Superscript",
       "subscript": "Subscript",
       "highlight": "Highlight",
       "inlineCode": "Inline Code",
       "inlineMath": "Inline Math",
       "hyperlink": "Hyperlink",
-      "clearFormatting": "Clear Formatting",
       "clearFormat": "Clear Formatting"
     },
     "theme": {
       "theme": "&Theme",
-      "light": "Light",
       "dark": "Dark",
-      "auto": "Auto",
       "followThemDisabled": "Theme selection disabled when following system theme",
       "lightThemes": "— Light Themes —",
       "darkThemes": "— Dark Themes —",
@@ -375,13 +337,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Resize Table",
-    "alignLeft": "Align Left",
-    "alignCenter": "Align Center",
-    "alignRight": "Align Right",
-    "deleteTable": "Delete Table"
-  },
   "recent": {
     "noTabsOpen": "You have no tabs open.",
     "newFile": "New File"
@@ -394,7 +349,6 @@
     "title": "Preferences",
     "search": {
       "placeholder": "Search preferences...",
-      "optionalValues": "optional values",
       "categories": {
         "general": "General",
         "editor": "Editor",
@@ -498,7 +452,6 @@
         "titleBarStyle": {
           "title": "Title Bar Style",
           "custom": "Custom",
-          "titleBarStyle": "Title Bar Style",
           "native": "Native"
         },
         "requiresRestart": "Requires restart",
@@ -631,53 +584,19 @@
         "relativeFolderName": "Relative folder name",
         "filenameNote": "The filename will be automatically generated."
       },
-      "imageInsertAction": {
-        "title": "Image insert action",
-        "folder": "Upload to folder",
-        "path": "Copy to path",
-        "upload": "Upload to cloud",
-        "copyToFolder": "Copy to folder",
-        "uploadToServer": "Upload to server"
-      },
-      "imageFolderPath": {
-        "title": "Image folder path",
-        "description": "Image folder path",
-        "selectFolder": "Select folder",
-        "relativePath": "Relative path",
-        "absolutePath": "Absolute path"
-      },
-      "cloudPictureBed": {
-        "title": "Cloud picture bed",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Prefer relative directory",
-        "description": "Prefer relative directory for images"
-      },
       "uploader": {
         "title": "Image Uploader",
         "currentUploader": "Current Uploader: {name}",
         "picgoNotInstalled": "PicGo is not installed",
-        "picgoDetectionStatus": "PicGo Detection Status",
         "picgoInstalled": "PicGo is installed",
         "picgoDetectionFailed": "PicGo detection failed",
         "debugInfo": "Debug Info",
-        "installCommand": "Install Command",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "chooseInstallMethod": "Choose installation method:",
         "retestPicgo": "Retest",
-        "detecting": "Detecting",
         "lastDetectionTime": "Last Detection Time",
-        "detectionStatus": "Detection Status",
         "picgoDetection": "PicGo Detection",
         "usageGuide": {
           "title": "PicGo Basic Usage Guide",
@@ -689,17 +608,9 @@
           "step3Description": "Use the following command to view current configuration:",
           "documentation": "View full documentation"
         },
-        "autoDetection": "Auto detecting",
         "lastSuccessTime": "Last success time",
         "neverDetected": "Never detected",
         "neverSuccessful": "Never successful",
-        "configureUploader": "Configure Uploader",
-        "configureDescription": "Use the following command to configure PicGo uploader:",
-        "uploadImage": "Upload Images",
-        "uploadDescription": "Use the following command to upload images:",
-        "viewConfig": "View Configuration",
-        "viewConfigDescription": "Use the following command to view current configuration:",
-        "viewDocumentation": "View full documentation",
         "scriptDescription": "Script Description",
         "scriptLocation": "Script Location",
         "save": "Save",
@@ -716,44 +627,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "List Item",
-        "preferLooseListItem": "Prefer loose list item",
-        "bulletListMarker": "Bullet list marker",
-        "orderListDelimiter": "Order list delimiter",
-        "listIndentation": {
-          "title": "List Indentation",
-          "dfm": "Default Format Mode",
-          "tab": "Tab",
-          "oneSpace": "One Space",
-          "twoSpaces": "Two Spaces",
-          "threeSpaces": "Three Spaces",
-          "fourSpaces": "Four Spaces"
-        }
-      },
-      "heading": {
-        "title": "Heading",
-        "preferHeadingStyle": "Prefer heading style"
-      },
-      "frontmatter": {
-        "title": "Front Matter",
-        "frontmatterType": "Front matter type"
-      },
       "extensions": {
         "title": "Extensions",
         "superSubScript": "Super/Sub script",
         "footnote": "Footnote",
-        "isHtmlEnabled": "HTML enabled",
-        "isGitlabCompatibilityEnabled": "GitLab compatibility",
-        "sequenceTheme": "Sequence theme",
-        "superscript": "Superscript",
-        "subscript": "Subscript",
-        "frontMatter": "Front matter",
-        "math": "Math",
-        "diagram": "Diagram",
         "footnoteNotes": "Footnote notes",
         "frontmatterType": {
-          "frontmatterType": "Frontmatter Type",
           "jsonBrace": "JSON with Braces",
           "jsonSemicolon": "JSON with Semicolon",
           "title": "Frontmatter Type"
@@ -761,12 +640,6 @@
       },
       "diagrams": {
         "title": "Diagrams",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega-Lite",
-        "flowchart": "Flowchart",
-        "sequence": "Sequence",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Sequence Theme",
           "handDrawn": "Hand Drawn",
@@ -775,11 +648,6 @@
         "plantumlServer": {
           "title": "PlantUML Server URL"
         }
-      },
-      "math": {
-        "title": "Math",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -810,28 +678,13 @@
         "title": "Lists"
       }
     },
-    "spelling": {
-      "title": "Spelling",
-      "enabled": "Enable spell checker",
-      "autoDetectLanguage": "Auto detect language",
-      "language": "Language",
-      "noSuggestions": "No suggestions",
-      "spellcheckerEnabled": "Enable spell checker",
-      "spellcheckerNoUnderline": "No underline for misspelled words",
-      "spellcheckerLanguage": "Spell checker language"
-    },
     "theme": {
       "title": "Theme",
-      "theme": "Theme",
       "followSystemTheme": "Follow System Theme",
       "modeThemes": "Theme Selection",
       "lightModeTheme": "Light mode theme",
       "darkModeTheme": "Dark mode theme",
       "customCss": "Custom CSS",
-      "codeBlockTheme": {
-        "title": "Code block theme",
-        "description": "Theme for code blocks"
-      },
       "importCustomThemes": "Import custom themes",
       "importTheme": "Import Theme",
       "openFolder": "Open Folder",
@@ -840,13 +693,6 @@
     "keybindings": {
       "title": "Keybindings",
       "description": "Customize keyboard shortcuts",
-      "searchPlaceholder": "Search keybindings",
-      "command": "Command",
-      "keybinding": "Keybinding",
-      "reset": "Reset",
-      "resetAll": "Reset all",
-      "edit": "Edit",
-      "cancel": "Cancel",
       "save": "Save",
       "restoreDefaults": "Restore defaults",
       "debugOptions": "Debug Options",
@@ -888,14 +734,6 @@
       "title": "Spell Checker"
     }
   },
-  "edit": {
-    "undo": "Undo",
-    "redo": "Redo",
-    "cut": "Cut",
-    "copy": "Copy",
-    "paste": "Paste",
-    "selectAll": "Select All"
-  },
   "about": {
     "copyright": "Copyright © Luo Ran 2017-{year}",
     "copyrightContributors": "Made with <3 by Github Contributors"
@@ -928,9 +766,7 @@
       "exportFile": "Export File",
       "exportFilePdf": "Export as PDF",
       "zoom": "Zoom",
-      "checkUpdate": "Check for Updates",
-      "lineEnding": "Line Ending",
-      "close": "Close"
+      "checkUpdate": "Check for Updates"
     },
     "edit": {
       "undo": "Undo",
@@ -950,8 +786,7 @@
       "findPrevious": "Find Previous",
       "replace": "Replace",
       "findInFolder": "Find in Folder",
-      "screenshot": "Screenshot",
-      "mathBlock": "Math Block"
+      "screenshot": "Screenshot"
     },
     "paragraph": {
       "heading1": "Heading 1",
@@ -1017,8 +852,6 @@
       "reloadImages": "Reload Images",
       "textDirection": "Text Direction",
       "actualSize": "Actual Size",
-      "zoomIn": "Zoom In",
-      "zoomOut": "Zoom Out",
       "devToggleDeveloperTools": "Toggle Developer Tools"
     },
     "tabs": {
@@ -1040,10 +873,6 @@
     "docs": {
       "userGuide": "User Guide",
       "markdownSyntax": "Markdown Syntax"
-    },
-    "utils": {
-      "noUpdateResourceFile": "No update resource file",
-      "todoUpdateCheck": "Check for updates"
     },
     "spellchecker": {
       "switchLanguage": "Switch Language"
@@ -1090,25 +919,6 @@
       "anchorLinkCopied": "Anchor link copied",
       "tabNotFound": "Tab not found",
       "tocItemNotFound": "Table of contents {key} not found",
-      "highlightStart": "[highlight start]",
-      "highlightEnd": "[highlight end]",
-      "typeAtToInsert": "Type / to insert",
-      "inputFootnoteDefinition": "Input the footnote definition...",
-      "inputYamlFrontMatter": "Input YAML Front Matter",
-      "inputLanguageIdentifier": "Input Language Identifier...",
-      "inputMathematicalFormula": "Input Mathematical Formula...",
-      "fence": "fence",
-      "indent": "indent",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Click to add an image",
-      "loadImageFailed": "Load image failed",
       "errorLoadingTabTitle": "Error loading tab",
       "errorLoadingTabMessage": "There was an error while loading the file change because the tab cannot be found.",
       "mixedLineEndingsNormalized": "\"{name}\" has mixed line endings which are automatically normalized to {lineEnding}.",
@@ -1125,205 +935,7 @@
     "failedToRemoveWord": "Failed to remove word from dictionary",
     "unexpectedError": "Unexpected spellchecker error"
   },
-  "quickInsert": {
-    "basicBlock": "Basic Block",
-    "header": "Header",
-    "advancedBlock": "Advanced Block",
-    "listBlock": "List Block",
-    "diagram": "Diagram",
-    "paragraph": {
-      "title": "Paragraph",
-      "subtitle": "Input text content"
-    },
-    "horizontalLine": {
-      "title": "Horizontal Line",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Front Matter",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Header 1",
-      "subtitle": "# Header"
-    },
-    "header2": {
-      "title": "Header 2",
-      "subtitle": "## Header"
-    },
-    "header3": {
-      "title": "Header 3",
-      "subtitle": "### Header"
-    },
-    "header4": {
-      "title": "Header 4",
-      "subtitle": "#### Header"
-    },
-    "header5": {
-      "title": "Header 5",
-      "subtitle": "##### Header"
-    },
-    "header6": {
-      "title": "Header 6",
-      "subtitle": "###### Header"
-    },
-    "tableBlock": {
-      "title": "Table Block",
-      "subtitle": "｜ Header ｜ Header ｜"
-    },
-    "mathFormula": {
-      "title": "Math Formula",
-      "subtitle": "$$ Formula $$"
-    },
-    "htmlBlock": {
-      "title": "HTML Block",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Code Block",
-      "subtitle": "``` Code ```"
-    },
-    "quoteBlock": {
-      "title": "Quote Block",
-      "subtitle": "> Quote content"
-    },
-    "orderedList": {
-      "title": "Ordered List",
-      "subtitle": "1. List item"
-    },
-    "bulletList": {
-      "title": "Bullet List",
-      "subtitle": "- List item"
-    },
-    "todoList": {
-      "title": "List",
-      "subtitle": "- [ ] Task item"
-    },
-    "vegaChart": {
-      "title": "Vega-Lite Chart",
-      "subtitle": "Data visualization chart"
-    },
-    "flowChart": {
-      "title": "Flow Chart",
-      "subtitle": "Flow chart diagram"
-    },
-    "sequenceChart": {
-      "title": "Sequence Chart",
-      "subtitle": "Sequence diagram"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML Chart",
-      "subtitle": "UML diagram"
-    },
-    "mermaid": {
-      "title": "Mermaid Chart",
-      "subtitle": "Mermaid diagram",
-      "gantt": {
-        "title": "Gantt Chart"
-      },
-      "pie": {
-        "title": "Pie Chart"
-      },
-      "flowchart": {
-        "title": "Flowchart"
-      },
-      "sequence": {
-        "title": "Sequence Diagram"
-      },
-      "class": {
-        "title": "Class Diagram"
-      },
-      "state": {
-        "title": "State Diagram",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "User Journey"
-      },
-      "git": {
-        "title": "Git Graph"
-      },
-      "er": {
-        "title": "ER Diagram"
-      },
-      "requirement": {
-        "title": "Requirement Diagram"
-      }
-    },
-    "taskList": {
-      "title": "Task List"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite Chart"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML Diagram"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid Diagram"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Duplicate",
-    "turnInto": "Turn Into",
-    "newParagraph": "New Paragraph",
-    "delete": "Delete",
-    "paragraph": "Paragraph",
-    "table": "Table",
-    "html": "HTML",
-    "mathblock": "Math Block",
-    "pre": "Code Block",
-    "frontMatter": "Front Matter",
-    "ulTask": "Task List",
-    "ulBullet": "Bullet List",
-    "olOrder": "Ordered List",
-    "blockquote": "Blockquote",
-    "heading1": "Heading 1",
-    "heading2": "Heading 2",
-    "heading3": "Heading 3",
-    "heading4": "Heading 4",
-    "heading5": "Heading 5",
-    "heading6": "Heading 6",
-    "hr": "Horizontal Rule"
-  },
   "editor": {
-    "words": {},
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Select",
-          "embedLink": "Embed link"
-        },
-        "select": {
-          "chooseButton": "Choose Image",
-          "tip": "Choose image from your computer."
-        },
-        "inputs": {
-          "alt": "Alt text",
-          "src": "Image link or local path",
-          "title": "Image title"
-        },
-        "embedButton": "Embed Image",
-        "hint": {
-          "prefix": "Paste web image or local image path. Use",
-          "simple": "simple mode",
-          "full": "full mode"
-        }
-      },
-      "toolbar": {
-        "edit": "Edit Image",
-        "inline": "Inline Image",
-        "alignLeft": "Align Left",
-        "alignCenter": "Align Center",
-        "alignRight": "Align Right",
-        "delete": "Remove Image"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "Input YAML Front Matter",
-      "languageIdentifier": "Input Language Identifier...",
-      "mathFormula": "Input Mathematical Formula..."
-    },
     "export": {
       "error": "Export error",
       "errorExporting": "Error exporting {type} file",
@@ -1350,53 +962,7 @@
       "errorSwitchingLanguage": "Error switching spellcheck language {languageCode}",
       "languageMissing": "Spellcheck language missing {languageCode}",
       "switchError": "Spellcheck switch error for {languageCode}, {error}",
-      "title": "Spellcheck",
-      "disabled": "Spellcheck disabled",
-      "enabled": "Spellcheck enabled",
-      "enabledError": "Error enabling spellcheck"
-    },
-    "table": "table",
-    "resizeTable": "Resize Table",
-    "left": "left",
-    "alignLeft": "Align Left",
-    "center": "center",
-    "alignCenter": "Align Center",
-    "right": "right",
-    "alignRight": "Align Right",
-    "delete": "delete",
-    "deleteTable": "Delete Table",
-    "insertRowAbove": "Insert Row Above",
-    "insertRowBelow": "Insert Row Below",
-    "removeRow": "Remove Row",
-    "insertColumnLeft": "Insert Column Left",
-    "insertColumnRight": "Insert Column Right",
-    "removeColumn": "Remove Column",
-    "copyContent": "Copy content",
-    "emptyMathFormula": "< Empty Mathematical Formula >",
-    "invalidMathFormula": "< Invalid Mathematical Formula >",
-    "emptyMermaidBlock": "< Empty Mermaid Block >",
-    "loading": "Loading...",
-    "emptyDiagramBlock": "< Empty Diagram Block >",
-    "emptyHtmlBlock": "< Empty HTML Block >",
-    "onlyTopBlockCanRenderIcon": "Only top most block can render front icon button.",
-    "unhandledFunctionType": "Unhandled functionType: {functionType}",
-    "highlight-start": "[highlight end]",
-    "highlight-end": "[highlight end]",
-    "type-at-to-insert": "Type / to insert",
-    "input-footnote-definition": "Input footnote definition",
-    "input-yaml-front-matter": "Input YAML front matter",
-    "input-language-identifier": "Input language identifier",
-    "input-mathematical-formula": "Input mathematical formula",
-    "fence": "fence",
-    "indent": "indent",
-    "front-matter-delimiter": "front matter delimiter",
-    "math-delimiter": "math delimiter",
-    "mermaid-start": "mermaid start",
-    "flowchart-start": "flowchart start",
-    "sequence-start": "sequence start",
-    "plantuml-start": "plantuml start",
-    "vega-lite-start": "vega-lite start",
-    "click-to-add-image": "Click to add image",
-    "load-image-failed": "Load image failed"
+      "title": "Spellcheck"
+    }
   }
 }

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -412,7 +412,6 @@
         "followSystemTheme": "Follow System Theme",
         "lightModeTheme": "Theme to use when system is in light mode",
         "darkModeTheme": "Theme to use when system is in dark mode",
-        "customCss": "Custom CSS to apply to the current theme",
         "spellcheckerEnabled": "Whether spell checking is enabled",
         "spellcheckerNoUnderline": "Don't underline spelling mistakes",
         "spellcheckerLanguage": "The spell checker language",
@@ -420,15 +419,9 @@
         "imagePreferRelativeDirectory": "Whether to prefer the relative image directory",
         "imageRelativeDirectoryBase": "Where relative images are copied",
         "imageRelativeDirectoryName": "The relative image folder name",
-        "sideBarVisibility": "Whether the side bar is visible",
-        "tabBarVisibility": "Whether the tabs are shown",
-        "sourceCodeModeEnabled": "Whether the source-code mode is enabled by default",
-        "searchExclusions": "List of glob patterns to exclude from search",
-        "searchMaxFileSize": "The maximal file size (<maxFileSize><suffix>). Suffixes of K, M or G are allowed if not suffix is given the number is treated as bytes",
-        "searchIncludeHidden": "Whether to search in hidden files and directories",
-        "searchNoIgnore": "Whether to ignore ignore files like .gitignore",
-        "searchFollowSymlinks": "Whether symlinks should be followed",
-        "watcherUsePolling": "Whether to use polling. Polling may leads to high CPU utilization but is necessary to watch files over a network"
+        "autoNormalizeLineEndings": "Automatically normalize line endings when opening files. When disabled, files are opened as-is.",
+        "fileSortOrder": "Sort order for files in opened folders: ascending or descending.",
+        "openedFilesInSidebar": "Whether to show opened files in the sidebar."
       }
     },
     "categories": {

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "Archivo",
-      "new": "Nuevo",
       "newTab": "Nueva Pestaña",
       "newWindow": "Nueva Ventana",
-      "open": "Abrir",
       "openFile": "Abrir Archivo...",
       "openFolder": "Abrir Carpeta...",
       "openRecent": "Abrir Reciente",
@@ -25,9 +23,6 @@
       "exportPdf": "Exportar como PDF",
       "import": "Importar",
       "print": "Imprimir",
-      "recent": "Archivos Recientes",
-      "close": "Cerrar",
-      "closeAll": "Cerrar",
       "closeTab": "Cerrar Pestaña",
       "closeWindow": "Cerrar Ventana",
       "quit": "Salir",
@@ -70,26 +65,19 @@
       "demoteHeading": "Degradar Encabezado",
       "table": "Tabla",
       "codeFences": "Bloques de Código",
-      "codeBlock": "Bloque de Código",
       "quoteBlock": "Bloque de Cita",
       "mathBlock": "Bloque Matemático",
       "htmlBlock": "Bloque HTML",
-      "quote": "Cita",
       "orderedList": "Lista Ordenada",
       "bulletList": "Lista con Viñetas",
-      "unorderedList": "Lista Desordenada",
       "taskList": "Lista de Tareas",
       "looseListItem": "Elemento de Lista Suelto",
-      "paragraphItem": "Elemento de Párrafo",
       "horizontalRule": "Regla Horizontal",
       "frontMatter": "Metadatos"
     },
     "window": {
       "title": "Ventana",
-      "window": "Ventana",
       "minimize": "Minimizar",
-      "close": "Cerrar",
-      "zoom": "Zoom",
       "zoomIn": "Acercar",
       "zoomOut": "Alejar",
       "fullScreen": "Pantalla Completa",
@@ -106,20 +94,16 @@
       "followUs": "Síguenos",
       "support": "Apoyar MarkText",
       "license": "Licencia",
-      "checkForUpdates": "Buscar Actualizaciones",
-      "aboutMarkText": "Acerca de MarkText",
       "about": "Acerca de",
       "checkUpdates": "Buscar Actualizaciones"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "Acerca de MarkText",
       "checkUpdates": "Buscar Actualizaciones...",
       "preferences": "Preferencias",
       "services": "Servicios",
       "hide": "Ocultar MarkText",
-      "hideMarkText": "Ocultar MarkText",
       "hideOthers": "Ocultar Otros",
       "showAll": "Mostrar",
       "quit": "Salir de MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Alternar Barra Lateral",
       "toggleTabbar": "Alternar Barra de Pestañas",
       "commandPalette": "Paleta de Comandos",
-      "sourceCode": "Modo Código Fuente",
       "sourceCodeMode": "Modo Código Fuente",
-      "typewriter": "Modo Máquina de Escribir",
       "typewriterMode": "Modo Máquina de Escribir",
-      "focus": "Modo Enfoque",
       "focusMode": "Modo Enfoque",
-      "showTabBar": "Mostrar Barra de Pestañas",
-      "toc": "Tabla de Contenidos",
       "toggleTableOfContents": "Alternar Tabla de Contenidos",
       "reloadImages": "Recargar Imágenes",
       "showDeveloperTools": "Mostrar Herramientas de Desarrollador",
@@ -148,35 +127,18 @@
       "italic": "Cursiva",
       "underline": "Subrayado",
       "strikethrough": "Tachado",
-      "code": "Código en Línea",
-      "codeBlock": "Bloque de Código",
-      "quote": "Cita",
-      "unorderedList": "Lista Desordenada",
-      "orderedList": "Lista Ordenada",
-      "taskList": "Lista de Tareas",
-      "table": "Tabla",
-      "link": "Enlace",
       "image": "Imagen",
-      "heading1": "Encabezado 1",
-      "heading2": "Encabezado 2",
-      "heading3": "Encabezado 3",
-      "heading4": "Encabezado 4",
-      "heading5": "Encabezado 5",
-      "heading6": "Encabezado 6",
       "superscript": "Superíndice",
       "subscript": "Subíndice",
       "highlight": "Resaltar",
       "inlineCode": "Código en Línea",
       "inlineMath": "Matemáticas en Línea",
       "hyperlink": "Hipervínculo",
-      "clearFormatting": "Limpiar Formato",
       "clearFormat": "Limpiar Formato"
     },
     "theme": {
       "theme": "&Tema",
-      "light": "Claro",
       "dark": "Oscuro",
-      "auto": "Automático",
       "followThemDisabled": "Selección de tema desactivada al seguir el tema del sistema",
       "lightThemes": "— Temas Claros —",
       "darkThemes": "— Temas Oscuros —",
@@ -375,13 +337,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Redimensionar Tabla",
-    "alignLeft": "Alinear a la Izquierda",
-    "alignCenter": "Alinear al Centro",
-    "alignRight": "Alinear a la Derecha",
-    "deleteTable": "Eliminar Tabla"
-  },
   "recent": {
     "noTabsOpen": "No tienes pestañas abiertas.",
     "newFile": "Nuevo Archivo"
@@ -394,7 +349,6 @@
     "title": "Preferencias",
     "search": {
       "placeholder": "Buscar preferencias...",
-      "optionalValues": "valores opcionales",
       "categories": {
         "general": "General",
         "editor": "Editor",
@@ -499,7 +453,6 @@
         "titleBarStyle": {
           "title": "Estilo de Barra de Título",
           "custom": "Personalizado",
-          "titleBarStyle": "Estilo de Barra de Título",
           "native": "Nativo"
         },
         "requiresRestart": "Requiere reinicio",
@@ -632,53 +585,19 @@
         "relativeFolderName": "Nombre de carpeta relativa",
         "filenameNote": "El nombre del archivo se generará automáticamente."
       },
-      "imageInsertAction": {
-        "title": "Acción de inserción de imagen",
-        "folder": "Subir a carpeta",
-        "path": "Copiar a ruta",
-        "upload": "Subir a la nube",
-        "copyToFolder": "Copiar a carpeta",
-        "uploadToServer": "Subir al servidor"
-      },
-      "imageFolderPath": {
-        "title": "Ruta de carpeta de imagen",
-        "description": "Ruta de carpeta de imagen",
-        "selectFolder": "Seleccionar carpeta",
-        "relativePath": "Ruta relativa",
-        "absolutePath": "Ruta absoluta"
-      },
-      "cloudPictureBed": {
-        "title": "Almacén de imágenes en la nube",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Preferir directorio relativo",
-        "description": "Preferir directorio relativo para imágenes"
-      },
       "uploader": {
         "title": "Subidor de Imágenes",
         "currentUploader": "Subidor actual: {name}",
         "picgoNotInstalled": "PicGo no está instalado",
-        "picgoDetectionStatus": "Estado de Detección de PicGo",
         "picgoInstalled": "PicGo está instalado",
         "picgoDetectionFailed": "Falló la detección de PicGo",
         "debugInfo": "Información de Depuración",
-        "installCommand": "Comando de Instalación",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "chooseInstallMethod": "Elegir método de instalación:",
         "retestPicgo": "Volver a probar",
-        "detecting": "Detectando...",
         "lastDetectionTime": "Última detección",
-        "detectionStatus": "Estado de detección",
         "usageGuide": {
           "title": "Guía básica de uso de PicGo",
           "step1": "Configurar cargador",
@@ -689,13 +608,6 @@
           "step3Description": "Use el siguiente comando para ver la configuración actual:",
           "documentation": "Ver documentación completa"
         },
-        "configureUploader": "Configurar cargador",
-        "configureDescription": "Use el siguiente comando para configurar el cargador PicGo:",
-        "uploadImage": "Subir imágenes",
-        "uploadDescription": "Use el siguiente comando para subir imágenes:",
-        "viewConfig": "Ver configuración",
-        "viewConfigDescription": "Use el siguiente comando para ver la configuración actual:",
-        "viewDocumentation": "Ver documentación completa",
         "scriptDescription": "Descripción del Script",
         "scriptLocation": "Ubicación del Script",
         "save": "Guardar",
@@ -708,7 +620,6 @@
         "pleaseInstall": "Por favor instala",
         "scriptPath": "Ruta del script",
         "picgoDetection": "Detección de PicGo",
-        "autoDetection": "Detección automática",
         "lastSuccessTime": "Última vez exitosa",
         "neverDetected": "Nunca detectado",
         "neverSuccessful": "Nunca exitoso"
@@ -717,44 +628,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "Elemento de Lista",
-        "preferLooseListItem": "Preferir elemento de lista suelto",
-        "bulletListMarker": "Marcador de lista con viñetas",
-        "orderListDelimiter": "Delimitador de lista ordenada",
-        "listIndentation": {
-          "title": "Sangría de Lista",
-          "dfm": "Por defecto",
-          "tab": "Tabulación",
-          "oneSpace": "Un espacio",
-          "twoSpaces": "Dos espacios",
-          "threeSpaces": "Tres espacios",
-          "fourSpaces": "Cuatro espacios"
-        }
-      },
-      "heading": {
-        "title": "Encabezado",
-        "preferHeadingStyle": "Preferir estilo de encabezado"
-      },
-      "frontmatter": {
-        "title": "Metadatos",
-        "frontmatterType": "Tipo de metadatos"
-      },
       "extensions": {
         "title": "Extensiones",
         "superSubScript": "Super/Sub script",
         "footnote": "Nota al pie",
-        "isHtmlEnabled": "HTML habilitado",
-        "isGitlabCompatibilityEnabled": "Compatibilidad con GitLab",
-        "sequenceTheme": "Tema de secuencia",
-        "superscript": "Superíndice",
-        "subscript": "Subíndice",
-        "frontMatter": "Metadatos",
-        "math": "Matemáticas",
-        "diagram": "Diagrama",
         "footnoteNotes": "Notas al pie",
         "frontmatterType": {
-          "frontmatterType": "Tipo de Metadatos",
           "jsonBrace": "JSON con Llaves",
           "jsonSemicolon": "JSON con Punto y Coma",
           "title": "Tipo de Metadatos"
@@ -762,12 +641,6 @@
       },
       "diagrams": {
         "title": "Diagramas",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "Diagrama de Flujo",
-        "sequence": "Secuencia",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Tema de Secuencia",
           "handDrawn": "Dibujado a Mano",
@@ -776,11 +649,6 @@
         "plantumlServer": {
           "title": "URL del servidor PlantUML"
         }
-      },
-      "math": {
-        "title": "Matemáticas",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -811,28 +679,13 @@
         "title": "Listas"
       }
     },
-    "spelling": {
-      "title": "Ortografía",
-      "enabled": "Habilitar corrector ortográfico",
-      "autoDetectLanguage": "Detectar idioma automáticamente",
-      "language": "Idioma",
-      "noSuggestions": "Sin sugerencias",
-      "spellcheckerEnabled": "Habilitar corrector ortográfico",
-      "spellcheckerNoUnderline": "Sin subrayado para palabras mal escritas",
-      "spellcheckerLanguage": "Idioma del corrector ortográfico"
-    },
     "theme": {
       "title": "Tema",
-      "theme": "Tema",
       "followSystemTheme": "Seguir tema del sistema",
       "modeThemes": "Selección de Tema",
       "lightModeTheme": "Tema de modo claro",
       "darkModeTheme": "Tema de modo oscuro",
       "customCss": "CSS Personalizado",
-      "codeBlockTheme": {
-        "title": "Tema de bloque de código",
-        "description": "Tema para bloques de código"
-      },
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Carpeta",
@@ -841,13 +694,6 @@
     "keybindings": {
       "title": "Atajos de Teclado",
       "description": "Personalizar atajos de teclado",
-      "searchPlaceholder": "Buscar atajos de teclado",
-      "command": "Comando",
-      "keybinding": "Atajo de Teclado",
-      "reset": "Restablecer",
-      "resetAll": "Restablecer",
-      "edit": "Editar",
-      "cancel": "Cancelar",
       "save": "Guardar",
       "restoreDefaults": "Restaurar predeterminados",
       "debugOptions": "Opciones de Depuración",
@@ -921,9 +767,7 @@
       "exportFile": "Exportar Archivo",
       "exportFilePdf": "Exportar como PDF",
       "zoom": "Zoom",
-      "checkUpdate": "Buscar Actualizaciones",
-      "lineEnding": "Final de línea",
-      "close": "Cerrar"
+      "checkUpdate": "Buscar Actualizaciones"
     },
     "edit": {
       "undo": "Deshacer",
@@ -943,8 +787,7 @@
       "findPrevious": "Buscar Anterior",
       "replace": "Reemplazar",
       "findInFolder": "Buscar en Carpeta",
-      "screenshot": "Captura de Pantalla",
-      "mathBlock": "Bloque matemático"
+      "screenshot": "Captura de Pantalla"
     },
     "paragraph": {
       "heading1": "Encabezado 1",
@@ -1010,8 +853,6 @@
       "reloadImages": "Recargar Imágenes",
       "textDirection": "Dirección del Texto",
       "actualSize": "Tamaño real",
-      "zoomIn": "Acercar",
-      "zoomOut": "Alejar",
       "devToggleDeveloperTools": "Alternar herramientas de desarrollador"
     },
     "tabs": {
@@ -1033,10 +874,6 @@
     "docs": {
       "userGuide": "Guía del Usuario",
       "markdownSyntax": "Sintaxis de Markdown"
-    },
-    "utils": {
-      "noUpdateResourceFile": "No hay archivo de recurso de actualización",
-      "todoUpdateCheck": "Buscar actualizaciones"
     },
     "spellchecker": {
       "switchLanguage": "Cambiar Idioma"
@@ -1083,25 +920,6 @@
       "anchorLinkCopied": "Enlace de ancla copiado",
       "tabNotFound": "Pestaña no encontrada",
       "tocItemNotFound": "Elemento de tabla de contenidos {key} no encontrado",
-      "highlightStart": "[Inicio de resaltado]",
-      "highlightEnd": "[Fin de resaltado]",
-      "typeAtToInsert": "Escriba / para insertar",
-      "inputFootnoteDefinition": "Ingrese definición de nota al pie...",
-      "inputYamlFrontMatter": "Ingrese metadatos YAML...",
-      "inputLanguageIdentifier": "Ingrese identificador de idioma...",
-      "inputMathematicalFormula": "Ingrese fórmula matemática...",
-      "fence": "Cerca",
-      "indent": "Sangría",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Haga clic para agregar imagen",
-      "loadImageFailed": "Error al cargar la imagen",
       "errorLoadingTabTitle": "Error al cargar la pestaña",
       "errorLoadingTabMessage": "Se produjo un error al cargar la modificación del archivo porque no se puede encontrar la pestaña.",
       "mixedLineEndingsNormalized": "«{name}» tiene finales de línea mixtos que se normalizaron automáticamente a {lineEnding}.",
@@ -1118,204 +936,7 @@
     "failedToRemoveWord": "Error al eliminar palabra del diccionario",
     "unexpectedError": "Error inesperado del corrector ortográfico"
   },
-  "quickInsert": {
-    "header": "Encabezado",
-    "paragraph": {
-      "title": "Párrafo",
-      "subtitle": "Ingrese contenido de texto"
-    },
-    "horizontalLine": {
-      "title": "Línea Horizontal",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Metadatos",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Encabezado 1",
-      "subtitle": "# Encabezado"
-    },
-    "header2": {
-      "title": "Encabezado 2",
-      "subtitle": "## Encabezado"
-    },
-    "header3": {
-      "title": "Encabezado 3",
-      "subtitle": "### Encabezado"
-    },
-    "header4": {
-      "title": "Encabezado 4",
-      "subtitle": "#### Encabezado"
-    },
-    "header5": {
-      "title": "Encabezado 5",
-      "subtitle": "##### Encabezado"
-    },
-    "header6": {
-      "title": "Encabezado 6",
-      "subtitle": "###### Encabezado"
-    },
-    "tableBlock": {
-      "title": "Bloque de Tabla",
-      "subtitle": "｜ Encabezado ｜ Encabezado ｜"
-    },
-    "mathFormula": {
-      "title": "Fórmula Matemática",
-      "subtitle": "$$ Fórmula $$"
-    },
-    "htmlBlock": {
-      "title": "Bloque HTML",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Bloque de Código",
-      "subtitle": "``` Código ```"
-    },
-    "quoteBlock": {
-      "title": "Bloque de Cita",
-      "subtitle": "> Contenido de cita"
-    },
-    "orderedList": {
-      "title": "Lista Ordenada",
-      "subtitle": "1. Elemento de lista"
-    },
-    "bulletList": {
-      "title": "Lista con Viñetas",
-      "subtitle": "- Elemento de lista"
-    },
-    "todoList": {
-      "title": "Lista de Tareas",
-      "subtitle": "- [x]"
-    },
-    "vegaChart": {
-      "title": "Gráfico Vega",
-      "subtitle": "Renderizar gráficos usando vega-lite.js."
-    },
-    "flowChart": {
-      "title": "Diagrama de Flujo",
-      "subtitle": "Diagrama de flujo"
-    },
-    "mermaid": {
-      "title": "Mermaid",
-      "subtitle": "Renderizar gráficos usando mermaid.",
-      "gantt": {
-        "title": "Diagrama de Gantt"
-      },
-      "pie": {
-        "title": "Gráfico circular"
-      },
-      "flowchart": {
-        "title": "Diagrama de flujo"
-      },
-      "sequence": {
-        "title": "Diagrama de secuencia"
-      },
-      "class": {
-        "title": "Diagrama de clases"
-      },
-      "state": {
-        "title": "Diagrama de estados",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "Viaje del usuario"
-      },
-      "git": {
-        "title": "Diagrama Git"
-      },
-      "er": {
-        "title": "Diagrama ER"
-      },
-      "requirement": {
-        "title": "Diagrama de requisitos"
-      }
-    },
-    "sequenceChart": {
-      "title": "Gráfico de Secuencia",
-      "subtitle": "Diagrama de secuencia"
-    },
-    "taskList": {
-      "title": "Lista de tareas"
-    },
-    "vegaliteChart": {
-      "title": "Gráfico Vega-Lite"
-    },
-    "plantUMLDiagram": {
-      "title": "Diagrama PlantUML"
-    },
-    "mermaidDiagram": {
-      "title": "Diagrama Mermaid"
-    },
-    "basicBlock": "Bloque Básico",
-    "advancedBlock": "Bloque Avanzado",
-    "listBlock": "Bloque de Lista",
-    "diagram": "Diagrama",
-    "plantUMLChart": {
-      "title": "Gráfico PlantUML",
-      "subtitle": "Gráfico UML"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Duplicar",
-    "turnInto": "Convertir en",
-    "newParagraph": "Nuevo párrafo",
-    "delete": "Eliminar",
-    "paragraph": "Párrafo",
-    "table": "Tabla",
-    "html": "HTML",
-    "mathblock": "Bloque matemático",
-    "pre": "Bloque de código",
-    "frontMatter": "Metadatos",
-    "ulTask": "Lista de tareas",
-    "ulBullet": "Lista con viñetas",
-    "olOrder": "Lista ordenada",
-    "blockquote": "Cita en bloque",
-    "heading1": "Encabezado 1",
-    "heading2": "Encabezado 2",
-    "heading3": "Encabezado 3",
-    "heading4": "Encabezado 4",
-    "heading5": "Encabezado 5",
-    "heading6": "Encabezado 6",
-    "hr": "Línea horizontal"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Seleccionar",
-          "embedLink": "Insertar enlace"
-        },
-        "select": {
-          "chooseButton": "Elegir imagen",
-          "tip": "Elige una imagen de tu ordenador."
-        },
-        "inputs": {
-          "alt": "Texto alternativo",
-          "src": "Enlace de imagen o ruta local",
-          "title": "Título de la imagen"
-        },
-        "embedButton": "Insertar imagen",
-        "hint": {
-          "prefix": "Pega imagen web o ruta local. Cambiar modo",
-          "simple": "modo simple",
-          "full": "modo completo"
-        }
-      },
-      "toolbar": {
-        "edit": "Editar imagen",
-        "inline": "Imagen en línea",
-        "alignLeft": "Alinear a la izquierda",
-        "alignCenter": "Alinear al centro",
-        "alignRight": "Alinear a la derecha",
-        "delete": "Eliminar imagen"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "Ingrese Metadatos YAML...",
-      "languageIdentifier": "Ingrese Identificador de Idioma...",
-      "mathFormula": "Ingrese Fórmula Matemática..."
-    },
     "export": {
       "error": "Error de exportación",
       "errorExporting": "Error al exportar archivo {type}",
@@ -1338,65 +959,11 @@
       "imageStructureDeletedComment": "Comentario de estructura de imagen eliminada"
     },
     "spellcheck": {
-      "enabled": "Corrector ortográfico habilitado",
-      "disabled": "Corrector ortográfico deshabilitado",
-      "enabledError": "Error al habilitar el corrector ortográfico",
       "disabledError": "Error al deshabilitar el corrector ortográfico",
       "errorSwitchingLanguage": "Error al cambiar el idioma del corrector ortográfico {languageCode}",
       "languageMissing": "Idioma del corrector ortográfico faltante {languageCode}",
       "switchError": "Error del corrector ortográfico para {languageCode}, {error}",
       "title": "Corrector ortográfico"
-    },
-    "table": "tabla",
-    "resizeTable": "Redimensionar tabla",
-    "left": "izquierda",
-    "alignLeft": "Alinear a la izquierda",
-    "center": "centro",
-    "alignCenter": "Alinear al centro",
-    "right": "derecha",
-    "alignRight": "Alinear a la derecha",
-    "delete": "eliminar",
-    "deleteTable": "Eliminar tabla",
-    "insertRowAbove": "Insertar fila arriba",
-    "insertRowBelow": "Insertar fila abajo",
-    "removeRow": "Eliminar fila",
-    "insertColumnLeft": "Insertar columna a la izquierda",
-    "insertColumnRight": "Insertar columna a la derecha",
-    "removeColumn": "Eliminar columna",
-    "copyContent": "Copiar contenido",
-    "emptyMathFormula": "< Fórmula matemática vacía >",
-    "invalidMathFormula": "< Fórmula matemática inválida >",
-    "emptyMermaidBlock": "< Bloque Mermaid vacío >",
-    "loading": "Cargando...",
-    "emptyDiagramBlock": "< Bloque de diagrama vacío >",
-    "emptyHtmlBlock": "< Bloque HTML vacío >",
-    "onlyTopBlockCanRenderIcon": "Solo el bloque superior puede renderizar el botón de icono frontal.",
-    "unhandledFunctionType": "Tipo de función no manejado: {functionType}",
-    "highlight-start": "[inicio de resaltado]",
-    "highlight-end": "[fin de resaltado]",
-    "type-at-to-insert": "Escriba / para insertar",
-    "input-footnote-definition": "Ingrese definición de nota al pie",
-    "input-yaml-front-matter": "Ingrese front matter YAML",
-    "input-language-identifier": "Ingrese identificador de idioma",
-    "input-mathematical-formula": "Ingrese fórmula matemática",
-    "fence": "cerca",
-    "indent": "sangría",
-    "front-matter-delimiter": "delimitador de front matter",
-    "math-delimiter": "delimitador matemático",
-    "mermaid-start": "inicio de mermaid",
-    "flowchart-start": "inicio de diagrama de flujo",
-    "sequence-start": "inicio de secuencia",
-    "plantuml-start": "inicio de plantuml",
-    "vega-lite-start": "inicio de vega-lite",
-    "click-to-add-image": "Haga clic para agregar imagen",
-    "load-image-failed": "Error al cargar imagen"
-  },
-  "edit": {
-    "undo": "Deshacer",
-    "redo": "Rehacer",
-    "cut": "Cortar",
-    "copy": "Copiar",
-    "paste": "Pegar",
-    "selectAll": "Seleccionar"
+    }
   }
 }

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -364,7 +364,7 @@
       "items": {
         "autoSave": "Guardar automáticamente el contenido que se está editando",
         "autoSaveDelay": "El tiempo en ms después de un cambio que se guarda el archivo",
-        "autoNormalizeLineEndings": "Normalizar automáticamente los finales de línea a LF y opcionalmente las nuevas líneas finales al abrir",
+        "autoNormalizeLineEndings": "Normalizar automáticamente los finales de línea al abrir archivos. Si está desactivado, los archivos se abren tal cual",
         "titleBarStyle": "El estilo de la barra de título (solo sistema Windows y Linux)",
         "openFilesInNewWindow": "Abrir archivos en una nueva ventana",
         "openFolderInNewWindow": "Abrir carpeta vía menú en una nueva ventana",
@@ -413,7 +413,6 @@
         "followSystemTheme": "Seguir tema del sistema",
         "lightModeTheme": "Tema a usar cuando el sistema está en modo claro",
         "darkModeTheme": "Tema a usar cuando el sistema está en modo oscuro",
-        "customCss": "CSS personalizado para aplicar al tema actual",
         "spellcheckerEnabled": "Si la verificación ortográfica está habilitada",
         "spellcheckerNoUnderline": "No subrayar errores ortográficos",
         "spellcheckerLanguage": "El idioma del verificador ortográfico",
@@ -421,15 +420,8 @@
         "imagePreferRelativeDirectory": "Si preferir el directorio de imagen relativo",
         "imageRelativeDirectoryBase": "Dónde se copian las imágenes relativas",
         "imageRelativeDirectoryName": "El nombre de la carpeta de imagen relativa",
-        "sideBarVisibility": "Si la barra lateral es visible",
-        "tabBarVisibility": "Si las pestañas se muestran",
-        "sourceCodeModeEnabled": "Si el modo de código fuente está habilitado por defecto",
-        "searchExclusions": "Lista de patrones glob para excluir de la búsqueda",
-        "searchMaxFileSize": "El tamaño máximo de archivo (<maxFileSize><suffix>). Se permiten sufijos de K, M o G si no se da sufijo el número se trata como bytes",
-        "searchIncludeHidden": "Si buscar en archivos y directorios ocultos",
-        "searchNoIgnore": "Si ignorar archivos de ignore como .gitignore",
-        "searchFollowSymlinks": "Si los enlaces simbólicos deben seguirse",
-        "watcherUsePolling": "Si usar polling. El polling puede llevar a alta utilización de CPU pero es necesario para observar archivos sobre una red"
+        "fileSortOrder": "El orden de clasificación de los archivos en las carpetas abiertas: ascendente o descendente",
+        "openedFilesInSidebar": "Si mostrar los archivos abiertos en la barra lateral"
       }
     },
     "categories": {

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "Fichier",
-      "new": "Nouveau",
       "newTab": "Nouvel onglet",
       "newWindow": "Nouvelle fenêtre",
-      "open": "Ouvrir",
       "openFile": "Ouvrir un fichier...",
       "openFolder": "Ouvrir un dossier...",
       "openRecent": "Ouvrir récent",
@@ -25,9 +23,6 @@
       "exportPdf": "Exporter en PDF",
       "import": "Importer",
       "print": "Imprimer",
-      "recent": "Fichiers récents",
-      "close": "Fermer",
-      "closeAll": "Fermer tout",
       "closeTab": "Fermer l'onglet",
       "closeWindow": "Fermer la fenêtre",
       "quit": "Quitter",
@@ -70,26 +65,19 @@
       "demoteHeading": "Rétrograder le titre",
       "table": "Tableau",
       "codeFences": "Clôtures de code",
-      "codeBlock": "Bloc de code",
       "quoteBlock": "Bloc de citation",
       "mathBlock": "Bloc mathématique",
       "htmlBlock": "Bloc HTML",
-      "quote": "Citation",
       "orderedList": "Liste ordonnée",
       "bulletList": "Liste à puces",
-      "unorderedList": "Liste non ordonnée",
       "taskList": "Liste de tâches",
       "looseListItem": "Élément de liste lâche",
-      "paragraphItem": "Élément de paragraphe",
       "horizontalRule": "Règle horizontale",
       "frontMatter": "Métadonnées"
     },
     "window": {
       "title": "Fenêtre",
-      "window": "Fenêtre",
       "minimize": "Réduire",
-      "close": "Fermer",
-      "zoom": "Zoom",
       "zoomIn": "Agrandir",
       "zoomOut": "Réduire",
       "fullScreen": "Plein écran",
@@ -106,20 +94,16 @@
       "followUs": "Suivez-nous",
       "support": "Soutenir MarkText",
       "license": "Licence",
-      "checkForUpdates": "Vérifier les mises à jour",
-      "aboutMarkText": "À propos de MarkText",
       "about": "À propos",
       "checkUpdates": "Vérifier les mises à jour"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "À propos de MarkText",
       "checkUpdates": "Vérifier les mises à jour...",
       "preferences": "Préférences",
       "services": "Services",
       "hide": "Masquer MarkText",
-      "hideMarkText": "Masquer MarkText",
       "hideOthers": "Masquer les autres",
       "showAll": "Tout afficher",
       "quit": "Quitter MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Basculer la barre latérale",
       "toggleTabbar": "Basculer la barre d'onglets",
       "commandPalette": "Palette de commandes",
-      "sourceCode": "Mode code source",
       "sourceCodeMode": "Mode code source",
-      "typewriter": "Mode machine à écrire",
       "typewriterMode": "Mode machine à écrire",
-      "focus": "Mode focus",
       "focusMode": "Mode focus",
-      "showTabBar": "Afficher la barre d'onglets",
-      "toc": "Table des matières",
       "toggleTableOfContents": "Basculer la table des matières",
       "reloadImages": "Recharger les images",
       "showDeveloperTools": "Afficher les outils de développement",
@@ -148,35 +127,18 @@
       "italic": "Italique",
       "underline": "Souligné",
       "strikethrough": "Barré",
-      "code": "Code en ligne",
-      "codeBlock": "Bloc de code",
-      "quote": "Citation",
-      "unorderedList": "Liste non ordonnée",
-      "orderedList": "Liste ordonnée",
-      "taskList": "Liste de tâches",
-      "table": "Tableau",
-      "link": "Lien",
       "image": "Image",
-      "heading1": "Titre 1",
-      "heading2": "Titre 2",
-      "heading3": "Titre 3",
-      "heading4": "Titre 4",
-      "heading5": "Titre 5",
-      "heading6": "Titre 6",
       "superscript": "Exposant",
       "subscript": "Indice",
       "highlight": "Surlignage",
       "inlineCode": "Code en ligne",
       "inlineMath": "Math en ligne",
       "hyperlink": "Hyperlien",
-      "clearFormatting": "Effacer le formatage",
       "clearFormat": "Effacer le format"
     },
     "theme": {
       "theme": "Thème (&T)",
-      "light": "Clair",
       "dark": "Sombre",
-      "auto": "Automatique",
       "followThemDisabled": "Sélection du thème désactivée lorsque le thème du système est suivi",
       "lightThemes": "— Thèmes Clairs —",
       "darkThemes": "— Thèmes Sombres —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Redimensionner le Tableau",
-    "alignLeft": "Aligner à Gauche",
-    "alignCenter": "Aligner au Centre",
-    "alignRight": "Aligner à Droite",
-    "deleteTable": "Supprimer le Tableau"
-  },
   "recent": {
     "noTabsOpen": "Vous n'avez aucun onglet ouvert.",
     "newFile": "Nouveau fichier"
@@ -395,7 +350,6 @@
     "title": "Préférences",
     "search": {
       "placeholder": "Rechercher dans les préférences...",
-      "optionalValues": "valeurs optionnelles",
       "categories": {
         "general": "Général",
         "editor": "Éditeur",
@@ -500,7 +454,6 @@
         "titleBarStyle": {
           "title": "Style de barre de titre",
           "custom": "Personnalisé",
-          "titleBarStyle": "Style de barre de titre",
           "native": "Natif"
         },
         "requiresRestart": "Nécessite un redémarrage",
@@ -633,54 +586,20 @@
         "relativeFolderName": "Nom du dossier relatif",
         "filenameNote": "Le nom de fichier sera généré automatiquement."
       },
-      "imageInsertAction": {
-        "title": "Action d'insertion d'image",
-        "folder": "Télécharger vers le dossier",
-        "path": "Copier vers le chemin",
-        "upload": "Télécharger vers le cloud",
-        "copyToFolder": "Copier vers le dossier",
-        "uploadToServer": "Télécharger vers le serveur"
-      },
-      "imageFolderPath": {
-        "title": "Chemin du dossier d'images",
-        "description": "Chemin du dossier d'images",
-        "selectFolder": "Sélectionner un dossier",
-        "relativePath": "Chemin relatif",
-        "absolutePath": "Chemin absolu"
-      },
-      "cloudPictureBed": {
-        "title": "Hébergement d'images cloud",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Préférer le répertoire relatif",
-        "description": "Répertoire relatif préféré pour les images"
-      },
       "uploader": {
         "title": "Téléchargeur d'images",
         "currentUploader": "Téléchargeur actuel",
         "picgoNotInstalled": "PicGo non installé",
-        "picgoDetectionStatus": "Statut de détection PicGo",
         "picgoInstalled": "PicGo installé",
         "picgoDetectionFailed": "Échec de la détection PicGo",
         "debugInfo": "Informations de débogage",
-        "installCommand": "Commande d'installation",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "Choisir la méthode d'installation :",
         "retestPicgo": "Retester",
-        "detecting": "Détection en cours...",
         "lastDetectionTime": "Dernière détection",
-        "detectionStatus": "Statut de détection",
         "usageGuide": {
           "title": "Guide d'utilisation de base PicGo",
           "step1": "Configurer l'uploader",
@@ -691,13 +610,6 @@
           "step3Description": "Utilisez la commande suivante pour voir la configuration actuelle :",
           "documentation": "Voir la documentation complète"
         },
-        "configureUploader": "Configurer l'uploader",
-        "configureDescription": "Utilisez la commande suivante pour configurer l'uploader PicGo :",
-        "uploadImage": "Télécharger des images",
-        "uploadDescription": "Utilisez la commande suivante pour télécharger des images :",
-        "viewConfig": "Voir la configuration",
-        "viewConfigDescription": "Utilisez la commande suivante pour voir la configuration actuelle :",
-        "viewDocumentation": "Voir la documentation complète",
         "scriptDescription": "Description du script",
         "scriptLocation": "Emplacement du script",
         "save": "Enregistrer",
@@ -710,7 +622,6 @@
         "pleaseInstall": "Veuillez installer",
         "scriptPath": "Chemin du script",
         "picgoDetection": "Détection PicGo",
-        "autoDetection": "Détection automatique",
         "lastSuccessTime": "Dernière heure de succès",
         "neverDetected": "Jamais détecté",
         "neverSuccessful": "Jamais réussi"
@@ -719,44 +630,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "Élément de liste",
-        "preferLooseListItem": "Préférer les éléments de liste lâches",
-        "bulletListMarker": "Marqueur de liste à puces",
-        "orderListDelimiter": "Délimiteur de liste ordonnée",
-        "listIndentation": {
-          "title": "Indentation de liste",
-          "dfm": "Défaut",
-          "tab": "Tabulation",
-          "oneSpace": "Un espace",
-          "twoSpaces": "Deux espaces",
-          "threeSpaces": "Trois espaces",
-          "fourSpaces": "Quatre espaces"
-        }
-      },
-      "heading": {
-        "title": "Titre",
-        "preferHeadingStyle": "Style de titre préféré"
-      },
-      "frontmatter": {
-        "title": "Métadonnées",
-        "frontmatterType": "Type de métadonnées"
-      },
       "extensions": {
         "title": "Extensions",
         "superSubScript": "Exposant/Indice",
         "footnote": "Note de bas de page",
-        "isHtmlEnabled": "HTML activé",
-        "isGitlabCompatibilityEnabled": "Compatibilité GitLab",
-        "sequenceTheme": "Thème de séquence",
-        "superscript": "Exposant",
-        "subscript": "Indice",
-        "frontMatter": "Métadonnées",
-        "math": "Mathématiques",
-        "diagram": "Diagramme",
         "footnoteNotes": "Notes de bas de page",
         "frontmatterType": {
-          "frontmatterType": "Type de métadonnées",
           "jsonBrace": "Accolade JSON",
           "jsonSemicolon": "Point-virgule JSON",
           "title": "Type de métadonnées"
@@ -764,12 +643,6 @@
       },
       "diagrams": {
         "title": "Diagrammes",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "Organigramme",
-        "sequence": "Séquence",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Thème de séquence",
           "handDrawn": "Dessiné à la main",
@@ -778,11 +651,6 @@
         "plantumlServer": {
           "title": "URL du serveur PlantUML"
         }
-      },
-      "math": {
-        "title": "Mathématiques",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -813,28 +681,13 @@
         "title": "Listes"
       }
     },
-    "spelling": {
-      "title": "Orthographe",
-      "enabled": "Activer la vérification orthographique",
-      "autoDetectLanguage": "Détection automatique de la langue",
-      "language": "Langue",
-      "noSuggestions": "Aucune suggestion",
-      "spellcheckerEnabled": "Vérificateur orthographique activé",
-      "spellcheckerNoUnderline": "Pas de soulignement pour les mots mal orthographiés",
-      "spellcheckerLanguage": "Langue du vérificateur orthographique"
-    },
     "theme": {
       "title": "Thème",
-      "theme": "Thème",
       "followSystemTheme": "Suivre le thème du système",
       "modeThemes": "Sélection du thème",
       "lightModeTheme": "Thème en mode clair",
       "darkModeTheme": "Thème en mode sombre",
       "customCss": "CSS personnalisé",
-      "codeBlockTheme": {
-        "title": "Thème de bloc de code",
-        "description": "Thème pour les blocs de code"
-      },
       "importCustomThemes": "Importer des thèmes personnalisés",
       "importTheme": "Importer un thème",
       "openFolder": "Ouvrir le dossier",
@@ -843,13 +696,6 @@
     "keybindings": {
       "title": "Raccourcis clavier",
       "description": "Personnaliser les raccourcis clavier",
-      "searchPlaceholder": "Rechercher des raccourcis clavier",
-      "command": "Commande",
-      "keybinding": "Raccourci clavier",
-      "reset": "Réinitialiser",
-      "resetAll": "Tout réinitialiser",
-      "edit": "Modifier",
-      "cancel": "Annuler",
       "save": "Enregistrer",
       "restoreDefaults": "Restaurer les valeurs par défaut",
       "debugOptions": "Options de débogage",
@@ -923,9 +769,7 @@
       "exportFile": "Exporter un fichier",
       "exportFilePdf": "Exporter en PDF",
       "zoom": "Zoom",
-      "checkUpdate": "Vérifier les mises à jour",
-      "lineEnding": "Fin de ligne",
-      "close": "Fermer"
+      "checkUpdate": "Vérifier les mises à jour"
     },
     "edit": {
       "undo": "Annuler",
@@ -945,8 +789,7 @@
       "findPrevious": "Rechercher précédent",
       "replace": "Remplacer",
       "findInFolder": "Rechercher dans le dossier",
-      "screenshot": "Capture d'écran",
-      "mathBlock": "Bloc mathématique"
+      "screenshot": "Capture d'écran"
     },
     "paragraph": {
       "heading1": "Titre 1",
@@ -1012,8 +855,6 @@
       "reloadImages": "Recharger les images",
       "textDirection": "Direction du texte",
       "actualSize": "Taille réelle",
-      "zoomIn": "Agrandir",
-      "zoomOut": "Réduire",
       "devToggleDeveloperTools": "Basculer les outils de développement"
     },
     "tabs": {
@@ -1035,10 +876,6 @@
     "docs": {
       "userGuide": "Guide utilisateur",
       "markdownSyntax": "Syntaxe Markdown"
-    },
-    "utils": {
-      "noUpdateResourceFile": "Aucun fichier de ressource de mise à jour",
-      "todoUpdateCheck": "Vérification de mise à jour"
     },
     "spellchecker": {
       "switchLanguage": "Changer de langue"
@@ -1085,25 +922,6 @@
       "anchorLinkCopied": "Lien d'ancrage copié",
       "tabNotFound": "Onglet introuvable",
       "tocItemNotFound": "Élément de table des matières introuvable",
-      "highlightStart": "[Début de surbrillance]",
-      "highlightEnd": "[Fin de surbrillance]",
-      "typeAtToInsert": "Tapez / pour insérer",
-      "inputFootnoteDefinition": "Saisir la définition de note de bas de page...",
-      "inputYamlFrontMatter": "Saisir les métadonnées YAML...",
-      "inputLanguageIdentifier": "Saisir l'identifiant de langue...",
-      "inputMathematicalFormula": "Saisir la formule mathématique...",
-      "fence": "Clôture",
-      "indent": "Indentation",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Cliquer pour ajouter une image",
-      "loadImageFailed": "Échec du chargement de l'image",
       "errorLoadingTabTitle": "Erreur lors du chargement de l’onglet",
       "errorLoadingTabMessage": "Une erreur s’est produite lors du chargement de la modification du fichier car l’onglet est introuvable.",
       "mixedLineEndingsNormalized": "« {name} » contient des fins de ligne mixtes qui ont été automatiquement normalisées en {lineEnding}.",
@@ -1120,204 +938,7 @@
     "failedToRemoveWord": "Échec de la suppression du mot du dictionnaire",
     "unexpectedError": "Erreur inattendue du correcteur orthographique"
   },
-  "quickInsert": {
-    "basicBlock": "Bloc de base",
-    "header": "En-tête",
-    "advancedBlock": "Bloc avancé",
-    "listBlock": "Bloc de liste",
-    "diagram": "Diagramme",
-    "paragraph": {
-      "title": "Paragraphe",
-      "subtitle": "Saisir le contenu du texte"
-    },
-    "horizontalLine": {
-      "title": "Ligne horizontale",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Métadonnées",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Titre 1",
-      "subtitle": "# Titre"
-    },
-    "header2": {
-      "title": "Titre 2",
-      "subtitle": "## Titre"
-    },
-    "header3": {
-      "title": "Titre 3",
-      "subtitle": "### Titre"
-    },
-    "header4": {
-      "title": "Titre 4",
-      "subtitle": "#### Titre"
-    },
-    "header5": {
-      "title": "Titre 5",
-      "subtitle": "##### Titre"
-    },
-    "header6": {
-      "title": "Titre 6",
-      "subtitle": "###### Titre"
-    },
-    "tableBlock": {
-      "title": "Bloc de tableau",
-      "subtitle": "｜ En-tête ｜ En-tête ｜"
-    },
-    "mathFormula": {
-      "title": "Formule mathématique",
-      "subtitle": "$$ Formule $$"
-    },
-    "htmlBlock": {
-      "title": "Bloc HTML",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Bloc de code",
-      "subtitle": "``` Code ```"
-    },
-    "quoteBlock": {
-      "title": "Bloc de citation",
-      "subtitle": "> Contenu de citation"
-    },
-    "orderedList": {
-      "title": "Liste ordonnée",
-      "subtitle": "1. Élément de liste"
-    },
-    "bulletList": {
-      "title": "Liste à puces",
-      "subtitle": "- Élément de liste"
-    },
-    "todoList": {
-      "title": "Liste de tâches",
-      "subtitle": "- [ ] Élément de tâche"
-    },
-    "vegaChart": {
-      "title": "Graphique Vega-Lite",
-      "subtitle": "Graphique de visualisation de données"
-    },
-    "flowChart": {
-      "title": "Organigramme",
-      "subtitle": "Diagramme de flux"
-    },
-    "sequenceChart": {
-      "title": "Graphique de séquence",
-      "subtitle": "Diagramme de séquence"
-    },
-    "plantUMLChart": {
-      "title": "Diagramme PlantUML",
-      "subtitle": "Diagramme UML"
-    },
-    "mermaid": {
-      "title": "Diagramme Mermaid",
-      "subtitle": "Diagramme Mermaid",
-      "gantt": {
-        "title": "Diagramme de Gantt"
-      },
-      "pie": {
-        "title": "Graphique en secteurs"
-      },
-      "flowchart": {
-        "title": "Organigramme"
-      },
-      "sequence": {
-        "title": "Diagramme de séquence"
-      },
-      "class": {
-        "title": "Diagramme de classes"
-      },
-      "state": {
-        "title": "Diagramme d'états",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "Parcours utilisateur"
-      },
-      "git": {
-        "title": "Diagramme Git"
-      },
-      "er": {
-        "title": "Diagramme ER"
-      },
-      "requirement": {
-        "title": "Diagramme d'exigences"
-      }
-    },
-    "taskList": {
-      "title": "Liste de tâches"
-    },
-    "vegaliteChart": {
-      "title": "Graphique Vega-Lite"
-    },
-    "plantUMLDiagram": {
-      "title": "Diagramme PlantUML"
-    },
-    "mermaidDiagram": {
-      "title": "Diagramme Mermaid"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Dupliquer",
-    "turnInto": "Transformer en",
-    "newParagraph": "Nouveau paragraphe",
-    "delete": "Supprimer",
-    "paragraph": "Paragraphe",
-    "table": "Tableau",
-    "html": "HTML",
-    "mathblock": "Bloc mathématique",
-    "pre": "Bloc de code",
-    "frontMatter": "Métadonnées",
-    "ulTask": "Liste de tâches",
-    "ulBullet": "Liste à puces",
-    "olOrder": "Liste ordonnée",
-    "blockquote": "Citation",
-    "heading1": "Titre 1",
-    "heading2": "Titre 2",
-    "heading3": "Titre 3",
-    "heading4": "Titre 4",
-    "heading5": "Titre 5",
-    "heading6": "Titre 6",
-    "hr": "Ligne horizontale"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Sélectionner",
-          "embedLink": "Intégrer un lien"
-        },
-        "select": {
-          "chooseButton": "Choisir une image",
-          "tip": "Choisissez une image depuis votre ordinateur."
-        },
-        "inputs": {
-          "alt": "Texte alternatif",
-          "src": "Lien de l'image ou chemin local",
-          "title": "Titre de l'image"
-        },
-        "embedButton": "Intégrer l'image",
-        "hint": {
-          "prefix": "Collez une image web ou un chemin local. Changer de mode",
-          "simple": "mode simple",
-          "full": "mode complet"
-        }
-      },
-      "toolbar": {
-        "edit": "Modifier l'image",
-        "inline": "Image en ligne",
-        "alignLeft": "Aligner à gauche",
-        "alignCenter": "Centrer",
-        "alignRight": "Aligner à droite",
-        "delete": "Supprimer l'image"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "Saisir les métadonnées YAML...",
-      "languageIdentifier": "Saisir l'identifiant de langue...",
-      "mathFormula": "Saisir la formule mathématique..."
-    },
     "export": {
       "error": "Erreur d'exportation",
       "errorExporting": "Erreur lors de l'exportation du fichier",
@@ -1340,65 +961,11 @@
       "imageStructureDeletedComment": "Commentaire de structure d'image supprimée"
     },
     "spellcheck": {
-      "enabled": "Vérification orthographique activée",
-      "disabled": "Vérification orthographique désactivée",
-      "enabledError": "Erreur d'activation de la vérification orthographique",
       "disabledError": "Erreur de désactivation de la vérification orthographique",
       "errorSwitchingLanguage": "Erreur lors du changement de langue de vérification orthographique",
       "languageMissing": "Langue de vérification orthographique manquante",
       "switchError": "Erreur de changement de vérification orthographique",
       "title": "Vérification orthographique"
-    },
-    "table": "tableau",
-    "resizeTable": "Redimensionner le tableau",
-    "left": "gauche",
-    "alignLeft": "Aligner à gauche",
-    "center": "centre",
-    "alignCenter": "Aligner au centre",
-    "right": "droite",
-    "alignRight": "Aligner à droite",
-    "delete": "supprimer",
-    "deleteTable": "Supprimer le tableau",
-    "insertRowAbove": "Insérer une ligne au-dessus",
-    "insertRowBelow": "Insérer une ligne en-dessous",
-    "removeRow": "Supprimer la ligne",
-    "insertColumnLeft": "Insérer une colonne à gauche",
-    "insertColumnRight": "Insérer une colonne à droite",
-    "removeColumn": "Supprimer la colonne",
-    "copyContent": "Copier le contenu",
-    "emptyMathFormula": "< Formule mathématique vide >",
-    "invalidMathFormula": "< Formule mathématique invalide >",
-    "emptyMermaidBlock": "< Bloc Mermaid vide >",
-    "loading": "Chargement...",
-    "emptyDiagramBlock": "< Bloc de diagramme vide >",
-    "emptyHtmlBlock": "< Bloc HTML vide >",
-    "onlyTopBlockCanRenderIcon": "Seul le bloc supérieur peut rendre le bouton d'icône avant.",
-    "unhandledFunctionType": "Type de fonction non géré : {functionType}",
-    "highlight-start": "[début de surbrillance]",
-    "highlight-end": "[fin de surbrillance]",
-    "type-at-to-insert": "Tapez / pour insérer",
-    "input-footnote-definition": "Saisir la définition de note de bas de page",
-    "input-yaml-front-matter": "Saisir le front matter YAML",
-    "input-language-identifier": "Saisir l'identifiant de langue",
-    "input-mathematical-formula": "Saisir la formule mathématique",
-    "fence": "clôture",
-    "indent": "indentation",
-    "front-matter-delimiter": "délimiteur de front matter",
-    "math-delimiter": "délimiteur mathématique",
-    "mermaid-start": "début mermaid",
-    "flowchart-start": "début organigramme",
-    "sequence-start": "début séquence",
-    "plantuml-start": "début plantuml",
-    "vega-lite-start": "début vega-lite",
-    "click-to-add-image": "Cliquez pour ajouter une image",
-    "load-image-failed": "Échec du chargement de l'image"
-  },
-  "edit": {
-    "undo": "Annuler",
-    "redo": "Rétablir",
-    "cut": "Couper",
-    "copy": "Copier",
-    "paste": "Coller",
-    "selectAll": "Tout sélectionner"
+    }
   }
 }

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -220,7 +220,6 @@
     "replaceSingle": "Remplacer un",
     "invalidRegex": "Expression régulière invalide \"{pattern}\"",
     "regexMatchEmpty": "L'expression régulière correspond à une chaîne vide \"{pattern}\"",
-    "searchResultCount": "Résultats de recherche",
     "searchResultInfo": "{matchCount} correspondances dans {fileCount} fichiers",
     "searchLimited": "Recherche limitée aux {count} premiers résultats"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "Sauvegarder automatiquement le contenu en cours d'édition",
         "autoSaveDelay": "Le temps en ms après un changement avant que le fichier soit sauvegardé",
-        "autoNormalizeLineEndings": "Normaliser automatiquement les fins de ligne en LF et éventuellement les nouvelles lignes de fin à l'ouverture",
+        "autoNormalizeLineEndings": "Normaliser automatiquement les fins de ligne à l'ouverture des fichiers. Lorsque désactivé, les fichiers sont ouverts tels quels.",
         "titleBarStyle": "Le style de la barre de titre (systèmes Windows et Linux uniquement)",
         "openFilesInNewWindow": "Ouvrir les fichiers dans une nouvelle fenêtre",
         "openFolderInNewWindow": "Ouvrir le dossier via le menu dans une nouvelle fenêtre",
@@ -414,7 +413,6 @@
         "followSystemTheme": "Suivre le thème du système",
         "lightModeTheme": "Thème à utiliser lorsque le système est en mode clair",
         "darkModeTheme": "Thème à utiliser lorsque le système est en mode sombre",
-        "customCss": "CSS personnalisé à appliquer au thème actuel",
         "spellcheckerEnabled": "La vérification orthographique est-elle activée",
         "spellcheckerNoUnderline": "Ne pas souligner les erreurs d'orthographe",
         "spellcheckerLanguage": "La langue du vérificateur orthographique",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "Préférer le répertoire d'image relatif",
         "imageRelativeDirectoryBase": "Où les images relatives sont copiées",
         "imageRelativeDirectoryName": "Le nom du dossier d'image relatif",
-        "sideBarVisibility": "La barre latérale est-elle visible",
-        "tabBarVisibility": "Les onglets sont-ils affichés",
-        "sourceCodeModeEnabled": "Le mode code source est-il activé par défaut",
-        "searchExclusions": "Liste des motifs glob à exclure de la recherche",
-        "searchMaxFileSize": "La taille maximale de fichier (<maxFileSize><suffix>). Les suffixes K, M ou G sont autorisés si aucun suffixe n'est donné, le nombre est traité comme des octets",
-        "searchIncludeHidden": "Rechercher dans les fichiers et répertoires cachés",
-        "searchNoIgnore": "Ignorer les fichiers d'ignore comme .gitignore",
-        "searchFollowSymlinks": "Les liens symboliques doivent-ils être suivis",
-        "watcherUsePolling": "Utiliser le polling. Le polling peut conduire à une utilisation élevée du CPU mais est nécessaire pour surveiller les fichiers sur un réseau"
+        "fileSortOrder": "Ordre de tri des fichiers dans les dossiers ouverts : croissant ou décroissant.",
+        "openedFilesInSidebar": "Afficher ou non les fichiers ouverts dans la barre latérale."
       }
     },
     "categories": {
@@ -596,7 +587,6 @@
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
-        "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "Choisir la méthode d'installation :",
         "retestPicgo": "Retester",
         "lastDetectionTime": "Dernière détection",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "ファイル",
-      "new": "新規",
       "newTab": "新しいタブ",
       "newWindow": "新しいウィンドウ",
-      "open": "開く",
       "openFile": "ファイルを開く...",
       "openFolder": "フォルダを開く...",
       "openRecent": "最近使用したファイル",
@@ -25,9 +23,6 @@
       "exportPdf": "PDFとしてエクスポート",
       "import": "インポート",
       "print": "印刷",
-      "recent": "最近使用したファイル",
-      "close": "閉じる",
-      "closeAll": "すべて閉じる",
       "closeTab": "タブを閉じる",
       "closeWindow": "ウィンドウを閉じる",
       "quit": "終了",
@@ -70,26 +65,19 @@
       "demoteHeading": "見出しレベルを下げる",
       "table": "表",
       "codeFences": "コードブロック",
-      "codeBlock": "コードブロック",
       "quoteBlock": "引用ブロック",
       "mathBlock": "数式ブロック",
       "htmlBlock": "HTMLブロック",
-      "quote": "引用",
       "orderedList": "番号付きリスト",
       "bulletList": "箇条書きリスト",
-      "unorderedList": "順序なしリスト",
       "taskList": "タスクリスト",
       "looseListItem": "ルーズリストアイテム",
-      "paragraphItem": "段落アイテム",
       "horizontalRule": "水平線",
       "frontMatter": "フロントマター"
     },
     "window": {
       "title": "ウィンドウ",
-      "window": "ウィンドウ",
       "minimize": "最小化",
-      "close": "閉じる",
-      "zoom": "ズーム",
       "zoomIn": "拡大",
       "zoomOut": "縮小",
       "fullScreen": "フルスクリーン",
@@ -106,20 +94,16 @@
       "followUs": "フォローする",
       "support": "MarkTextを支援",
       "license": "ライセンス",
-      "checkForUpdates": "アップデートを確認",
-      "aboutMarkText": "MarkTextについて",
       "about": "について",
       "checkUpdates": "アップデートを確認"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "MarkTextについて",
       "checkUpdates": "アップデートを確認...",
       "preferences": "環境設定",
       "services": "サービス",
       "hide": "MarkTextを隠す",
-      "hideMarkText": "MarkTextを隠す",
       "hideOthers": "他を隠す",
       "showAll": "すべて表示",
       "quit": "MarkTextを終了"
@@ -129,14 +113,9 @@
       "toggleSidebar": "サイドバーの切り替え",
       "toggleTabbar": "タブバーの切り替え",
       "commandPalette": "コマンドパレット",
-      "sourceCode": "ソースコードモード",
       "sourceCodeMode": "ソースコードモード",
-      "typewriter": "タイプライターモード",
       "typewriterMode": "タイプライターモード",
-      "focus": "フォーカスモード",
       "focusMode": "フォーカスモード",
-      "showTabBar": "タブバーを表示",
-      "toc": "目次",
       "toggleTableOfContents": "目次の切り替え",
       "reloadImages": "画像を再読み込み",
       "showDeveloperTools": "開発者ツールを表示",
@@ -148,35 +127,18 @@
       "italic": "斜体",
       "underline": "下線",
       "strikethrough": "取り消し線",
-      "code": "インラインコード",
-      "codeBlock": "コードブロック",
-      "quote": "引用",
-      "unorderedList": "順序なしリスト",
-      "orderedList": "番号付きリスト",
-      "taskList": "タスクリスト",
-      "table": "表",
-      "link": "リンク",
       "image": "画像",
-      "heading1": "見出し1",
-      "heading2": "見出し2",
-      "heading3": "見出し3",
-      "heading4": "見出し4",
-      "heading5": "見出し5",
-      "heading6": "見出し6",
       "superscript": "上付き文字",
       "subscript": "下付き文字",
       "highlight": "ハイライト",
       "inlineCode": "インラインコード",
       "inlineMath": "インライン数式",
       "hyperlink": "ハイパーリンク",
-      "clearFormatting": "書式をクリア",
       "clearFormat": "書式をクリア"
     },
     "theme": {
       "theme": "テーマ (&T)",
-      "light": "ライト",
       "dark": "ダーク",
-      "auto": "自動",
       "followThemDisabled": "システムテーマに従う場合、テーマ選択は無効です",
       "lightThemes": "— ライトテーマ —",
       "darkThemes": "— ダークテーマ —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "テーブルサイズ変更",
-    "alignLeft": "左揃え",
-    "alignCenter": "中央揃え",
-    "alignRight": "右揃え",
-    "deleteTable": "テーブル削除"
-  },
   "recent": {
     "noTabsOpen": "開いているタブがありません。",
     "newFile": "新しいファイル"
@@ -395,7 +350,6 @@
     "title": "環境設定",
     "search": {
       "placeholder": "設定を検索...",
-      "optionalValues": "オプション値",
       "categories": {
         "general": "一般",
         "editor": "エディター",
@@ -500,7 +454,6 @@
         "titleBarStyle": {
           "title": "タイトルバースタイル",
           "custom": "カスタム",
-          "titleBarStyle": "タイトルバースタイル",
           "native": "ネイティブ"
         },
         "requiresRestart": "再起動が必要",
@@ -633,54 +586,20 @@
         "relativeFolderName": "相対フォルダ名",
         "filenameNote": "ファイル名は自動生成されます。"
       },
-      "imageInsertAction": {
-        "title": "画像挿入アクション",
-        "folder": "フォルダにアップロード",
-        "path": "パスにコピー",
-        "upload": "クラウドにアップロード",
-        "copyToFolder": "フォルダにコピー",
-        "uploadToServer": "サーバーにアップロード"
-      },
-      "imageFolderPath": {
-        "title": "画像フォルダパス",
-        "description": "画像フォルダパス",
-        "selectFolder": "フォルダを選択",
-        "relativePath": "相対パス",
-        "absolutePath": "絶対パス"
-      },
-      "cloudPictureBed": {
-        "title": "クラウド画像ベッド",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "相対ディレクトリを優先",
-        "description": "画像の優先相対ディレクトリ"
-      },
       "uploader": {
         "title": "画像アップローダー",
         "currentUploader": "現在のアップローダー",
         "picgoNotInstalled": "PicGoがインストールされていません",
-        "picgoDetectionStatus": "PicGo検出ステータス",
         "picgoInstalled": "PicGoがインストールされています",
         "picgoDetectionFailed": "PicGo検出に失敗しました",
         "debugInfo": "デバッグ情報",
-        "installCommand": "インストールコマンド",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "インストール方法を選択:",
         "retestPicgo": "再テスト",
-        "detecting": "検出中...",
         "lastDetectionTime": "最後の検出時間",
-        "detectionStatus": "検出ステータス",
         "usageGuide": {
           "title": "PicGo基本使用ガイド",
           "step1": "アップローダーを設定",
@@ -691,13 +610,6 @@
           "step3Description": "以下のコマンドを使用して現在の設定を表示してください：",
           "documentation": "完全なドキュメントを表示"
         },
-        "configureUploader": "アップローダーを設定",
-        "configureDescription": "以下のコマンドを使用してPicGoアップローダーを設定してください：",
-        "uploadImage": "画像をアップロード",
-        "uploadDescription": "以下のコマンドを使用して画像をアップロードしてください：",
-        "viewConfig": "設定を表示",
-        "viewConfigDescription": "以下のコマンドを使用して現在の設定を表示してください：",
-        "viewDocumentation": "完全なドキュメントを表示",
         "scriptDescription": "スクリプトの説明",
         "scriptLocation": "スクリプトの場所",
         "save": "保存",
@@ -710,7 +622,6 @@
         "pleaseInstall": "インストールしてください",
         "scriptPath": "スクリプトパス",
         "picgoDetection": "PicGo検出",
-        "autoDetection": "自動検出中",
         "lastSuccessTime": "最後の成功時刻",
         "neverDetected": "検出されたことがない",
         "neverSuccessful": "成功したことがない"
@@ -719,44 +630,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "リストアイテム",
-        "preferLooseListItem": "ルーズリストアイテムを優先",
-        "bulletListMarker": "箇条書きマーカー",
-        "orderListDelimiter": "番号付きリスト区切り文字",
-        "listIndentation": {
-          "title": "リストインデント",
-          "dfm": "デフォルトフォーマットモード",
-          "tab": "タブ",
-          "oneSpace": "1つのスペース",
-          "twoSpaces": "2つのスペース",
-          "threeSpaces": "3つのスペース",
-          "fourSpaces": "4つのスペース"
-        }
-      },
-      "heading": {
-        "title": "見出し",
-        "preferHeadingStyle": "優先見出しスタイル"
-      },
-      "frontmatter": {
-        "title": "フロントマター",
-        "frontmatterType": "フロントマタータイプ"
-      },
       "extensions": {
         "title": "拡張機能",
         "superSubScript": "上付き/下付き文字",
         "footnote": "脚注",
-        "isHtmlEnabled": "HTML有効",
-        "isGitlabCompatibilityEnabled": "GitLab互換性",
-        "sequenceTheme": "シーケンステーマ",
-        "superscript": "上付き文字",
-        "subscript": "下付き文字",
-        "frontMatter": "フロントマター",
-        "math": "数式",
-        "diagram": "図表",
         "footnoteNotes": "脚注",
         "frontmatterType": {
-          "frontmatterType": "フロントマタータイプ",
           "jsonBrace": "JSON括弧",
           "jsonSemicolon": "JSONセミコロン",
           "title": "フロントマタータイプ"
@@ -764,12 +643,6 @@
       },
       "diagrams": {
         "title": "図表",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "フローチャート",
-        "sequence": "シーケンス",
-        "gantt": "ガント",
         "sequenceTheme": {
           "title": "シーケンステーマ",
           "handDrawn": "手描き",
@@ -778,11 +651,6 @@
         "plantumlServer": {
           "title": "PlantUMLサーバーのURL"
         }
-      },
-      "math": {
-        "title": "数式",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -813,28 +681,13 @@
         "title": "リスト"
       }
     },
-    "spelling": {
-      "title": "スペルチェック",
-      "enabled": "スペルチェックを有効",
-      "autoDetectLanguage": "言語を自動検出",
-      "language": "言語",
-      "noSuggestions": "提案なし",
-      "spellcheckerEnabled": "スペルチェック有効",
-      "spellcheckerNoUnderline": "スペルミスの単語に下線なし",
-      "spellcheckerLanguage": "スペルチェック言語"
-    },
     "theme": {
       "title": "テーマ",
-      "theme": "テーマ",
       "followSystemTheme": "システムのテーマに従う",
       "modeThemes": "テーマの選択",
       "lightModeTheme": "ライトモードのテーマ",
       "darkModeTheme": "ダークモードのテーマ",
       "customCss": "カスタムCSS",
-      "codeBlockTheme": {
-        "title": "コードブロックテーマ",
-        "description": "コードブロックのテーマ"
-      },
       "importCustomThemes": "カスタムテーマをインポート",
       "importTheme": "テーマをインポート",
       "openFolder": "フォルダを開く",
@@ -843,13 +696,6 @@
     "keybindings": {
       "title": "キーバインド",
       "description": "キーバインドをカスタマイズ",
-      "searchPlaceholder": "キーバインドを検索",
-      "command": "コマンド",
-      "keybinding": "キーバインド",
-      "reset": "リセット",
-      "resetAll": "すべてリセット",
-      "edit": "編集",
-      "cancel": "キャンセル",
       "save": "保存",
       "restoreDefaults": "デフォルトに復元",
       "debugOptions": "デバッグオプション",
@@ -923,9 +769,7 @@
       "exportFile": "ファイルをエクスポート",
       "exportFilePdf": "PDFとしてエクスポート",
       "zoom": "ズーム",
-      "checkUpdate": "アップデートを確認",
-      "lineEnding": "行末文字",
-      "close": "閉じる"
+      "checkUpdate": "アップデートを確認"
     },
     "edit": {
       "undo": "元に戻す",
@@ -945,8 +789,7 @@
       "findPrevious": "前を検索",
       "replace": "置換",
       "findInFolder": "フォルダ内を検索",
-      "screenshot": "スクリーンショット",
-      "mathBlock": "数式ブロック"
+      "screenshot": "スクリーンショット"
     },
     "paragraph": {
       "heading1": "見出し1",
@@ -1012,8 +855,6 @@
       "reloadImages": "画像を再読み込み",
       "textDirection": "テキスト方向",
       "actualSize": "実際のサイズ",
-      "zoomIn": "拡大",
-      "zoomOut": "縮小",
       "devToggleDeveloperTools": "開発者ツールの切り替え"
     },
     "tabs": {
@@ -1035,10 +876,6 @@
     "docs": {
       "userGuide": "ユーザーガイド",
       "markdownSyntax": "Markdown構文"
-    },
-    "utils": {
-      "noUpdateResourceFile": "アップデートリソースファイルなし",
-      "todoUpdateCheck": "アップデートチェック"
     },
     "spellchecker": {
       "switchLanguage": "言語を切り替え"
@@ -1085,25 +922,6 @@
       "anchorLinkCopied": "アンカーリンクがコピーされました",
       "tabNotFound": "タブが見つかりません",
       "tocItemNotFound": "目次アイテムが見つかりません",
-      "highlightStart": "[ハイライト開始]",
-      "highlightEnd": "[ハイライト終了]",
-      "typeAtToInsert": "/ を入力して挿入",
-      "inputFootnoteDefinition": "脚注定義を入力...",
-      "inputYamlFrontMatter": "YAML フロントマターを入力...",
-      "inputLanguageIdentifier": "言語識別子を入力...",
-      "inputMathematicalFormula": "数式を入力...",
-      "fence": "フェンス",
-      "indent": "インデント",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "画像を追加するにはクリック",
-      "loadImageFailed": "画像の読み込みに失敗しました",
       "errorLoadingTabTitle": "タブの読み込みエラー",
       "errorLoadingTabMessage": "ファイル変更の読み込み中にエラーが発生しました。タブが見つかりません。",
       "mixedLineEndingsNormalized": "「{name}」には混在した改行コードが含まれており、{lineEnding} に自動正規化されました。",
@@ -1120,204 +938,7 @@
     "failedToRemoveWord": "辞書から単語を削除できませんでした",
     "unexpectedError": "予期しないスペルチェックエラー"
   },
-  "quickInsert": {
-    "basicBlock": "基本ブロック",
-    "header": "ヘッダー",
-    "advancedBlock": "高度なブロック",
-    "listBlock": "リストブロック",
-    "diagram": "図表",
-    "paragraph": {
-      "title": "段落",
-      "subtitle": "テキスト内容を入力"
-    },
-    "horizontalLine": {
-      "title": "水平線",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "フロントマター",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "見出し1",
-      "subtitle": "# 見出し"
-    },
-    "header2": {
-      "title": "見出し2",
-      "subtitle": "## 見出し"
-    },
-    "header3": {
-      "title": "見出し3",
-      "subtitle": "### 見出し"
-    },
-    "header4": {
-      "title": "見出し4",
-      "subtitle": "#### 見出し"
-    },
-    "header5": {
-      "title": "見出し5",
-      "subtitle": "##### 見出し"
-    },
-    "header6": {
-      "title": "見出し6",
-      "subtitle": "###### 見出し"
-    },
-    "tableBlock": {
-      "title": "表ブロック",
-      "subtitle": "｜ ヘッダー ｜ ヘッダー ｜"
-    },
-    "mathFormula": {
-      "title": "数式",
-      "subtitle": "$$ 数式 $$"
-    },
-    "htmlBlock": {
-      "title": "HTMLブロック",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "コードブロック",
-      "subtitle": "``` コード ```"
-    },
-    "quoteBlock": {
-      "title": "引用ブロック",
-      "subtitle": "> 引用内容"
-    },
-    "orderedList": {
-      "title": "番号付きリスト",
-      "subtitle": "1. リスト項目"
-    },
-    "bulletList": {
-      "title": "箇条書きリスト",
-      "subtitle": "- リスト項目"
-    },
-    "todoList": {
-      "title": "タスクリスト",
-      "subtitle": "- [ ] タスク項目"
-    },
-    "vegaChart": {
-      "title": "Vega-Liteチャート",
-      "subtitle": "データ可視化チャート"
-    },
-    "flowChart": {
-      "title": "フローチャート",
-      "subtitle": "フローチャート"
-    },
-    "sequenceChart": {
-      "title": "シーケンス図",
-      "subtitle": "シーケンス図"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML図",
-      "subtitle": "UML図"
-    },
-    "mermaid": {
-      "title": "Mermaid図",
-      "subtitle": "Mermaid図",
-      "gantt": {
-        "title": "ガントチャート"
-      },
-      "pie": {
-        "title": "円グラフ"
-      },
-      "flowchart": {
-        "title": "フローチャート"
-      },
-      "sequence": {
-        "title": "シーケンス図"
-      },
-      "class": {
-        "title": "クラス図"
-      },
-      "state": {
-        "title": "状態図",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "ユーザージャーニー"
-      },
-      "git": {
-        "title": "Gitグラフ"
-      },
-      "er": {
-        "title": "ER図"
-      },
-      "requirement": {
-        "title": "要件図"
-      }
-    },
-    "taskList": {
-      "title": "タスクリスト"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Liteチャート"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML図表"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid図表"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "複製",
-    "turnInto": "変換",
-    "newParagraph": "新しい段落",
-    "delete": "削除",
-    "paragraph": "段落",
-    "table": "表",
-    "html": "HTML",
-    "mathblock": "数式ブロック",
-    "pre": "コードブロック",
-    "frontMatter": "フロントマター",
-    "ulTask": "タスクリスト",
-    "ulBullet": "箇条書きリスト",
-    "olOrder": "番号付きリスト",
-    "blockquote": "引用",
-    "heading1": "見出し1",
-    "heading2": "見出し2",
-    "heading3": "見出し3",
-    "heading4": "見出し4",
-    "heading5": "見出し5",
-    "heading6": "見出し6",
-    "hr": "水平線"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "選択",
-          "embedLink": "リンクを埋め込む"
-        },
-        "select": {
-          "chooseButton": "画像を選択",
-          "tip": "コンピュータから画像を選択します。"
-        },
-        "inputs": {
-          "alt": "代替テキスト",
-          "src": "画像リンクまたはローカルパス",
-          "title": "画像タイトル"
-        },
-        "embedButton": "画像を埋め込む",
-        "hint": {
-          "prefix": "Web画像またはローカルパスを貼り付け。モードを切替",
-          "simple": "シンプルモード",
-          "full": "フルモード"
-        }
-      },
-      "toolbar": {
-        "edit": "画像を編集",
-        "inline": "インライン画像",
-        "alignLeft": "左揃え",
-        "alignCenter": "中央揃え",
-        "alignRight": "右揃え",
-        "delete": "画像を削除"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "YAML フロントマターを入力...",
-      "languageIdentifier": "言語識別子を入力...",
-      "mathFormula": "数式を入力..."
-    },
     "export": {
       "error": "エクスポートエラー",
       "errorExporting": "ファイルのエクスポート中にエラーが発生しました",
@@ -1340,65 +961,11 @@
       "imageStructureDeletedComment": "画像構造削除コメント"
     },
     "spellcheck": {
-      "enabled": "スペルチェックが有効になりました",
-      "disabled": "スペルチェックが無効になりました",
-      "enabledError": "スペルチェックの有効化エラー",
       "disabledError": "スペルチェックの無効化エラー",
       "errorSwitchingLanguage": "スペルチェック言語の切り替えエラー",
       "languageMissing": "スペルチェック言語が見つかりません",
       "switchError": "スペルチェックの切り替えエラー",
       "title": "スペルチェック"
-    },
-    "table": "表",
-    "resizeTable": "表のサイズ変更",
-    "left": "左",
-    "alignLeft": "左揃え",
-    "center": "中央",
-    "alignCenter": "中央揃え",
-    "right": "右",
-    "alignRight": "右揃え",
-    "delete": "削除",
-    "deleteTable": "表を削除",
-    "insertRowAbove": "上に行を挿入",
-    "insertRowBelow": "下に行を挿入",
-    "removeRow": "行を削除",
-    "insertColumnLeft": "左に列を挿入",
-    "insertColumnRight": "右に列を挿入",
-    "removeColumn": "列を削除",
-    "copyContent": "内容をコピー",
-    "emptyMathFormula": "< 空の数式 >",
-    "invalidMathFormula": "< 無効な数式 >",
-    "emptyMermaidBlock": "< 空のMermaidブロック >",
-    "loading": "読み込み中...",
-    "emptyDiagramBlock": "< 空の図表ブロック >",
-    "emptyHtmlBlock": "< 空のHTMLブロック >",
-    "onlyTopBlockCanRenderIcon": "最上位ブロックのみが前のアイコンボタンをレンダリングできます。",
-    "unhandledFunctionType": "未処理の関数タイプ: {functionType}",
-    "highlight-start": "[ハイライト開始]",
-    "highlight-end": "[ハイライト終了]",
-    "type-at-to-insert": "/を入力して挿入",
-    "input-footnote-definition": "脚注定義を入力",
-    "input-yaml-front-matter": "YAMLフロントマターを入力",
-    "input-language-identifier": "言語識別子を入力",
-    "input-mathematical-formula": "数式を入力",
-    "fence": "フェンス",
-    "indent": "インデント",
-    "front-matter-delimiter": "フロントマター区切り文字",
-    "math-delimiter": "数式区切り文字",
-    "mermaid-start": "mermaid開始",
-    "flowchart-start": "フローチャート開始",
-    "sequence-start": "シーケンス開始",
-    "plantuml-start": "plantuml開始",
-    "vega-lite-start": "vega-lite開始",
-    "click-to-add-image": "クリックして画像を追加",
-    "load-image-failed": "画像の読み込みに失敗しました"
-  },
-  "edit": {
-    "undo": "元に戻す",
-    "redo": "やり直し",
-    "cut": "切り取り",
-    "copy": "コピー",
-    "paste": "貼り付け",
-    "selectAll": "すべて選択"
+    }
   }
 }

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -220,7 +220,6 @@
     "replaceSingle": "単一置換",
     "invalidRegex": "無効な正規表現 \"{pattern}\"",
     "regexMatchEmpty": "正規表現が空文字列 \"{pattern}\" にマッチ",
-    "searchResultCount": "検索結果",
     "searchResultInfo": "{fileCount} 件のファイルで {matchCount} 件一致",
     "searchLimited": "最初の {count} 件まで検索しました"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "編集中のコンテンツを自動保存",
         "autoSaveDelay": "変更後にファイルが保存されるまでの時間（ミリ秒）",
-        "autoNormalizeLineEndings": "開くときに改行コードを LF に自動正規化し、オプションで末尾の改行も処理します",
+        "autoNormalizeLineEndings": "ファイルを開くときに改行コードを自動正規化します。無効にすると、ファイルはそのまま開かれます",
         "titleBarStyle": "タイトルバーのスタイル（WindowsおよびLinuxシステムのみ）",
         "openFilesInNewWindow": "新しいウィンドウでファイルを開く",
         "openFolderInNewWindow": "メニューから新しいウィンドウでフォルダを開く",
@@ -414,7 +413,6 @@
         "followSystemTheme": "システムのテーマに従う",
         "lightModeTheme": "システムがライトモードの時に使用するテーマ",
         "darkModeTheme": "システムがダークモードの時に使用するテーマ",
-        "customCss": "現在のテーマに適用するカスタムCSS",
         "spellcheckerEnabled": "スペルチェックが有効かどうか",
         "spellcheckerNoUnderline": "スペルミスに下線を引かない",
         "spellcheckerLanguage": "スペルチェッカーの言語",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "相対画像ディレクトリを優先するかどうか",
         "imageRelativeDirectoryBase": "相対画像のコピー先",
         "imageRelativeDirectoryName": "相対画像フォルダ名",
-        "sideBarVisibility": "サイドバーが表示されているかどうか",
-        "tabBarVisibility": "タブが表示されているかどうか",
-        "sourceCodeModeEnabled": "ソースコードモードがデフォルトで有効かどうか",
-        "searchExclusions": "検索から除外するglobパターンのリスト",
-        "searchMaxFileSize": "最大ファイルサイズ（<maxFileSize><suffix>）。K、M、またはGの接尾辞が許可されます。接尾辞がない場合、数値はバイトとして扱われます",
-        "searchIncludeHidden": "隠しファイルとディレクトリで検索するかどうか",
-        "searchNoIgnore": ".gitignoreのような無視ファイルを無視するかどうか",
-        "searchFollowSymlinks": "シンボリックリンクをフォローするかどうか",
-        "watcherUsePolling": "ポーリングを使用するかどうか。ポーリングは高いCPU使用率につながる可能性がありますが、ネットワーク上のファイルを監視するために必要です"
+        "fileSortOrder": "開いたフォルダ内のファイルの並べ替え順、昇順または降順",
+        "openedFilesInSidebar": "開いているファイルをサイドバーに表示するかどうか"
       }
     },
     "categories": {
@@ -596,7 +587,6 @@
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
-        "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "インストール方法を選択:",
         "retestPicgo": "再テスト",
         "lastDetectionTime": "最後の検出時間",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "파일",
-      "new": "새로 만들기",
       "newTab": "새 탭",
       "newWindow": "새 창",
-      "open": "열기",
       "openFile": "파일 열기...",
       "openFolder": "폴더 열기...",
       "openRecent": "최근 파일",
@@ -25,9 +23,6 @@
       "exportPdf": "PDF로 내보내기",
       "import": "가져오기",
       "print": "인쇄",
-      "recent": "최근 파일",
-      "close": "닫기",
-      "closeAll": "모두 닫기",
       "closeTab": "탭 닫기",
       "closeWindow": "창 닫기",
       "quit": "종료",
@@ -70,26 +65,19 @@
       "demoteHeading": "제목 수준 내리기",
       "table": "표",
       "codeFences": "코드 블록",
-      "codeBlock": "코드 블록",
       "quoteBlock": "인용 블록",
       "mathBlock": "수식 블록",
       "htmlBlock": "HTML 블록",
-      "quote": "인용",
       "orderedList": "순서 목록",
       "bulletList": "글머리 기호 목록",
-      "unorderedList": "순서 없는 목록",
       "taskList": "작업 목록",
       "looseListItem": "느슨한 목록 항목",
-      "paragraphItem": "단락 항목",
       "horizontalRule": "수평선",
       "frontMatter": "프론트 매터"
     },
     "window": {
       "title": "창",
-      "window": "창",
       "minimize": "최소화",
-      "close": "닫기",
-      "zoom": "확대/축소",
       "zoomIn": "확대",
       "zoomOut": "축소",
       "fullScreen": "전체 화면",
@@ -106,20 +94,16 @@
       "followUs": "팔로우하기",
       "support": "MarkText 후원",
       "license": "라이선스",
-      "checkForUpdates": "업데이트 확인",
-      "aboutMarkText": "MarkText 정보",
       "about": "정보",
       "checkUpdates": "업데이트 확인"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "MarkText 정보",
       "checkUpdates": "업데이트 확인...",
       "preferences": "환경설정",
       "services": "서비스",
       "hide": "MarkText 숨기기",
-      "hideMarkText": "MarkText 숨기기",
       "hideOthers": "다른 앱 숨기기",
       "showAll": "모두 보기",
       "quit": "MarkText 종료"
@@ -129,14 +113,9 @@
       "toggleSidebar": "사이드바 토글",
       "toggleTabbar": "탭바 토글",
       "commandPalette": "명령 팔레트",
-      "sourceCode": "소스 코드 모드",
       "sourceCodeMode": "소스 코드 모드",
-      "typewriter": "타자기 모드",
       "typewriterMode": "타자기 모드",
-      "focus": "집중 모드",
       "focusMode": "집중 모드",
-      "showTabBar": "탭바 보기",
-      "toc": "목차",
       "toggleTableOfContents": "목차 토글",
       "reloadImages": "이미지 새로고침",
       "showDeveloperTools": "개발자 도구 보기",
@@ -148,35 +127,18 @@
       "italic": "기울임",
       "underline": "밑줄",
       "strikethrough": "취소선",
-      "code": "인라인 코드",
-      "codeBlock": "코드 블록",
-      "quote": "인용",
-      "unorderedList": "순서 없는 목록",
-      "orderedList": "순서 목록",
-      "taskList": "작업 목록",
-      "table": "표",
-      "link": "링크",
       "image": "이미지",
-      "heading1": "제목 1",
-      "heading2": "제목 2",
-      "heading3": "제목 3",
-      "heading4": "제목 4",
-      "heading5": "제목 5",
-      "heading6": "제목 6",
       "superscript": "위 첨자",
       "subscript": "아래 첨자",
       "highlight": "강조",
       "inlineCode": "인라인 코드",
       "inlineMath": "인라인 수식",
       "hyperlink": "하이퍼링크",
-      "clearFormatting": "서식 지우기",
       "clearFormat": "서식 지우기"
     },
     "theme": {
       "theme": "&테마",
-      "light": "밝게",
       "dark": "어둡게",
-      "auto": "자동",
       "followThemDisabled": "시스템 테마를 따를 때는 테마 선택이 비활성화됩니다",
       "lightThemes": "— 라이트 테마 —",
       "darkThemes": "— 다크 테마 —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "테이블 크기 조정",
-    "alignLeft": "왼쪽 정렬",
-    "alignCenter": "가운데 정렬",
-    "alignRight": "오른쪽 정렬",
-    "deleteTable": "테이블 삭제"
-  },
   "recent": {
     "noTabsOpen": "열린 탭이 없습니다.",
     "newFile": "새 파일"
@@ -395,7 +350,6 @@
     "title": "환경설정",
     "search": {
       "placeholder": "환경설정 검색...",
-      "optionalValues": "선택적 값",
       "categories": {
         "general": "일반",
         "editor": "편집기",
@@ -500,7 +454,6 @@
         "titleBarStyle": {
           "title": "제목 표시줄 스타일",
           "custom": "사용자 정의",
-          "titleBarStyle": "제목 표시줄 스타일",
           "native": "네이티브"
         },
         "requiresRestart": "재시작 필요",
@@ -633,54 +586,20 @@
         "relativeFolderName": "상대 폴더 이름",
         "filenameNote": "파일 이름은 자동으로 생성됩니다."
       },
-      "imageInsertAction": {
-        "title": "이미지 삽입 동작",
-        "folder": "폴더에 업로드",
-        "path": "경로에 복사",
-        "upload": "클라우드에 업로드",
-        "copyToFolder": "폴더에 복사",
-        "uploadToServer": "서버에 업로드"
-      },
-      "imageFolderPath": {
-        "title": "이미지 폴더 경로",
-        "description": "이미지 폴더 경로",
-        "selectFolder": "폴더 선택",
-        "relativePath": "상대 경로",
-        "absolutePath": "절대 경로"
-      },
-      "cloudPictureBed": {
-        "title": "클라우드 이미지 저장소",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "상대 디렉터리 선호",
-        "description": "이미지에 대해 상대 디렉터리 선호"
-      },
       "uploader": {
         "title": "이미지 업로더",
         "currentUploader": "현재 업로더",
         "picgoNotInstalled": "PicGo가 설치되지 않음",
-        "picgoDetectionStatus": "PicGo 감지 상태",
         "picgoInstalled": "PicGo가 설치됨",
         "picgoDetectionFailed": "PicGo 감지 실패",
         "debugInfo": "디버그 정보",
-        "installCommand": "설치 명령",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "설치 방법 선택:",
         "retestPicgo": "다시 테스트",
-        "detecting": "감지 중...",
         "lastDetectionTime": "마지막 감지 시간",
-        "detectionStatus": "감지 상태",
         "usageGuide": {
           "title": "PicGo 기본 사용 가이드",
           "step1": "업로더 구성",
@@ -691,13 +610,6 @@
           "step3Description": "다음 명령을 사용하여 현재 구성을 보세요:",
           "documentation": "전체 문서 보기"
         },
-        "configureUploader": "업로더 구성",
-        "configureDescription": "다음 명령을 사용하여 PicGo 업로더를 구성하세요:",
-        "uploadImage": "이미지 업로드",
-        "uploadDescription": "다음 명령을 사용하여 이미지를 업로드하세요:",
-        "viewConfig": "구성 보기",
-        "viewConfigDescription": "다음 명령을 사용하여 현재 구성을 보세요:",
-        "viewDocumentation": "전체 문서 보기",
         "scriptDescription": "스크립트 설명",
         "scriptLocation": "스크립트 위치",
         "save": "저장",
@@ -710,7 +622,6 @@
         "pleaseInstall": "설치하세요",
         "scriptPath": "스크립트 경로",
         "picgoDetection": "PicGo 감지",
-        "autoDetection": "자동 감지 중",
         "lastSuccessTime": "마지막 성공 시간",
         "neverDetected": "감지된 적 없음",
         "neverSuccessful": "성공한 적 없음"
@@ -719,44 +630,12 @@
     },
     "markdown": {
       "title": "마크다운",
-      "listItem": {
-        "title": "목록 항목",
-        "preferLooseListItem": "느슨한 목록 항목 선호",
-        "bulletListMarker": "글머리 기호 목록 마커",
-        "orderListDelimiter": "순서 목록 구분자",
-        "listIndentation": {
-          "title": "목록 들여쓰기",
-          "dfm": "기본 형식 모드",
-          "tab": "탭",
-          "oneSpace": "한 칸 공백",
-          "twoSpaces": "두 칸 공백",
-          "threeSpaces": "세 칸 공백",
-          "fourSpaces": "네 칸 공백"
-        }
-      },
-      "heading": {
-        "title": "제목",
-        "preferHeadingStyle": "제목 스타일 선호"
-      },
-      "frontmatter": {
-        "title": "프론트 매터",
-        "frontmatterType": "프론트 매터 유형"
-      },
       "extensions": {
         "title": "확장",
         "superSubScript": "위/아래 첨자",
         "footnote": "각주",
-        "isHtmlEnabled": "HTML 활성화",
-        "isGitlabCompatibilityEnabled": "GitLab 호환성",
-        "sequenceTheme": "시퀀스 테마",
-        "superscript": "위 첨자",
-        "subscript": "아래 첨자",
-        "frontMatter": "프론트 매터",
-        "math": "수학",
-        "diagram": "다이어그램",
         "footnoteNotes": "각주 노트",
         "frontmatterType": {
-          "frontmatterType": "프론트매터 유형",
           "jsonBrace": "중괄호가 있는 JSON",
           "jsonSemicolon": "세미콜론이 있는 JSON",
           "title": "프론트매터 유형"
@@ -764,12 +643,6 @@
       },
       "diagrams": {
         "title": "다이어그램",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "플로우차트",
-        "sequence": "시퀀스",
-        "gantt": "간트",
         "sequenceTheme": {
           "title": "시퀀스 테마",
           "handDrawn": "손으로 그린",
@@ -778,11 +651,6 @@
         "plantumlServer": {
           "title": "PlantUML 서버 URL"
         }
-      },
-      "math": {
-        "title": "수학",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -813,28 +681,13 @@
         "title": "목록"
       }
     },
-    "spelling": {
-      "title": "맞춤법",
-      "enabled": "맞춤법 검사 활성화",
-      "autoDetectLanguage": "언어 자동 감지",
-      "language": "언어",
-      "noSuggestions": "제안 없음",
-      "spellcheckerEnabled": "맞춤법 검사 활성화",
-      "spellcheckerNoUnderline": "맞춤법 오류에 밑줄 없음",
-      "spellcheckerLanguage": "맞춤법 검사 언어"
-    },
     "theme": {
       "title": "테마",
-      "theme": "테마",
       "followSystemTheme": "시스템 테마 따르기",
       "modeThemes": "테마 선택",
       "lightModeTheme": "라이트 모드 테마",
       "darkModeTheme": "다크 모드 테마",
       "customCss": "사용자 정의 CSS",
-      "codeBlockTheme": {
-        "title": "코드 블록 테마",
-        "description": "코드 블록용 테마"
-      },
       "importCustomThemes": "사용자 정의 테마 가져오기",
       "importTheme": "테마 가져오기",
       "openFolder": "폴더 열기",
@@ -843,13 +696,6 @@
     "keybindings": {
       "title": "키 바인딩",
       "description": "키보드 단축키 사용자 정의",
-      "searchPlaceholder": "키 바인딩 검색",
-      "command": "명령",
-      "keybinding": "키 바인딩",
-      "reset": "재설정",
-      "resetAll": "모두 재설정",
-      "edit": "편집",
-      "cancel": "취소",
       "save": "저장",
       "restoreDefaults": "기본값 복원",
       "debugOptions": "디버그 옵션",
@@ -923,9 +769,7 @@
       "exportFile": "파일 내보내기",
       "exportFilePdf": "PDF로 내보내기",
       "zoom": "확대/축소",
-      "checkUpdate": "업데이트 확인",
-      "lineEnding": "줄 끝",
-      "close": "닫기"
+      "checkUpdate": "업데이트 확인"
     },
     "edit": {
       "undo": "실행 취소",
@@ -945,8 +789,7 @@
       "findPrevious": "이전 찾기",
       "replace": "바꾸기",
       "findInFolder": "폴더에서 찾기",
-      "screenshot": "스크린샷",
-      "mathBlock": "수식 블록"
+      "screenshot": "스크린샷"
     },
     "paragraph": {
       "heading1": "제목 1",
@@ -1012,8 +855,6 @@
       "reloadImages": "이미지 새로고침",
       "textDirection": "텍스트 방향",
       "actualSize": "실제 크기",
-      "zoomIn": "확대",
-      "zoomOut": "축소",
       "devToggleDeveloperTools": "개발자 도구 전환"
     },
     "tabs": {
@@ -1035,10 +876,6 @@
     "docs": {
       "userGuide": "사용자 가이드",
       "markdownSyntax": "마크다운 문법"
-    },
-    "utils": {
-      "noUpdateResourceFile": "업데이트 리소스 파일 없음",
-      "todoUpdateCheck": "업데이트 확인"
     },
     "spellchecker": {
       "switchLanguage": "언어 전환"
@@ -1085,25 +922,6 @@
       "anchorLinkCopied": "앵커 링크 복사됨",
       "tabNotFound": "탭을 찾을 수 없음",
       "tocItemNotFound": "목차 항목을 찾을 수 없음",
-      "highlightStart": "[하이라이트 시작]",
-      "highlightEnd": "[하이라이트 끝]",
-      "typeAtToInsert": "/ 입력하여 삽입",
-      "inputFootnoteDefinition": "각주 정의 입력...",
-      "inputYamlFrontMatter": "YAML 프론트 매터 입력...",
-      "inputLanguageIdentifier": "언어 식별자 입력...",
-      "inputMathematicalFormula": "수학 공식 입력...",
-      "fence": "펜스",
-      "indent": "들여쓰기",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "이미지 추가하려면 클릭",
-      "loadImageFailed": "이미지 로드 실패",
       "errorLoadingTabTitle": "탭 로드 오류",
       "errorLoadingTabMessage": "파일 변경을 로드하는 동안 오류가 발생했습니다. 탭을 찾을 수 없습니다.",
       "mixedLineEndingsNormalized": "“{name}”에 혼합 줄 끝이 포함되어 있으며 {lineEnding}(으)로 자동 정규화되었습니다.",
@@ -1120,204 +938,7 @@
     "failedToRemoveWord": "사전에서 단어 제거 실패",
     "unexpectedError": "예상치 못한 맞춤법 검사 오류"
   },
-  "quickInsert": {
-    "basicBlock": "기본 블록",
-    "header": "헤더",
-    "advancedBlock": "고급 블록",
-    "listBlock": "목록 블록",
-    "diagram": "다이어그램",
-    "paragraph": {
-      "title": "단락",
-      "subtitle": "텍스트 내용 입력"
-    },
-    "horizontalLine": {
-      "title": "수평선",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "프론트 매터",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "헤더 1",
-      "subtitle": "# 제목"
-    },
-    "header2": {
-      "title": "헤더 2",
-      "subtitle": "## 제목"
-    },
-    "header3": {
-      "title": "헤더 3",
-      "subtitle": "### 제목"
-    },
-    "header4": {
-      "title": "헤더 4",
-      "subtitle": "#### 제목"
-    },
-    "header5": {
-      "title": "헤더 5",
-      "subtitle": "##### 제목"
-    },
-    "header6": {
-      "title": "헤더 6",
-      "subtitle": "###### 제목"
-    },
-    "tableBlock": {
-      "title": "표 블록",
-      "subtitle": "｜ 헤더 ｜ 헤더 ｜"
-    },
-    "mathFormula": {
-      "title": "수학 공식",
-      "subtitle": "$$ 공식 $$"
-    },
-    "htmlBlock": {
-      "title": "HTML 블록",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "코드 블록",
-      "subtitle": "``` 코드 ```"
-    },
-    "quoteBlock": {
-      "title": "인용 블록",
-      "subtitle": "> 인용 내용"
-    },
-    "orderedList": {
-      "title": "순서 목록",
-      "subtitle": "1. 목록 항목"
-    },
-    "bulletList": {
-      "title": "글머리 기호 목록",
-      "subtitle": "- 목록 항목"
-    },
-    "todoList": {
-      "title": "할 일 목록",
-      "subtitle": "- [ ] 작업 항목"
-    },
-    "vegaChart": {
-      "title": "Vega-Lite 차트",
-      "subtitle": "데이터 시각화 차트"
-    },
-    "flowChart": {
-      "title": "플로우차트",
-      "subtitle": "순서도"
-    },
-    "sequenceChart": {
-      "title": "시퀀스 차트",
-      "subtitle": "시퀀스 다이어그램"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML 차트",
-      "subtitle": "UML 다이어그램"
-    },
-    "mermaid": {
-      "title": "Mermaid 차트",
-      "subtitle": "Mermaid 다이어그램",
-      "gantt": {
-        "title": "간트 차트"
-      },
-      "pie": {
-        "title": "원형 차트"
-      },
-      "flowchart": {
-        "title": "순서도"
-      },
-      "sequence": {
-        "title": "시퀀스 다이어그램"
-      },
-      "class": {
-        "title": "클래스 다이어그램"
-      },
-      "state": {
-        "title": "상태 다이어그램",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "사용자 여정"
-      },
-      "git": {
-        "title": "Git 다이어그램"
-      },
-      "er": {
-        "title": "ER 다이어그램"
-      },
-      "requirement": {
-        "title": "요구사항 다이어그램"
-      }
-    },
-    "taskList": {
-      "title": "작업 목록"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite 차트"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML 다이어그램"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid 다이어그램"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "복제",
-    "turnInto": "변환",
-    "newParagraph": "새 단락",
-    "delete": "삭제",
-    "paragraph": "단락",
-    "table": "표",
-    "html": "HTML",
-    "mathblock": "수식 블록",
-    "pre": "코드 블록",
-    "frontMatter": "프론트 매터",
-    "ulTask": "작업 목록",
-    "ulBullet": "글머리 기호 목록",
-    "olOrder": "번호 목록",
-    "blockquote": "인용문",
-    "heading1": "제목 1",
-    "heading2": "제목 2",
-    "heading3": "제목 3",
-    "heading4": "제목 4",
-    "heading5": "제목 5",
-    "heading6": "제목 6",
-    "hr": "수평선"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "선택",
-          "embedLink": "링크 삽입"
-        },
-        "select": {
-          "chooseButton": "이미지 선택",
-          "tip": "컴퓨터에서 이미지를 선택하세요."
-        },
-        "inputs": {
-          "alt": "대체 텍스트",
-          "src": "이미지 링크 또는 로컬 경로",
-          "title": "이미지 제목"
-        },
-        "embedButton": "이미지 삽입",
-        "hint": {
-          "prefix": "웹 이미지 또는 로컬 경로를 붙여넣기. 모드 전환",
-          "simple": "간단 모드",
-          "full": "전체 모드"
-        }
-      },
-      "toolbar": {
-        "edit": "이미지 편집",
-        "inline": "인라인 이미지",
-        "alignLeft": "왼쪽 정렬",
-        "alignCenter": "가운데 정렬",
-        "alignRight": "오른쪽 정렬",
-        "delete": "이미지 삭제"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "YAML 프론트 매터 입력...",
-      "languageIdentifier": "언어 식별자 입력...",
-      "mathFormula": "수학 공식 입력..."
-    },
     "export": {
       "error": "내보내기 오류",
       "errorExporting": "파일 내보내기 오류",
@@ -1340,65 +961,11 @@
       "imageStructureDeletedComment": "이미지 구조 삭제 주석"
     },
     "spellcheck": {
-      "enabled": "맞춤법 검사가 활성화되었습니다",
-      "disabled": "맞춤법 검사가 비활성화되었습니다",
-      "enabledError": "맞춤법 검사 활성화 오류",
       "disabledError": "맞춤법 검사 비활성화 오류",
       "errorSwitchingLanguage": "맞춤법 검사 언어 전환 오류",
       "languageMissing": "맞춤법 검사 언어가 없습니다",
       "switchError": "맞춤법 검사 전환 오류",
       "title": "맞춤법 검사"
-    },
-    "table": "표",
-    "resizeTable": "표 크기 조정",
-    "left": "왼쪽",
-    "alignLeft": "왼쪽 정렬",
-    "center": "가운데",
-    "alignCenter": "가운데 정렬",
-    "right": "오른쪽",
-    "alignRight": "오른쪽 정렬",
-    "delete": "삭제",
-    "deleteTable": "표 삭제",
-    "insertRowAbove": "위에 행 삽입",
-    "insertRowBelow": "아래에 행 삽입",
-    "removeRow": "행 제거",
-    "insertColumnLeft": "왼쪽에 열 삽입",
-    "insertColumnRight": "오른쪽에 열 삽입",
-    "removeColumn": "열 제거",
-    "copyContent": "내용 복사",
-    "emptyMathFormula": "< 빈 수학 공식 >",
-    "invalidMathFormula": "< 잘못된 수학 공식 >",
-    "emptyMermaidBlock": "< 빈 Mermaid 블록 >",
-    "loading": "로딩 중...",
-    "emptyDiagramBlock": "< 빈 다이어그램 블록 >",
-    "emptyHtmlBlock": "< 빈 HTML 블록 >",
-    "onlyTopBlockCanRenderIcon": "최상위 블록만 앞의 아이콘 버튼을 렌더링할 수 있습니다.",
-    "unhandledFunctionType": "처리되지 않은 함수 유형: {functionType}",
-    "highlight-start": "[하이라이트 시작]",
-    "highlight-end": "[하이라이트 끝]",
-    "type-at-to-insert": "/를 입력하여 삽입",
-    "input-footnote-definition": "각주 정의 입력",
-    "input-yaml-front-matter": "YAML 프론트 매터 입력",
-    "input-language-identifier": "언어 식별자 입력",
-    "input-mathematical-formula": "수학 공식 입력",
-    "fence": "펜스",
-    "indent": "들여쓰기",
-    "front-matter-delimiter": "프론트 매터 구분자",
-    "math-delimiter": "수학 구분자",
-    "mermaid-start": "mermaid 시작",
-    "flowchart-start": "플로우차트 시작",
-    "sequence-start": "시퀀스 시작",
-    "plantuml-start": "plantuml 시작",
-    "vega-lite-start": "vega-lite 시작",
-    "click-to-add-image": "클릭하여 이미지 추가",
-    "load-image-failed": "이미지 로드 실패"
-  },
-  "edit": {
-    "undo": "실행 취소",
-    "redo": "다시 실행",
-    "cut": "잘라내기",
-    "copy": "복사",
-    "paste": "붙여넣기",
-    "selectAll": "모두 선택"
+    }
   }
 }

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -220,7 +220,6 @@
     "replaceSingle": "하나 바꾸기",
     "invalidRegex": "잘못된 정규식 \"{pattern}\"",
     "regexMatchEmpty": "정규식이 빈 문자열 \"{pattern}\"과 일치",
-    "searchResultCount": "검색 결과",
     "searchResultInfo": "{fileCount}개의 파일에서 {matchCount}개 일치",
     "searchLimited": "처음 {count}개의 결과까지만 검색"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "편집 중인 내용을 자동으로 저장",
         "autoSaveDelay": "변경 후 파일이 저장되기까지의 시간(밀리초)",
-        "autoNormalizeLineEndings": "파일을 열 때 줄 끝을 LF로 자동 정규화하고 선택적으로 후행 줄 바꿈을 처리합니다",
+        "autoNormalizeLineEndings": "파일을 열 때 줄 끝을 자동으로 정규화합니다. 비활성화하면 파일을 있는 그대로 엽니다.",
         "titleBarStyle": "제목 표시줄 스타일(Windows 및 Linux 시스템만)",
         "openFilesInNewWindow": "새 창에서 파일 열기",
         "openFolderInNewWindow": "메뉴를 통해 새 창에서 폴더 열기",
@@ -414,7 +413,6 @@
         "followSystemTheme": "시스템 테마 따르기",
         "lightModeTheme": "시스템이 라이트 모드일 때 사용할 테마",
         "darkModeTheme": "시스템이 다크 모드일 때 사용할 테마",
-        "customCss": "현재 테마에 적용할 사용자 정의 CSS",
         "spellcheckerEnabled": "맞춤법 검사가 활성화되어 있는지 여부",
         "spellcheckerNoUnderline": "맞춤법 오류에 밑줄을 그지 않음",
         "spellcheckerLanguage": "맞춤법 검사기 언어",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "상대 이미지 디렉터리를 선호할지 여부",
         "imageRelativeDirectoryBase": "상대 이미지가 복사되는 위치",
         "imageRelativeDirectoryName": "상대 이미지 폴더 이름",
-        "sideBarVisibility": "사이드바가 보이는지 여부",
-        "tabBarVisibility": "탭이 표시되는지 여부",
-        "sourceCodeModeEnabled": "소스 코드 모드가 기본적으로 활성화되어 있는지 여부",
-        "searchExclusions": "검색에서 제외할 glob 패턴 목록",
-        "searchMaxFileSize": "최대 파일 크기(<maxFileSize><suffix>). 접미사가 주어지지 않으면 K, M 또는 G 접미사가 허용되며, 숫자는 바이트로 처리됩니다",
-        "searchIncludeHidden": "숨겨진 파일과 디렉터리에서 검색할지 여부",
-        "searchNoIgnore": ".gitignore와 같은 무시 파일을 무시할지 여부",
-        "searchFollowSymlinks": "심볼릭 링크를 따라야 하는지 여부",
-        "watcherUsePolling": "폴링을 사용할지 여부. 폴링은 높은 CPU 사용률을 초래할 수 있지만 네트워크의 파일을 감시하는 데 필요합니다"
+        "fileSortOrder": "열린 폴더의 파일 정렬 순서: 오름차순 또는 내림차순",
+        "openedFilesInSidebar": "사이드바에 열린 파일을 표시할지 여부"
       }
     },
     "categories": {
@@ -596,7 +587,6 @@
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
-        "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "설치 방법 선택:",
         "retestPicgo": "다시 테스트",
         "lastDetectionTime": "마지막 감지 시간",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "Arquivo",
-      "new": "Novo",
       "newTab": "Nova Aba",
       "newWindow": "Nova Janela",
-      "open": "Abrir",
       "openFile": "Abrir Arquivo...",
       "openFolder": "Abrir Pasta...",
       "openRecent": "Abrir Recente",
@@ -25,9 +23,6 @@
       "exportPdf": "Exportar como PDF",
       "import": "Importar",
       "print": "Imprimir",
-      "recent": "Arquivos Recentes",
-      "close": "Fechar",
-      "closeAll": "Fechar Todos",
       "closeTab": "Fechar Aba",
       "closeWindow": "Fechar Janela",
       "quit": "Sair",
@@ -70,26 +65,19 @@
       "demoteHeading": "Rebaixar Cabeçalho",
       "table": "Tabela",
       "codeFences": "Blocos de Código",
-      "codeBlock": "Bloco de Código",
       "quoteBlock": "Bloco de Citação",
       "mathBlock": "Bloco Matemático",
       "htmlBlock": "Bloco HTML",
-      "quote": "Citação",
       "orderedList": "Lista Ordenada",
       "bulletList": "Lista com Marcadores",
-      "unorderedList": "Lista Não Ordenada",
       "taskList": "Lista de Tarefas",
       "looseListItem": "Item de Lista Solta",
-      "paragraphItem": "Item de Parágrafo",
       "horizontalRule": "Linha Horizontal",
       "frontMatter": "Front Matter"
     },
     "window": {
       "title": "Janela",
-      "window": "Janela",
       "minimize": "Minimizar",
-      "close": "Fechar",
-      "zoom": "Zoom",
       "zoomIn": "Aumentar Zoom",
       "zoomOut": "Diminuir Zoom",
       "fullScreen": "Tela Cheia",
@@ -106,20 +94,16 @@
       "followUs": "Siga-nos",
       "support": "Apoiar MarkText",
       "license": "Licença",
-      "checkForUpdates": "Verificar Atualizações",
-      "aboutMarkText": "Sobre MarkText",
       "about": "Sobre",
       "checkUpdates": "Verificar Atualizações"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "Sobre MarkText",
       "checkUpdates": "Verificar Atualizações...",
       "preferences": "Preferências",
       "services": "Serviços",
       "hide": "Ocultar MarkText",
-      "hideMarkText": "Ocultar MarkText",
       "hideOthers": "Ocultar Outros",
       "showAll": "Mostrar Todos",
       "quit": "Sair do MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Alternar Barra Lateral",
       "toggleTabbar": "Alternar Barra de Abas",
       "commandPalette": "Paleta de Comandos",
-      "sourceCode": "Modo Código Fonte",
       "sourceCodeMode": "Modo Código Fonte",
-      "typewriter": "Modo Máquina de Escrever",
       "typewriterMode": "Modo Máquina de Escrever",
-      "focus": "Modo Foco",
       "focusMode": "Modo Foco",
-      "showTabBar": "Mostrar Barra de Abas",
-      "toc": "Índice",
       "toggleTableOfContents": "Alternar Índice",
       "reloadImages": "Recarregar Imagens",
       "showDeveloperTools": "Mostrar Ferramentas de Desenvolvedor",
@@ -148,35 +127,18 @@
       "italic": "Itálico",
       "underline": "Sublinhado",
       "strikethrough": "Riscado",
-      "code": "Código Inline",
-      "codeBlock": "Bloco de Código",
-      "quote": "Citação",
-      "unorderedList": "Lista Não Ordenada",
-      "orderedList": "Lista Ordenada",
-      "taskList": "Lista de Tarefas",
-      "table": "Tabela",
-      "link": "Link",
       "image": "Imagem",
-      "heading1": "Cabeçalho 1",
-      "heading2": "Cabeçalho 2",
-      "heading3": "Cabeçalho 3",
-      "heading4": "Cabeçalho 4",
-      "heading5": "Cabeçalho 5",
-      "heading6": "Cabeçalho 6",
       "superscript": "Sobrescrito",
       "subscript": "Subscrito",
       "highlight": "Destacar",
       "inlineCode": "Código Inline",
       "inlineMath": "Matemática Inline",
       "hyperlink": "Hiperlink",
-      "clearFormatting": "Limpar Formatação",
       "clearFormat": "Limpar Formatação"
     },
     "theme": {
       "theme": "&Tema",
-      "light": "Claro",
       "dark": "Escuro",
-      "auto": "Automático",
       "followThemDisabled": "Seleção de tema desativada ao seguir o tema do sistema",
       "lightThemes": "— Temas Claros —",
       "darkThemes": "— Temas Escuros —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Redimensionar Tabela",
-    "alignLeft": "Alinhar à Esquerda",
-    "alignCenter": "Alinhar ao Centro",
-    "alignRight": "Alinhar à Direita",
-    "deleteTable": "Excluir Tabela"
-  },
   "recent": {
     "noTabsOpen": "Você não tem abas abertas.",
     "newFile": "Novo Arquivo"
@@ -395,7 +350,6 @@
     "title": "Preferências",
     "search": {
       "placeholder": "Pesquisar preferências...",
-      "optionalValues": "valores opcionais",
       "categories": {
         "general": "Geral",
         "editor": "Editor",
@@ -500,7 +454,6 @@
         "titleBarStyle": {
           "title": "Estilo da Barra de Título",
           "custom": "Personalizado",
-          "titleBarStyle": "Estilo da Barra de Título",
           "native": "Nativo"
         },
         "requiresRestart": "Requer reinicialização",
@@ -633,54 +586,20 @@
         "relativeFolderName": "Nome da pasta relativa",
         "filenameNote": "O nome do arquivo será gerado automaticamente."
       },
-      "imageInsertAction": {
-        "title": "Ação de inserção de imagem",
-        "folder": "Enviar para pasta",
-        "path": "Copiar para caminho",
-        "upload": "Enviar para nuvem",
-        "copyToFolder": "Copiar para pasta",
-        "uploadToServer": "Enviar para servidor"
-      },
-      "imageFolderPath": {
-        "title": "Caminho da pasta de imagens",
-        "description": "Caminho da pasta de imagens",
-        "selectFolder": "Selecionar pasta",
-        "relativePath": "Caminho relativo",
-        "absolutePath": "Caminho absoluto"
-      },
-      "cloudPictureBed": {
-        "title": "Hospedagem de imagens na nuvem",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Preferir diretório relativo",
-        "description": "Preferir diretório relativo para imagens"
-      },
       "uploader": {
         "title": "Carregador de Imagens",
         "currentUploader": "Carregador Atual",
         "picgoNotInstalled": "PicGo não está instalado",
-        "picgoDetectionStatus": "Status de Detecção do PicGo",
         "picgoInstalled": "PicGo está instalado",
         "picgoDetectionFailed": "Detecção do PicGo falhou",
         "debugInfo": "Informações de Debug",
-        "installCommand": "Comando de Instalação",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "Escolha o méde instalação:",
         "retestPicgo": "Testar novamente",
-        "detecting": "Detectando...",
         "lastDetectionTime": "Última detecção",
-        "detectionStatus": "Status de detecção",
         "usageGuide": {
           "title": "Guia básico de uso do PicGo",
           "step1": "Configurar carregador",
@@ -691,13 +610,6 @@
           "step3Description": "Use o seguinte comando para ver a configuração atual:",
           "documentation": "Ver documentação completa"
         },
-        "configureUploader": "Configurar carregador",
-        "configureDescription": "Use o seguinte comando para configurar o carregador PicGo:",
-        "uploadImage": "Carregar imagens",
-        "uploadDescription": "Use o seguinte comando para carregar imagens:",
-        "viewConfig": "Ver configuração",
-        "viewConfigDescription": "Use o seguinte comando para ver a configuração atual:",
-        "viewDocumentation": "Ver documentação completa",
         "scriptDescription": "Descrição do Script",
         "scriptLocation": "Localização do Script",
         "save": "Salvar",
@@ -710,7 +622,6 @@
         "pleaseInstall": "Por favor instale",
         "scriptPath": "Caminho do script",
         "picgoDetection": "Detecção do PicGo",
-        "autoDetection": "Detecção automática",
         "lastSuccessTime": "Última vez bem-sucedida",
         "neverDetected": "Nunca detectado",
         "neverSuccessful": "Nunca bem-sucedido"
@@ -719,44 +630,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "Item de Lista",
-        "preferLooseListItem": "Preferir item de lista solta",
-        "bulletListMarker": "Marcador de lista com marcadores",
-        "orderListDelimiter": "Delimitador de lista ordenada",
-        "listIndentation": {
-          "title": "Indentação de Lista",
-          "dfm": "Padrão",
-          "tab": "Tabulação",
-          "oneSpace": "Um espaço",
-          "twoSpaces": "Dois espaços",
-          "threeSpaces": "Três espaços",
-          "fourSpaces": "Quatro espaços"
-        }
-      },
-      "heading": {
-        "title": "Cabeçalho",
-        "preferHeadingStyle": "Preferir estilo de cabeçalho"
-      },
-      "frontmatter": {
-        "title": "Front Matter",
-        "frontmatterType": "Tipo de front matter"
-      },
       "extensions": {
         "title": "Extensões",
         "superSubScript": "Super/Sub script",
         "footnote": "Nota de rodapé",
-        "isHtmlEnabled": "HTML habilitado",
-        "isGitlabCompatibilityEnabled": "Compatibilidade GitLab",
-        "sequenceTheme": "Tema de sequência",
-        "superscript": "Sobrescrito",
-        "subscript": "Subscrito",
-        "frontMatter": "Front matter",
-        "math": "Matemática",
-        "diagram": "Diagrama",
         "footnoteNotes": "Notas de rodapé",
         "frontmatterType": {
-          "frontmatterType": "Tipo de Frontmatter",
           "jsonBrace": "JSON com Chaves",
           "jsonSemicolon": "JSON com Ponto e Vírgula",
           "title": "Tipo de Frontmatter"
@@ -764,12 +643,6 @@
       },
       "diagrams": {
         "title": "Diagramas",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "Fluxograma",
-        "sequence": "Sequência",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Tema de Sequência",
           "handDrawn": "Desenhado à Mão",
@@ -778,11 +651,6 @@
         "plantumlServer": {
           "title": "URL do servidor PlantUML"
         }
-      },
-      "math": {
-        "title": "Matemática",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -813,28 +681,13 @@
         "title": "Listas"
       }
     },
-    "spelling": {
-      "title": "Ortografia",
-      "enabled": "Habilitar corretor ortográfico",
-      "autoDetectLanguage": "Detectar idioma automaticamente",
-      "language": "Idioma",
-      "noSuggestions": "Nenhuma sugestão",
-      "spellcheckerEnabled": "Habilitar corretor ortográfico",
-      "spellcheckerNoUnderline": "Sem sublinhado para palavras com erro ortográfico",
-      "spellcheckerLanguage": "Idioma do corretor ortográfico"
-    },
     "theme": {
       "title": "Tema",
-      "theme": "Tema",
       "followSystemTheme": "Seguir tema do sistema",
       "modeThemes": "Seleção de Tema",
       "lightModeTheme": "Tema do modo claro",
       "darkModeTheme": "Tema do modo escuro",
       "customCss": "CSS Personalizado",
-      "codeBlockTheme": {
-        "title": "Tema do bloco de código",
-        "description": "Tema para blocos de código"
-      },
       "importCustomThemes": "Importar temas personalizados",
       "importTheme": "Importar Tema",
       "openFolder": "Abrir Pasta",
@@ -843,13 +696,6 @@
     "keybindings": {
       "title": "Atalhos de Teclado",
       "description": "Personalizar atalhos de teclado",
-      "searchPlaceholder": "Pesquisar atalhos de teclado",
-      "command": "Comando",
-      "keybinding": "Atalho de Teclado",
-      "reset": "Resetar",
-      "resetAll": "Resetar todos",
-      "edit": "Editar",
-      "cancel": "Cancelar",
       "save": "Salvar",
       "restoreDefaults": "Restaurar padrões",
       "debugOptions": "Opções de Debug",
@@ -923,9 +769,7 @@
       "exportFile": "Exportar Arquivo",
       "exportFilePdf": "Exportar como PDF",
       "zoom": "Zoom",
-      "checkUpdate": "Verificar Atualizações",
-      "lineEnding": "Final de linha",
-      "close": "Fechar"
+      "checkUpdate": "Verificar Atualizações"
     },
     "edit": {
       "undo": "Desfazer",
@@ -945,8 +789,7 @@
       "findPrevious": "Localizar Anterior",
       "replace": "Substituir",
       "findInFolder": "Localizar na Pasta",
-      "screenshot": "Captura de Tela",
-      "mathBlock": "Bloco matemático"
+      "screenshot": "Captura de Tela"
     },
     "paragraph": {
       "heading1": "Cabeçalho 1",
@@ -1012,8 +855,6 @@
       "reloadImages": "Recarregar Imagens",
       "textDirection": "Direção do Texto",
       "actualSize": "Tamanho real",
-      "zoomIn": "Ampliar",
-      "zoomOut": "Reduzir",
       "devToggleDeveloperTools": "Alternar ferramentas de desenvolvedor"
     },
     "tabs": {
@@ -1035,10 +876,6 @@
     "docs": {
       "userGuide": "Guia do Usuário",
       "markdownSyntax": "Sintaxe Markdown"
-    },
-    "utils": {
-      "noUpdateResourceFile": "Nenhum arquivo de recurso de atualização",
-      "todoUpdateCheck": "Verificar atualizações"
     },
     "spellchecker": {
       "switchLanguage": "Alterar Idioma"
@@ -1085,25 +922,6 @@
       "anchorLinkCopied": "Link âncora copiado",
       "tabNotFound": "Aba não encontrada",
       "tocItemNotFound": "Item do índice não encontrado",
-      "highlightStart": "[Início do destaque]",
-      "highlightEnd": "[Fim do destaque]",
-      "typeAtToInsert": "Digite / para inserir",
-      "inputFootnoteDefinition": "Digite definição da nota de rodapé...",
-      "inputYamlFrontMatter": "Digite metadados YAML...",
-      "inputLanguageIdentifier": "Digite identificador de idioma...",
-      "inputMathematicalFormula": "Digite fórmula matemática...",
-      "fence": "Cerca",
-      "indent": "Indentação",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Clique para adicionar imagem",
-      "loadImageFailed": "Falha ao carregar imagem",
       "errorLoadingTabTitle": "Erro ao carregar a aba",
       "errorLoadingTabMessage": "Ocorreu um erro ao carregar a alteração do arquivo porque a aba não pôde ser encontrada.",
       "mixedLineEndingsNormalized": "“{name}” possui finais de linha mistos que foram normalizados automaticamente para {lineEnding}.",
@@ -1120,204 +938,7 @@
     "failedToRemoveWord": "Falha ao remover palavra do dicionário",
     "unexpectedError": "Erro inesperado do corretor ortográfico"
   },
-  "quickInsert": {
-    "basicBlock": "Bloco Básico",
-    "header": "Cabeçalho",
-    "advancedBlock": "Bloco Avançado",
-    "listBlock": "Bloco de Lista",
-    "diagram": "Diagrama",
-    "paragraph": {
-      "title": "Parágrafo",
-      "subtitle": "Digite o conteúdo do texto"
-    },
-    "horizontalLine": {
-      "title": "Linha Horizontal",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Front Matter",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Cabeçalho 1",
-      "subtitle": "# Cabeçalho"
-    },
-    "header2": {
-      "title": "Cabeçalho 2",
-      "subtitle": "## Cabeçalho"
-    },
-    "header3": {
-      "title": "Cabeçalho 3",
-      "subtitle": "### Cabeçalho"
-    },
-    "header4": {
-      "title": "Cabeçalho 4",
-      "subtitle": "#### Cabeçalho"
-    },
-    "header5": {
-      "title": "Cabeçalho 5",
-      "subtitle": "##### Cabeçalho"
-    },
-    "header6": {
-      "title": "Cabeçalho 6",
-      "subtitle": "###### Cabeçalho"
-    },
-    "tableBlock": {
-      "title": "Bloco de Tabela",
-      "subtitle": "｜ Cabeçalho ｜ Cabeçalho ｜"
-    },
-    "mathFormula": {
-      "title": "Fórmula Matemática",
-      "subtitle": "$$ Fórmula $$"
-    },
-    "htmlBlock": {
-      "title": "Bloco HTML",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Bloco de Código",
-      "subtitle": "``` Código ```"
-    },
-    "quoteBlock": {
-      "title": "Bloco de Citação",
-      "subtitle": "> Conteúdo da citação"
-    },
-    "orderedList": {
-      "title": "Lista Ordenada",
-      "subtitle": "1. Item da lista"
-    },
-    "bulletList": {
-      "title": "Lista com Marcadores",
-      "subtitle": "- Item da lista"
-    },
-    "todoList": {
-      "title": "Lista de tarefas",
-      "subtitle": "- [ ] Item de tarefa"
-    },
-    "vegaChart": {
-      "title": "Gráfico Vega-Lite",
-      "subtitle": "Visualização de dados"
-    },
-    "flowChart": {
-      "title": "Fluxograma",
-      "subtitle": "Fluxograma"
-    },
-    "sequenceChart": {
-      "title": "Gráfico de Sequência",
-      "subtitle": "Diagrama de sequência"
-    },
-    "plantUMLChart": {
-      "title": "Gráfico PlantUML",
-      "subtitle": "Diagrama UML"
-    },
-    "mermaid": {
-      "title": "Gráfico Mermaid",
-      "subtitle": "Diagrama Mermaid",
-      "gantt": {
-        "title": "Gráfico de Gantt"
-      },
-      "pie": {
-        "title": "Gráfico de pizza"
-      },
-      "flowchart": {
-        "title": "Fluxograma"
-      },
-      "sequence": {
-        "title": "Diagrama de sequência"
-      },
-      "class": {
-        "title": "Diagrama de classes"
-      },
-      "state": {
-        "title": "Diagrama de estados",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "Jornada do usuário"
-      },
-      "git": {
-        "title": "Diagrama Git"
-      },
-      "er": {
-        "title": "Diagrama ER"
-      },
-      "requirement": {
-        "title": "Diagrama de requisitos"
-      }
-    },
-    "taskList": {
-      "title": "Lista de tarefas"
-    },
-    "vegaliteChart": {
-      "title": "Gráfico Vega-Lite"
-    },
-    "plantUMLDiagram": {
-      "title": "Diagrama PlantUML"
-    },
-    "mermaidDiagram": {
-      "title": "Diagrama Mermaid"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Duplicar",
-    "turnInto": "Transformar em",
-    "newParagraph": "Novo parágrafo",
-    "delete": "Excluir",
-    "paragraph": "Parágrafo",
-    "table": "Tabela",
-    "html": "HTML",
-    "mathblock": "Bloco matemático",
-    "pre": "Bloco de código",
-    "frontMatter": "Front Matter",
-    "ulTask": "Lista de tarefas",
-    "ulBullet": "Lista com marcadores",
-    "olOrder": "Lista ordenada",
-    "blockquote": "Citação",
-    "heading1": "Cabeçalho 1",
-    "heading2": "Cabeçalho 2",
-    "heading3": "Cabeçalho 3",
-    "heading4": "Cabeçalho 4",
-    "heading5": "Cabeçalho 5",
-    "heading6": "Cabeçalho 6",
-    "hr": "Linha horizontal"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Selecionar",
-          "embedLink": "Inserir link"
-        },
-        "select": {
-          "chooseButton": "Escolher imagem",
-          "tip": "Escolha uma imagem do seu computador."
-        },
-        "inputs": {
-          "alt": "Texto alternativo",
-          "src": "Link da imagem ou caminho local",
-          "title": "Título da imagem"
-        },
-        "embedButton": "Inserir imagem",
-        "hint": {
-          "prefix": "Cole imagem da web ou caminho local. Alternar modo",
-          "simple": "modo simples",
-          "full": "modo completo"
-        }
-      },
-      "toolbar": {
-        "edit": "Editar imagem",
-        "inline": "Imagem embutida",
-        "alignLeft": "Alinhar à esquerda",
-        "alignCenter": "Alinhar ao centro",
-        "alignRight": "Alinhar à direita",
-        "delete": "Remover imagem"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "Inserir YAML Front Matter...",
-      "languageIdentifier": "Inserir Identificador de Linguagem...",
-      "mathFormula": "Inserir Fórmula Matemática..."
-    },
     "export": {
       "error": "Erro de exportação",
       "errorExporting": "Erro ao exportar arquivo",
@@ -1340,65 +961,11 @@
       "imageStructureDeletedComment": "Comentário de estrutura de imagem excluída"
     },
     "spellcheck": {
-      "enabled": "Verificação ortográfica ativada",
-      "disabled": "Verificação ortográfica desativada",
-      "enabledError": "Erro ao ativar verificação ortográfica",
       "disabledError": "Erro ao desativar verificação ortográfica",
       "errorSwitchingLanguage": "Erro ao trocar idioma da verificação ortográfica",
       "languageMissing": "Idioma da verificação ortográfica não encontrado",
       "switchError": "Erro ao trocar verificação ortográfica",
       "title": "Verificação Ortográfica"
-    },
-    "table": "tabela",
-    "resizeTable": "Redimensionar tabela",
-    "left": "esquerda",
-    "alignLeft": "Alinhar à esquerda",
-    "center": "centro",
-    "alignCenter": "Alinhar ao centro",
-    "right": "direita",
-    "alignRight": "Alinhar à direita",
-    "delete": "excluir",
-    "deleteTable": "Excluir tabela",
-    "insertRowAbove": "Inserir linha acima",
-    "insertRowBelow": "Inserir linha abaixo",
-    "removeRow": "Remover linha",
-    "insertColumnLeft": "Inserir coluna à esquerda",
-    "insertColumnRight": "Inserir coluna à direita",
-    "removeColumn": "Remover coluna",
-    "copyContent": "Copiar conteúdo",
-    "emptyMathFormula": "< Fórmula matemática vazia >",
-    "invalidMathFormula": "< Fórmula matemática inválida >",
-    "emptyMermaidBlock": "< Bloco Mermaid vazio >",
-    "loading": "Carregando...",
-    "emptyDiagramBlock": "< Bloco de diagrama vazio >",
-    "emptyHtmlBlock": "< Bloco HTML vazio >",
-    "onlyTopBlockCanRenderIcon": "Apenas o bloco superior pode renderizar o botão de ícone anterior.",
-    "unhandledFunctionType": "Tipo de função não tratado: {functionType}",
-    "highlight-start": "[início do destaque]",
-    "highlight-end": "[fim do destaque]",
-    "type-at-to-insert": "Digite / para inserir",
-    "input-footnote-definition": "Inserir definição de nota de rodapé",
-    "input-yaml-front-matter": "Inserir front matter YAML",
-    "input-language-identifier": "Inserir identificador de idioma",
-    "input-mathematical-formula": "Inserir fórmula matemática",
-    "fence": "cerca",
-    "indent": "indentação",
-    "front-matter-delimiter": "delimitador de front matter",
-    "math-delimiter": "delimitador matemático",
-    "mermaid-start": "início mermaid",
-    "flowchart-start": "início fluxograma",
-    "sequence-start": "início sequência",
-    "plantuml-start": "início plantuml",
-    "vega-lite-start": "início vega-lite",
-    "click-to-add-image": "Clique para adicionar imagem",
-    "load-image-failed": "Falha ao carregar imagem"
-  },
-  "edit": {
-    "undo": "Desfazer",
-    "redo": "Refazer",
-    "cut": "Cortar",
-    "copy": "Copiar",
-    "paste": "Colar",
-    "selectAll": "Selecionar tudo"
+    }
   }
 }

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -220,7 +220,6 @@
     "replaceSingle": "Substituir Um",
     "invalidRegex": "Expressão regular inválida \"{pattern}\"",
     "regexMatchEmpty": "Expressão regular corresponde à string vazia \"{pattern}\"",
-    "searchResultCount": "Resultados da pesquisa",
     "searchResultInfo": "{matchCount} correspondências em {fileCount} arquivos",
     "searchLimited": "Pesquisa limitada aos primeiros {count} resultados"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "Salvar automaticamente o conteúdo sendo editado",
         "autoSaveDelay": "O tempo em ms após uma mudança que o arquivo é salvo",
-        "autoNormalizeLineEndings": "Normalizar automaticamente as quebras de linha para LF e opcionalmente novas linhas finais ao abrir",
+        "autoNormalizeLineEndings": "Normalizar automaticamente as quebras de linha ao abrir arquivos. Quando desativado, os arquivos são abertos como estão.",
         "titleBarStyle": "O estilo da barra de título (apenas sistemas Windows e Linux)",
         "openFilesInNewWindow": "Abrir arquivos em uma nova janela",
         "openFolderInNewWindow": "Abrir pasta via menu em uma nova janela",
@@ -414,7 +413,6 @@
         "followSystemTheme": "Seguir tema do sistema",
         "lightModeTheme": "Tema a ser usado quando o sistema está no modo claro",
         "darkModeTheme": "Tema a ser usado quando o sistema está no modo escuro",
-        "customCss": "CSS personalizado para aplicar ao tema atual",
         "spellcheckerEnabled": "Se a verificação ortográfica está habilitada",
         "spellcheckerNoUnderline": "Não sublinhar erros ortográficos",
         "spellcheckerLanguage": "O idioma do verificador ortográfico",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "Se preferir o diretório de imagem relativo",
         "imageRelativeDirectoryBase": "Onde as imagens relativas são copiadas",
         "imageRelativeDirectoryName": "O nome da pasta de imagem relativa",
-        "sideBarVisibility": "Se a barra lateral está visível",
-        "tabBarVisibility": "Se as abas são mostradas",
-        "sourceCodeModeEnabled": "Se o modo código fonte está habilitado por padrão",
-        "searchExclusions": "Lista de padrões glob para excluir da pesquisa",
-        "searchMaxFileSize": "O tamanho máximo de arquivo (<maxFileSize><suffix>). Sufixos de K, M ou G são permitidos se nenhum sufixo for dado, o número é tratado como bytes",
-        "searchIncludeHidden": "Se pesquisar em arquivos e diretórios ocultos",
-        "searchNoIgnore": "Se ignorar arquivos de ignore como .gitignore",
-        "searchFollowSymlinks": "Se os links simbólicos devem ser seguidos",
-        "watcherUsePolling": "Se usar polling. O polling pode levar a alta utilização de CPU mas é necessário para observar arquivos sobre uma rede"
+        "fileSortOrder": "Ordem de classificação dos arquivos nas pastas abertas: ascendente ou descendente.",
+        "openedFilesInSidebar": "Se os arquivos abertos são mostrados na barra lateral."
       }
     },
     "categories": {
@@ -596,7 +587,6 @@
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
-        "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "Escolha o méde instalação:",
         "retestPicgo": "Testar novamente",
         "lastDetectionTime": "Última detecção",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -411,7 +411,6 @@
         "followSystemTheme": "Sistem Temasını Takip Et",
         "lightModeTheme": "Sistem açık moddayken kullanılacak tema",
         "darkModeTheme": "Sistem koyu moddayken kullanılacak tema",
-        "customCss": "Geçerli temaya uygulanacak özel CSS",
         "spellcheckerEnabled": "Yazım denetiminin etkinleştirilip etkinleştirilmeyeceği",
         "spellcheckerNoUnderline": "Yazım hatalarının altını çizme",
         "spellcheckerLanguage": "Yazım denetleyici dili",
@@ -419,16 +418,10 @@
         "imagePreferRelativeDirectory": "Göreli görsel klasörünün tercih edilip edilmeyeceği",
         "imageRelativeDirectoryBase": "Göreli görsellerin nereye kopyalanacağı",
         "imageRelativeDirectoryName": "Göreli görsel klasörünün adı",
-        "sideBarVisibility": "Kenar çubuğunun görünür olup olmadığı",
-        "tabBarVisibility": "Sekmelerin gösterilip gösterilmediği",
-        "sourceCodeModeEnabled": "Kaynak kod modunun varsayılan olarak etkin olup olmadığı",
-        "searchExclusions": "Aramadan hariç tutulacak glob desenleri listesi",
-        "searchMaxFileSize": "Maksimum dosya boyutu (<maxFileSize><suffix>). K, M veya G son ekleri kullanılabilir; son ek verilmezse sayı bayt olarak kabul edilir",
-        "searchIncludeHidden": "Gizli dosya ve klasörlerde arama yapılıp yapılmayacağı",
-        "searchNoIgnore": ".gitignore gibi yoksayma dosyalarının yoksayılıp yoksayılmayacağı",
-        "searchFollowSymlinks": "Sembolik bağlantıların izlenip izlenmeyeceği",
-        "watcherUsePolling": "Yoklama kullanılıp kullanılmayacağı. Yoklama yüksek CPU kullanımına yol açabilir ancak ağ üzerindeki dosyaları izlemek için gereklidir",
-        "plantumlServer": "PlantUML sunucu URL'si"
+        "plantumlServer": "PlantUML sunucu URL'si",
+        "autoNormalizeLineEndings": "Dosyaları açarken yeni satır karakterlerini otomatik olarak normalleştir. Devre dışı bırakıldığında dosyalar olduğu gibi açılır.",
+        "fileSortOrder": "Açık klasörlerdeki dosyaların sıralama düzeni: artan veya azalan.",
+        "openedFilesInSidebar": "Açık dosyaların kenar çubuğunda gösterilip gösterilmeyeceği."
       }
     },
     "categories": {

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "Dosya",
-      "new": "Yeni",
       "newTab": "Yeni Sekme",
       "newWindow": "Yeni Pencere",
-      "open": "Aç",
       "openFile": "Dosya Aç...",
       "openFolder": "Klasör Aç...",
       "openRecent": "Son Kullanılanları Aç",
@@ -25,9 +23,6 @@
       "exportPdf": "PDF Olarak Dışa Aktar",
       "import": "İçe Aktar",
       "print": "Yazdır",
-      "recent": "Son Dosyalar",
-      "close": "Kapat",
-      "closeAll": "Tümünü Kapat",
       "closeTab": "Sekmeyi Kapat",
       "closeWindow": "Pencereyi Kapat",
       "quit": "Çıkış",
@@ -70,26 +65,19 @@
       "demoteHeading": "Başlığı Alçalt",
       "table": "Tablo",
       "codeFences": "Kod Blokları",
-      "codeBlock": "Kod Bloğu",
       "quoteBlock": "Alıntı Bloğu",
       "mathBlock": "Matematik Bloğu",
       "htmlBlock": "HTML Bloğu",
-      "quote": "Alıntı",
       "orderedList": "Sıralı Liste",
       "bulletList": "Sırasız Liste",
-      "unorderedList": "Sırasız Liste",
       "taskList": "Görev Listesi",
       "looseListItem": "Gevşek Liste Öğesi",
-      "paragraphItem": "Paragraf Öğesi",
       "horizontalRule": "Yatay Çizgi",
       "frontMatter": "Ön Bilgi"
     },
     "window": {
       "title": "Pencere",
-      "window": "Pencere",
       "minimize": "Simge Durumuna Küçült",
-      "close": "Kapat",
-      "zoom": "Yakınlaştırma",
       "zoomIn": "Yakınlaştır",
       "zoomOut": "Uzaklaştır",
       "fullScreen": "Tam Ekran",
@@ -106,20 +94,16 @@
       "followUs": "Bizi Takip Edin",
       "support": "MarkText'e Destek Ol",
       "license": "Lisans",
-      "checkForUpdates": "Güncellemeleri Denetle",
-      "aboutMarkText": "MarkText Hakkında",
       "about": "Hakkında",
       "checkUpdates": "Güncellemeleri Denetle"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "MarkText Hakkında",
       "checkUpdates": "Güncellemeleri Denetle...",
       "preferences": "Tercihler",
       "services": "Hizmetler",
       "hide": "MarkText'i Gizle",
-      "hideMarkText": "MarkText'i Gizle",
       "hideOthers": "Diğerlerini Gizle",
       "showAll": "Tümünü Göster",
       "quit": "MarkText'ten Çık"
@@ -129,14 +113,9 @@
       "toggleSidebar": "Kenar Çubuğunu Aç/Kapat",
       "toggleTabbar": "Sekme Çubuğunu Aç/Kapat",
       "commandPalette": "Komut Paleti",
-      "sourceCode": "Kaynak Kod Modu",
       "sourceCodeMode": "Kaynak Kod Modu",
-      "typewriter": "Daktilo Modu",
       "typewriterMode": "Daktilo Modu",
-      "focus": "Odak Modu",
       "focusMode": "Odak Modu",
-      "showTabBar": "Sekme Çubuğunu Göster",
-      "toc": "İçindekiler",
       "toggleTableOfContents": "İçindekileri Aç/Kapat",
       "reloadImages": "Görselleri Yeniden Yükle",
       "showDeveloperTools": "Geliştirici Araçlarını Göster",
@@ -148,35 +127,18 @@
       "italic": "İtalik",
       "underline": "Altı Çizili",
       "strikethrough": "Üstü Çizili",
-      "code": "Satır İçi Kod",
-      "codeBlock": "Kod Bloğu",
-      "quote": "Alıntı",
-      "unorderedList": "Sırasız Liste",
-      "orderedList": "Sıralı Liste",
-      "taskList": "Görev Listesi",
-      "table": "Tablo",
-      "link": "Bağlantı",
       "image": "Görsel",
-      "heading1": "Başlık 1",
-      "heading2": "Başlık 2",
-      "heading3": "Başlık 3",
-      "heading4": "Başlık 4",
-      "heading5": "Başlık 5",
-      "heading6": "Başlık 6",
       "superscript": "Üst Simge",
       "subscript": "Alt Simge",
       "highlight": "Vurgu",
       "inlineCode": "Satır İçi Kod",
       "inlineMath": "Satır İçi Matematik",
       "hyperlink": "Köprü",
-      "clearFormatting": "Biçimlendirmeyi Temizle",
       "clearFormat": "Biçimlendirmeyi Temizle"
     },
     "theme": {
       "theme": "&Tema",
-      "light": "Açık",
       "dark": "Koyu",
-      "auto": "Otomatik",
       "followThemDisabled": "Sistem temasını takip ederken tema seçimi devre dışı",
       "lightThemes": "— Açık Temalar —",
       "darkThemes": "— Koyu Temalar —",
@@ -375,13 +337,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "Tabloyu Yeniden Boyutlandır",
-    "alignLeft": "Sola Hizala",
-    "alignCenter": "Ortala",
-    "alignRight": "Sağa Hizala",
-    "deleteTable": "Tabloyu Sil"
-  },
   "recent": {
     "noTabsOpen": "Açık sekmeniz yok.",
     "newFile": "Yeni Dosya"
@@ -394,7 +349,6 @@
     "title": "Tercihler",
     "search": {
       "placeholder": "Tercihlerde ara...",
-      "optionalValues": "isteğe bağlı değerler",
       "categories": {
         "general": "Genel",
         "editor": "Düzenleyici",
@@ -497,7 +451,6 @@
         "titleBarStyle": {
           "title": "Başlık Çubuğu Stili",
           "custom": "Özel",
-          "titleBarStyle": "Başlık Çubuğu Stili",
           "native": "Yerel"
         },
         "requiresRestart": "Yeniden başlatma gerektirir",
@@ -630,53 +583,19 @@
         "relativeFolderName": "Göreli klasör adı",
         "filenameNote": "Dosya adı otomatik olarak oluşturulacak."
       },
-      "imageInsertAction": {
-        "title": "Görsel ekleme eylemi",
-        "folder": "Klasöre yükle",
-        "path": "Yola kopyala",
-        "upload": "Buluta yükle",
-        "copyToFolder": "Klasöre kopyala",
-        "uploadToServer": "Sunucuya yükle"
-      },
-      "imageFolderPath": {
-        "title": "Görsel klasörü yolu",
-        "description": "Görsel klasörü yolu",
-        "selectFolder": "Klasör seç",
-        "relativePath": "Göreli yol",
-        "absolutePath": "Mutlak yol"
-      },
-      "cloudPictureBed": {
-        "title": "Bulut görsel deposu",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "Qiniu",
-        "upyun": "UpYun",
-        "tcyun": "Tencent Cloud",
-        "aliyun": "Alibaba Cloud",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "Göreli klasörü tercih et",
-        "description": "Görseller için göreli klasörü tercih et"
-      },
       "uploader": {
         "title": "Görsel Yükleyici",
         "currentUploader": "Geçerli Yükleyici: {name}",
         "picgoNotInstalled": "PicGo yüklü değil",
-        "picgoDetectionStatus": "PicGo Algılama Durumu",
         "picgoInstalled": "PicGo yüklü",
         "picgoDetectionFailed": "PicGo algılaması başarısız",
         "debugInfo": "Hata Ayıklama Bilgisi",
-        "installCommand": "Yükleme Komutu",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "chooseInstallMethod": "Yükleme yöntemini seçin:",
         "retestPicgo": "Yeniden Test Et",
-        "detecting": "Algılanıyor",
         "lastDetectionTime": "Son Algılama Zamanı",
-        "detectionStatus": "Algılama Durumu",
         "picgoDetection": "PicGo Algılama",
         "usageGuide": {
           "title": "PicGo Temel Kullanım Kılavuzu",
@@ -688,17 +607,9 @@
           "step3Description": "Geçerli yapılandırmayı görüntülemek için aşağıdaki komutu kullanın:",
           "documentation": "Tam belgeleri görüntüle"
         },
-        "autoDetection": "Otomatik algılanıyor",
         "lastSuccessTime": "Son başarı zamanı",
         "neverDetected": "Hiç algılanmadı",
         "neverSuccessful": "Hiç başarılı olmadı",
-        "configureUploader": "Yükleyiciyi Yapılandır",
-        "configureDescription": "PicGo yükleyicisini yapılandırmak için aşağıdaki komutu kullanın:",
-        "uploadImage": "Görselleri Yükle",
-        "uploadDescription": "Görselleri yüklemek için aşağıdaki komutu kullanın:",
-        "viewConfig": "Yapılandırmayı Görüntüle",
-        "viewConfigDescription": "Geçerli yapılandırmayı görüntülemek için aşağıdaki komutu kullanın:",
-        "viewDocumentation": "Tam belgeleri görüntüle",
         "scriptDescription": "Betik Açıklaması",
         "scriptLocation": "Betik Konumu",
         "save": "Kaydet",
@@ -715,44 +626,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "Liste Öğesi",
-        "preferLooseListItem": "Gevşek liste öğesini tercih et",
-        "bulletListMarker": "Sırasız liste işareti",
-        "orderListDelimiter": "Sıralı liste ayracı",
-        "listIndentation": {
-          "title": "Liste Girintisi",
-          "dfm": "Varsayılan Biçim Modu",
-          "tab": "Sekme",
-          "oneSpace": "Bir Boşluk",
-          "twoSpaces": "İki Boşluk",
-          "threeSpaces": "Üç Boşluk",
-          "fourSpaces": "Dört Boşluk"
-        }
-      },
-      "heading": {
-        "title": "Başlık",
-        "preferHeadingStyle": "Başlık stilini tercih et"
-      },
-      "frontmatter": {
-        "title": "Ön Bilgi",
-        "frontmatterType": "Ön bilgi türü"
-      },
       "extensions": {
         "title": "Uzantılar",
         "superSubScript": "Üst/Alt Simge",
         "footnote": "Dipnot",
-        "isHtmlEnabled": "HTML etkin",
-        "isGitlabCompatibilityEnabled": "GitLab uyumluluğu",
-        "sequenceTheme": "Dizi teması",
-        "superscript": "Üst Simge",
-        "subscript": "Alt Simge",
-        "frontMatter": "Ön Bilgi",
-        "math": "Matematik",
-        "diagram": "Diyagram",
         "footnoteNotes": "Dipnot notları",
         "frontmatterType": {
-          "frontmatterType": "Ön Bilgi Türü",
           "jsonBrace": "Süslü Parantezli JSON",
           "jsonSemicolon": "Noktalı Virgüllü JSON",
           "title": "Ön Bilgi Türü"
@@ -760,22 +639,11 @@
       },
       "diagrams": {
         "title": "Diyagramlar",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega-Lite",
-        "flowchart": "Akış Şeması",
-        "sequence": "Dizi",
-        "gantt": "Gantt",
         "sequenceTheme": {
           "title": "Dizi Teması",
           "handDrawn": "El Çizimi",
           "simple": "Basit"
         }
-      },
-      "math": {
-        "title": "Matematik",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -806,28 +674,13 @@
         "title": "Listeler"
       }
     },
-    "spelling": {
-      "title": "Yazım",
-      "enabled": "Yazım denetleyiciyi etkinleştir",
-      "autoDetectLanguage": "Dili otomatik algıla",
-      "language": "Dil",
-      "noSuggestions": "Öneri yok",
-      "spellcheckerEnabled": "Yazım denetleyiciyi etkinleştir",
-      "spellcheckerNoUnderline": "Yanlış yazılan sözcüklerin altını çizme",
-      "spellcheckerLanguage": "Yazım denetleyici dili"
-    },
     "theme": {
       "title": "Tema",
-      "theme": "Tema",
       "followSystemTheme": "Sistem Temasını Takip Et",
       "modeThemes": "Tema Seçimi",
       "lightModeTheme": "Açık mod teması",
       "darkModeTheme": "Koyu mod teması",
       "customCss": "Özel CSS",
-      "codeBlockTheme": {
-        "title": "Kod bloğu teması",
-        "description": "Kod blokları için tema"
-      },
       "importCustomThemes": "Özel temaları içe aktar",
       "importTheme": "Temayı İçe Aktar",
       "openFolder": "Klasör Aç",
@@ -836,13 +689,6 @@
     "keybindings": {
       "title": "Kısayol Tuşları",
       "description": "Klavye kısayollarını özelleştir",
-      "searchPlaceholder": "Kısayol tuşlarında ara",
-      "command": "Komut",
-      "keybinding": "Kısayol",
-      "reset": "Sıfırla",
-      "resetAll": "Tümünü sıfırla",
-      "edit": "Düzenle",
-      "cancel": "İptal",
       "save": "Kaydet",
       "restoreDefaults": "Varsayılanları geri yükle",
       "debugOptions": "Hata Ayıklama Seçenekleri",
@@ -884,14 +730,6 @@
       "title": "Yazım Denetleyici"
     }
   },
-  "edit": {
-    "undo": "Geri Al",
-    "redo": "Yinele",
-    "cut": "Kes",
-    "copy": "Kopyala",
-    "paste": "Yapıştır",
-    "selectAll": "Tümünü Seç"
-  },
   "about": {
     "copyright": "Telif Hakkı © Luo Ran 2017-{year}",
     "copyrightContributors": "Github Katkıda Bulunanlar tarafından <3 ile yapıldı"
@@ -924,9 +762,7 @@
       "exportFile": "Dosya Dışa Aktar",
       "exportFilePdf": "PDF Olarak Dışa Aktar",
       "zoom": "Yakınlaştırma",
-      "checkUpdate": "Güncellemeleri Denetle",
-      "lineEnding": "Satır Sonu",
-      "close": "Kapat"
+      "checkUpdate": "Güncellemeleri Denetle"
     },
     "edit": {
       "undo": "Geri Al",
@@ -946,8 +782,7 @@
       "findPrevious": "Öncekini Bul",
       "replace": "Değiştir",
       "findInFolder": "Klasörde Bul",
-      "screenshot": "Ekran Görüntüsü",
-      "mathBlock": "Matematik Bloğu"
+      "screenshot": "Ekran Görüntüsü"
     },
     "paragraph": {
       "heading1": "Başlık 1",
@@ -1013,8 +848,6 @@
       "reloadImages": "Görselleri Yeniden Yükle",
       "textDirection": "Metin Yönü",
       "actualSize": "Gerçek Boyut",
-      "zoomIn": "Yakınlaştır",
-      "zoomOut": "Uzaklaştır",
       "devToggleDeveloperTools": "Geliştirici Araçlarını Aç/Kapat"
     },
     "tabs": {
@@ -1036,10 +869,6 @@
     "docs": {
       "userGuide": "Kullanıcı Kılavuzu",
       "markdownSyntax": "Markdown Söz Dizimi"
-    },
-    "utils": {
-      "noUpdateResourceFile": "Güncelleme kaynak dosyası yok",
-      "todoUpdateCheck": "Güncellemeleri denetle"
     },
     "spellchecker": {
       "switchLanguage": "Dili Değiştir"
@@ -1086,25 +915,6 @@
       "anchorLinkCopied": "Çapa bağlantısı kopyalandı",
       "tabNotFound": "Sekme bulunamadı",
       "tocItemNotFound": "İçindekiler {key} bulunamadı",
-      "highlightStart": "[highlight start]",
-      "highlightEnd": "[highlight end]",
-      "typeAtToInsert": "Eklemek için / yazın",
-      "inputFootnoteDefinition": "Dipnot tanımını girin...",
-      "inputYamlFrontMatter": "YAML Ön Bilgisini girin",
-      "inputLanguageIdentifier": "Dil Tanımlayıcısını girin...",
-      "inputMathematicalFormula": "Matematiksel Formülü girin...",
-      "fence": "kod bloğu",
-      "indent": "girinti",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "Görsel eklemek için tıklayın",
-      "loadImageFailed": "Görsel yüklenemedi",
       "errorLoadingTabTitle": "Sekme yüklenirken hata",
       "errorLoadingTabMessage": "Sekme bulunamadığı için dosya değişikliği yüklenirken bir hata oluştu.",
       "mixedLineEndingsNormalized": "\"{name}\" karışık satır sonları içeriyor; otomatik olarak {lineEnding} biçimine normalleştirildi.",
@@ -1121,205 +931,7 @@
     "failedToRemoveWord": "Sözcük sözlükten kaldırılamadı",
     "unexpectedError": "Beklenmeyen yazım denetleyici hatası"
   },
-  "quickInsert": {
-    "basicBlock": "Temel Blok",
-    "header": "Başlık",
-    "advancedBlock": "Gelişmiş Blok",
-    "listBlock": "Liste Bloğu",
-    "diagram": "Diyagram",
-    "paragraph": {
-      "title": "Paragraf",
-      "subtitle": "Metin içeriği girin"
-    },
-    "horizontalLine": {
-      "title": "Yatay Çizgi",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "Ön Bilgi",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "Başlık 1",
-      "subtitle": "# Başlık"
-    },
-    "header2": {
-      "title": "Başlık 2",
-      "subtitle": "## Başlık"
-    },
-    "header3": {
-      "title": "Başlık 3",
-      "subtitle": "### Başlık"
-    },
-    "header4": {
-      "title": "Başlık 4",
-      "subtitle": "#### Başlık"
-    },
-    "header5": {
-      "title": "Başlık 5",
-      "subtitle": "##### Başlık"
-    },
-    "header6": {
-      "title": "Başlık 6",
-      "subtitle": "###### Başlık"
-    },
-    "tableBlock": {
-      "title": "Tablo Bloğu",
-      "subtitle": "｜ Başlık ｜ Başlık ｜"
-    },
-    "mathFormula": {
-      "title": "Matematik Formülü",
-      "subtitle": "$$ Formül $$"
-    },
-    "htmlBlock": {
-      "title": "HTML Bloğu",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "Kod Bloğu",
-      "subtitle": "``` Kod ```"
-    },
-    "quoteBlock": {
-      "title": "Alıntı Bloğu",
-      "subtitle": "> Alıntı içeriği"
-    },
-    "orderedList": {
-      "title": "Sıralı Liste",
-      "subtitle": "1. Liste öğesi"
-    },
-    "bulletList": {
-      "title": "Sırasız Liste",
-      "subtitle": "- Liste öğesi"
-    },
-    "todoList": {
-      "title": "Liste",
-      "subtitle": "- [ ] Görev öğesi"
-    },
-    "vegaChart": {
-      "title": "Vega-Lite Grafiği",
-      "subtitle": "Veri görselleştirme grafiği"
-    },
-    "flowChart": {
-      "title": "Akış Şeması",
-      "subtitle": "Akış şeması diyagramı"
-    },
-    "sequenceChart": {
-      "title": "Dizi Grafiği",
-      "subtitle": "Dizi diyagramı"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML Grafiği",
-      "subtitle": "UML diyagramı"
-    },
-    "mermaid": {
-      "title": "Mermaid Grafiği",
-      "subtitle": "Mermaid diyagramı",
-      "gantt": {
-        "title": "Gantt Grafiği"
-      },
-      "pie": {
-        "title": "Pasta Grafiği"
-      },
-      "flowchart": {
-        "title": "Akış Şeması"
-      },
-      "sequence": {
-        "title": "Dizi Diyagramı"
-      },
-      "class": {
-        "title": "Sınıf Diyagramı"
-      },
-      "state": {
-        "title": "Durum Diyagramı",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "Kullanıcı Yolculuğu"
-      },
-      "git": {
-        "title": "Git Grafiği"
-      },
-      "er": {
-        "title": "ER Diyagramı"
-      },
-      "requirement": {
-        "title": "Gereksinim Diyagramı"
-      }
-    },
-    "taskList": {
-      "title": "Görev Listesi"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite Grafiği"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML Diyagramı"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid Diyagramı"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "Çoğalt",
-    "turnInto": "Dönüştür",
-    "newParagraph": "Yeni Paragraf",
-    "delete": "Sil",
-    "paragraph": "Paragraf",
-    "table": "Tablo",
-    "html": "HTML",
-    "mathblock": "Matematik Bloğu",
-    "pre": "Kod Bloğu",
-    "frontMatter": "Ön Bilgi",
-    "ulTask": "Görev Listesi",
-    "ulBullet": "Sırasız Liste",
-    "olOrder": "Sıralı Liste",
-    "blockquote": "Alıntı",
-    "heading1": "Başlık 1",
-    "heading2": "Başlık 2",
-    "heading3": "Başlık 3",
-    "heading4": "Başlık 4",
-    "heading5": "Başlık 5",
-    "heading6": "Başlık 6",
-    "hr": "Yatay Çizgi"
-  },
   "editor": {
-    "words": {},
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "Seç",
-          "embedLink": "Bağlantı göm"
-        },
-        "select": {
-          "chooseButton": "Görsel Seç",
-          "tip": "Bilgisayarınızdan bir görsel seçin."
-        },
-        "inputs": {
-          "alt": "Alternatif metin",
-          "src": "Görsel bağlantısı veya yerel yol",
-          "title": "Görsel başlığı"
-        },
-        "embedButton": "Görseli Göm",
-        "hint": {
-          "prefix": "Web görseli veya yerel görsel yolu yapıştırın. Şunu kullanın:",
-          "simple": "basit mod",
-          "full": "tam mod"
-        }
-      },
-      "toolbar": {
-        "edit": "Görseli Düzenle",
-        "inline": "Satır İçi Görsel",
-        "alignLeft": "Sola Hizala",
-        "alignCenter": "Ortala",
-        "alignRight": "Sağa Hizala",
-        "delete": "Görseli Kaldır"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "YAML Ön Bilgisini girin",
-      "languageIdentifier": "Dil Tanımlayıcısını girin...",
-      "mathFormula": "Matematiksel Formülü girin..."
-    },
     "export": {
       "error": "Dışa aktarma hatası",
       "errorExporting": "{type} dosyası dışa aktarılırken hata",
@@ -1346,53 +958,7 @@
       "errorSwitchingLanguage": "Yazım denetimi dili değiştirilirken hata {languageCode}",
       "languageMissing": "Yazım denetimi dili eksik {languageCode}",
       "switchError": "{languageCode} için yazım denetimi değiştirme hatası, {error}",
-      "title": "Yazım Denetimi",
-      "disabled": "Yazım denetimi devre dışı",
-      "enabled": "Yazım denetimi etkin",
-      "enabledError": "Yazım denetimi etkinleştirilirken hata"
-    },
-    "table": "tablo",
-    "resizeTable": "Tabloyu Yeniden Boyutlandır",
-    "left": "sol",
-    "alignLeft": "Sola Hizala",
-    "center": "orta",
-    "alignCenter": "Ortala",
-    "right": "sağ",
-    "alignRight": "Sağa Hizala",
-    "delete": "sil",
-    "deleteTable": "Tabloyu Sil",
-    "insertRowAbove": "Üste Satır Ekle",
-    "insertRowBelow": "Alta Satır Ekle",
-    "removeRow": "Satırı Kaldır",
-    "insertColumnLeft": "Sola Sütun Ekle",
-    "insertColumnRight": "Sağa Sütun Ekle",
-    "removeColumn": "Sütunu Kaldır",
-    "copyContent": "İçeriği kopyala",
-    "emptyMathFormula": "< Boş Matematiksel Formül >",
-    "invalidMathFormula": "< Geçersiz Matematiksel Formül >",
-    "emptyMermaidBlock": "< Boş Mermaid Bloğu >",
-    "loading": "Yükleniyor...",
-    "emptyDiagramBlock": "< Boş Diyagram Bloğu >",
-    "emptyHtmlBlock": "< Boş HTML Bloğu >",
-    "onlyTopBlockCanRenderIcon": "Yalnızca en üstteki blok ön simge düğmesini işleyebilir.",
-    "unhandledFunctionType": "İşlenmeyen functionType: {functionType}",
-    "highlight-start": "[highlight end]",
-    "highlight-end": "[highlight end]",
-    "type-at-to-insert": "Eklemek için / yazın",
-    "input-footnote-definition": "Dipnot tanımını girin",
-    "input-yaml-front-matter": "YAML ön bilgisini girin",
-    "input-language-identifier": "Dil tanımlayıcısını girin",
-    "input-mathematical-formula": "Matematiksel formülü girin",
-    "fence": "kod bloğu",
-    "indent": "girinti",
-    "front-matter-delimiter": "ön bilgi ayracı",
-    "math-delimiter": "matematik ayracı",
-    "mermaid-start": "mermaid başlangıcı",
-    "flowchart-start": "akış şeması başlangıcı",
-    "sequence-start": "dizi başlangıcı",
-    "plantuml-start": "plantuml başlangıcı",
-    "vega-lite-start": "vega-lite başlangıcı",
-    "click-to-add-image": "Görsel eklemek için tıklayın",
-    "load-image-failed": "Görsel yüklenemedi"
+      "title": "Yazım Denetimi"
+    }
   }
 }

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -427,7 +427,8 @@
         "searchIncludeHidden": "Gizli dosya ve klasörlerde arama yapılıp yapılmayacağı",
         "searchNoIgnore": ".gitignore gibi yoksayma dosyalarının yoksayılıp yoksayılmayacağı",
         "searchFollowSymlinks": "Sembolik bağlantıların izlenip izlenmeyeceği",
-        "watcherUsePolling": "Yoklama kullanılıp kullanılmayacağı. Yoklama yüksek CPU kullanımına yol açabilir ancak ağ üzerindeki dosyaları izlemek için gereklidir"
+        "watcherUsePolling": "Yoklama kullanılıp kullanılmayacağı. Yoklama yüksek CPU kullanımına yol açabilir ancak ağ üzerindeki dosyaları izlemek için gereklidir",
+        "plantumlServer": "PlantUML sunucu URL'si"
       }
     },
     "categories": {
@@ -643,6 +644,9 @@
           "title": "Dizi Teması",
           "handDrawn": "El Çizimi",
           "simple": "Basit"
+        },
+        "plantumlServer": {
+          "title": "PlantUML Sunucu URL'si"
         }
       },
       "misc": {

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "文件",
-      "new": "新建",
       "newTab": "新建标签页",
       "newWindow": "新建窗口",
-      "open": "打开",
       "openFile": "打开文件…",
       "openFolder": "打开文件夹…",
       "openRecent": "打开最近",
@@ -25,9 +23,6 @@
       "exportPdf": "导出为 PDF",
       "import": "导入",
       "print": "打印",
-      "recent": "最近文件",
-      "close": "关闭",
-      "closeAll": "关闭全部",
       "closeTab": "关闭标签页",
       "closeWindow": "关闭窗口",
       "quit": "退出",
@@ -70,26 +65,19 @@
       "demoteHeading": "降低标题级别",
       "table": "表格",
       "codeFences": "代码围栏",
-      "codeBlock": "代码块",
       "quoteBlock": "引用块",
       "mathBlock": "数学块",
       "htmlBlock": "HTML 块",
-      "quote": "引用",
       "orderedList": "有序列表",
       "bulletList": "无序列表",
-      "unorderedList": "无序列表",
       "taskList": "任务列表",
       "looseListItem": "宽松列表项",
-      "paragraphItem": "段落项",
       "horizontalRule": "水平分割线",
       "frontMatter": "前置元数据"
     },
     "window": {
       "title": "窗口",
-      "window": "窗口",
       "minimize": "最小化",
-      "close": "关闭",
-      "zoom": "缩放",
       "zoomIn": "放大",
       "zoomOut": "缩小",
       "fullScreen": "全屏",
@@ -106,20 +94,16 @@
       "followUs": "关注我们",
       "support": "支持 MarkText",
       "license": "许可证",
-      "checkForUpdates": "检查更新",
-      "aboutMarkText": "关于 MarkText",
       "about": "关于",
       "checkUpdates": "检查更新"
     },
     "marktext": {
       "title": "MarkText",
-      "marktext": "MarkText",
       "about": "关于 MarkText",
       "checkUpdates": "检查更新…",
       "preferences": "偏好设置",
       "services": "服务",
       "hide": "隐藏 MarkText",
-      "hideMarkText": "隐藏 MarkText",
       "hideOthers": "隐藏其他",
       "showAll": "显示全部",
       "quit": "退出 MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "切换侧边栏",
       "toggleTabbar": "切换标签栏",
       "commandPalette": "命令面板",
-      "sourceCode": "源码模式",
       "sourceCodeMode": "源码模式",
-      "typewriter": "打字机模式",
       "typewriterMode": "打字机模式",
-      "focus": "专注模式",
       "focusMode": "专注模式",
-      "showTabBar": "显示标签栏",
-      "toc": "目录",
       "toggleTableOfContents": "切换目录",
       "reloadImages": "重新加载图片",
       "showDeveloperTools": "显示开发者工具",
@@ -148,35 +127,18 @@
       "italic": "斜体",
       "underline": "下划线",
       "strikethrough": "删除线",
-      "code": "行内代码",
-      "codeBlock": "代码块",
-      "quote": "引用",
-      "unorderedList": "无序列表",
-      "orderedList": "有序列表",
-      "taskList": "任务列表",
-      "table": "表格",
-      "link": "链接",
       "image": "图片",
-      "heading1": "标题 1",
-      "heading2": "标题 2",
-      "heading3": "标题 3",
-      "heading4": "标题 4",
-      "heading5": "标题 5",
-      "heading6": "标题 6",
       "superscript": "上标",
       "subscript": "下标",
       "highlight": "高亮",
       "inlineCode": "行内代码",
       "inlineMath": "行内数学",
       "hyperlink": "超链接",
-      "clearFormatting": "清除格式",
       "clearFormat": "清除格式"
     },
     "theme": {
       "theme": "主题(&T)",
-      "light": "浅色",
       "dark": "深色",
-      "auto": "自动",
       "followThemDisabled": "跟随系统主题时无法选择主题",
       "lightThemes": "— 浅色主题 —",
       "darkThemes": "— 深色主题 —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "调整表格大小",
-    "alignLeft": "左对齐",
-    "alignCenter": "居中对齐",
-    "alignRight": "右对齐",
-    "deleteTable": "删除表格"
-  },
   "recent": {
     "noTabsOpen": "您没有打开的标签页。",
     "newFile": "新建文件"
@@ -395,7 +350,6 @@
     "title": "偏好设置",
     "search": {
       "placeholder": "搜索偏好设置…",
-      "optionalValues": "可选值",
       "categories": {
         "general": "通用",
         "editor": "编辑器",
@@ -500,8 +454,7 @@
         "titleBarStyle": {
           "title": "标题栏样式",
           "custom": "自定义",
-          "native": "原生",
-          "titleBarStyle": "标题栏样式"
+          "native": "原生"
         },
         "requiresRestart": "需要重启",
         "hideScrollbars": "隐藏滚动条",
@@ -633,53 +586,19 @@
         "relativeFolderName": "相对文件夹名称",
         "filenameNote": "文件名将自动生成。"
       },
-      "imageInsertAction": {
-        "title": "图片插入操作",
-        "folder": "上传到文件夹",
-        "path": "复制到路径",
-        "upload": "上传到云端",
-        "copyToFolder": "复制到文件夹",
-        "uploadToServer": "上传到服务器"
-      },
-      "imageFolderPath": {
-        "title": "图片文件夹路径",
-        "description": "图片文件夹路径",
-        "selectFolder": "选择文件夹",
-        "relativePath": "相对路径",
-        "absolutePath": "绝对路径"
-      },
-      "cloudPictureBed": {
-        "title": "云图床",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "七牛",
-        "upyun": "又拍云",
-        "tcyun": "腾讯云",
-        "aliyun": "阿里云",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "首选相对目录",
-        "description": "图片首选相对目录"
-      },
       "uploader": {
         "title": "图片上传器",
         "currentUploader": "当前上传器",
         "picgoNotInstalled": "PicGo 未安装",
-        "picgoDetectionStatus": "PicGo 检测状态",
         "picgoInstalled": "PicGo 已安装",
         "picgoDetectionFailed": "PicGo 检测失败",
         "debugInfo": "调试信息",
-        "installCommand": "安装命令",
         "npmInstallCommand": "npm install picgo -g",
         "yarnInstallCommand": "yarn global add picgo",
         "pnpmInstallCommand": "pnpm add -g picgo",
         "chooseInstallMethod": "选择安装方式：",
         "retestPicgo": "重新检测",
-        "detecting": "检测中…",
         "lastDetectionTime": "上次检测时间",
-        "detectionStatus": "检测状态",
         "picgoDetection": "PicGo 检测",
         "usageGuide": {
           "title": "PicGo 基本使用说明",
@@ -691,17 +610,9 @@
           "step3Description": "使用以下命令查看当前配置：",
           "documentation": "查看完整文档"
         },
-        "autoDetection": "自动检测中",
         "lastSuccessTime": "上次成功时间",
         "neverDetected": "从未检测",
         "neverSuccessful": "从未成功",
-        "configureUploader": "配置上传器",
-        "configureDescription": "使用以下命令配置 PicGo 上传器：",
-        "uploadImage": "上传图片",
-        "uploadDescription": "使用以下命令上传图片：",
-        "viewConfig": "查看配置",
-        "viewConfigDescription": "使用以下命令查看当前配置：",
-        "viewDocumentation": "查看完整文档",
         "scriptDescription": "脚本描述",
         "scriptLocation": "脚本位置",
         "save": "保存",
@@ -718,44 +629,12 @@
     },
     "markdown": {
       "title": "Markdown",
-      "listItem": {
-        "title": "列表项",
-        "preferLooseListItem": "首选宽松列表项",
-        "bulletListMarker": "无序列表标记",
-        "orderListDelimiter": "有序列表分隔符",
-        "listIndentation": {
-          "title": "列表缩进",
-          "dfm": "默认格式模式",
-          "tab": "制表符",
-          "oneSpace": "一个空格",
-          "twoSpaces": "两个空格",
-          "threeSpaces": "三个空格",
-          "fourSpaces": "四个空格"
-        }
-      },
-      "heading": {
-        "title": "标题",
-        "preferHeadingStyle": "首选标题样式"
-      },
-      "frontmatter": {
-        "title": "前置元数据",
-        "frontmatterType": "前置元数据类型"
-      },
       "extensions": {
         "title": "扩展",
         "superSubScript": "上标/下标",
         "footnote": "脚注",
-        "isHtmlEnabled": "启用 HTML",
-        "isGitlabCompatibilityEnabled": "GitLab 兼容性",
-        "sequenceTheme": "序列主题",
-        "superscript": "上标",
-        "subscript": "下标",
-        "frontMatter": "前置元数据",
-        "math": "数学",
-        "diagram": "图表",
         "footnoteNotes": "脚注注释",
         "frontmatterType": {
-          "frontmatterType": "前置元数据类型",
           "jsonBrace": "带大括号的 JSON",
           "jsonSemicolon": "带分号的 JSON",
           "title": "前置元数据类型"
@@ -763,12 +642,6 @@
       },
       "diagrams": {
         "title": "图表",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "流程图",
-        "sequence": "序列图",
-        "gantt": "甘特图",
         "sequenceTheme": {
           "title": "序列图主题",
           "handDrawn": "手绘",
@@ -777,11 +650,6 @@
         "plantumlServer": {
           "title": "PlantUML 服务器 URL"
         }
-      },
-      "math": {
-        "title": "数学",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -812,28 +680,13 @@
         "title": "列表"
       }
     },
-    "spelling": {
-      "title": "拼写",
-      "enabled": "启用拼写检查器",
-      "autoDetectLanguage": "自动检测语言",
-      "language": "语言",
-      "noSuggestions": "无建议",
-      "spellcheckerEnabled": "启用拼写检查器",
-      "spellcheckerNoUnderline": "拼写错误不显示下划线",
-      "spellcheckerLanguage": "拼写检查器语言"
-    },
     "theme": {
       "title": "主题",
-      "theme": "主题",
       "followSystemTheme": "跟随系统主题",
       "modeThemes": "主题选择",
       "lightModeTheme": "浅色模式主题",
       "darkModeTheme": "深色模式主题",
       "customCss": "自定义 CSS",
-      "codeBlockTheme": {
-        "title": "代码块主题",
-        "description": "代码块的主题"
-      },
       "importCustomThemes": "导入自定义主题",
       "importTheme": "导入主题",
       "openFolder": "打开文件夹",
@@ -842,13 +695,6 @@
     "keybindings": {
       "title": "快捷键",
       "description": "自定义键盘快捷键",
-      "searchPlaceholder": "搜索快捷键",
-      "command": "命令",
-      "keybinding": "快捷键",
-      "reset": "重置",
-      "resetAll": "重置全部",
-      "edit": "编辑",
-      "cancel": "取消",
       "save": "保存",
       "restoreDefaults": "恢复默认",
       "debugOptions": "调试选项",
@@ -890,14 +736,6 @@
       "title": "拼写检查器"
     }
   },
-  "edit": {
-    "undo": "撤销",
-    "redo": "重做",
-    "cut": "剪切",
-    "copy": "复制",
-    "paste": "粘贴",
-    "selectAll": "全选"
-  },
   "about": {
     "copyright": "版权",
     "copyrightContributors": "版权贡献者"
@@ -918,11 +756,9 @@
       "renameFile": "重命名文件",
       "quickOpen": "快速打开",
       "changeEncoding": "更改编码",
-      "lineEnding": "行结束符",
       "trailingNewline": "尾随换行",
       "print": "打印",
       "preferences": "偏好设置",
-      "close": "关闭",
       "closeTab": "关闭标签页",
       "closeWindow": "关闭窗口",
       "quit": "退出",
@@ -952,7 +788,6 @@
       "findPrevious": "查找上一个",
       "replace": "替换",
       "findInFolder": "在文件夹中查找",
-      "mathBlock": "数学块",
       "screenshot": "截图"
     },
     "paragraph": {
@@ -1016,8 +851,6 @@
       "toggleTabbar": "切换标签栏",
       "toggleDevTools": "切换开发者工具",
       "actualSize": "实际大小",
-      "zoomIn": "放大",
-      "zoomOut": "缩小",
       "devToggleDeveloperTools": "切换开发者工具",
       "devReload": "开发者重载",
       "reloadImages": "重新加载图片",
@@ -1042,10 +875,6 @@
     "docs": {
       "userGuide": "用户指南",
       "markdownSyntax": "Markdown 语法"
-    },
-    "utils": {
-      "noUpdateResourceFile": "没有更新资源文件",
-      "todoUpdateCheck": "检查更新"
     },
     "spellchecker": {
       "switchLanguage": "切换拼写检查语言"
@@ -1092,25 +921,6 @@
       "anchorLinkCopied": "锚点链接已复制",
       "tabNotFound": "未找到标签页",
       "tocItemNotFound": "未找到目录项",
-      "highlightStart": "[高亮开始]",
-      "highlightEnd": "[高亮结束]",
-      "typeAtToInsert": "输入 / 来插入",
-      "inputFootnoteDefinition": "输入脚注定义…",
-      "inputYamlFrontMatter": "输入 YAML 前置元数据",
-      "inputLanguageIdentifier": "输入语言标识符…",
-      "inputMathematicalFormula": "输入数学公式…",
-      "fence": "围栏",
-      "indent": "缩进",
-      "frontMatterDelimiter": "---",
-      "mathDelimiter": "$$",
-      "mermaidStart": "``` mermaid",
-      "flowchartStart": "``` flowchart",
-      "sequenceStart": "``` sequence",
-      "plantumlStart": "``` plantuml",
-      "vegaLiteStart": "``` vega-lite",
-      "codeFence": "```",
-      "clickToAddImage": "点击添加图片",
-      "loadImageFailed": "图片加载失败",
       "errorLoadingTabTitle": "加载标签页出错",
       "errorLoadingTabMessage": "加载文件变更时发生错误，因为找不到该标签页。",
       "mixedLineEndingsNormalized": "“{name}” 含有混合换行符，已自动规范化为 {lineEnding}。",
@@ -1127,204 +937,7 @@
     "failedToRemoveWord": "从词典中删除单词失败",
     "unexpectedError": "意外的拼写检查器错误"
   },
-  "quickInsert": {
-    "basicBlock": "基础块",
-    "header": "标题",
-    "advancedBlock": "高级块",
-    "listBlock": "列表块",
-    "diagram": "图表",
-    "paragraph": {
-      "title": "段落",
-      "subtitle": "输入文本内容"
-    },
-    "horizontalLine": {
-      "title": "水平分割线",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "前置元数据",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "标题 1",
-      "subtitle": "# 标题"
-    },
-    "header2": {
-      "title": "标题 2",
-      "subtitle": "## 标题"
-    },
-    "header3": {
-      "title": "标题 3",
-      "subtitle": "### 标题"
-    },
-    "header4": {
-      "title": "标题 4",
-      "subtitle": "#### 标题"
-    },
-    "header5": {
-      "title": "标题 5",
-      "subtitle": "##### 标题"
-    },
-    "header6": {
-      "title": "标题 6",
-      "subtitle": "###### 标题"
-    },
-    "tableBlock": {
-      "title": "表格块",
-      "subtitle": "｜ 标题 ｜ 标题 ｜"
-    },
-    "mathFormula": {
-      "title": "数学公式",
-      "subtitle": "$$ 公式 $$"
-    },
-    "htmlBlock": {
-      "title": "HTML 块",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "代码块",
-      "subtitle": "``` 代码 ```"
-    },
-    "quoteBlock": {
-      "title": "引用块",
-      "subtitle": "> 引用内容"
-    },
-    "orderedList": {
-      "title": "有序列表",
-      "subtitle": "1. 列表项"
-    },
-    "bulletList": {
-      "title": "无序列表",
-      "subtitle": "- 列表项"
-    },
-    "todoList": {
-      "title": "任务列表",
-      "subtitle": "- [ ] 任务项"
-    },
-    "vegaChart": {
-      "title": "Vega-Lite图表",
-      "subtitle": "数据可视化图表"
-    },
-    "flowChart": {
-      "title": "流程图",
-      "subtitle": "流程图表"
-    },
-    "sequenceChart": {
-      "title": "时序图",
-      "subtitle": "时序图表"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML图表",
-      "subtitle": "UML图表"
-    },
-    "mermaid": {
-      "title": "Mermaid图表",
-      "subtitle": "Mermaid图表",
-      "gantt": {
-        "title": "甘特图"
-      },
-      "pie": {
-        "title": "饼图"
-      },
-      "flowchart": {
-        "title": "流程图"
-      },
-      "sequence": {
-        "title": "时序图"
-      },
-      "class": {
-        "title": "类图"
-      },
-      "state": {
-        "title": "状态图",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "用户旅程"
-      },
-      "git": {
-        "title": "Git图"
-      },
-      "er": {
-        "title": "ER图"
-      },
-      "requirement": {
-        "title": "需求图"
-      }
-    },
-    "taskList": {
-      "title": "任务列表"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite图表"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML图表"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid图表"
-    }
-  },
-  "frontMenu": {
-    "duplicate": "创建副本",
-    "turnInto": "转换为",
-    "newParagraph": "新段落",
-    "delete": "删除",
-    "paragraph": "段落",
-    "table": "表格",
-    "html": "HTML",
-    "mathblock": "数学公式块",
-    "pre": "代码块",
-    "frontMatter": "前置信息",
-    "ulTask": "任务列表",
-    "ulBullet": "无序列表",
-    "olOrder": "有序列表",
-    "blockquote": "引用块",
-    "heading1": "一级标题",
-    "heading2": "二级标题",
-    "heading3": "三级标题",
-    "heading4": "四级标题",
-    "heading5": "五级标题",
-    "heading6": "六级标题",
-    "hr": "分隔线"
-  },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "选择",
-          "embedLink": "插入链接"
-        },
-        "select": {
-          "chooseButton": "选择图片",
-          "tip": "从你的电脑选择图片。"
-        },
-        "inputs": {
-          "alt": "替代文本",
-          "src": "图片链接或本地路径",
-          "title": "图片标题"
-        },
-        "embedButton": "嵌入图片",
-        "hint": {
-          "prefix": "粘贴网络图片或本地路径。切换模式",
-          "simple": "简洁模式",
-          "full": "完整模式"
-        }
-      },
-      "toolbar": {
-        "edit": "编辑图片",
-        "inline": "行内图片",
-        "alignLeft": "左对齐",
-        "alignCenter": "居中对齐",
-        "alignRight": "右对齐",
-        "delete": "删除图片"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "输入 YAML 前置信息",
-      "languageIdentifier": "输入语言标识符…",
-      "mathFormula": "输入数学公式…"
-    },
     "insertTable": {
       "title": "插入表格",
       "rows": "行",
@@ -1351,53 +964,7 @@
       "disabledError": "拼写检查已禁用错误",
       "errorSwitchingLanguage": "切换拼写检查语言时出错",
       "languageMissing": "拼写检查语言缺失",
-      "switchError": "拼写检查切换错误",
-      "disabled": "拼写检查已禁用",
-      "enabled": "拼写检查已启用",
-      "enabledError": "启用拼写检查时出错"
-    },
-    "table": "表格",
-    "resizeTable": "调整表格大小",
-    "left": "左对齐",
-    "alignLeft": "左对齐",
-    "center": "居中对齐",
-    "alignCenter": "居中对齐",
-    "right": "右对齐",
-    "alignRight": "右对齐",
-    "delete": "删除",
-    "deleteTable": "删除表格",
-    "insertRowAbove": "在上方插入行",
-    "insertRowBelow": "在下方插入行",
-    "removeRow": "删除行",
-    "insertColumnLeft": "在左侧插入列",
-    "insertColumnRight": "在右侧插入列",
-    "removeColumn": "删除列",
-    "copyContent": "复制内容",
-    "emptyMathFormula": "< 空数学公式 >",
-    "invalidMathFormula": "< 无效数学公式 >",
-    "emptyMermaidBlock": "< 空 Mermaid 块 >",
-    "loading": "加载中…",
-    "emptyDiagramBlock": "< 空图表块 >",
-    "emptyHtmlBlock": "< 空 HTML 块 >",
-    "onlyTopBlockCanRenderIcon": "只有顶级块可以渲染前置图标按钮。",
-    "unhandledFunctionType": "未处理的功能类型: {functionType}",
-    "highlight-start": "[高亮开始]",
-    "highlight-end": "[高亮结束]",
-    "type-at-to-insert": "输入 / 来插入",
-    "input-footnote-definition": "输入脚注定义",
-    "input-yaml-front-matter": "输入 YAML 前置内容",
-    "input-language-identifier": "输入语言标识符",
-    "input-mathematical-formula": "输入数学公式",
-    "fence": "围栏",
-    "indent": "缩进",
-    "front-matter-delimiter": "前置内容分隔符",
-    "math-delimiter": "数学分隔符",
-    "mermaid-start": "mermaid 开始",
-    "flowchart-start": "流程图 开始",
-    "sequence-start": "时序图 开始",
-    "plantuml-start": "plantuml 开始",
-    "vega-lite-start": "vega-lite 开始",
-    "click-to-add-image": "点击添加图片",
-    "load-image-failed": "图片加载失败"
+      "switchError": "拼写检查切换错误"
+    }
   }
 }

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -220,7 +220,6 @@
     "replaceSingle": "单个替换",
     "invalidRegex": "无效的正则表达式 \"{pattern}\"",
     "regexMatchEmpty": "正则表达式 \"{pattern}\" 匹配到了空字符串",
-    "searchResultCount": "搜索结果",
     "searchResultInfo": "在 {fileCount} 个文件中找到 {matchCount} 个匹配项",
     "searchLimited": "仅搜索前 {count} 个结果"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "自动保存正在编辑的内容",
         "autoSaveDelay": "文件保存前的延迟时间（毫秒）",
-        "autoNormalizeLineEndings": "打开时自动将行尾规范化为 LF，可选择处理末尾换行符",
+        "autoNormalizeLineEndings": "打开文件时自动规范化行尾。禁用时按原样打开文件",
         "titleBarStyle": "标题栏样式（仅限 Windows 和 Linux 系统）",
         "openFilesInNewWindow": "在新窗口中打开文件",
         "openFolderInNewWindow": "通过菜单在新窗口中打开文件夹",
@@ -414,7 +413,6 @@
         "followSystemTheme": "跟随系统主题",
         "lightModeTheme": "系统处于浅色模式时使用的主题",
         "darkModeTheme": "系统处于深色模式时使用的主题",
-        "customCss": "应用到当前主题的自定义 CSS",
         "spellcheckerEnabled": "是否启用拼写检查",
         "spellcheckerNoUnderline": "不要为拼写错误添加下划线",
         "spellcheckerLanguage": "拼写检查器语言",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "是否首选相对图片目录",
         "imageRelativeDirectoryBase": "相对图片的复制位置",
         "imageRelativeDirectoryName": "相对图片文件夹名称",
-        "sideBarVisibility": "侧边栏是否可见",
-        "tabBarVisibility": "是否显示标签页",
-        "sourceCodeModeEnabled": "是否默认启用源代码模式",
-        "searchExclusions": "要从搜索中排除的 glob 模式列表",
-        "searchMaxFileSize": "最大文件大小（<maxFileSize><suffix>）。如果没有后缀，允许使用 K、M 或 G 后缀，数字会被视为字节",
-        "searchIncludeHidden": "是否在隐藏文件和目录中搜索",
-        "searchNoIgnore": "是否忽略像 .gitignore 这样的忽略文件",
-        "searchFollowSymlinks": "是否应该跟随符号链接",
-        "watcherUsePolling": "是否使用轮询。轮询可能导致高 CPU 使用率，但对于监视网络上的文件是必要的"
+        "fileSortOrder": "打开文件夹中文件的排序顺序：升序或降序",
+        "openedFilesInSidebar": "是否在侧边栏中显示已打开文件"
       }
     },
     "categories": {

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -7,10 +7,8 @@
     },
     "file": {
       "file": "檔案",
-      "new": "新建",
       "newTab": "新建標籤頁",
       "newWindow": "新建視窗",
-      "open": "開啟",
       "openFile": "開啟檔案…",
       "openFolder": "開啟資料夾…",
       "openRecent": "開啟最近使用",
@@ -25,9 +23,6 @@
       "exportPdf": "匯出為 PDF",
       "import": "匯入",
       "print": "列印",
-      "recent": "最近檔案",
-      "close": "關閉",
-      "closeAll": "全部關閉",
       "closeTab": "關閉標籤頁",
       "closeWindow": "關閉視窗",
       "quit": "退出",
@@ -70,26 +65,19 @@
       "demoteHeading": "降低標題級別",
       "table": "表格",
       "codeFences": "程式碼圍欄",
-      "codeBlock": "程式碼區塊",
       "quoteBlock": "引用區塊",
       "mathBlock": "數學區塊",
       "htmlBlock": "HTML 區塊",
-      "quote": "引用",
       "orderedList": "有序清單",
       "bulletList": "項目符號清單",
-      "unorderedList": "無序清單",
       "taskList": "任務清單",
       "looseListItem": "鬆散清單項目",
-      "paragraphItem": "段落項目",
       "horizontalRule": "水平線",
       "frontMatter": "前置資料"
     },
     "window": {
       "title": "視窗",
-      "window": "視窗",
       "minimize": "最小化",
-      "close": "關閉",
-      "zoom": "縮放",
       "zoomIn": "放大",
       "zoomOut": "縮小",
       "fullScreen": "全螢幕",
@@ -106,20 +94,16 @@
       "followUs": "關注我們",
       "support": "支持 MarkText",
       "license": "授權條款",
-      "checkForUpdates": "檢查更新",
-      "aboutMarkText": "關於 MarkText",
       "about": "關於",
       "checkUpdates": "檢查更新"
     },
     "marktext": {
       "title": "關於",
-      "marktext": "MarkText",
       "about": "關於 MarkText",
       "checkUpdates": "檢查更新…",
       "preferences": "偏好設定",
       "services": "服務",
       "hide": "隱藏 MarkText",
-      "hideMarkText": "隱藏 MarkText",
       "hideOthers": "隱藏其他",
       "showAll": "顯示全部",
       "quit": "退出 MarkText"
@@ -129,14 +113,9 @@
       "toggleSidebar": "切換側邊欄",
       "toggleTabbar": "切換標籤欄",
       "commandPalette": "命令面板",
-      "sourceCode": "原始碼模式",
       "sourceCodeMode": "原始碼模式",
-      "typewriter": "打字機模式",
       "typewriterMode": "打字機模式",
-      "focus": "專注模式",
       "focusMode": "專注模式",
-      "showTabBar": "顯示標籤欄",
-      "toc": "目錄",
       "toggleTableOfContents": "切換目錄",
       "reloadImages": "重新載入圖片",
       "showDeveloperTools": "顯示開發者工具",
@@ -148,35 +127,18 @@
       "italic": "斜體",
       "underline": "底線",
       "strikethrough": "刪除線",
-      "code": "行內程式碼",
-      "codeBlock": "程式碼區塊",
-      "quote": "引用",
-      "unorderedList": "無序清單",
-      "orderedList": "有序清單",
-      "taskList": "任務清單",
-      "table": "表格",
-      "link": "連結",
       "image": "圖片",
-      "heading1": "標題 1",
-      "heading2": "標題 2",
-      "heading3": "標題 3",
-      "heading4": "標題 4",
-      "heading5": "標題 5",
-      "heading6": "標題 6",
       "superscript": "上標",
       "subscript": "下標",
       "highlight": "螢光標記",
       "inlineCode": "行內程式碼",
       "inlineMath": "行內數學",
       "hyperlink": "超連結",
-      "clearFormatting": "清除格式",
       "clearFormat": "清除格式"
     },
     "theme": {
       "theme": "主題(&T)",
-      "light": "淺色",
       "dark": "深色",
-      "auto": "自動",
       "followThemDisabled": "跟隨系統主題時無法選擇主題",
       "lightThemes": "— 淺色主題 —",
       "darkThemes": "— 深色主題 —",
@@ -376,13 +338,6 @@
       }
     }
   },
-  "table": {
-    "resizeTable": "調整表格大小",
-    "alignLeft": "靠左對齊",
-    "alignCenter": "置中對齊",
-    "alignRight": "靠右對齊",
-    "deleteTable": "刪除表格"
-  },
   "recent": {
     "noTabsOpen": "您沒有開啟的標籤頁。",
     "newFile": "新建檔案"
@@ -395,7 +350,6 @@
     "title": "偏好設定",
     "search": {
       "placeholder": "搜尋偏好設定…",
-      "optionalValues": "可選值",
       "categories": {
         "general": "一般",
         "editor": "編輯器",
@@ -500,7 +454,6 @@
         "titleBarStyle": {
           "title": "標題欄樣式",
           "custom": "自訂",
-          "titleBarStyle": "標題欄樣式",
           "native": "原生"
         },
         "requiresRestart": "需要重新啟動",
@@ -633,54 +586,20 @@
         "relativeFolderName": "相對資料夾名稱",
         "filenameNote": "檔案名稱將自動產生。"
       },
-      "imageInsertAction": {
-        "title": "圖片插入動作",
-        "folder": "上傳到資料夾",
-        "path": "複製到路徑",
-        "upload": "上傳到雲端",
-        "copyToFolder": "複製到資料夾",
-        "uploadToServer": "上傳到伺服器"
-      },
-      "imageFolderPath": {
-        "title": "圖片資料夾路徑",
-        "description": "圖片資料夾路徑",
-        "selectFolder": "選擇資料夾",
-        "relativePath": "相對路徑",
-        "absolutePath": "絕對路徑"
-      },
-      "cloudPictureBed": {
-        "title": "雲端圖床",
-        "github": "GitHub",
-        "smms": "SM.MS",
-        "qiniu": "七牛",
-        "upyun": "又拍雲",
-        "tcyun": "騰訊雲",
-        "aliyun": "阿里雲",
-        "imgur": "Imgur",
-        "picgo": "PicGo"
-      },
-      "preferRelativeDirectory": {
-        "title": "偏好相對目錄",
-        "description": "圖片偏好相對目錄"
-      },
       "uploader": {
         "title": "圖片上傳器",
         "currentUploader": "目前上傳器",
         "picgoNotInstalled": "PicGo 未安裝",
-        "picgoDetectionStatus": "PicGo 偵測狀態",
         "picgoInstalled": "PicGo 已安裝",
         "picgoDetectionFailed": "PicGo 偵測失敗",
         "debugInfo": "除錯資訊",
-        "installCommand": "安裝命令",
         "npmInstallCommand": "npm install picgo",
         "yarnInstallCommand": "yarn add picgo",
         "pnpmInstallCommand": "pnpm add picgo",
         "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "選擇安裝方法：",
         "retestPicgo": "重新檢測",
-        "detecting": "檢測中…",
         "lastDetectionTime": "上次檢測時間",
-        "detectionStatus": "檢測狀態",
         "usageGuide": {
           "title": "PicGo 基本使用說明",
           "step1": "設定上傳器",
@@ -691,13 +610,6 @@
           "step3Description": "使用以下命令檢視目前設定：",
           "documentation": "檢視完整文件"
         },
-        "configureUploader": "設定上傳器",
-        "configureDescription": "使用以下命令設定 PicGo 上傳器：",
-        "uploadImage": "上傳圖片",
-        "uploadDescription": "使用以下命令上傳圖片：",
-        "viewConfig": "檢視設定",
-        "viewConfigDescription": "使用以下命令檢視目前設定：",
-        "viewDocumentation": "檢視完整文件",
         "scriptDescription": "腳本描述",
         "scriptLocation": "腳本位置",
         "save": "儲存",
@@ -710,7 +622,6 @@
         "pleaseInstall": "請安裝",
         "scriptPath": "腳本路徑",
         "picgoDetection": "PicGo 偵測",
-        "autoDetection": "自動偵測中",
         "lastSuccessTime": "上次成功時間",
         "neverDetected": "從未偵測",
         "neverSuccessful": "從未成功"
@@ -719,44 +630,12 @@
     },
     "markdown": {
       "title": "PicGo 設定",
-      "listItem": {
-        "title": "清單項目",
-        "preferLooseListItem": "偏好鬆散清單項目",
-        "bulletListMarker": "項目符號清單標記",
-        "orderListDelimiter": "有序清單分隔符",
-        "listIndentation": {
-          "title": "清單縮排",
-          "dfm": "預設格式模式",
-          "tab": "製表符",
-          "oneSpace": "一個空格",
-          "twoSpaces": "兩個空格",
-          "threeSpaces": "三個空格",
-          "fourSpaces": "四個空格"
-        }
-      },
-      "heading": {
-        "title": "標題",
-        "preferHeadingStyle": "偏好標題樣式"
-      },
-      "frontmatter": {
-        "title": "前置資料",
-        "frontmatterType": "前置資料類型"
-      },
       "extensions": {
         "title": "擴充功能",
         "superSubScript": "上標/下標",
         "footnote": "腳註",
-        "isHtmlEnabled": "HTML 已啟用",
-        "isGitlabCompatibilityEnabled": "GitLab 相容性",
-        "sequenceTheme": "序列主題",
-        "superscript": "上標",
-        "subscript": "下標",
-        "frontMatter": "前置資料",
-        "math": "數學",
-        "diagram": "圖表",
         "footnoteNotes": "腳註備註",
         "frontmatterType": {
-          "frontmatterType": "前置資料類型",
           "jsonBrace": "JSON 大括號",
           "jsonSemicolon": "JSON 分號",
           "title": "前置資料類型"
@@ -764,12 +643,6 @@
       },
       "diagrams": {
         "title": "圖表",
-        "plantuml": "PlantUML",
-        "mermaid": "Mermaid",
-        "vega": "Vega",
-        "flowchart": "流程圖",
-        "sequence": "序列",
-        "gantt": "甘特圖",
         "sequenceTheme": {
           "title": "序列主題",
           "handDrawn": "手繪",
@@ -778,11 +651,6 @@
         "plantumlServer": {
           "title": "PlantUML 伺服器 URL"
         }
-      },
-      "math": {
-        "title": "數學",
-        "katex": "KaTeX",
-        "mathJax": "MathJax"
       },
       "misc": {
         "preferHeadingStyle": {
@@ -813,28 +681,13 @@
         "title": "清單"
       }
     },
-    "spelling": {
-      "title": "拼字",
-      "enabled": "啟用拼字檢查",
-      "autoDetectLanguage": "自動偵測語言",
-      "language": "語言",
-      "noSuggestions": "無建議",
-      "spellcheckerEnabled": "啟用拼字檢查",
-      "spellcheckerNoUnderline": "拼錯單字不加底線",
-      "spellcheckerLanguage": "拼字檢查語言"
-    },
     "theme": {
       "title": "主題",
-      "theme": "主題",
       "followSystemTheme": "跟隨系統主題",
       "modeThemes": "主題選擇",
       "lightModeTheme": "淺色模式主題",
       "darkModeTheme": "深色模式主題",
       "customCss": "自訂 CSS",
-      "codeBlockTheme": {
-        "title": "程式碼區塊主題",
-        "description": "程式碼區塊的主題"
-      },
       "importCustomThemes": "匯入自訂主題",
       "importTheme": "匯入主題",
       "openFolder": "開啟資料夾",
@@ -843,13 +696,6 @@
     "keybindings": {
       "title": "按鍵綁定",
       "description": "自訂鍵盤快捷鍵",
-      "searchPlaceholder": "搜尋按鍵綁定",
-      "command": "命令",
-      "keybinding": "按鍵綁定",
-      "reset": "重設",
-      "resetAll": "全部重設",
-      "edit": "編輯",
-      "cancel": "取消",
       "save": "儲存",
       "restoreDefaults": "還原預設值",
       "debugOptions": "除錯選項",
@@ -923,9 +769,7 @@
       "exportFile": "匯出檔案",
       "exportFilePdf": "匯出為 PDF",
       "zoom": "縮放",
-      "checkUpdate": "檢查更新",
-      "lineEnding": "行尾字元",
-      "close": "關閉"
+      "checkUpdate": "檢查更新"
     },
     "edit": {
       "undo": "復原",
@@ -945,8 +789,7 @@
       "findPrevious": "尋找上一個",
       "replace": "取代",
       "findInFolder": "在資料夾中尋找",
-      "screenshot": "螢幕截圖",
-      "mathBlock": "數學區塊"
+      "screenshot": "螢幕截圖"
     },
     "paragraph": {
       "heading1": "標題 1",
@@ -1012,8 +855,6 @@
       "reloadImages": "重新載入圖片",
       "textDirection": "文字方向",
       "actualSize": "實際大小",
-      "zoomIn": "放大",
-      "zoomOut": "縮小",
       "devToggleDeveloperTools": "切換開發者工具"
     },
     "tabs": {
@@ -1035,10 +876,6 @@
     "docs": {
       "userGuide": "使用者指南",
       "markdownSyntax": "Markdown 語法"
-    },
-    "utils": {
-      "noUpdateResourceFile": "沒有更新資源檔案",
-      "todoUpdateCheck": "檢查更新"
     },
     "spellchecker": {
       "switchLanguage": "切換語言"
@@ -1085,25 +922,6 @@
       "anchorLinkCopied": "錨點連結已複製",
       "tabNotFound": "找不到標籤頁",
       "tocItemNotFound": "找不到目錄項目",
-      "highlightStart": "[高亮開始]",
-      "highlightEnd": "[高亮結束]",
-      "typeAtToInsert": "輸入 / 來插入",
-      "inputFootnoteDefinition": "輸入腳註定義…",
-      "inputYamlFrontMatter": "輸入 YAML 前置資料…",
-      "inputLanguageIdentifier": "輸入語言識別符…",
-      "inputMathematicalFormula": "輸入數學公式…",
-      "fence": "圍欄",
-      "indent": "縮排",
-      "frontMatterDelimiter": "前置分隔符",
-      "mathDelimiter": "數學分隔符",
-      "mermaidStart": "Mermaid 開始標記",
-      "flowchartStart": "流程圖開始標記",
-      "sequenceStart": "時序圖開始標記",
-      "plantumlStart": "PlantUML 開始標記",
-      "vegaLiteStart": "Vega-Lite 開始標記",
-      "codeFence": "程式碼柵欄",
-      "clickToAddImage": "點擊新增圖片",
-      "loadImageFailed": "圖片載入失敗",
       "errorLoadingTabTitle": "載入標籤頁發生錯誤",
       "errorLoadingTabMessage": "載入檔案變更時發生錯誤，因為找不到該標籤頁。",
       "mixedLineEndingsNormalized": "「{name}」含有混合換行字元，已自動正規化為 {lineEnding}。",
@@ -1121,83 +939,6 @@
     "unexpectedError": "意外的拼字檢查錯誤"
   },
   "quickInsert": {
-    "header": "標題",
-    "paragraph": {
-      "title": "段落",
-      "subtitle": "輸入文字內容"
-    },
-    "horizontalLine": {
-      "title": "水平線",
-      "subtitle": "---"
-    },
-    "frontMatter": {
-      "title": "前置資料",
-      "subtitle": "--- YAML ---"
-    },
-    "header1": {
-      "title": "標題 1",
-      "subtitle": "# 標題"
-    },
-    "header2": {
-      "title": "標題 2",
-      "subtitle": "## 標題"
-    },
-    "header3": {
-      "title": "標題 3",
-      "subtitle": "### 標題"
-    },
-    "header4": {
-      "title": "標題 4",
-      "subtitle": "#### 標題"
-    },
-    "header5": {
-      "title": "標題 5",
-      "subtitle": "##### 標題"
-    },
-    "header6": {
-      "title": "標題 6",
-      "subtitle": "###### 標題"
-    },
-    "tableBlock": {
-      "title": "表格區塊",
-      "subtitle": "｜ 標題 ｜ 標題 ｜"
-    },
-    "mathFormula": {
-      "title": "數學公式",
-      "subtitle": "$$ 公式 $$"
-    },
-    "htmlBlock": {
-      "title": "HTML 區塊",
-      "subtitle": "<div> HTML </div>"
-    },
-    "codeBlock": {
-      "title": "程式碼區塊",
-      "subtitle": "``` 程式碼 ```"
-    },
-    "quoteBlock": {
-      "title": "引用區塊",
-      "subtitle": "> 引用內容"
-    },
-    "orderedList": {
-      "title": "有序清單",
-      "subtitle": "1. 列表項"
-    },
-    "bulletList": {
-      "title": "項目符號清單",
-      "subtitle": "- 列表項"
-    },
-    "todoList": {
-      "title": "待辦清單",
-      "subtitle": "- [x]"
-    },
-    "vegaChart": {
-      "title": "Vega 圖表",
-      "subtitle": "使用 vega-lite.js 渲染圖表。"
-    },
-    "flowChart": {
-      "title": "流程圖",
-      "subtitle": "流程圖表"
-    },
     "sequenceDiagram": {
       "title": "序列圖",
       "subtitle": "使用 js-sequence 渲染序列圖。"
@@ -1205,127 +946,9 @@
     "plantumlDiagram": {
       "title": "PlantUML 圖表",
       "subtitle": "渲染 PlantUML 圖表"
-    },
-    "mermaid": {
-      "title": "Mermaid",
-      "subtitle": "使用 mermaid 渲染圖表。",
-      "gantt": {
-        "title": "甘特圖"
-      },
-      "pie": {
-        "title": "圓餅圖"
-      },
-      "flowchart": {
-        "title": "流程圖"
-      },
-      "sequence": {
-        "title": "序列圖"
-      },
-      "class": {
-        "title": "類別圖"
-      },
-      "state": {
-        "title": "狀態圖",
-        "subtitle": "stateDiagram"
-      },
-      "journey": {
-        "title": "使用者旅程"
-      },
-      "git": {
-        "title": "Git 圖表"
-      },
-      "er": {
-        "title": "ER 圖"
-      },
-      "requirement": {
-        "title": "需求圖"
-      }
-    },
-    "sequenceChart": {
-      "title": "序列圖表",
-      "subtitle": "時序圖表"
-    },
-    "plantUMLChart": {
-      "title": "PlantUML 圖表",
-      "subtitle": "渲染 PlantUML 圖表"
-    },
-    "taskList": {
-      "title": "任務清單"
-    },
-    "vegaliteChart": {
-      "title": "Vega-Lite 圖表"
-    },
-    "plantUMLDiagram": {
-      "title": "PlantUML 圖表"
-    },
-    "mermaidDiagram": {
-      "title": "Mermaid 圖表"
-    },
-    "basicBlock": "基礎塊",
-    "advancedBlock": "高級塊",
-    "listBlock": "列表塊",
-    "diagram": "圖表"
-  },
-  "frontMenu": {
-    "duplicate": "複製",
-    "turnInto": "轉換為",
-    "newParagraph": "新段落",
-    "delete": "刪除",
-    "paragraph": "段落",
-    "table": "表格",
-    "html": "HTML",
-    "mathblock": "數學區塊",
-    "pre": "程式碼區塊",
-    "frontMatter": "前置資料",
-    "ulTask": "任務清單",
-    "ulBullet": "項目符號清單",
-    "olOrder": "有序清單",
-    "blockquote": "引用區塊",
-    "heading1": "標題 1",
-    "heading2": "標題 2",
-    "heading3": "標題 3",
-    "heading4": "標題 4",
-    "heading5": "標題 5",
-    "heading6": "標題 6",
-    "hr": "水平線"
+    }
   },
   "editor": {
-    "image": {
-      "selector": {
-        "tab": {
-          "select": "選擇",
-          "embedLink": "插入連結"
-        },
-        "select": {
-          "chooseButton": "選擇圖片",
-          "tip": "從你的電腦選擇圖片。"
-        },
-        "inputs": {
-          "alt": "替代文字",
-          "src": "圖片連結或本機路徑",
-          "title": "圖片標題"
-        },
-        "embedButton": "嵌入圖片",
-        "hint": {
-          "prefix": "貼上網路圖片或本機路徑。切換模式",
-          "simple": "精簡模式",
-          "full": "完整模式"
-        }
-      },
-      "toolbar": {
-        "edit": "編輯圖片",
-        "inline": "行內圖片",
-        "alignLeft": "靠左對齊",
-        "alignCenter": "置中對齊",
-        "alignRight": "靠右對齊",
-        "delete": "刪除圖片"
-      }
-    },
-    "placeholders": {
-      "frontMatter": "輸入 YAML 前置資料…",
-      "languageIdentifier": "輸入語言識別碼…",
-      "mathFormula": "輸入數學公式…"
-    },
     "export": {
       "error": "匯出錯誤",
       "errorExporting": "匯出檔案時發生錯誤",
@@ -1348,65 +971,11 @@
       "imageStructureDeletedComment": "圖片結構已刪除註解"
     },
     "spellcheck": {
-      "enabled": "拼字檢查已啟用",
-      "disabled": "拼字檢查已停用",
-      "enabledError": "拼字檢查啟用錯誤",
       "disabledError": "拼字檢查停用錯誤",
       "errorSwitchingLanguage": "切換拼字檢查語言時發生錯誤",
       "languageMissing": "拼字檢查語言遺失",
       "switchError": "拼字檢查切換錯誤",
       "title": "拼字檢查"
-    },
-    "table": "表格",
-    "resizeTable": "調整表格大小",
-    "left": "靠左對齊",
-    "alignLeft": "靠左對齊",
-    "center": "置中對齊",
-    "alignCenter": "置中對齊",
-    "right": "靠右對齊",
-    "alignRight": "靠右對齊",
-    "delete": "刪除",
-    "deleteTable": "刪除表格",
-    "insertRowAbove": "在上方插入列",
-    "insertRowBelow": "在下方插入列",
-    "removeRow": "刪除列",
-    "insertColumnLeft": "在左側插入欄",
-    "insertColumnRight": "在右側插入欄",
-    "removeColumn": "刪除欄",
-    "copyContent": "複製內容",
-    "emptyMathFormula": "< 空數學公式 >",
-    "invalidMathFormula": "< 無效數學公式 >",
-    "emptyMermaidBlock": "< 空 Mermaid 區塊 >",
-    "loading": "載入中…",
-    "emptyDiagramBlock": "< 空圖表區塊 >",
-    "emptyHtmlBlock": "< 空 HTML 區塊 >",
-    "onlyTopBlockCanRenderIcon": "只有最上層區塊可以渲染前置圖示按鈕。",
-    "unhandledFunctionType": "未處理的功能類型: {functionType}",
-    "highlight-start": "[高亮開始]",
-    "highlight-end": "[高亮結束]",
-    "type-at-to-insert": "輸入 / 來插入",
-    "input-footnote-definition": "輸入腳註定義",
-    "input-yaml-front-matter": "輸入 YAML 前置內容",
-    "input-language-identifier": "輸入語言識別符",
-    "input-mathematical-formula": "輸入數學公式",
-    "fence": "圍欄",
-    "indent": "縮排",
-    "front-matter-delimiter": "前置內容分隔符",
-    "math-delimiter": "數學分隔符",
-    "mermaid-start": "mermaid 開始",
-    "flowchart-start": "流程圖 開始",
-    "sequence-start": "時序圖 開始",
-    "plantuml-start": "plantuml 開始",
-    "vega-lite-start": "vega-lite 開始",
-    "click-to-add-image": "點擊新增圖片",
-    "load-image-failed": "圖片載入失敗"
-  },
-  "edit": {
-    "undo": "復原",
-    "redo": "重做",
-    "cut": "剪下",
-    "copy": "複製",
-    "paste": "貼上",
-    "selectAll": "全選"
+    }
   }
 }

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -220,7 +220,6 @@
     "replaceSingle": "單一取代",
     "invalidRegex": "無效的正規表示式 \"{pattern}\"",
     "regexMatchEmpty": "正規表示式 \"{pattern}\" 符合空字串",
-    "searchResultCount": "搜尋結果",
     "searchResultInfo": "在 {fileCount} 個檔案中找到 {matchCount} 個符合項目",
     "searchLimited": "搜尋僅限前 {count} 個結果"
   },
@@ -365,7 +364,7 @@
       "items": {
         "autoSave": "自動儲存正在編輯的內容",
         "autoSaveDelay": "檔案儲存前的延遲時間（毫秒）",
-        "autoNormalizeLineEndings": "開啟時自動將行尾標準化為 LF，可選擇處理結尾換行符",
+        "autoNormalizeLineEndings": "開啟檔案時自動將行尾標準化。停用時，檔案會以原樣開啟",
         "titleBarStyle": "標題欄樣式（僅限 Windows 和 Linux 系統）",
         "openFilesInNewWindow": "在新視窗中開啟檔案",
         "openFolderInNewWindow": "透過選單在新視窗中開啟資料夾",
@@ -414,7 +413,6 @@
         "followSystemTheme": "跟隨系統主題",
         "lightModeTheme": "系統處於淺色模式時使用的主題",
         "darkModeTheme": "系統處於深色模式時使用的主題",
-        "customCss": "套用到當前主題的自訂 CSS",
         "spellcheckerEnabled": "是否啟用拼字檢查",
         "spellcheckerNoUnderline": "不要為拼字錯誤加上底線",
         "spellcheckerLanguage": "拼字檢查器語言",
@@ -422,15 +420,8 @@
         "imagePreferRelativeDirectory": "是否首選相對圖片目錄",
         "imageRelativeDirectoryBase": "相對圖片的複製位置",
         "imageRelativeDirectoryName": "相對圖片資料夾名稱",
-        "sideBarVisibility": "側邊欄是否可見",
-        "tabBarVisibility": "是否顯示標籤頁",
-        "sourceCodeModeEnabled": "是否預設啟用原始碼模式",
-        "searchExclusions": "要從搜尋中排除的 glob 模式清單",
-        "searchMaxFileSize": "最大檔案大小（<maxFileSize><suffix>）。如果沒有後綴，允許使用 K、M 或 G 後綴，數字會被視為位元組",
-        "searchIncludeHidden": "是否在隱藏檔案和目錄中搜尋",
-        "searchNoIgnore": "是否忽略像 .gitignore 這樣的忽略檔案",
-        "searchFollowSymlinks": "是否應該跟隨符號連結",
-        "watcherUsePolling": "是否使用輪詢。輪詢可能導致高 CPU 使用率，但對於監視網路上的檔案是必要的"
+        "fileSortOrder": "開啟資料夾中檔案的排序順序：遞增或遞減",
+        "openedFilesInSidebar": "是否在側邊欄中顯示已開啟的檔案"
       }
     },
     "categories": {
@@ -596,7 +587,6 @@
         "npmInstallCommand": "npm install picgo",
         "yarnInstallCommand": "yarn add picgo",
         "pnpmInstallCommand": "pnpm add picgo",
-        "brewInstallCommand": "brew install picgo",
         "chooseInstallMethod": "選擇安裝方法：",
         "retestPicgo": "重新檢測",
         "lastDetectionTime": "上次檢測時間",
@@ -937,16 +927,6 @@
   "spellchecker": {
     "failedToRemoveWord": "從字典中移除單字失敗",
     "unexpectedError": "意外的拼字檢查錯誤"
-  },
-  "quickInsert": {
-    "sequenceDiagram": {
-      "title": "序列圖",
-      "subtitle": "使用 js-sequence 渲染序列圖。"
-    },
-    "plantumlDiagram": {
-      "title": "PlantUML 圖表",
-      "subtitle": "渲染 PlantUML 圖表"
-    }
   },
   "editor": {
     "export": {

--- a/packages/muya/src/locales/de.ts
+++ b/packages/muya/src/locales/de.ts
@@ -77,8 +77,6 @@ export const de = {
         'Inline Image': 'Inline-Bild',
         'Remove Image': 'Bild entfernen',
         // ImageSelector
-        'Image src placeholder': 'Bild-URL',
-        'Confirm Text': 'OK',
         'Select': 'Auswählen',
         'Embed link': 'Link einbetten',
         'Choose Image': 'Bild wählen',

--- a/packages/muya/src/locales/en.ts
+++ b/packages/muya/src/locales/en.ts
@@ -77,8 +77,6 @@ export const en = {
         'Inline Image': 'Inline Image',
         'Remove Image': 'Remove Image',
         // ImageSelector
-        'Image src placeholder': 'Image src',
-        'Confirm Text': 'Ok',
         'Select': 'Select',
         'Embed link': 'Embed link',
         'Choose Image': 'Choose Image',

--- a/packages/muya/src/locales/es.ts
+++ b/packages/muya/src/locales/es.ts
@@ -77,8 +77,6 @@ export const es = {
         'Inline Image': 'Imagen en línea',
         'Remove Image': 'Eliminar imagen',
         // ImageSelector
-        'Image src placeholder': 'URL de la imagen',
-        'Confirm Text': 'Aceptar',
         'Select': 'Seleccionar',
         'Embed link': 'Insertar enlace',
         'Choose Image': 'Elegir imagen',

--- a/packages/muya/src/locales/fr.ts
+++ b/packages/muya/src/locales/fr.ts
@@ -77,8 +77,6 @@ export const fr = {
         'Inline Image': 'Image en ligne',
         'Remove Image': 'Supprimer l\'image',
         // ImageSelector
-        'Image src placeholder': 'URL de l\'image',
-        'Confirm Text': 'OK',
         'Select': 'Sélectionner',
         'Embed link': 'Intégrer un lien',
         'Choose Image': 'Choisir une image',

--- a/packages/muya/src/locales/ja.ts
+++ b/packages/muya/src/locales/ja.ts
@@ -77,8 +77,6 @@ export const ja = {
         'Inline Image': '行内画像',
         'Remove Image': '画像を削除する',
         // ImageSelector
-        'Image src placeholder': '画像のURL',
-        'Confirm Text': 'OK',
         'Select': '選択',
         'Embed link': 'リンクを埋め込む',
         'Choose Image': '画像を選択',

--- a/packages/muya/src/locales/ko.ts
+++ b/packages/muya/src/locales/ko.ts
@@ -77,8 +77,6 @@ export const ko = {
         'Inline Image': '인라인 이미지',
         'Remove Image': '이미지 삭제',
         // ImageSelector
-        'Image src placeholder': '이미지 URL',
-        'Confirm Text': '확인',
         'Select': '선택',
         'Embed link': '링크 삽입',
         'Choose Image': '이미지 선택',

--- a/packages/muya/src/locales/pt.ts
+++ b/packages/muya/src/locales/pt.ts
@@ -77,8 +77,6 @@ export const pt = {
         'Inline Image': 'Imagem em linha',
         'Remove Image': 'Remover imagem',
         // ImageSelector
-        'Image src placeholder': 'URL da imagem',
-        'Confirm Text': 'OK',
         'Select': 'Selecionar',
         'Embed link': 'Inserir link',
         'Choose Image': 'Escolher imagem',

--- a/packages/muya/src/locales/tr.ts
+++ b/packages/muya/src/locales/tr.ts
@@ -77,8 +77,6 @@ export const tr = {
         'Inline Image': 'Satır İçi Görsel',
         'Remove Image': 'Görseli Kaldır',
         // ImageSelector
-        'Image src placeholder': 'Görsel kaynağı',
-        'Confirm Text': 'Tamam',
         'Select': 'Seç',
         'Embed link': 'Bağlantı göm',
         'Choose Image': 'Görsel Seç',

--- a/packages/muya/src/locales/zh-CN.ts
+++ b/packages/muya/src/locales/zh-CN.ts
@@ -77,8 +77,6 @@ export const zhCN = {
         'Inline Image': '行内图片',
         'Remove Image': '删除图片',
         // ImageSelector
-        'Image src placeholder': '图片链接',
-        'Confirm Text': '确定',
         'Select': '选择',
         'Embed link': '插入链接',
         'Choose Image': '选择图片',

--- a/packages/muya/src/locales/zh-TW.ts
+++ b/packages/muya/src/locales/zh-TW.ts
@@ -77,8 +77,6 @@ export const zhTW = {
         'Inline Image': '行內圖片',
         'Remove Image': '刪除圖片',
         // ImageSelector
-        'Image src placeholder': '圖片連結',
-        'Confirm Text': '確定',
         'Select': '選擇',
         'Embed link': '插入連結',
         'Choose Image': '選擇圖片',


### PR DESCRIPTION
## Summary

The muya core rewrite (muyajs → `@muyajs/core`) moved the editor-surface strings into muya's own i18n store, leaving the desktop locale files full of orphaned keys plus a few missing/mismatched ones. This PR audits **both** i18n systems and reconciles every locale.

Two separate i18n systems were audited:
- **desktop** — `packages/desktop/static/locales/*.json` (10 langs), used by the renderer (vue-i18n `t`/`$t`) and the main process (`getTranslation`), dotted keys, `en` is the source.
- **muya** — `packages/muya/src/locales/*.ts` (10 langs), flat-string `i18n.t()`, some keys resolved dynamically from config arrays.

Every candidate removal was verified with an exact, quote-delimited repo-wide sweep, and every dynamic lookup (`COMMAND_KEY_MAP`, `preferences.search.*` template keys, muya config arrays) was resolved before deleting, so no in-use key is removed.

## Changes (one commit per concern)

1. **muya: drop unused i18n keys** — remove `'Confirm Text'` and `'Image src placeholder'` (no references anywhere). All 10 muya locales stay aligned at 85 keys.
2. **desktop: remove keys orphaned by the muya refactor** — ~300 dead keys across `editor.*`, `frontMenu.*`, `quickInsert.*`, `table.*`, `store.editor.*` (moved into muya) plus stale duplicate `menu.*` / `preferences.*` / `commands.*` entries. Empty parent objects pruned.
3. **desktop: backfill PlantUML server keys into the Turkish locale** — #4400 added `preferences.markdown.diagrams.plantumlServer.title` and `preferences.search.items.plantumlServer` to the other 9 locales but not to the (then brand-new) `tr.json`. Add the Turkish translations.
4. **desktop: align the `preferences.search.items.*` namespace** — this namespace is built dynamically from the non-`--internal` keys of `preferences/schema.json`, so it must mirror the searchable schema keys. Add the 3 searchable prefs that had no entry (`autoNormalizeLineEndings`, `fileSortOrder`, `openedFilesInSidebar`) — these previously rendered raw key strings in prefs-search — and drop 10 entries that map to `--internal` keys plus a few stale leftovers.
5. **desktop: fix the command-palette theme switcher** — `window.change-theme` set its labels via `t('theme.*')`, a namespace that never existed, so the palette showed raw keys. Repointed to the existing `menu.theme.*` keys already used by the View → Theme menu (translated in every locale). No new keys.

Result: all 10 desktop locales aligned at **741 keys**, all 10 muya locales at **85 keys**, with **0 missing** and **0 redundant** keys in either system. New translations (incl. Turkish) were produced for the added entries, matching each locale's existing terminology.

## Verification

- `pnpm -C packages/desktop run typecheck` (vue-tsc) ✓
- `pnpm -C packages/muya lint:types` ✓
- eslint over all 10 desktop locales + all 10 muya locales + `commands/index.ts` ✓
- i18n unit tests: desktop `i18n.spec.ts` (2/2), muya `localeRefresh` + `headingLocaleCrash` (11/11) ✓

Rebased on the latest `develop`; the Turkish locale (#4510) and the configurable PlantUML server pref (#4400) are both covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)