### PR TITLE
fix(test): correct PlantUML custom-server URL assertion

### DIFF
--- a/packages/desktop/test/e2e/plantuml.spec.ts
+++ b/packages/desktop/test/e2e/plantuml.spec.ts
@@ -48,7 +48,7 @@ test.describe('PlantUML render via plantuml-encoder', () => {
     const img = page.locator(`img[src*="${CUSTOM_SERVER}"]`).first()
     await expect(img).toHaveCount(1, { timeout: 10000 })
     const src = await img.getAttribute('src')
-    expect(src).toMatch(new RegExp(`^${escapeRegex(CUSTOM_SERVER)}/svg/~1[A-Za-z0-9_-]+$`))
+    expect(src).toMatch(new RegExp(`^${escapeRegex(CUSTOM_SERVER)}/svg/[A-Za-z0-9_-]+$`))
   })
 })
 


### PR DESCRIPTION
## Summary

The PlantUML custom-server e2e case (`test/e2e/plantuml.spec.ts:38`, added in #4400) asserts a `~1` deflate prefix on the encoded diagram path:

```js
expect(src).toMatch(new RegExp(`^${escapeRegex(CUSTOM_SERVER)}/svg/~1[A-Za-z0-9_-]+$`))
```

But `plantuml-encoder` emits prefix-less base64, and the encoding is independent of the server URL — `Diagram` only swaps `this.plantumlServer` into `${server}/svg/${encodedInput}`. The default-server test in the **same file** correctly asserts no `~1` prefix:

```js
expect(src).toMatch(/^https:\/\/www\.plantuml\.com\/plantuml\/svg\/[A-Za-z0-9_-]+$/)
```

So the two assertions contradicted each other and the custom-server case failed deterministically (received e.g. `.../svg/SoWkIImgAStDuN9KqBLJSE9oICrB0N81`, no `~1`). This currently fails the `e2e` job on `develop` and every PR branch.

The fix drops the `~1` from the custom-server regex so it matches the encoder output (and the default-server assertion).

## Verification

Built locally (`pnpm run build:unpack`) and ran the spec:

```
✓ plantuml block renders an img with the default plantuml.com src
✓ plantuml block uses custom server URL when preference is set
  2 passed (2.1s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
