### PR TITLE
refactor(muya): keep table rect selection exclusive of text selection

### DIFF
--- a/packages/muya/e2e/tests/editing/table-rect-clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/table-rect-clipboard.spec.ts
@@ -1,0 +1,127 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { metaKey } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+/**
+ * Gate for PR5 (table rect selection exclusive of text selection). The frozen
+ * table rectangle no longer plants a model-level text caret in the anchor
+ * cell — focus stays on the editor root and the clipboard listeners moved to
+ * `document` with an ownership guard. This spec proves a real Cmd/Ctrl+C still
+ * fires copy (clipboard receives the GFM sub-table) and Cmd/Ctrl+X still fires
+ * cut (the spanned cells are emptied) under that new arrangement, in real
+ * Chromium.
+ *
+ * Firefox/WebKit headless clipboard read is unreliable (same constraint as
+ * editing/clipboard.spec.ts); tracked in BACKLOG Phase 3.
+ */
+
+const TABLE_MD = [
+    '| a1 | b1 | c1 |',
+    '| --- | --- | --- |',
+    '| a2 | b2 | c2 |',
+    '| a3 | b3 | c3 |',
+    '',
+].join('\n');
+
+async function seedTable(page: Page): Promise<void> {
+    await page.evaluate(md => window.muya!.setContent(md), TABLE_MD);
+    await expect(page.locator(editor.table).first()).toBeVisible();
+}
+
+async function cellCenter(page: Page, row: number, column: number) {
+    const cell = page.locator(editor.table).first()
+        .locator('tr').nth(row)
+        .locator('td').nth(column);
+    const box = await cell.boundingBox();
+    if (!box)
+        throw new Error(`cell (${row}, ${column}) has no bounding box`);
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+async function dragSelect(
+    page: Page,
+    from: { row: number; column: number },
+    to: { row: number; column: number },
+): Promise<void> {
+    const start = await cellCenter(page, from.row, from.column);
+    const end = await cellCenter(page, to.row, to.column);
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move((start.x + end.x) / 2, (start.y + end.y) / 2, { steps: 4 });
+    await page.mouse.move(end.x, end.y, { steps: 4 });
+    await page.mouse.up();
+}
+
+function selectedCount(page: Page) {
+    return page.locator(`${editor.table} td.mu-table-cell-selected`).count();
+}
+
+test.describe('table rect clipboard (root-focus exclusivity)', () => {
+    test('a frozen rectangle leaves no text caret or native range behind', async ({ page }) => {
+        await seedTable(page);
+        await dragSelect(page, { row: 0, column: 0 }, { row: 1, column: 1 });
+        await expect.poll(() => selectedCount(page)).toBe(4);
+
+        const state = await page.evaluate(() => ({
+            hasTableSelection: window.muya!.editor.selection.table.hasSelection,
+            activeContentBlock: window.muya!.editor.activeContentBlock,
+            // Focusing the contenteditable root plants a collapsed caret range;
+            // what matters for exclusivity is that no *text* is selected, so the
+            // native blue highlight is gone — the cell rectangle is the only
+            // visible selection.
+            nativeSelectionText: document.getSelection()?.toString() ?? '',
+            activeIsEditorRoot: document.activeElement === window.muya!.domNode,
+            editorHasFocus: window.muya!.domNode.contains(document.activeElement),
+        }));
+
+        expect(state.hasTableSelection).toBe(true);
+        expect(state.activeContentBlock).toBe(null);
+        expect(state.nativeSelectionText).toBe('');
+        // Focus stays on the editor root (not a cell caret) so copy/cut fire.
+        expect(state.activeIsEditorRoot).toBe(true);
+        expect(state.editorHasFocus).toBe(true);
+    });
+
+    test('Cmd/Ctrl+C copies the selected rectangle as a GFM sub-table', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'clipboard read unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+        await seedTable(page);
+
+        await dragSelect(page, { row: 0, column: 0 }, { row: 1, column: 1 });
+        await expect.poll(() => selectedCount(page)).toBe(4);
+
+        await page.keyboard.press(`${metaKey()}+c`);
+
+        const copied = await page.evaluate(() => navigator.clipboard.readText());
+        expect(copied).toContain('a1');
+        expect(copied).toContain('b1');
+        expect(copied).toContain('a2');
+        expect(copied).toContain('b2');
+        expect(copied).not.toContain('c1');
+        expect(copied).not.toContain('a3');
+        expect(copied).toMatch(/\|\s*-+/);
+    });
+
+    test('Cmd/Ctrl+X cuts the selected rectangle, emptying only those cells', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'clipboard unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+        await seedTable(page);
+
+        await dragSelect(page, { row: 0, column: 0 }, { row: 1, column: 1 });
+        await expect.poll(() => selectedCount(page)).toBe(4);
+
+        await page.keyboard.press(`${metaKey()}+x`);
+
+        await expect.poll(() => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).not.toMatch(/\ba1\b/);
+
+        const md = await getMarkdown(page);
+        expect(md).not.toMatch(/\bb2\b/);
+        expect(md).toContain('c1');
+        expect(md).toContain('a3');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import type TableBlock from '../../block/gfm/table';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+
+// A plain Backspace/Delete while a table rectangle is frozen must NOT fall
+// through to `cutHandler()`. The `keydownHandler` short-circuits on
+// `selection.table.hasSelection`, so the selected cells keep their text. The
+// document-level `keydown` listener is registered via
+// `eventCenter.attachDOMEvent(document, 'keydown', ...)`, so dispatching the
+// event on `document` exercises the real handler.
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as sibling specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstTable(muya: Muya): TableBlock {
+    return muya.editor.scrollPage!.firstContentInDescendant()!.closestBlock('table') as TableBlock;
+}
+
+function cellDom(table: TableBlock, row: number, column: number): HTMLElement {
+    const cell = table.cellAt(row, column)!;
+    return (cell.firstChild as { domNode: HTMLElement }).domNode;
+}
+
+function fireMouse(node: HTMLElement, type: string): void {
+    const event = new MouseEvent(type, { bubbles: true, button: 0 });
+    if (!('x' in event))
+        Object.defineProperty(event, 'x', { value: 0, configurable: true });
+    node.dispatchEvent(event);
+}
+
+// Build a genuine frozen rectangle selection through real DOM mouse events
+// (same pattern as selection/__tests__/TableRectSelection.spec.ts).
+function dragSelect(table: TableBlock, r1: number, c1: number, r2: number, c2: number): void {
+    fireMouse(cellDom(table, r1, c1), 'mousedown');
+    fireMouse(cellDom(table, r2, c2), 'mousemove');
+    fireMouse(cellDom(table, r2, c2), 'mouseup');
+}
+
+describe('track C — keydown table.hasSelection guard', () => {
+    it('a plain Backspace over a frozen table rect does not empty the cells', async () => {
+        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+        const table = firstTable(muya);
+
+        // Freeze the whole 2x2 body grid so `selection.table.hasSelection`.
+        dragSelect(table, 0, 0, 1, 1);
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+
+        // `ownsEvent()` requires `document.activeElement` inside `muya.domNode`.
+        cellDom(table, 0, 0).focus();
+        expect(muya.domNode.contains(document.activeElement)).toBe(true);
+
+        const event = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true });
+        document.dispatchEvent(event);
+
+        // The frozen selection still stands and the cells keep their text —
+        // the guard stopped the handler before `cutHandler()` ran.
+        await new Promise(r => setTimeout(r, 40));
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        const md = muya.getMarkdown();
+        expect(md).toContain('a1');
+        expect(md).toContain('b1');
+        expect(md).toContain('a2');
+        expect(md).toContain('b2');
+    });
+
+    it('a plain Delete over a frozen table rect does not empty the cells', async () => {
+        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+        const table = firstTable(muya);
+
+        dragSelect(table, 0, 0, 1, 1);
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+
+        cellDom(table, 0, 0).focus();
+        expect(muya.domNode.contains(document.activeElement)).toBe(true);
+
+        const event = new KeyboardEvent('keydown', { key: 'Delete', bubbles: true });
+        document.dispatchEvent(event);
+
+        await new Promise(r => setTimeout(r, 40));
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        const md = muya.getMarkdown();
+        expect(md).toContain('a1');
+        expect(md).toContain('b1');
+        expect(md).toContain('a2');
+        expect(md).toContain('b2');
+    });
+});

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -1,6 +1,5 @@
 import type { Muya } from '../muya';
 import type { IClipboardPayload } from './copyData';
-import { fromEvent, merge } from 'rxjs';
 import { isClipboardEvent, isKeyboardEvent } from '../utils';
 import { getClipboardData, writeClipboardData } from './copyData';
 import { cutSelection } from './cut';
@@ -30,10 +29,10 @@ class Clipboard {
     constructor(public muya: Muya) {}
 
     listen() {
-        const { domNode } = this.muya;
+        const ownsEvent = () => this.muya.hasFocus();
 
         const copyCutHandler = (event: Event) => {
-            if (!isClipboardEvent(event))
+            if (!ownsEvent() || !isClipboardEvent(event))
                 return;
             event.preventDefault();
             event.stopPropagation();
@@ -47,9 +46,12 @@ class Clipboard {
         };
 
         const keydownHandler = (event: Event) => {
-            if (!isKeyboardEvent(event))
+            if (!ownsEvent() || !isKeyboardEvent(event))
                 return;
             const { key, metaKey } = event;
+
+            if (this.selection.table.hasSelection)
+                return;
 
             const { isSelectionInSameBlock } = this.selection.getSelection() ?? {};
             if (isSelectionInSameBlock)
@@ -74,15 +76,16 @@ class Clipboard {
         };
 
         const pasteHandler = (event: Event) => {
-            if (isClipboardEvent(event))
+            if (ownsEvent() && isClipboardEvent(event))
                 this.pasteHandler(event);
         };
 
-        merge(fromEvent(domNode, 'copy'), fromEvent(domNode, 'cut'))
-            .subscribe(copyCutHandler);
+        const { eventCenter } = this.muya;
 
-        fromEvent(domNode, 'paste').subscribe(pasteHandler);
-        fromEvent(domNode, 'keydown').subscribe(keydownHandler);
+        eventCenter.attachDOMEvent(document, 'copy', copyCutHandler);
+        eventCenter.attachDOMEvent(document, 'cut', copyCutHandler);
+        eventCenter.attachDOMEvent(document, 'paste', pasteHandler);
+        eventCenter.attachDOMEvent(document, 'keydown', keydownHandler);
     }
 
     getClipboardData(): IClipboardPayload {

--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -80,7 +80,7 @@ class TableRectSelection {
             column: focusCell.columnOffset,
         };
         this._isSelecting = true;
-        this._collapseCaretToAnchor();
+        this._freezeNativeSelection();
         this._renderHighlight();
     }
 
@@ -96,7 +96,7 @@ class TableRectSelection {
         this._anchor = position;
         this._focus = position;
         this._isSelecting = true;
-        this._collapseCaretToAnchor();
+        this._freezeNativeSelection();
         this._renderHighlight();
     }
 
@@ -146,19 +146,13 @@ class TableRectSelection {
             && !this._isSelecting
         ) {
             this._isSelecting = true;
-            // Collapse the native text range to a caret in the anchor cell so
-            // the rectangle highlight is the only visible *range* selection,
-            // while the editor stays focused — copy/cut events fire only on the
-            // focused element, so a full blur would break the clipboard.
-            this._collapseCaretToAnchor();
+            this._freezeNativeSelection();
         }
 
         if (!this._isSelecting)
             return;
 
-        // The browser keeps trying to extend a native text selection during the
-        // drag; collapse it again each move so only the cell rectangle shows.
-        this._collapseCaretToAnchor();
+        this._suppressNativeRange();
 
         // Off-table moves null the focus, so releasing outside the table
         // cancels the selection rather than freezing a 1×1 anchor-cell range.
@@ -175,12 +169,15 @@ class TableRectSelection {
             this.clear();
     };
 
-    private _collapseCaretToAnchor(): void {
-        const content = this._anchor?.cell.firstChild;
-        if (content && content.isContent())
-            content.setCursor(0, 0, false);
-
+    private _freezeNativeSelection(): void {
+        document.getSelection()?.removeAllRanges();
+        this.muya.domNode.focus();
+        this.muya.editor.activeContentBlock = null;
         this.muya.ui.hideAllFloatTools();
+    }
+
+    private _suppressNativeRange(): void {
+        document.getSelection()?.removeAllRanges();
     }
 
     private _detachDragEvents(): void {

--- a/packages/muya/src/selection/__tests__/TableRectSelection.spec.ts
+++ b/packages/muya/src/selection/__tests__/TableRectSelection.spec.ts
@@ -108,6 +108,17 @@ describe('cross-cell table selection — highlight', () => {
         expect(muya.editor.selection.table.hasSelection).toBe(true);
     });
 
+    it('keeps the table selection exclusive of any text selection', () => {
+        const muya = bootMuya(TABLE_MD);
+        const table = firstTable(muya);
+        dragSelect(table, 0, 0, 1, 1);
+        // The rectangle is the only selection: no model-level text caret and
+        // no native range survive alongside it.
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        expect(muya.editor.activeContentBlock).toBe(null);
+        expect(document.getSelection()?.rangeCount).toBe(0);
+    });
+
     it('does not start a selection when the pointer stays in one cell', () => {
         const muya = bootMuya(TABLE_MD);
         const table = firstTable(muya);


### PR DESCRIPTION
## Summary

Part 5/5 of a muya selection/cursor API cleanup (stacked on #4521).

- Deletes `TableRectSelection._collapseCaretToAnchor()`, which planted a model-level Text caret in the anchor cell — making `Selection.type` report `Table` while a Text caret + `activeContentBlock` lingered. Replaces it with `_freezeNativeSelection()` (clear native range, focus the editor root, `activeContentBlock = null`, hide float tools) and a per-mousemove `_suppressNativeRange()`. Table-rect and Text selections are now genuinely mutually exclusive.
- Because the editor root (not a cell) holds focus during a rectangle selection, clipboard `copy`/`cut`/`paste`/`keydown` listeners move from `domNode` to `document` (via `eventCenter.attachDOMEvent`, so they are torn down on `destroy()`), guarded by `muya.hasFocus()`; the keydown handler also short-circuits when a table rectangle is frozen.

## Test Plan

- [x] `pnpm -C packages/muya lint` · `lint:types` · `check-circular`
- [x] `pnpm -C packages/muya test` (767 passing); new `keydownTableGuard.spec.ts` + updated `TableRectSelection.spec.ts`
- [x] `pnpm -C packages/muya/e2e e2e --project=chromium` — new `table-rect-clipboard.spec.ts` verifies Cmd/Ctrl+C copies the GFM sub-table and Cmd/Ctrl+X empties only the selected cells, in real Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)