### PR TITLE
refactor(muya): simplify selectAll into three escalation rules

### DIFF
--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -84,6 +84,12 @@ class TableRectSelection {
         this._renderHighlight();
     }
 
+    selectWholeTable(): void {
+        const table = this._table;
+        if (table)
+            this.selectTable(table);
+    }
+
     selectSingleCell(cell: TableBodyCell): void {
         this.clear();
 

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -2,8 +2,10 @@
 
 import type Content from '../../block/base/content';
 import type Table from '../../block/gfm/table';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ISelection } from '../types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../types';
 
 // `selectAll` escalates through three rules:
 //   1. A frozen rectangular table selection: a partial rectangle (single cell
@@ -15,6 +17,13 @@ import { Muya } from '../../muya';
 //   3. A selection spanning multiple content blocks (two cells of the same
 //      table, cells of different tables, or plain paragraphs) goes straight to
 //      the whole document.
+//
+// selectAll reads the live DOM selection. happy-dom's Selection cannot
+// represent a range (extend is a no-op, so every range collapses to its
+// anchor), so we mirror the engine's tracked text endpoints back through
+// getSelection — exactly what a real browser reports when the cached state and
+// the live DOM agree. The stale-cache regression test below overrides this to
+// model the one case where they diverge.
 
 const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
@@ -27,6 +36,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.restoreAllMocks();
     while (bootedMuyas.length)
         bootedMuyas.pop()!.destroy();
     if (hadVersion)
@@ -35,12 +45,43 @@ afterEach(() => {
         delete (window as Partial<Window>).MUYA_VERSION;
 });
 
+// Mirror the engine's tracked text endpoints back through getSelection so the
+// live read inside selectAll sees what a real browser would report.
+function mirrorLiveSelection(muya: Muya): void {
+    const selection = muya.editor.selection;
+    const text = (selection as unknown as { _text: {
+        anchorBlock: Content | null;
+        focusBlock: Content | null;
+        anchor: { offset: number } | null;
+        focus: { offset: number } | null;
+    }; })._text;
+
+    vi.spyOn(selection, 'getSelection').mockImplementation((): ISelection | null => {
+        const { anchorBlock, focusBlock, anchor, focus } = text;
+        if (!anchorBlock || !focusBlock || anchor == null || focus == null)
+            return null;
+
+        const isSelectionInSameBlock = anchorBlock === focusBlock;
+        const isCollapsed = isSelectionInSameBlock && anchor.offset === focus.offset;
+
+        return {
+            anchor: { offset: anchor.offset, block: anchorBlock, path: anchorBlock.path },
+            focus: { offset: focus.offset, block: focusBlock, path: focusBlock.path },
+            isCollapsed,
+            isSelectionInSameBlock,
+            direction: SelectionDirection.None,
+            type: isCollapsed ? SelectionCaretType.Caret : SelectionCaretType.Range,
+        };
+    });
+}
+
 function bootMuya(markdown: string): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
     bootedMuyas.push(muya);
+    mirrorLiveSelection(muya);
     return muya;
 }
 
@@ -239,5 +280,44 @@ describe('selection.selectAll code / language blocks', () => {
         selection.selectAll();
         expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
         expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
+    });
+});
+
+describe('selection.selectAll honors the live selection over stale cache', () => {
+    it('selects the clicked block, not the document, after a whole-document selection', () => {
+        const muya = bootMuya('hello world\n\nsecond line\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const second = sp.lastContentInDescendant()!;
+        const { selection } = muya.editor;
+
+        // The whole document is selected: the cached endpoints span first →
+        // second across two blocks.
+        selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: second.text.length, block: second, path: second.path },
+        );
+        expect(selection.anchorBlock).toBe(first);
+        expect(selection.focusBlock).toBe(second);
+
+        // The user clicks into the second block: the live DOM is a caret there,
+        // but the cached endpoints stay stale (the menu-driven selectAll never
+        // saw a setSelection refreshing them).
+        vi.mocked(selection.getSelection).mockReturnValue({
+            anchor: { offset: 3, block: second, path: second.path },
+            focus: { offset: 3, block: second, path: second.path },
+            isCollapsed: true,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.None,
+            type: SelectionCaretType.Caret,
+        });
+
+        // selectAll must honor the live caret and grow to the whole second
+        // block, not jump straight to the whole document.
+        selection.selectAll();
+        expect(selection.anchorBlock).toBe(second);
+        expect(selection.focusBlock).toBe(second);
+        expect(selection.anchor!.offset).toBe(0);
+        expect(selection.focus!.offset).toBe(second.text.length);
     });
 });

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -5,15 +5,16 @@ import type Table from '../../block/gfm/table';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Muya } from '../../muya';
 
-// Port of the legacy `packages/muyajs` `selectAll` behavior
-// (`contentState/paragraphCtrl.js`). Cmd+A escalates level-by-level:
-//   - cursor inside a single table cell      → freeze that 1x1 cell
-//   - one cell already frozen                → select the whole table
-//   - whole table already frozen             → clear + select whole document
-//   - selection spanning two cells (same)    → select the whole table
-//   - selection spanning two DIFFERENT tables → no-op (don't select document)
-// Code / language-input content blocks clamp inside their own block and stay
-// idempotent on repeated Cmd+A (never escalate to the whole document).
+// `selectAll` escalates through three rules:
+//   1. A frozen rectangular table selection: a partial rectangle (single cell
+//      included) grows to the whole table; the whole table jumps to the whole
+//      document.
+//   2. A caret/selection inside a single content block: a table cell freezes as
+//      a 1x1 rectangle; any other block (paragraph, heading, code, …) grows to
+//      the whole block, then to the whole document.
+//   3. A selection spanning multiple content blocks (two cells of the same
+//      table, cells of different tables, or plain paragraphs) goes straight to
+//      the whole document.
 
 const bootedMuyas: Muya[] = [];
 let originalVersion: string | undefined;
@@ -128,11 +129,12 @@ describe('selection.selectAll table escalation', () => {
         expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
     });
 
-    it('selecting two cells of the SAME table escalates to the whole table', () => {
-        const muya = bootMuya(TABLE_MD);
+    it('selecting two cells of the SAME table escalates to the whole document', () => {
+        const muya = bootMuya(`${TABLE_MD}\nbelow\n`);
         const table = getTable(muya);
         const { selection } = muya.editor;
         const tableSelection = selection.table;
+        const sp = muya.editor.scrollPage!;
 
         const a = cellContent(table, 0, 0);
         const b = cellContent(table, 1, 1);
@@ -143,11 +145,12 @@ describe('selection.selectAll table escalation', () => {
 
         selection.selectAll();
 
-        expect(tableSelection.hasSelection).toBe(true);
-        expect(tableSelection.isWholeTableSelected()).toBe(true);
+        expect(tableSelection.hasSelection).toBe(false);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
     });
 
-    it('selecting cells across TWO different tables is a no-op (no document selection)', () => {
+    it('selecting cells across TWO different tables escalates to the whole document', () => {
         const muya = bootMuya(`${TABLE_MD}\n${TABLE_MD}`);
         const sp = muya.editor.scrollPage!;
         const { selection } = muya.editor;
@@ -169,15 +172,14 @@ describe('selection.selectAll table escalation', () => {
 
         selection.selectAll();
 
-        // No table selection frozen and no whole-document escalation.
         expect(tableSelection.hasSelection).toBe(false);
-        expect(selection.anchorBlock).toBe(a);
-        expect(selection.focusBlock).toBe(b);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
     });
 });
 
-describe('selection.selectAll code / language clamp', () => {
-    it('clamps inside a code block and stays idempotent on repeated Cmd+A', () => {
+describe('selection.selectAll code / language blocks', () => {
+    it('selects the whole code block first, then escalates to the whole document', () => {
         const muya = bootMuya('```js\nconst a = 1\nconst b = 2\n```\n');
         const sp = muya.editor.scrollPage!;
         const codeLeaf = sp.lastContentInDescendant()!;
@@ -185,38 +187,40 @@ describe('selection.selectAll code / language clamp', () => {
 
         codeLeaf.setCursor(0, 3, false);
 
+        // First Cmd+A selects the whole code block content.
         selection.selectAll();
         expect(selection.anchorBlock).toBe(codeLeaf);
         expect(selection.focusBlock).toBe(codeLeaf);
         expect(selection.anchor!.offset).toBe(0);
         expect(selection.focus!.offset).toBe(codeLeaf.text.length);
 
-        // Second Cmd+A: stays clamped inside the code block (no document).
+        // Second Cmd+A escalates to the whole document.
         selection.selectAll();
-        expect(selection.anchorBlock).toBe(codeLeaf);
-        expect(selection.focusBlock).toBe(codeLeaf);
-        expect(selection.focus!.offset).toBe(codeLeaf.text.length);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
     });
 
-    it('clamps inside the language-input and stays idempotent on repeated Cmd+A', () => {
-        const muya = bootMuya('```js\nconst a = 1\n```\n');
+    it('selects the whole language-input first, then escalates to the whole document', () => {
+        const muya = bootMuya('```js\nconst a = 1\n```\n\nbelow\n');
         const sp = muya.editor.scrollPage!;
         const langInput = sp.firstContentInDescendant()!;
         expect(langInput.blockName).toBe('language-input');
+        expect(langInput.text).toBe('js');
         const { selection } = muya.editor;
 
         langInput.setCursor(0, 0, false);
 
+        // First Cmd+A selects the whole language-input content ("js").
         selection.selectAll();
         expect(selection.anchorBlock).toBe(langInput);
         expect(selection.focusBlock).toBe(langInput);
         expect(selection.anchor!.offset).toBe(0);
         expect(selection.focus!.offset).toBe(langInput.text.length);
 
+        // Second Cmd+A escalates to the whole document.
         selection.selectAll();
-        expect(selection.anchorBlock).toBe(langInput);
-        expect(selection.focusBlock).toBe(langInput);
-        expect(selection.focus!.offset).toBe(langInput.text.length);
+        expect(selection.anchorBlock).toBe(sp.firstContentInDescendant());
+        expect(selection.focusBlock).toBe(sp.lastContentInDescendant());
     });
 
     it('plain paragraph still escalates to the whole document', () => {

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -45,16 +45,18 @@ afterEach(() => {
         delete (window as Partial<Window>).MUYA_VERSION;
 });
 
+interface ITrackedEndpoints {
+    anchorBlock: Content | null;
+    focusBlock: Content | null;
+    anchor: { offset: number } | null;
+    focus: { offset: number } | null;
+}
+
 // Mirror the engine's tracked text endpoints back through getSelection so the
 // live read inside selectAll sees what a real browser would report.
 function mirrorLiveSelection(muya: Muya): void {
     const selection = muya.editor.selection;
-    const text = (selection as unknown as { _text: {
-        anchorBlock: Content | null;
-        focusBlock: Content | null;
-        anchor: { offset: number } | null;
-        focus: { offset: number } | null;
-    }; })._text;
+    const text = (selection as unknown as { _text: ITrackedEndpoints })._text;
 
     vi.spyOn(selection, 'getSelection').mockImplementation((): ISelection | null => {
         const { anchorBlock, focusBlock, anchor, focus } = text;

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -127,7 +127,6 @@ class Selection {
     }
 
     selectAll(): void {
-        const { anchor, focus, isSelectionInSameBlock, anchorBlock, anchorPath } = this._text;
         const tableSelection = this._table;
 
         // A frozen rectangular table selection escalates: the whole table jumps
@@ -144,8 +143,18 @@ class Selection {
             return;
         }
 
+        // Read the live DOM selection so the caret the user actually sees is
+        // honored. selectAll is driven from the application menu, so the cached
+        // endpoints may be stale — e.g. after a whole-document selection blurred
+        // the editor and the user clicked back into a single block.
+        const live = this.getSelection();
+        const anchorBlock = live ? live.anchor.block : this._text.anchorBlock;
+        const focusBlock = live ? live.focus.block : this._text.focusBlock;
+        const anchorOffset = live ? live.anchor.offset : this._text.anchor?.offset;
+        const focusOffset = live ? live.focus.offset : this._text.focus?.offset;
+
         // A caret or selection contained in a single content block.
-        if (isSelectionInSameBlock && anchor && focus && anchorBlock) {
+        if (anchorBlock && anchorBlock === focusBlock && anchorOffset != null && focusOffset != null) {
             // Inside one table cell: freeze it as a 1x1 rectangle.
             if (anchorBlock.blockName === 'table.cell.content') {
                 const cellBlock = anchorBlock.closestBlock('table.cell') as TableBodyCell | null;
@@ -157,10 +166,11 @@ class Selection {
 
             // A partial selection grows to the whole block; a full-block
             // selection falls through to the whole document.
-            if (Math.abs(focus.offset - anchor.offset) < anchorBlock.text.length) {
+            if (Math.abs(focusOffset - anchorOffset) < anchorBlock.text.length) {
+                const path = anchorBlock.path;
                 this._text.setSelection(
-                    { offset: 0, block: anchorBlock, path: anchorPath },
-                    { offset: anchorBlock.text.length, block: anchorBlock, path: anchorPath },
+                    { offset: 0, block: anchorBlock, path },
+                    { offset: anchorBlock.text.length, block: anchorBlock, path },
                 );
                 return;
             }

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -1,4 +1,3 @@
-import type Table from '../block/gfm/table';
 import type TableBodyCell from '../block/gfm/table/cell';
 import type { Muya } from '../muya';
 import type { IAnchorFocusInfo, IImageSelectionData, ISelection } from './types';
@@ -128,75 +127,46 @@ class Selection {
     }
 
     selectAll(): void {
-        const { anchor, focus, isSelectionInSameBlock, anchorBlock, focusBlock, anchorPath } = this._text;
+        const { anchor, focus, isSelectionInSameBlock, anchorBlock, anchorPath } = this._text;
         const tableSelection = this._table;
 
-        if (tableSelection.isWholeTableSelected()) {
-            tableSelection.clear();
-            this._text.selectAllContent();
+        // A frozen rectangular table selection escalates: the whole table jumps
+        // to the whole document; any partial rectangle (a single cell included)
+        // grows to the whole table first.
+        if (tableSelection.hasSelection) {
+            if (tableSelection.isWholeTableSelected()) {
+                tableSelection.clear();
+                this._text.selectAllContent();
+            }
+            else {
+                tableSelection.selectWholeTable();
+            }
             return;
         }
 
-        if (tableSelection.isSingleCellSelected()) {
-            const cellBlock = anchorBlock?.closestBlock('table.cell') as TableBodyCell | null;
-            const table = cellBlock?.table ?? null;
-
-            if (table) {
-                tableSelection.selectTable(table);
-                return;
-            }
-        }
-
-        if (
-            anchorBlock?.blockName === 'table.cell.content'
-            && focusBlock?.blockName === 'table.cell.content'
-        ) {
-            const anchorTable = anchorBlock.closestBlock('table') as Table | null;
-            const focusTable = focusBlock.closestBlock('table') as Table | null;
-            if (anchorBlock === focusBlock) {
+        // A caret or selection contained in a single content block.
+        if (isSelectionInSameBlock && anchor && focus && anchorBlock) {
+            // Inside one table cell: freeze it as a 1x1 rectangle.
+            if (anchorBlock.blockName === 'table.cell.content') {
                 const cellBlock = anchorBlock.closestBlock('table.cell') as TableBodyCell | null;
                 if (cellBlock) {
                     tableSelection.selectSingleCell(cellBlock);
                     return;
                 }
             }
-            else if (anchorTable && focusTable && anchorTable === focusTable) {
-                tableSelection.selectTable(anchorTable);
-                return;
-            }
-            else {
+
+            // A partial selection grows to the whole block; a full-block
+            // selection falls through to the whole document.
+            if (Math.abs(focus.offset - anchor.offset) < anchorBlock.text.length) {
+                this._text.setSelection(
+                    { offset: 0, block: anchorBlock, path: anchorPath },
+                    { offset: anchorBlock.text.length, block: anchorBlock, path: anchorPath },
+                );
                 return;
             }
         }
 
-        // Code content and the fenced language input clamp inside their own
-        // block and stay idempotent on repeated Cmd+A — never escalate to the
-        // whole document.
-        if (
-            anchorBlock
-            && (anchorBlock.blockName === 'codeblock.content'
-                || anchorBlock.blockName === 'language-input')
-        ) {
-            this._text.setSelection(
-                { offset: 0, block: anchorBlock, path: anchorPath },
-                { offset: anchorBlock.text.length, block: anchorBlock, path: anchorPath },
-            );
-            return;
-        }
-        if (
-            isSelectionInSameBlock
-            && anchor
-            && focus
-            && anchorBlock
-            && Math.abs(focus.offset - anchor.offset) < anchorBlock.text.length
-        ) {
-            this._text.setSelection(
-                { offset: 0, block: anchorBlock, path: anchorPath },
-                { offset: anchorBlock.text.length, block: anchorBlock, path: anchorPath },
-            );
-            return;
-        }
-
+        // Spanning multiple blocks, or a single block already fully selected.
         this._text.selectAllContent();
     }
 }


### PR DESCRIPTION
## Summary

Reworks `Selection.selectAll()` (the editor's Cmd/Ctrl+A handler) into three clear, uniform escalation rules, fixing an unhandled case and removing inconsistent special cases.

### Behavior

1. **An active rectangular table selection** — a partial rectangle (single cell included) grows to the **whole table**; the whole table jumps to the **whole document**.
2. **A caret/selection inside one content block** — a table cell freezes as a **1×1 rectangle**; any other block (paragraph, heading, **code block**, language-input) grows to the **whole block**, then to the **whole document**.
3. **A selection spanning multiple content blocks** (incl. two cells of the same table, or cells of different tables) goes straight to the **whole document**.

### Why

The previous implementation, ported verbatim from the legacy `muyajs` engine, was inconsistent:

- It only handled the *single-cell* and *whole-table* rectangular states, so a **partial multi-cell rectangle** fell through and wrongly selected the whole document.
- It carried a **code-block / language-input guard** that clamped Cmd+A inside the block forever, diverging from how every other block behaves.
- It special-cased same-table two-cell text selections (→ whole table) and cross-table selections (→ no-op), which conflict with the simpler "selection spanning multiple blocks → whole document" model.

The rewrite also drops the method's cyclomatic complexity from **24 → ~10**, clearing the ESLint `complexity` warning.

## Changes

- `TableRectSelection`: add `selectWholeTable()` helper (expands the current rectangle to the whole table).
- `Selection.selectAll()`: rewritten into the three rules above; guard and special cases removed.
- Tests updated to reflect the new escalation; code/language blocks now escalate to the whole document on the second Cmd+A.

## Verification

- `pnpm -C packages/muya test src/selection/__tests__/selectAll.spec.ts` → 9 passed
- Full muya unit suite → 982 passed (121 files)
- `lint:types`, `lint` (0 errors), `check-circular` → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)