### PR TITLE
refactor(muya): return enums from TextSelection direction/type

### DIFF
--- a/packages/muya/src/__tests__/getCursorOffset.spec.ts
+++ b/packages/muya/src/__tests__/getCursorOffset.spec.ts
@@ -4,6 +4,7 @@ import type { ISelection } from '../selection/types';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Muya } from '../muya';
 import { injectStateSentinels, locateSentinelOffsets } from '../selection/offsetCursor';
+import { SelectionCaretType, SelectionDirection } from '../selection/types';
 
 // PARITY (gap PG2 / Phase G — G7): `getCursorOffset` is the READ inverse of
 // `setCursorByOffset`. It maps the live WYSIWYG block-key caret back to a
@@ -91,8 +92,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
             focus: { offset: 5, block, path: [0, 'text'] },
             isCollapsed: false,
             isSelectionInSameBlock: true,
-            direction: 'forward',
-            type: 'Range',
+            direction: SelectionDirection.Forward,
+            type: SelectionCaretType.Range,
         };
         const sentinelState = injectStateSentinels(muya.getState(), selection);
         expect(sentinelState).not.toBeNull();
@@ -111,8 +112,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
             focus: { offset: 2, block, path: [0, 'text'] }, //  after "he"
             isCollapsed: false,
             isSelectionInSameBlock: true,
-            direction: 'backward',
-            type: 'Range',
+            direction: SelectionDirection.Backward,
+            type: SelectionCaretType.Range,
         };
         const sentinelState = injectStateSentinels(muya.getState(), selection);
         expect(sentinelState).not.toBeNull();

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -300,7 +300,7 @@ class Format extends Content {
     }
 
     // TODO: @JOCS remove use this.selection directly
-    checkNeedRender(cursor: ICursor = this.selection as ICursor) {
+    checkNeedRender(cursor: ICursor = { anchor: this.selection.anchor ?? null, focus: this.selection.focus ?? null }) {
         const { labels } = this.inlineRenderer;
         const { text } = this;
         const { start: cStart, end: cEnd, anchor, focus } = cursor;

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -5,6 +5,7 @@ import type TableBlock from '../../block/gfm/table';
 import type { Muya } from '../../muya';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
 
 // Track C — Cut (clipboard chain step 2). Ports `packages/muyajs`
 // `copyCutCtrl.cutHandler` + `removeBlocks` semantics into `@muyajs/core`:
@@ -76,7 +77,7 @@ function stubSelection(
     aOff: number,
     f: Content,
     fOff: number,
-    direction = 'forward',
+    direction = SelectionDirection.Forward,
 ) {
     const aPath = a.path;
     const fPath = f.path;
@@ -86,7 +87,7 @@ function stubSelection(
         isCollapsed: false,
         isSelectionInSameBlock: a === f,
         direction,
-        type: 'Range',
+        type: SelectionCaretType.Range,
     });
 }
 

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -7,6 +7,7 @@ import type { Nullable } from '../types';
 import type Clipboard from './index';
 import { ScrollPage } from '../block/scrollPage';
 import { CLASS_NAMES } from '../config';
+import { SelectionDirection } from '../selection/types';
 import { getBlock } from '../utils/dom';
 
 /**
@@ -332,8 +333,8 @@ export function cutSelection(clipboard: Clipboard): void {
     if (isSelectionInSameBlock) {
         const { text } = anchorBlock;
         const startOffset
-            = direction === 'forward' ? anchor.offset : focus.offset;
-        const endOffset = direction === 'forward' ? focus.offset : anchor.offset;
+            = direction === SelectionDirection.Forward ? anchor.offset : focus.offset;
+        const endOffset = direction === SelectionDirection.Forward ? focus.offset : anchor.offset;
 
         anchorBlock.text
             = text.substring(0, startOffset) + text.substring(endOffset);
@@ -341,10 +342,10 @@ export function cutSelection(clipboard: Clipboard): void {
         return anchorBlock.setCursor(startOffset, startOffset, true);
     }
 
-    const startBlock = direction === 'forward' ? anchorBlock : focusBlock;
-    const endBlock = direction === 'forward' ? focusBlock : anchorBlock;
-    const startOffset = direction === 'forward' ? anchor.offset : focus.offset;
-    const endOffset = direction === 'forward' ? focus.offset : anchor.offset;
+    const startBlock = direction === SelectionDirection.Forward ? anchorBlock : focusBlock;
+    const endBlock = direction === SelectionDirection.Forward ? focusBlock : anchorBlock;
+    const startOffset = direction === SelectionDirection.Forward ? anchor.offset : focus.offset;
+    const endOffset = direction === SelectionDirection.Forward ? focus.offset : anchor.offset;
 
     // Whole-document selection collapses to a single empty paragraph.
     if (isSelectAll(clipboard, startBlock, startOffset, endBlock, endOffset)) {

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -18,7 +18,7 @@ import {
     getNodeAndOffset,
     getOffsetOfParagraph,
 } from './dom';
-import { SelectionType } from './types';
+import { SelectionCaretType, SelectionDirection, SelectionType } from './types';
 
 class TextSelection {
     public anchorPath: TBlockPath = [];
@@ -74,29 +74,29 @@ class TextSelection {
             isCollapsed,
         } = this;
         if (anchor == null || focus == null || !anchorBlock || !focusBlock)
-            return 'none';
+            return SelectionDirection.None;
 
         if (isCollapsed)
-            return 'none';
+            return SelectionDirection.None;
 
         if (isSelectionInSameBlock) {
-            return anchor.offset < focus.offset ? 'forward' : 'backward';
+            return anchor.offset < focus.offset ? SelectionDirection.Forward : SelectionDirection.Backward;
         }
         else {
             const aDom = anchorBlock.domNode!;
             const fDom = focusBlock.domNode!;
             const order = compareParagraphsOrder(aDom, fDom);
 
-            return order ? 'forward' : 'backward';
+            return order ? SelectionDirection.Forward : SelectionDirection.Backward;
         }
     }
 
     get type() {
         const { anchorBlock, focusBlock, isCollapsed } = this;
         if (!anchorBlock && !focusBlock)
-            return 'None';
+            return SelectionCaretType.None;
 
-        return isCollapsed ? 'Caret' : 'Range';
+        return isCollapsed ? SelectionCaretType.Caret : SelectionCaretType.Range;
     }
 
     collapse(): void {
@@ -162,19 +162,19 @@ class TextSelection {
         const isCollapsed = anchorBlock === focusBlock && anchor.offset === focus.offset;
         const isSelectionInSameBlock = anchorBlock === focusBlock;
 
-        let direction: string;
+        let direction: SelectionDirection;
 
         if (isSelectionInSameBlock) {
-            direction = anchor.offset < focus.offset ? 'forward' : 'backward';
+            direction = anchor.offset < focus.offset ? SelectionDirection.Forward : SelectionDirection.Backward;
         }
         else {
             const aDom = anchorBlock.domNode!;
             const fDom = focusBlock.domNode!;
             const order = compareParagraphsOrder(aDom, fDom);
-            direction = order ? 'forward' : 'backward';
+            direction = order ? SelectionDirection.Forward : SelectionDirection.Backward;
         }
 
-        const type = isCollapsed ? 'Caret' : 'Range';
+        const type = isCollapsed ? SelectionCaretType.Caret : SelectionCaretType.Range;
 
         return {
             anchor: { offset: anchor.offset, block: anchorBlock, path: anchorPath },
@@ -213,7 +213,7 @@ class TextSelection {
 
         // Follow the caret (focus end) for forward selections so typewriter
         // scrolling tracks the cursor rather than the selection start.
-        const cursorCoords = getCursorCoords(direction === 'forward');
+        const cursorCoords = getCursorCoords(direction === SelectionDirection.Forward);
         // Duck-type the Format block — a value import of Format here would
         // create a selection -> format circular dependency.
         const anchorBlockRef = this.anchorBlock as Format | null;

--- a/packages/muya/src/selection/__tests__/selectionEnums.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectionEnums.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { SelectionCaretType, SelectionDirection } from '../types';
+
+describe('selection enums', () => {
+    it('keep wire-compatible string values', () => {
+        expect(SelectionDirection.Forward).toBe('forward');
+        expect(SelectionDirection.Backward).toBe('backward');
+        expect(SelectionDirection.None).toBe('none');
+        expect(SelectionCaretType.Caret).toBe('Caret');
+        expect(SelectionCaretType.Range).toBe('Range');
+        expect(SelectionCaretType.None).toBe('None');
+    });
+});

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -22,8 +22,8 @@ export interface ICursor {
     focusPath?: TBlockPath;
     isCollapsed?: boolean;
     isSelectionInSameBlock?: boolean;
-    direction?: string;
-    type?: string;
+    direction?: SelectionDirection;
+    type?: SelectionCaretType;
 }
 
 // One endpoint of a selection: the offset plus the live block reference and its
@@ -41,8 +41,8 @@ export interface ISelection {
     focus: IAnchorFocusInfo;
     isCollapsed: boolean;
     isSelectionInSameBlock: boolean;
-    direction: string;
-    type: string;
+    direction: SelectionDirection;
+    type: SelectionCaretType;
 }
 
 // An endpoint whose live `block` reference is optional — used by the history
@@ -65,6 +65,18 @@ export enum SelectionType {
     Text = 'text',
     Table = 'table',
     Image = 'image',
+}
+
+export enum SelectionDirection {
+    None = 'none',
+    Forward = 'forward',
+    Backward = 'backward',
+}
+
+export enum SelectionCaretType {
+    None = 'None',
+    Caret = 'Caret',
+    Range = 'Range',
 }
 
 export interface IImageSelectionData {


### PR DESCRIPTION
## Summary

Part 1/5 of a muya selection/cursor API cleanup (stacked PRs; this one targets `develop`).

- `TextSelection.direction`/`type` now return `SelectionDirection` / `SelectionCaretType` enums instead of bare strings. The string **values** are unchanged (`'none'|'forward'|'backward'`, `'None'|'Caret'|'Range'`), so the undo-history serialized form and the `selection-change` wire payload stay byte-compatible (the desktop renderer does not read these fields).
- Updated producers (`direction`/`type` getters, `getSelection()`), consumers (typewriter scroll follow, `clipboard/cut.ts`), and the `ISelection`/`IHistorySelection` field types.

## Test Plan

- [x] `pnpm -C packages/muya lint` · `lint:types` · `check-circular`
- [x] `pnpm -C packages/muya test` (764 passing)
- [x] New `selectionEnums.spec.ts` pins the wire-compatible string values

🤖 Generated with [Claude Code](https://claude.com/claude-code)