### PR TITLE
refactor(muya): split ICursor into focused interfaces

### DIFF
--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -1,6 +1,6 @@
 import type { IHighlight } from '../../inlineRenderer/types';
 import type { Muya } from '../../muya';
-import type { ICursor, INodeOffset } from '../../selection/types';
+import type { IContentCursor, INodeOffset, IRenderCursor } from '../../selection/types';
 import type { Nullable } from '../../types';
 import type { TBlockPath } from '../types';
 import type Parent from './parent';
@@ -288,7 +288,7 @@ class Content extends TreeNode {
     /**
      * Get cursor if selection is in this block.
      */
-    getCursor() {
+    getCursor(): IContentCursor | null {
         const selection = this.selection.getSelection();
         if (selection == null)
             return null;
@@ -328,14 +328,14 @@ class Content extends TreeNode {
         const focus = { offset: end, block: this, path: this.path };
 
         if (needUpdate)
-            this.update({ anchor, focus, block: this, path: this.path });
+            this.update({ anchor, focus, block: this });
 
         this.muya.editor.activeContentBlock = this;
 
         this.selection.setSelection(anchor, focus);
     }
 
-    update(_cursor?: ICursor, _highlights: IHighlight[] = []) {
+    update(_cursor?: IRenderCursor, _highlights: IHighlight[] = []) {
         const { text } = this;
         this.domNode!.innerHTML = `<span class="mu-syntax-text">${text}</span>`;
     }

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -4,7 +4,7 @@ import type {
     TextToken,
     Token,
 } from '../../inlineRenderer/types';
-import type { ICursor } from '../../selection/types';
+import type { IContentCursor, IRenderCursor } from '../../selection/types';
 import type { IBulletListState, IListItemState, IOrderListState, IParagraphState } from '../../state/types';
 import type { Nullable } from '../../types';
 import type { IImageInfo } from '../../utils/image';
@@ -143,7 +143,7 @@ function getOffset(offset: number, token: Token) {
     }
 }
 
-function clearFormat(token: Token, cursor: ICursor) {
+function clearFormat(token: Token, cursor: IContentCursor) {
     switch (token.type) {
         case 'strong':
 
@@ -300,7 +300,7 @@ class Format extends Content {
     }
 
     // TODO: @JOCS remove use this.selection directly
-    checkNeedRender(cursor: ICursor = { anchor: this.selection.anchor ?? null, focus: this.selection.focus ?? null }) {
+    checkNeedRender(cursor: IRenderCursor = { anchor: this.selection.anchor ?? undefined, focus: this.selection.focus ?? undefined }) {
         const { labels } = this.inlineRenderer;
         const { text } = this;
         const { start: cStart, end: cEnd, anchor, focus } = cursor;
@@ -518,7 +518,6 @@ class Format extends Content {
 
             const cursor = Object.assign({}, currentCursor, {
                 block: this,
-                path: this.path,
             });
 
             // TODO: The codes bellow maybe is wrong? and remove use this.selection directly
@@ -565,7 +564,7 @@ class Format extends Content {
             || focus.offset !== oldFocus?.offset
         ) {
             const needUpdate = this.checkNeedRender({ anchor, focus });
-            const cursor = { anchor, focus, block: this, path: this.path };
+            const cursor = { anchor, focus, block: this };
 
             if (needUpdate)
                 this.update(cursor);
@@ -645,7 +644,6 @@ class Format extends Content {
         this.text = text;
 
         const cursor = {
-            path: this.path,
             block: this,
             anchor: {
                 offset: start.offset,
@@ -1519,7 +1517,7 @@ class Format extends Content {
         cursorBlock.setCursor(0, 0, true);
     }
 
-    getFormatsInRange(cursor = this.getCursor()) {
+    getFormatsInRange(cursor: IContentCursor | null = this.getCursor()) {
         if (cursor == null)
             return { formats: [], tokens: [], neighbors: [] };
 
@@ -1591,7 +1589,7 @@ class Format extends Content {
         // cache delta
         if (type === 'clear') {
             for (const neighbor of neighbors)
-                clearFormat(neighbor, { start, end });
+                clearFormat(neighbor, cursor);
 
             start.offset += start.delta;
             end.offset += end.delta;
@@ -1600,7 +1598,7 @@ class Format extends Content {
         }
         else if (currentFormats.length) {
             for (const token of currentFormats)
-                clearFormat(token, { start, end });
+                clearFormat(token, cursor);
 
             start.offset += start.delta;
             end.offset += end.delta;
@@ -1609,7 +1607,7 @@ class Format extends Content {
         else {
             if (currentNeighbors.length) {
                 for (const neighbor of currentNeighbors)
-                    clearFormat(neighbor, { start, end });
+                    clearFormat(neighbor, cursor);
             }
 
             start.offset += start.delta;

--- a/packages/muya/src/block/content/atxHeadingContent/index.ts
+++ b/packages/muya/src/block/content/atxHeadingContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type AtxHeading from '../../commonMark/atxHeading';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
@@ -26,7 +26,7 @@ class AtxHeadingContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type {
     CodeContentState,
     ICodeBlockState,
@@ -138,7 +138,7 @@ class CodeBlockContent extends Content {
             (this.outContainer?.attachments?.head as HTMLPreview).update(text);
     }
 
-    override update(_cursor: ICursor, highlights = []) {
+    override update(_cursor?: IRenderCursor, highlights = []) {
         const { lang, text } = this;
         // transform alias to original language
         const fullLengthLang = transformAliasToOrigin([lang])[0];

--- a/packages/muya/src/block/content/langInputContent/index.ts
+++ b/packages/muya/src/block/content/langInputContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type { ICodeBlockState } from '../../../state/types';
 import type CodeBlock from '../../commonMark/codeBlock';
 import { CLASS_NAMES } from '../../../config';
@@ -28,7 +28,7 @@ class LangInputContent extends Content {
         return this.parent;
     }
 
-    override update(_cursor?: ICursor, highlights = []) {
+    override update(_cursor?: IRenderCursor, highlights = []) {
         this.domNode!.innerHTML = escapeLangInputInnerHtml(this.text, highlights);
     }
 

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -1,6 +1,6 @@
 import type { Muya } from '../../../index';
 import type { ImageToken, LinkToken, Token } from '../../../inlineRenderer/types';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type {
     IBlockQuoteState,
     IBulletListState,
@@ -100,7 +100,7 @@ class ParagraphContent extends Format {
         return this.parent;
     }
 
-    override update(cursor?: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         this.inlineRenderer.patch(this, cursor, highlights);
         const { label } = this.inlineRenderer.getLabelInfo(this);
 

--- a/packages/muya/src/block/content/setextHeadingContent/index.ts
+++ b/packages/muya/src/block/content/setextHeadingContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
@@ -23,7 +23,7 @@ class SetextHeadingContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/tableCell/index.ts
+++ b/packages/muya/src/block/content/tableCell/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type Table from '../../gfm/table';
 import type Cell from '../../gfm/table/cell';
 import type Row from '../../gfm/table/row';
@@ -46,7 +46,7 @@ class TableCellContent extends Format {
         return this.table;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/block/content/thematicBreakContent/index.ts
+++ b/packages/muya/src/block/content/thematicBreakContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../muya';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import { isKeyboardEvent } from '../../../utils';
 import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
@@ -23,7 +23,7 @@ class ThematicBreakContent extends Format {
         return this.parent;
     }
 
-    override update(cursor: ICursor, highlights = []) {
+    override update(cursor?: IRenderCursor, highlights = []) {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 

--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -1,7 +1,7 @@
 import type Format from '../block/base/format';
 import type ParagraphContent from '../block/content/paragraphContent';
 import type { Muya } from '../muya';
-import type { ICursor } from '../selection/types';
+import type { IRenderCursor } from '../selection/types';
 import type { IParagraphState, TContainerState, TState } from '../state/types';
 import type { IHighlight, Labels } from './types';
 import logger from '../utils/logger';
@@ -59,7 +59,7 @@ class InlineRenderer {
         });
     }
 
-    patch(block: Format, cursor?: ICursor, highlights: IHighlight[] = []) {
+    patch(block: Format, cursor?: IRenderCursor, highlights: IHighlight[] = []) {
         this.collectReferenceDefinitions();
         const { domNode } = block;
         if (block.isParent())

--- a/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/image.spec.ts
@@ -2,7 +2,7 @@
 
 import type { VNode } from 'snabbdom';
 import type Format from '../../../block/base/format';
-import type { ICursor } from '../../../selection/types';
+import type { IRenderCursor } from '../../../selection/types';
 import type { ImageToken } from '../../types';
 import type Renderer from '../index';
 import { describe, expect, it, vi } from 'vitest';
@@ -91,11 +91,11 @@ function findImgSrc(vnodes: VNode | VNode[]): string | undefined {
 }
 
 // Narrow casts shared by every test: the fake renderer and block stubs
-// don't satisfy the full Renderer / Format / ICursor surface, but
+// don't satisfy the full Renderer / Format / IRenderCursor surface, but
 // `image()` only touches the loadImageAsync / urlMap / muya fields and
 // the token range.
 const fakeBlock = {} as unknown as Format;
-const fakeCursor = {} as unknown as ICursor;
+const fakeCursor = {} as unknown as IRenderCursor;
 function asRenderer(r: IFakeRenderer): Renderer {
     return r as unknown as Renderer;
 }

--- a/packages/muya/src/inlineRenderer/renderer/index.ts
+++ b/packages/muya/src/inlineRenderer/renderer/index.ts
@@ -2,7 +2,7 @@
 import type { VNode } from 'snabbdom';
 import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
-import type { ICursor } from '../../selection/types';
+import type { IRenderCursor } from '../../selection/types';
 import type InlineRenderer from '../index';
 import type { ISyntaxRenderOptions, Token } from '../types';
 import { CLASS_NAMES } from '../../config';
@@ -108,7 +108,7 @@ class Renderer {
 
     constructor(public muya: Muya, public parent: InlineRenderer) {}
 
-    checkConflicted(block: Format, token: Token, cursor: ICursor = {}) {
+    checkConflicted(block: Format, token: Token, cursor: IRenderCursor = {}) {
         const anchor = cursor.anchor || cursor.start;
         const focus = cursor.focus || cursor.end;
         if (!anchor || !focus || (cursor.block && cursor.block !== block))
@@ -126,7 +126,7 @@ class Renderer {
         outerClass: string | undefined,
         block: Format,
         token: Token,
-        cursor: ICursor,
+        cursor: IRenderCursor,
     ) {
         return (
             outerClass
@@ -155,7 +155,7 @@ class Renderer {
         return map[name](opts);
     }
 
-    output(tokens: Token[], block: Format, cursor: ICursor) {
+    output(tokens: Token[], block: Format, cursor: IRenderCursor) {
         const children: VNode[] = tokens.reduce(
             (acc, token) => [
                 ...acc,

--- a/packages/muya/src/inlineRenderer/types.ts
+++ b/packages/muya/src/inlineRenderer/types.ts
@@ -1,12 +1,12 @@
 import type { h } from 'snabbdom';
 import type Format from '../block/base/format';
-import type { ICursor } from '../selection/types';
+import type { IRenderCursor } from '../selection/types';
 
 export type H = typeof h;
 
 export interface ISyntaxRenderOptions {
     h: H;
-    cursor: ICursor;
+    cursor: IRenderCursor;
     block: Format;
     token: Token;
     outerClass?: string;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -3,7 +3,7 @@ import type Parent from './block/base/parent';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
 import type { IIndexCursor } from './selection/offsetCursor';
-import type { ICursor, IHistorySelection } from './selection/types';
+import type { IHistorySelection, IPublicCursorInput } from './selection/types';
 import type { ITocItem } from './state/getTOC';
 import type { IBulletListState, IOrderListState, ITableState, ITaskListState, TState } from './state/types';
 import type { IMuyaOptions, Nullable } from './types';
@@ -737,13 +737,13 @@ export class Muya {
      * resolve and pass the block instance. No-op when the target can't be
      * resolved.
      */
-    setCursor(cursor: ICursor) {
+    setCursor(cursor: IPublicCursorInput) {
         const { scrollPage } = this.editor;
         if (!scrollPage)
             return;
 
         // Accept both the `{ anchor, focus, anchorPath, focusPath }` and the
-        // `{ start, end, path }`/`block` shapes of ICursor.
+        // `{ start, end, path }`/`block` shapes of IPublicCursorInput.
         const anchor = cursor.anchor ?? cursor.start ?? null;
         const focus = cursor.focus ?? cursor.end ?? anchor;
         const anchorPath = cursor.anchorPath ?? cursor.path;

--- a/packages/muya/src/selection/offsetCursor.ts
+++ b/packages/muya/src/selection/offsetCursor.ts
@@ -6,7 +6,7 @@
 import type Content from '../block/base/content';
 import type { ScrollPage } from '../block/scrollPage';
 import type { TState } from '../state/types';
-import type { ICursor, ISelection } from './types';
+import type { IPathCursor, ISelection } from './types';
 
 /** One end of a source-mode (CodeMirror) selection: a `{ line, ch }` offset. */
 export interface IIndexPosition {
@@ -113,7 +113,7 @@ function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit |
 
 /**
  * Resolve the index cursor against the live (sentinel-bearing) block tree into
- * a PATH-ONLY `ICursor` (json paths + offsets), or `null` when neither sentinel
+ * a PATH-ONLY `IPathCursor` (json paths + offsets), or `null` when neither sentinel
  * resolved to a content block.
  *
  * Only the plain `anchorPath`/`focusPath` arrays are captured (snapshotted from
@@ -126,7 +126,7 @@ function _findSentinel(scrollPage: ScrollPage, sentinel: string): ISentinelHit |
  * The returned offsets are sentinel-free: the focus offset is decremented when
  * the anchor sentinel precedes it in the same block.
  */
-export function resolveSentinelCursor(scrollPage: ScrollPage): ICursor | null {
+export function resolveSentinelCursor(scrollPage: ScrollPage): IPathCursor | null {
     const anchorHit = _findSentinel(scrollPage, ANCHOR_SENTINEL);
     const focusHit = _findSentinel(scrollPage, FOCUS_SENTINEL);
 

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -7,23 +7,37 @@ export interface INodeOffset {
     offset: number;
 }
 
-// TODO: @JOCS, optimization of Cursor type, split it into for getCursor return type and setSelection params type?
-export interface ICursor {
+export interface IContentCursor extends ISelection {
+    start: INodeOffset;
+    end: INodeOffset;
+}
+
+export interface IRenderCursor {
+    start?: INodeOffset;
+    end?: INodeOffset;
+    anchor?: INodeOffset;
+    focus?: INodeOffset;
+    block?: ContentBlock;
+}
+
+export interface IPublicCursorInput {
     start?: INodeOffset | null;
     end?: INodeOffset | null;
-    block?: ContentBlock;
-    path?: TBlockPath;
-    // The same as TSelection
     anchor?: INodeOffset | null;
     focus?: INodeOffset | null;
+    block?: ContentBlock;
+    path?: TBlockPath;
     anchorBlock?: ContentBlock;
     anchorPath?: TBlockPath;
     focusBlock?: ContentBlock;
     focusPath?: TBlockPath;
-    isCollapsed?: boolean;
-    isSelectionInSameBlock?: boolean;
-    direction?: SelectionDirection;
-    type?: SelectionCaretType;
+}
+
+export interface IPathCursor {
+    anchor: INodeOffset;
+    anchorPath: TBlockPath;
+    focus: INodeOffset;
+    focusPath: TBlockPath;
 }
 
 // One endpoint of a selection: the offset plus the live block reference and its


### PR DESCRIPTION
Re-targets the changes from #4521 onto `develop`. The original #4521 was stacked on the PR3 branch and merged into that transient base (which had not yet been deleted) rather than `develop`, so this PR delivers the same reviewed changes directly to `develop`.

## Summary

- Deletes the over-broad `ICursor` and replaces it with `IContentCursor` (getCursor read shape), `IRenderCursor` (update/inline-renderer), `IPublicCursorInput` (the permissive `muya.setCursor` input), and `IPathCursor` (path-only `resolveSentinelCursor` return). Pure type refactor, zero runtime behavior change.

## Test Plan

- [x] `rg "ICursor" packages/muya/src` → empty
- [x] `pnpm -C packages/muya lint` · `lint:types` · `check-circular`
- [x] `pnpm -C packages/muya test` (979 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)