### PR TITLE
test(muya): replace any with precise block/state types in specs

### DIFF
--- a/packages/muya/src/__tests__/frontMatter.spec.ts
+++ b/packages/muya/src/__tests__/frontMatter.spec.ts
@@ -2,6 +2,7 @@
 
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
+import type { IFrontmatterState } from '../state/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../muya';
 import { replaceBlockByLabel } from '../ui/paragraphQuickInsertMenu/config';
@@ -113,8 +114,7 @@ describe('muya.updateParagraph(\'front-matter\')', () => {
             expect(muya.getState()[0].name).toBe('frontmatter');
         });
 
-        // eslint-disable-next-line ts/no-explicit-any
-        expect((muya.getState()[0] as any).meta.lang).toBe('yaml');
+        expect((muya.getState()[0] as IFrontmatterState).meta.lang).toBe('yaml');
         expect(muya.getMarkdown().startsWith('---\n')).toBe(true);
     });
 
@@ -127,8 +127,7 @@ describe('muya.updateParagraph(\'front-matter\')', () => {
             expect(muya.getState()[0].name).toBe('frontmatter');
         });
 
-        // eslint-disable-next-line ts/no-explicit-any
-        expect((muya.getState()[0] as any).meta.lang).toBe('toml');
+        expect((muya.getState()[0] as IFrontmatterState).meta.lang).toBe('toml');
         expect(muya.getMarkdown().startsWith('+++\n')).toBe(true);
     });
 
@@ -141,8 +140,7 @@ describe('muya.updateParagraph(\'front-matter\')', () => {
             expect(muya.getState()[0].name).toBe('frontmatter');
         });
 
-        // eslint-disable-next-line ts/no-explicit-any
-        expect((muya.getState()[0] as any).meta.lang).toBe('json');
+        expect((muya.getState()[0] as IFrontmatterState).meta.lang).toBe('json');
         expect(muya.getMarkdown().startsWith(';;;\n')).toBe(true);
     });
 
@@ -155,8 +153,7 @@ describe('muya.updateParagraph(\'front-matter\')', () => {
             expect(muya.getState()[0].name).toBe('frontmatter');
         });
 
-        // eslint-disable-next-line ts/no-explicit-any
-        const meta = (muya.getState()[0] as any).meta;
+        const meta = (muya.getState()[0] as IFrontmatterState).meta;
         expect(meta.lang).toBe('json');
         expect(meta.style).toBe('{');
         // The `{` style serializes the JSON-braces variant, NOT the `;;;` fences.
@@ -222,8 +219,7 @@ describe('quick-insert front matter (replaceBlockByLabel)', () => {
             expect(muya.getState()[0].name).toBe('frontmatter');
         });
 
-        // eslint-disable-next-line ts/no-explicit-any
-        expect((muya.getState()[0] as any).meta.lang).toBe('toml');
+        expect((muya.getState()[0] as IFrontmatterState).meta.lang).toBe('toml');
         expect(muya.getMarkdown().startsWith('+++\n')).toBe(true);
     });
 });

--- a/packages/muya/src/block/gfm/table/__tests__/alignColumn.spec.ts
+++ b/packages/muya/src/block/gfm/table/__tests__/alignColumn.spec.ts
@@ -1,5 +1,9 @@
 // @vitest-environment happy-dom
 
+import type TableBodyCell from '../cell';
+import type Table from '../index';
+import type TableRow from '../row';
+import type TableInner from '../table';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Muya } from '../../../../muya';
 
@@ -45,10 +49,8 @@ function bootMuya(markdown: string): Muya {
     return muya;
 }
 
-// eslint-disable-next-line ts/no-explicit-any
-function findTable(muya: Muya): any {
-    // eslint-disable-next-line ts/no-explicit-any
-    let table: any = null;
+function findTable(muya: Muya): Table {
+    let table: Table | null = null;
     // eslint-disable-next-line ts/no-explicit-any
     const visit = (block: any) => {
         if (block.constructor?.blockName === 'table')
@@ -67,16 +69,14 @@ function flush(): Promise<void> {
 }
 
 // Collect every cell in a given column (header + body) off the live block tree.
-/* eslint-disable ts/no-explicit-any */
-function cellsInColumn(table: any, column: number): any[] {
-    const inner = table.firstChild;
-    const cells: any[] = [];
-    inner.forEach((row: any) => {
-        cells.push(row.find(column));
+function cellsInColumn(table: Table, column: number): TableBodyCell[] {
+    const inner = table.firstChild as TableInner;
+    const cells: TableBodyCell[] = [];
+    inner.forEach((row) => {
+        cells.push((row as TableRow).find(column) as TableBodyCell);
     });
     return cells;
 }
-/* eslint-enable ts/no-explicit-any */
 
 // A plain 2-column table with no explicit alignment — both columns parse as
 // align 'none'.
@@ -93,7 +93,7 @@ describe('table.alignColumn', () => {
         for (const cell of cellsInColumn(table, 0)) {
             expect(cell.meta.align).toBe('center');
             expect(cell.align).toBe('center');
-            expect(cell.domNode.dataset.align).toBe('center');
+            expect(cell.domNode!.dataset.align).toBe('center');
         }
         // Column 1 is untouched.
         for (const cell of cellsInColumn(table, 1))
@@ -137,7 +137,7 @@ describe('table.alignColumn', () => {
 
         for (const cell of cellsInColumn(table, 0)) {
             expect(cell.meta.align).toBe('none');
-            expect(cell.domNode.dataset.align).toBe('none');
+            expect(cell.domNode!.dataset.align).toBe('none');
         }
         // The center delimiter is gone; the default un-aligned delimiter row
         // (only dashes, no colons) is serialized.

--- a/packages/muya/src/block/gfm/table/__tests__/insertRowColumn.spec.ts
+++ b/packages/muya/src/block/gfm/table/__tests__/insertRowColumn.spec.ts
@@ -1,5 +1,7 @@
 // @vitest-environment happy-dom
 
+import type TreeNode from '../../../base/treeNode';
+import type Table from '../index';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Muya } from '../../../../muya';
 
@@ -42,18 +44,15 @@ function bootMuya(markdown: string): Muya {
     return muya;
 }
 
-// eslint-disable-next-line ts/no-explicit-any
-function findTable(muya: Muya): any {
-    // eslint-disable-next-line ts/no-explicit-any
-    let table: any = null;
-    // eslint-disable-next-line ts/no-explicit-any
-    const visit = (block: any) => {
-        if (block.constructor?.blockName === 'table')
-            table = block;
-        // eslint-disable-next-line ts/no-explicit-any
-        block.children?.forEach((c: any) => visit(c));
+function findTable(muya: Muya): Table {
+    let table: Table | null = null;
+    const visit = (block: TreeNode) => {
+        if ((block.constructor as typeof TreeNode)?.blockName === 'table')
+            table = block as Table;
+        if (block.isParent())
+            block.children.forEach(c => visit(c));
     };
-    visit(muya.editor.scrollPage);
+    visit(muya.editor.scrollPage!);
     if (!table)
         throw new Error('no table found');
     return table;
@@ -105,7 +104,7 @@ describe('table.insertRow', () => {
         const caretCell = table.insertRow(1);
 
         expect(caretCell).toBeTruthy();
-        expect(caretCell.constructor.blockName).toBe('table.cell.content');
+        expect((caretCell.constructor as { blockName?: string }).blockName).toBe('table.cell.content');
         expect(caretCell.text).toBe('');
     });
 
@@ -157,7 +156,7 @@ describe('table.insertColumn', () => {
         const caretCell = table.insertColumn(1, 'center');
 
         expect(caretCell).toBeTruthy();
-        expect(caretCell.constructor.blockName).toBe('table.cell.content');
+        expect((caretCell.constructor as { blockName?: string }).blockName).toBe('table.cell.content');
         expect(caretCell.text).toBe('');
     });
 

--- a/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
@@ -1,6 +1,7 @@
-/* eslint-disable ts/no-explicit-any */
 import type Content from '../../block/base/content';
+import type Parent from '../../block/base/parent';
 import type { Muya } from '../../muya';
+import type { TLeafState } from '../../state/types';
 import { describe, expect, it, vi } from 'vitest';
 import { ScrollPage } from '../../block/scrollPage';
 
@@ -154,11 +155,11 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
         // through `MarkdownToState` (Track D / sub-item 1), so the captured text
         // lands in a created paragraph block rather than being spliced into the
         // anchor verbatim. Mock `loadBlock` to capture the created block's state.
-        const created: any[] = [];
+        const created: TLeafState[] = [];
         const spy = vi
             .spyOn(ScrollPage, 'loadBlock')
             .mockImplementation(() => ({
-                create: (_muya: unknown, state: any) => {
+                create: (_muya: unknown, state: TLeafState) => {
                     created.push(state);
                     return {
                         firstContentInDescendant: () => ({
@@ -167,7 +168,7 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
                         }),
                     };
                 },
-            }) as any);
+            }) as unknown as ReturnType<typeof ScrollPage.loadBlock>);
 
         const clipboardFilePath = vi.fn().mockResolvedValue('');
         const anchorBlock = makeAnchorBlock('', 0);
@@ -178,8 +179,8 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
             getState: () => ({ name: 'paragraph', text: '' }),
             remove: vi.fn(),
             parent: { insertAfter: vi.fn() },
-        };
-        (anchorBlock as any).getAnchor = () => wrapper;
+        } as unknown as Parent;
+        anchorBlock.getAnchor = () => wrapper;
         const clipboard = makeClipboard({ clipboardFilePath }, anchorBlock);
         const { event, getData } = makePasteEvent({ 'text/plain': 'hello world' });
 

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -94,8 +94,7 @@ function stubSelection(
 // json state applies composed ops on a requestAnimationFrame; wait for the
 // authoritative markdown to settle.
 async function cutAndRead(muya: Muya): Promise<string> {
-    // eslint-disable-next-line ts/no-explicit-any
-    (muya.editor as any).clipboard.cutHandler();
+    muya.editor.clipboard.cutHandler();
     await new Promise(r => setTimeout(r, 40));
     return muya.getMarkdown();
 }
@@ -242,8 +241,7 @@ describe('track C — cross-block cut keeps both endpoint tails (leaf merge)', (
         const blocks = contentBlocks(muya);
         const start = blocks[0];
         stubSelection(muya, start, 2, blocks[blocks.length - 1], 3);
-        // eslint-disable-next-line ts/no-explicit-any
-        (muya.editor as any).clipboard.cutHandler();
+        muya.editor.clipboard.cutHandler();
         await new Promise(r => setTimeout(r, 40));
         // The caret is seated on the merged start block at the cut offset. The
         // happy-dom native selection does not round-trip, so assert on the
@@ -303,8 +301,7 @@ function dragSelect(table: TableBlock, r1: number, c1: number, r2: number, c2: n
 }
 
 async function cutSelectionAndRead(muya: Muya): Promise<string> {
-    // eslint-disable-next-line ts/no-explicit-any
-    (muya.editor as any).clipboard.cutHandler();
+    muya.editor.clipboard.cutHandler();
     await new Promise(r => setTimeout(r, 40));
     return muya.getMarkdown();
 }

--- a/packages/muya/src/state/__tests__/blockSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/blockSerialization.spec.ts
@@ -1,4 +1,7 @@
 // @vitest-environment happy-dom
+import type TreeNode from '../../block/base/treeNode';
+import type CodeBlock from '../../block/commonMark/codeBlock';
+import type { Nullable } from '../../types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../muya';
 import { MarkdownToState } from '../markdownToState';
@@ -52,13 +55,11 @@ function bootMuya(markdown: string): Muya {
 
 // Walk up from the first content leaf to the enclosing `code-block` parent
 // (the block that owns the `lang` setter and the `meta.type` field).
-// eslint-disable-next-line ts/no-explicit-any
-function findCodeBlock(muya: Muya): any {
-    // eslint-disable-next-line ts/no-explicit-any
-    let node: any = muya.editor.scrollPage!.firstContentInDescendant();
+function findCodeBlock(muya: Muya): CodeBlock {
+    let node: Nullable<TreeNode> = muya.editor.scrollPage!.firstContentInDescendant();
     while (node && node.blockName !== 'code-block')
         node = node.parent;
-    return node;
+    return node as CodeBlock;
 }
 
 describe('stateToMarkdown — heading round-trip', () => {


### PR DESCRIPTION
## Summary

Companion to #4527, for the **`packages/muya`** side. Removes the `ts/no-explicit-any` suppressions in the muya unit specs by typing the test helpers and assertions with real engine types instead of `any`:

- Block-tree traversal helpers (`findTable`, visitors) typed with `TreeNode` / `Table` rather than `any`.
- State assertions typed with the real state interfaces (e.g. `IFrontmatterState`).
- Static `blockName` reads use the established `(block.constructor as { blockName?: string }).blockName` idiom already used elsewhere in the suite.

These are test-only changes; no production muya code is touched.

## Verification

- `pnpm -C packages/muya run lint:types` — pass
- `pnpm -C packages/muya run lint` — pass (0 errors)
- `pnpm -C packages/muya run test` — 983 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
