### PR TITLE
refactor(muya): split ICursor into focused interfaces

### DIFF
--- a/packages/muya/e2e/tests/editing/selection-setcursor.spec.ts
+++ b/packages/muya/e2e/tests/editing/selection-setcursor.spec.ts
@@ -1,0 +1,123 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+/**
+ * Real-Chromium regression for the PR3 conversion of the format / code-block
+ * cursor handlers from `this.selection.setSelection(...)` to
+ * `this.setCursor(...)`. Exercises the two user paths that now flow through
+ * `setCursor`:
+ *   - typing a character (paragraph `inputHandler` -> `setCursor`), and
+ *   - shift+Arrow extending a selection (`keyupHandler` -> `setCursor`),
+ * asserting the typed text lands and the resulting caret / selection offsets
+ * are exactly where the keystrokes placed them.
+ *
+ * Caret placement uses a real DOM Range so the click lands on an exact text
+ * offset; selection state is read from muya's public selection API. Drives the
+ * suite's `expect.poll` idiom — no raw sleeps.
+ */
+
+interface SelectionSnapshot {
+    anchorText: string | null;
+    focusText: string | null;
+    anchorOffset: number | null;
+    focusOffset: number | null;
+    isCollapsed: boolean | null;
+}
+
+async function readSelection(page: Page): Promise<SelectionSnapshot> {
+    return page.evaluate(() => {
+        const sel = window.muya!.editor.selection;
+        const live = sel.getSelection();
+        return {
+            anchorText: sel.anchorBlock?.text ?? null,
+            focusText: sel.focusBlock?.text ?? null,
+            anchorOffset: sel.anchor?.offset ?? null,
+            focusOffset: sel.focus?.offset ?? null,
+            isCollapsed: live ? live.isCollapsed : null,
+        };
+    });
+}
+
+// Pixel centre of the character at `charOffset` in the nth matched paragraph,
+// measured from a real DOM Range so the click lands on an exact text offset.
+async function pointAtChar(
+    page: Page,
+    selector: string,
+    paragraphIndex: number,
+    charOffset: number,
+): Promise<{ x: number; y: number }> {
+    return page.evaluate(
+        ({ selector, paragraphIndex, charOffset }) => {
+            const p = document.querySelectorAll(selector)[paragraphIndex] as HTMLElement;
+            const textNode = document.createTreeWalker(p, NodeFilter.SHOW_TEXT).nextNode()!;
+            const range = document.createRange();
+            range.setStart(textNode, charOffset);
+            range.setEnd(textNode, charOffset + 1);
+            const r = range.getBoundingClientRect();
+            return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+        },
+        { selector, paragraphIndex, charOffset },
+    );
+}
+
+test.describe('selection setcursor regression', () => {
+    test('typing routes through setCursor and lands the character at the caret', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('hello world\n'));
+        const para = page.locator(editor.paragraph).first();
+        await expect(para).toBeVisible();
+
+        // Click between "hello" and " world" (offset 5), then type 'X'.
+        const point = await pointAtChar(page, editor.paragraph, 0, 5);
+        await page.mouse.click(point.x, point.y);
+        await slowType(page, 'X');
+
+        await expect(para).toContainText('helloX world');
+        expect(await getMarkdown(page)).toContain('helloX world');
+
+        // After inputHandler -> setCursor the caret is collapsed right after the
+        // inserted 'X' (offset 6).
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(6);
+        const snap = await readSelection(page);
+        expect(snap.focusOffset).toBe(6);
+        expect(snap.isCollapsed).toBe(true);
+        expect(snap.anchorText).toBe('helloX world');
+    });
+
+    test('shift+Arrow extends a selection that survives setCursor', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('hello world\n'));
+        const para = page.locator(editor.paragraph).first();
+        await expect(para).toBeVisible();
+
+        // Caret after "hello" (offset 5), then extend two chars to the right.
+        const point = await pointAtChar(page, editor.paragraph, 0, 5);
+        await page.mouse.click(point.x, point.y);
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(5);
+
+        await page.keyboard.press('Shift+ArrowRight');
+        await page.keyboard.press('Shift+ArrowRight');
+
+        // Forward selection from 5 to 7 (anchor stays at 5, focus advances).
+        await expect.poll(() => readSelection(page).then(s => s.focusOffset)).toBe(7);
+        const forward = await readSelection(page);
+        expect(forward.anchorOffset).toBe(5);
+        expect(forward.isCollapsed).toBe(false);
+        expect(forward.anchorText).toBe('hello world');
+
+        // Now collapse and extend LEFT to build a backward selection: the anchor
+        // sits AFTER the focus, which must survive the setCursor round-trip.
+        await page.keyboard.press('ArrowRight');
+        await expect.poll(() => readSelection(page).then(s => s.anchorOffset)).toBe(7);
+        await page.keyboard.press('Shift+ArrowLeft');
+        await page.keyboard.press('Shift+ArrowLeft');
+
+        await expect.poll(() => readSelection(page).then(s => s.focusOffset)).toBe(5);
+        const backward = await readSelection(page);
+        expect(backward.anchorOffset).toBe(7);
+        expect(backward.isCollapsed).toBe(false);
+        // anchor (7) is after focus (5): a genuine backward selection.
+        expect(backward.anchorOffset).toBeGreaterThan(backward.focusOffset!);
+    });
+});

--- a/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+import { SelectionDirection } from '../../../selection/types';
+
+// Regression for the PR3 conversion of `Format.clickHandler` (and its siblings)
+// from a direct `this.selection.setSelection(anchor, focus)` to
+// `this.setCursor(anchor.offset, focus.offset)`. `setCursor(begin, end)` maps
+// `begin -> anchor.offset` and `end -> focus.offset`, so a BACKWARD click-drag
+// (anchor AFTER focus) must survive the conversion: the resulting selection has
+// to stay backward with the original anchor / focus offsets, NOT get normalized
+// to min/max.
+//
+// happy-dom collapses a non-collapsed selection whose two endpoints land in the
+// same text node (anchorOffset and focusOffset both snap to the anchor), so a
+// genuine backward selection cannot be planted through the native DOM and read
+// back via `getSelection()`. We therefore exercise the conversion at the two
+// deterministic seams it actually routes through:
+//   1. `setCursor(begin, end)` itself — the method the handlers now call — must
+//      keep `begin > end` backward, asserted via the engine-stored anchor/focus
+//      (which the wrapper exposes directly, independent of the DOM readback).
+//   2. `clickHandler` must forward `cursor.anchor.offset` / `cursor.focus.offset`
+//      (NOT the normalized `start` / `end`) into `setCursor`, so a backward
+//      `getCursor()` is passed through backward.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function directionOf(anchorOffset: number, focusOffset: number): SelectionDirection {
+    return anchorOffset < focusOffset ? SelectionDirection.Forward : SelectionDirection.Backward;
+}
+
+function flushFrame(): Promise<void> {
+    return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('setCursor preserves a backward selection (begin > end stays backward)', () => {
+    it('setCursor(7, 2) leaves anchor 7 / focus 2 — a Backward selection, not min/max', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        content.setCursor(7, 2);
+
+        const { selection } = muya.editor;
+        expect(selection.anchor!.offset).toBe(7);
+        expect(selection.focus!.offset).toBe(2);
+        expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
+            SelectionDirection.Backward,
+        );
+    });
+
+    it('setCursor(2, 7) leaves anchor 2 / focus 7 — a Forward selection', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        content.setCursor(2, 7);
+
+        const { selection } = muya.editor;
+        expect(selection.anchor!.offset).toBe(2);
+        expect(selection.focus!.offset).toBe(7);
+        expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
+            SelectionDirection.Forward,
+        );
+    });
+});
+
+describe('clickHandler forwards the backward anchor/focus (not normalized start/end) into setCursor', () => {
+    it('a backward cursor (anchor 7, focus 2) is passed straight through to setCursor(7, 2)', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+
+        // happy-dom can't hold a real backward DOM selection in a single text
+        // node, so feed the handler a backward cursor directly. This is exactly
+        // the value `getCursor()` returns for a right-to-left drag in a real
+        // browser: `start`/`end` are normalized (2/7) but `anchor`/`focus` carry
+        // the true direction (7/2).
+        vi.spyOn(content, 'getCursor').mockReturnValue({
+            start: { offset: 2 },
+            end: { offset: 7 },
+            anchor: { offset: 7, block: content as never, path: content.path },
+            focus: { offset: 2, block: content as never, path: content.path },
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.Backward,
+            type: 'Range' as never,
+        });
+        const setCursorSpy = vi.spyOn(content, 'setCursor');
+
+        // `isMouseEvent` is `'x' in event`; happy-dom's MouseEvent never exposes
+        // `x`, and `event.target` is nulled once dispatch completes — so forge
+        // both a real Element target and the `x`/`y` keys the guard checks.
+        const event = new MouseEvent('click', { bubbles: true });
+        const target = content.domNode!.querySelector('span') ?? content.domNode!;
+        Object.defineProperty(event, 'target', { value: target, configurable: true });
+        Object.assign(event, { x: 0, y: 0 });
+
+        content.clickHandler(event);
+
+        await flushFrame();
+
+        await vi.waitFor(() => {
+            // anchor.offset (7) -> begin, focus.offset (2) -> end. If the handler
+            // had used start/end it would be (2, 7) and the backward drag would be
+            // silently flipped to forward.
+            expect(setCursorSpy).toHaveBeenCalledWith(7, 2);
+        });
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -1,6 +1,6 @@
 import type { IHighlight } from '../../inlineRenderer/types';
 import type { Muya } from '../../muya';
-import type { ICursor, INodeOffset } from '../../selection/types';
+import type { IContentCursor, INodeOffset, IRenderCursor } from '../../selection/types';
 import type { Nullable } from '../../types';
 import type { TBlockPath } from '../types';
 import type Parent from './parent';
@@ -288,7 +288,7 @@ class Content extends TreeNode {
     /**
      * Get cursor if selection is in this block.
      */
-    getCursor() {
+    getCursor(): IContentCursor | null {
         const selection = this.selection.getSelection();
         if (selection == null)
             return null;
@@ -328,14 +328,14 @@ class Content extends TreeNode {
         const focus = { offset: end, block: this, path: this.path };
 
         if (needUpdate)
-            this.update({ anchor, focus, block: this, path: this.path });
+            this.update({ anchor, focus, block: this });
 
         this.muya.editor.activeContentBlock = this;
 
         this.selection.setSelection(anchor, focus);
     }
 
-    update(_cursor?: ICursor, _highlights: IHighlight[] = []) {
+    update(_cursor?: IRenderCursor, _highlights: IHighlight[] = []) {
         const { text } = this;
         this.domNode!.innerHTML = `<span class="mu-syntax-text">${text}</span>`;
     }

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -4,7 +4,7 @@ import type {
     TextToken,
     Token,
 } from '../../inlineRenderer/types';
-import type { ICursor } from '../../selection/types';
+import type { IContentCursor, IRenderCursor } from '../../selection/types';
 import type { IBulletListState, IListItemState, IOrderListState, IParagraphState } from '../../state/types';
 import type { Nullable } from '../../types';
 import type { IImageInfo } from '../../utils/image';
@@ -143,7 +143,7 @@ function getOffset(offset: number, token: Token) {
     }
 }
 
-function clearFormat(token: Token, cursor: ICursor) {
+function clearFormat(token: Token, cursor: IContentCursor) {
     switch (token.type) {
         case 'strong':
 
@@ -300,7 +300,7 @@ class Format extends Content {
     }
 
     // TODO: @JOCS remove use this.selection directly
-    checkNeedRender(cursor: ICursor = { anchor: this.selection.anchor ?? null, focus: this.selection.focus ?? null }) {
+    checkNeedRender(cursor: IRenderCursor = { anchor: this.selection.anchor ?? undefined, focus: this.selection.focus ?? undefined }) {
         const { labels } = this.inlineRenderer;
         const { text } = this;
         const { start: cStart, end: cEnd, anchor, focus } = cursor;
@@ -518,7 +518,6 @@ class Format extends Content {
 
             const cursor = Object.assign({}, currentCursor, {
                 block: this,
-                path: this.path,
             });
 
             // TODO: The codes bellow maybe is wrong? and remove use this.selection directly
@@ -565,7 +564,7 @@ class Format extends Content {
             || focus.offset !== oldFocus?.offset
         ) {
             const needUpdate = this.checkNeedRender({ anchor, focus });
-            const cursor = { anchor, focus, block: this, path: this.path };
+            const cursor = { anchor, focus, block: this };
 
             if (needUpdate)
                 this.update(cursor);
@@ -645,7 +644,6 @@ class Format extends Content {
         this.text = text;
 
         const cursor = {
-            path: this.path,
             block: this,
             anchor: {
                 offset: start.offset,
@@ -1519,7 +1517,7 @@ class Format extends Content {
         cursorBlock.setCursor(0, 0, true);
     }
 
-    getFormatsInRange(cursor = this.getCursor()) {
+    getFormatsInRange(cursor: IContentCursor | null = this.getCursor()) {
         if (cursor == null)
             return { formats: [], tokens: [], neighbors: [] };
 
@@ -1591,7 +1589,7 @@ class Format extends Content {
         // cache delta
         if (type === 'clear') {
             for (const neighbor of neighbors)
-                clearFormat(neighbor, { start, end });
+                clearFormat(neighbor, cursor);
 
             start.offset += start.delta;
             end.offset += end.delta;
@@ -1600,7 +1598,7 @@ class Format extends Content {
         }
         else if (currentFormats.length) {
             for (const token of currentFormats)
-                clearFormat(token, { start, end });
+                clearFormat(token, cursor);
 
             start.offset += start.delta;
             end.offset += end.delta;
@@ -1609,7 +1607,7 @@ class Format extends Content {
         else {
             if (currentNeighbors.length) {
                 for (const neighbor of currentNeighbors)
-                    clearFormat(neighbor, { start, end });
+                    clearFormat(neighbor, cursor);
             }
 
             start.offset += start.delta;

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -530,10 +530,7 @@ class Format extends Content {
             if (needRender)
                 this.update(cursor);
 
-            this.selection.setSelection(
-                { offset: cursor.anchor.offset, block: this, path: this.path },
-                { offset: cursor.focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(currentCursor.anchor.offset, currentCursor.focus.offset);
 
             // Check and show format picker
             if (cursor.start.offset !== cursor.end.offset) {
@@ -573,10 +570,7 @@ class Format extends Content {
             if (needUpdate)
                 this.update(cursor);
 
-            this.selection.setSelection(
-                { offset: anchor.offset, block: this, path: this.path },
-                { offset: focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(anchor.offset, focus.offset);
         }
 
         // Check not edit emoji
@@ -666,10 +660,7 @@ class Format extends Content {
         if (checkMarkedUpdate || needRender)
             this.update(cursor);
 
-        this.selection.setSelection(
-            { offset: start.offset, block: this, path: this.path },
-            { offset: end.offset, block: this, path: this.path },
-        );
+        this.setCursor(start.offset, end.offset);
         // check edit emoji
         if (
             inputType !== 'insertFromPaste'

--- a/packages/muya/src/block/content/atxHeadingContent/index.ts
+++ b/packages/muya/src/block/content/atxHeadingContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type AtxHeading from '../../commonMark/atxHeading';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
@@ -26,7 +26,7 @@ class AtxHeadingContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -422,10 +422,7 @@ class CodeBlockContent extends Content {
             anchor.offset !== oldAnchor?.offset
             || focus.offset !== oldFocus?.offset
         ) {
-            this.selection.setSelection(
-                { offset: anchor.offset, block: this, path: this.path },
-                { offset: focus.offset, block: this, path: this.path },
-            );
+            this.setCursor(anchor.offset, focus.offset);
         }
     }
 }

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type {
     CodeContentState,
     ICodeBlockState,
@@ -138,7 +138,7 @@ class CodeBlockContent extends Content {
             (this.outContainer?.attachments?.head as HTMLPreview).update(text);
     }
 
-    override update(_cursor: ICursor, highlights = []) {
+    override update(_cursor?: IRenderCursor, highlights = []) {
         const { lang, text } = this;
         // transform alias to original language
         const fullLengthLang = transformAliasToOrigin([lang])[0];

--- a/packages/muya/src/block/content/langInputContent/index.ts
+++ b/packages/muya/src/block/content/langInputContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type { ICodeBlockState } from '../../../state/types';
 import type CodeBlock from '../../commonMark/codeBlock';
 import { CLASS_NAMES } from '../../../config';
@@ -28,7 +28,7 @@ class LangInputContent extends Content {
         return this.parent;
     }
 
-    override update(_cursor?: ICursor, highlights = []) {
+    override update(_cursor?: IRenderCursor, highlights = []) {
         this.domNode!.innerHTML = escapeLangInputInnerHtml(this.text, highlights);
     }
 

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -1,6 +1,6 @@
 import type { Muya } from '../../../index';
 import type { ImageToken, LinkToken, Token } from '../../../inlineRenderer/types';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type {
     IBlockQuoteState,
     IBulletListState,
@@ -100,7 +100,7 @@ class ParagraphContent extends Format {
         return this.parent;
     }
 
-    override update(cursor?: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         this.inlineRenderer.patch(this, cursor, highlights);
         const { label } = this.inlineRenderer.getLabelInfo(this);
 

--- a/packages/muya/src/block/content/setextHeadingContent/index.ts
+++ b/packages/muya/src/block/content/setextHeadingContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
@@ -23,7 +23,7 @@ class SetextHeadingContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/tableCell/index.ts
+++ b/packages/muya/src/block/content/tableCell/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type Table from '../../gfm/table';
 import type Cell from '../../gfm/table/cell';
 import type Row from '../../gfm/table/row';
@@ -46,7 +46,7 @@ class TableCellContent extends Format {
         return this.table;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/thematicBreakContent/index.ts
+++ b/packages/muya/src/block/content/thematicBreakContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
@@ -23,7 +23,7 @@ class ThematicBreakContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -1,7 +1,7 @@
 import type Format from '../block/base/format';
 import type ParagraphContent from '../block/content/paragraphContent';
 import type { Muya } from '../muya';
-import type { ICursor } from '../selection/types';
+import type { IRenderCursor } from '../selection/types';
 import type { IParagraphState, TContainerState, TState } from '../state/types';
 import type { IHighlight, Labels } from './types';
 import logger from '../utils/logger';
@@ -59,7 +59,7 @@ class InlineRenderer {
         });
     }
 
-    patch(block: Format, cursor?: ICursor, highlights: IHighlight[] = []) {
+    patch(block: Format, cursor?: IRenderCursor, highlights: IHighlight[] = []) {
         this.collectReferenceDefinitions();
         const { domNode } = block;
         if (block.isParent())

--- a/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
@@ -2,7 +2,7 @@
 
 import type { VNode } from 'snabbdom';
 import type Format from '../../../block/base/format';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type { ImageToken } from '../../types';
 import type Renderer from '../index';
 import { describe, expect, it, vi } from 'vitest';
@@ -91,11 +91,11 @@ function findImgSrc(vnodes: VNode | VNode[]): string | undefined {
 }
 
 // Narrow casts shared by every test: the fake renderer and block stubs
-// don't satisfy the full Renderer / Format / ICursor surface, but
+// don't satisfy the full Renderer / Format / IRenderCursor surface, but
 // `image()` only touches the loadImageAsync / urlMap / muya fields and
 // the token range.
 const fakeBlock = {} as unknown as Format;
-const fakeCursor = {} as unknown as ICursor;
+const fakeCursor = {} as unknown as IRenderCursor;
 function asRenderer(r: IFakeRenderer): Renderer {
     return r as unknown as Renderer;
 }

--- a/packages/muya/src/inlineRenderer/renderer/index.ts
+++ b/packages/muya/src/inlineRenderer/renderer/index.ts
@@ -2,7 +2,7 @@
 import type { VNode } from 'snabbdom';
 import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
-import type { ICursor } from '../../selection/types';
+import type { IRenderCursor } from '../../selection/types';
 import type InlineRenderer from '../index';
 import type { ISyntaxRenderOptions, Token } from '../types';
 import { CLASS_NAMES } from '../../config';
@@ -108,7 +108,7 @@ class Renderer {
 
     constructor(public muya: Muya, public parent: InlineRenderer) {}
 
-    checkConflicted(block: Format, token: Token, cursor: ICursor = {}) {
+    checkConflicted(block: Format, token: Token, cursor: IRenderCursor = {}) {
         const anchor = cursor.anchor || cursor.start;
         const focus = cursor.focus || cursor.end;
         if (!anchor || !focus || (cursor.block && cursor.block !== block))
@@ -126,7 +126,7 @@ class Renderer {
         outerClass: string | undefined,
         block: Format,
         token: Token,
-        cursor: ICursor,
+        cursor: IRenderCursor,
     ) {
         return (
             outerClass
@@ -155,7 +155,7 @@ class Renderer {
         return map[name](opts);
     }
 
-    output(tokens: Token[], block: Format, cursor: ICursor) {
+    output(tokens: Token[], block: Format, cursor: IRenderCursor) {
         const children: VNode[] = tokens.reduce(
             (acc, token) => [
                 ...acc,

--- a/packages/muya/src/inlineRenderer/types.ts
+++ b/packages/muya/src/inlineRenderer/types.ts
@@ -1,12 +1,12 @@
 import type { h } from 'snabbdom';
 import type Format from '../block/base/format';
-import type { ICursor } from '../selection/types';
+import type { IRenderCursor } from '../selection/types';
 
 export type H = typeof h;
 
 export interface ISyntaxRenderOptions {
     h: H;
-    cursor: ICursor;
+    cursor: IRenderCursor;
     block: Format;
     token: Token;
     outerClass?: string;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -3,7 +3,7 @@ import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
 import type { IIndexCursor } from './selection/offsetCursor';
-import type { ICursor, IHistorySelection } from './selection/types';
+import type { IHistorySelection, IPublicCursorInput } from './selection/types';
 import type { ITocItem } from './state/getTOC';
 import type { IBulletListState, IOrderListState, ITableState, ITaskListState, TState } from './state/types';
 import type { IMuyaOptions, Nullable } from './types';
@@ -737,13 +737,13 @@ export class Muya {
      * resolve and pass the block instance. No-op when the target can't be
      * resolved.
      */
-    setCursor(cursor: ICursor) {
+    setCursor(cursor: IPublicCursorInput) {
         const { scrollPage } = this.editor;
         if (!scrollPage)
             return;
 
         // Accept both the `{ anchor, focus, anchorPath, focusPath }` and the
-        // `{ start, end, path }`/`block` shapes of ICursor.
+        // `{ start, end, path }`/`block` shapes of IPublicCursorInput.
         const anchor = cursor.anchor ?? cursor.start ?? null;
         const focus = cursor.focus ?? cursor.end ?? anchor;
         const anchorPath = cursor.anchorPath ?? cursor.path;

--- a/packages/muya/src/selection/offsetCursor.ts
+++ b/packages/muya/src/selection/offsetCursor.ts
@@ -6,7 +6,7 @@
 import type Content from '../block/base/content';
 import type { ScrollPage } from '../block/scrollPage';
 import type { TState } from '../state/types';
-import type { ICursor, ISelection } from './types';
+import type { IPathCursor, ISelection } from './types';
 
 /** One end of a source-mode (CodeMirror) selection: a `{ line, ch }` offset. */
 export interface IIndexPosition {
@@ -113,7 +113,7 @@ function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit |
 
 /**
  * Resolve the index cursor against the live (sentinel-bearing) block tree into
- * a PATH-ONLY `ICursor` (json paths + offsets), or `null` when neither sentinel
+ * a PATH-ONLY `IPathCursor` (json paths + offsets), or `null` when neither sentinel
  * resolved to a content block.
  *
  * Only the plain `anchorPath`/`focusPath` arrays are captured (snapshotted from
@@ -126,7 +126,7 @@ function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit |
  * The returned offsets are sentinel-free: the focus offset is decremented when
  * the anchor sentinel precedes it in the same block.
  */
-export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
+export function resolveSentinelCursor(scrollPage: ScrollPage): IPathCursor | null {
     const anchorHit = _findSentinel(scrollPage, ANCHOR_SENTINEL);
     const focusHit = _findSentinel(scrollPage, FOCUS_SENTINEL);
 

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -7,23 +7,37 @@ export interface INodeOffset {
     offset: number;
 }
 
-// TODO: @JOCS, optimization of Cursor type, split it into for getCursor return type and setSelection params type?
-export interface ICursor {
+export interface IContentCursor extends ISelection {
+    start: INodeOffset;
+    end: INodeOffset;
+}
+
+export interface IRenderCursor {
+    start?: INodeOffset;
+    end?: INodeOffset;
+    anchor?: INodeOffset;
+    focus?: INodeOffset;
+    block?: ContentBlock;
+}
+
+export interface IPublicCursorInput {
     start?: INodeOffset | null;
     end?: INodeOffset | null;
-    block?: ContentBlock;
-    path?: TBlockPath;
-    // The same as TSelection
     anchor?: INodeOffset | null;
     focus?: INodeOffset | null;
+    block?: ContentBlock;
+    path?: TBlockPath;
     anchorBlock?: ContentBlock;
     anchorPath?: TBlockPath;
     focusBlock?: ContentBlock;
     focusPath?: TBlockPath;
-    isCollapsed?: boolean;
-    isSelectionInSameBlock?: boolean;
-    direction?: SelectionDirection;
-    type?: SelectionCaretType;
+}
+
+export interface IPathCursor {
+    anchor: INodeOffset;
+    anchorPath: TBlockPath;
+    focus: INodeOffset;
+    focusPath: TBlockPath;
 }
 
 // One endpoint of a selection: the offset plus the live block reference and its


### PR DESCRIPTION
## Summary

Part 4/5 of a muya selection/cursor API cleanup (stacked on #4520).

- Deletes the over-broad `ICursor` (13 optional fields serving three roles) and replaces it with four role-scoped interfaces: `IContentCursor` (the `getCursor()` read shape), `IRenderCursor` (the loose read-surface for `update()` / inline renderer), `IPublicCursorInput` (the permissive public input for `muya.setCursor`, isolating the legacy looseness to one entry point), and `IPathCursor` (the path-only `resolveSentinelCursor` return).
- Pure type refactor — zero runtime behavior change. As a side effect it tightens 5 content-block `update()` overrides that had drifted to a non-optional param.

## Test Plan

- [x] `rg "ICursor" packages/muya/src` → empty
- [x] `pnpm -C packages/muya lint` · `lint:types` · `check-circular`
- [x] `pnpm -C packages/muya test` (764 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)