### PR TITLE
refactor(muya): route format/codeblock selection through setCursor

### DIFF
--- a/packages/muya/e2e/tests/editing/selection-setcursor.spec.ts
+++ b/packages/muya/e2e/tests/editing/selection-setcursor.spec.ts
@@ -1,0 +1,123 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+/**
+ * Real-Chromium regression for the PR3 conversion of the format / code-block
+ * cursor handlers from `this.selection.setSelection(...)` to
+ * `this.setCursor(...)`. Exercises the two user paths that now flow through
+ * `setCursor`:
+ *   - typing a character (paragraph `inputHandler` -> `setCursor`), and
+ *   - shift+Arrow extending a selection (`keyupHandler` -> `setCursor`),
+ * asserting the typed text lands and the resulting caret / selection offsets
+ * are exactly where the keystrokes placed them.
+ *
+ * Caret placement uses a real DOM Range so the click lands on an exact text
+ * offset; selection state is read from muya's public selection API. Drives the
+ * suite's `expect.poll` idiom — no raw sleeps.
+ */
+
+interface SelectionSnapshot {
+    anchorText: string | null;
+    focusText: string | null;
+    anchorOffset: number | null;
+    focusOffset: number | null;
+    isCollapsed: boolean | null;
+}
+
+async function readSelection(page: Page): Promise<SelectionSnapshot> {
+    return page.evaluate(() => {
+        const sel = window.muya!.editor.selection;
+        const live = sel.getSelection();
+        return {
+            anchorText: sel.anchorBlock?.text ?? null,
+            focusText: sel.focusBlock?.text ?? null,
+            anchorOffset: sel.anchor?.offset ?? null,
+            focusOffset: sel.focus?.offset ?? null,
+            isCollapsed: live ? live.isCollapsed : null,
+        };
+    });
+}
+
+// Pixel centre of the character at `charOffset` in the nth matched paragraph,
+// measured from a real DOM Range so the click lands on an exact text offset.
+async function pointAtChar(
+    page: Page,
+    selector: string,
+    paragraphIndex: number,
+    charOffset: number,
+): Promise<{ x: number; y: number }> {
+    return page.evaluate(
+        ({ selector, paragraphIndex, charOffset }) => {
+            const p = document.querySelectorAll(selector)[paragraphIndex] as HTMLElement;
+            const textNode = document.createTreeWalker(p, NodeFilter.SHOW_TEXT).nextNode()!;
+            const range = document.createRange();
+            range.setStart(textNode, charOffset);
+            range.setEnd(textNode, charOffset + 1);
+            const r = range.getBoundingClientRect();
+            return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+        },
+        { selector, paragraphIndex, charOffset },
+    );
+}
+
+test.describe('selection setcursor regression', () => {
+    test('typing routes through setCursor and lands the character at the caret', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('hello world\n'));
+        const para = page.locator(editor.paragraph).first();
+        await expect(para).toBeVisible();
+
+        // Click between "hello" and " world" (offset 5), then type 'X'.
+        const point = await pointAtChar(page, editor.paragraph, 0, 5);
+        await page.mouse.click(point.x, point.y);
+        await slowType(page, 'X');
+
+        await expect(para).toContainText('helloX world');
+        expect(await getMarkdown(page)).toContain('helloX world');
+
+        // After inputHandler -> setCursor the caret is collapsed right after the
+        // inserted 'X' (offset 6).
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(6);
+        const snap = await readSelection(page);
+        expect(snap.focusOffset).toBe(6);
+        expect(snap.isCollapsed).toBe(true);
+        expect(snap.anchorText).toBe('helloX world');
+    });
+
+    test('shift+Arrow extends a selection that survives setCursor', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('hello world\n'));
+        const para = page.locator(editor.paragraph).first();
+        await expect(para).toBeVisible();
+
+        // Caret after "hello" (offset 5), then extend two chars to the right.
+        const point = await pointAtChar(page, editor.paragraph, 0, 5);
+        await page.mouse.click(point.x, point.y);
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(5);
+
+        await page.keyboard.press('Shift+ArrowRight');
+        await page.keyboard.press('Shift+ArrowRight');
+
+        // Forward selection from 5 to 7 (anchor stays at 5, focus advances).
+        await expect.poll(() => readSelection(page).then(s => s.focusOffset)).toBe(7);
+        const forward = await readSelection(page);
+        expect(forward.anchorOffset).toBe(5);
+        expect(forward.isCollapsed).toBe(false);
+        expect(forward.anchorText).toBe('hello world');
+
+        // Now collapse and extend LEFT to build a backward selection: the anchor
+        // sits AFTER the focus, which must survive the setCursor round-trip.
+        await page.keyboard.press('ArrowRight');
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(7);
+        await page.keyboard.press('Shift+ArrowLeft');
+        await page.keyboard.press('Shift+ArrowLeft');
+
+        await expect.poll(() => readSelection(page).then(s => s.focusOffset)).toBe(5);
+        const backward = await readSelection(page);
+        expect(backward.anchorOffset).toBe(7);
+        expect(backward.isCollapsed).toBe(false);
+        // anchor (7) is after focus (5): a genuine backward selection.
+        expect(backward.anchorOffset).toBeGreaterThan(backward.focusOffset!);
+    });
+});

--- a/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+import { SelectionDirection } from '../../../selection/types';
+
+// Regression for the PR3 conversion of `Format.clickHandler` (and its siblings)
+// from a direct `this.selection.setSelection(anchor, focus)` to
+// `this.setCursor(anchor.offset, focus.offset)`. `setCursor(begin, end)` maps
+// `begin -> anchor.offset` and `end -> focus.offset`, so a BACKWARD click-drag
+// (anchor AFTER focus) must survive the conversion: the resulting selection has
+// to stay backward with the original anchor / focus offsets, NOT get normalized
+// to min/max.
+//
+// happy-dom collapses a non-collapsed selection whose two endpoints land in the
+// same text node (anchorOffset and focusOffset both snap to the anchor), so a
+// genuine backward selection cannot be planted through the native DOM and read
+// back via `getSelection()`. We therefore exercise the conversion at the two
+// deterministic seams it actually routes through:
+//   1. `setCursor(begin, end)` itself — the method the handlers now call — must
+//      keep `begin > end` backward, asserted via the engine-stored anchor/focus
+//      (which the wrapper exposes directly, independent of the DOM readback).
+//   2. `clickHandler` must forward `cursor.anchor.offset` / `cursor.focus.offset`
+//      (NOT the normalized `start` / `end`) into `setCursor`, so a backward
+//      `getCursor()` is passed through backward.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function directionOf(anchorOffset: number, focusOffset: number): SelectionDirection {
+    return anchorOffset < focusOffset ? SelectionDirection.Forward : SelectionDirection.Backward;
+}
+
+function flushFrame(): Promise<void> {
+    return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('setCursor preserves a backward selection (begin > end stays backward)', () => {
+    it('setCursor(7, 2) leaves anchor 7 / focus 2 — a Backward selection, not min/max', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        content.setCursor(7, 2);
+
+        const { selection } = muya.editor;
+        expect(selection.anchor!.offset).toBe(7);
+        expect(selection.focus!.offset).toBe(2);
+        expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
+            SelectionDirection.Backward,
+        );
+    });
+
+    it('setCursor(2, 7) leaves anchor 2 / focus 7 — a Forward selection', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        content.setCursor(2, 7);
+
+        const { selection } = muya.editor;
+        expect(selection.anchor!.offset).toBe(2);
+        expect(selection.focus!.offset).toBe(7);
+        expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
+            SelectionDirection.Forward,
+        );
+    });
+});
+
+describe('clickHandler forwards the backward anchor/focus (not normalized start/end) into setCursor', () => {
+    it('a backward cursor (anchor 7, focus 2) is passed straight through to setCursor(7, 2)', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        // happy-dom can't hold a real backward DOM selection in a single text
+        // node, so feed the handler a backward cursor directly. This is exactly
+        // the value `getCursor()` returns for a right-to-left drag in a real
+        // browser: `start`/`end` are normalized (2/7) but `anchor`/`focus` carry
+        // the true direction (7/2).
+        vi.spyOn(content, 'getCursor').mockReturnValue({
+            start: { offset: 2 },
+            end: { offset: 7 },
+            anchor: { offset: 7, block: content as never, path: content.path },
+            focus: { offset: 2, block: content as never, path: content.path },
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.Backward,
+            type: 'Range' as never,
+        });
+        const setCursorSpy = vi.spyOn(content, 'setCursor');
+
+        // `isMouseEvent` is `'x' in event`; happy-dom's MouseEvent never exposes
+        // `x`, and `event.target` is nulled once dispatch completes — so forge
+        // both a real Element target and the `x`/`y` keys the guard checks.
+        const event = new MouseEvent('click', { bubbles: true });
+        const target = content.domNode!.querySelector('span') ?? content.domNode!;
+        Object.defineProperty(event, 'target', { value: target, configurable: true });
+        Object.assign(event, { x: 0, y: 0 });
+
+        content.clickHandler(event);
+
+        await flushFrame();
+
+        await vi.waitFor(() => {
+            // anchor.offset (7) -> begin, focus.offset (2) -> end. If the handler
+            // had used start/end it would be (2, 7) and the backward drag would be
+            // silently flipped to forward.
+            expect(setCursorSpy).toHaveBeenCalledWith(7, 2);
+        });
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -530,10 +530,7 @@ class Format extends Content {
             if (needRender)
                 this.update(cursor);
 
-            this.selection.setSelection(
-                { offset: cursor.anchor.offset, block: this, path: this.path },
-                { offset: cursor.focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(currentCursor.anchor.offset, currentCursor.focus.offset);
 
             // Check and show format picker
             if (cursor.start.offset !== cursor.end.offset) {
@@ -573,10 +570,7 @@ class Format extends Content {
             if (needUpdate)
                 this.update(cursor);
 
-            this.selection.setSelection(
-                { offset: anchor.offset, block: this, path: this.path },
-                { offset: focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(anchor.offset, focus.offset);
         }
 
         // Check not edit emoji
@@ -666,10 +660,7 @@ class Format extends Content {
         if (checkMarkedUpdate || needRender)
             this.update(cursor);
 
-        this.selection.setSelection(
-            { offset: start.offset, block: this, path: this.path },
-            { offset: end.offset, block: this, path: this.path },
-        );
+        this.setCursor(start.offset, end.offset);
         // check edit emoji
         if (
             inputType !== 'insertFromPaste'

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -422,10 +422,7 @@ class CodeBlockContent extends Content {
             anchor.offset !== oldAnchor?.offset
             || focus.offset !== oldFocus?.offset
         ) {
-            this.selection.setSelection(
-                { offset: anchor.offset, block: this, path: this.path },
-                { offset: focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(anchor.offset, focus.offset);
         }
     }
 }


### PR DESCRIPTION
## Summary

Part 3/5 of a muya selection/cursor API cleanup (stacked on #4523).

- Content/format blocks now set the cursor only via `this.setCursor(...)`, never by calling `this.selection.setSelection(...)` directly. Converts the 4 call sites in `format.ts` (click/keyup/input handlers) and `codeBlockContent` (keyup). Selection direction (backward shift-click) and the conditional `update()` timing are preserved.

## Test Plan

- [x] `pnpm -C packages/muya lint` · `lint:types` · `check-circular`
- [x] `pnpm -C packages/muya test` (764 passing); new `formatClickCursor.spec.ts` covers backward-selection preservation
- [x] `pnpm -C packages/muya/e2e e2e --project=chromium` — new `selection-setcursor.spec.ts` (click→caret, type, shift+Arrow incl. real backward selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)