### PR TITLE
refactor(muya): drop cyclomatic complexity below 20 across the engine

### DIFF
--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -93,6 +93,228 @@ function extractWord(
     };
 }
 
+function shouldRemoveClosingChar(
+    inputChar: string,
+    prePreInputChar: string,
+    options: { autoPairBracket: boolean; autoPairMarkdownSyntax: boolean; autoPairQuote: boolean },
+) {
+    const { autoPairBracket, autoPairMarkdownSyntax, autoPairQuote } = options;
+
+    return (
+        (autoPairQuote && /'/.test(inputChar))
+        || (autoPairQuote && /"/.test(inputChar))
+        || (autoPairBracket && /[}\])]/.test(inputChar))
+        || (autoPairMarkdownSyntax && /\$/.test(inputChar))
+        || (autoPairMarkdownSyntax
+            && /[*$`~_]/.test(inputChar)
+            && /[_*~]/.test(prePreInputChar))
+    );
+}
+
+function shouldInsertClosingPair(
+    inputChar: string,
+    preInputChar: string,
+    postIsNotTouching: boolean,
+    ctx: {
+        autoPairBracket: boolean;
+        autoPairMarkdownSyntax: boolean;
+        autoPairQuote: boolean;
+        isInInlineMath: boolean;
+        isInInlineCode: boolean;
+        type: string;
+    },
+) {
+    const {
+        autoPairBracket,
+        autoPairMarkdownSyntax,
+        autoPairQuote,
+        isInInlineMath,
+        isInInlineCode,
+        type,
+    } = ctx;
+
+    return (
+        (autoPairQuote
+            && /'/.test(inputChar)
+            && postIsNotTouching
+            && !/[a-z\d]/i.test(preInputChar))
+        || (autoPairQuote && /"/.test(inputChar) && postIsNotTouching)
+        || (autoPairBracket && /[{[(]/.test(inputChar) && postIsNotTouching)
+        || (type === 'format'
+            && !isInInlineMath
+            && !isInInlineCode
+            && autoPairMarkdownSyntax
+            && !/[a-z0-9]/i.test(preInputChar)
+            && /[*$`~_]/.test(inputChar))
+    );
+}
+
+const FLOAT_PREVENT_DEFAULT_NAMES = new Set([
+    'mu-format-picker',
+    'mu-table-picker',
+    'mu-quick-insert',
+    'mu-emoji-picker',
+    'mu-front-menu',
+    'mu-list-picker',
+    'mu-image-selector',
+    'mu-table-column-tools',
+    'mu-table-bar-tools',
+]);
+
+interface IAutoPairCollapsedContext {
+    blockText: string;
+    options: {
+        autoPairBracket: boolean;
+        autoPairMarkdownSyntax: boolean;
+        autoPairQuote: boolean;
+    };
+    isInInlineMath: boolean;
+    isInInlineCode: boolean;
+    type: string;
+}
+
+function deleteAutoPair(
+    event: InputEvent,
+    text: string,
+    start: INodeOffset,
+    end: INodeOffset,
+    offset: number,
+    inputChar: string,
+    postInputChar: string,
+    blockText: string,
+) {
+    let needRender = false;
+    // handle `deleteContentBackward` or `deleteContentForward`
+    const deletedChar = blockText[offset];
+    if (
+        event.inputType === 'deleteContentBackward'
+        && postInputChar === BRACKET_HASH[deletedChar]
+    ) {
+        needRender = true;
+        text = text.substring(0, offset) + text.substring(offset + 1);
+    }
+
+    if (
+        event.inputType === 'deleteContentForward'
+        && inputChar === BACK_HASH[deletedChar]
+    ) {
+        needRender = true;
+        start.offset -= 1;
+        end.offset -= 1;
+        text = text.substring(0, offset - 1) + text.substring(offset);
+    }
+
+    return { text, needRender };
+}
+
+function collapsedInputAutoPair(
+    event: InputEvent,
+    text: string,
+    start: INodeOffset,
+    end: INodeOffset,
+    ctx: IAutoPairCollapsedContext,
+) {
+    const { blockText, options, isInInlineMath, isInInlineCode, type } = ctx;
+    const { autoPairBracket, autoPairMarkdownSyntax, autoPairQuote } = options;
+    const { offset } = start;
+    const inputChar = text.charAt(+offset - 1);
+    const preInputChar = text.charAt(+offset - 2);
+    const prePreInputChar = text.charAt(+offset - 3);
+    const postInputChar = text.charAt(+offset);
+    let needRender = false;
+
+    if (event.inputType.startsWith('delete'))
+        return deleteAutoPair(event, text, start, end, offset, inputChar, postInputChar, blockText);
+
+    if (
+        !event.inputType.includes('delete')
+        && inputChar === postInputChar
+        && shouldRemoveClosingChar(inputChar, prePreInputChar, options)
+    ) {
+        needRender = true;
+        text = text.substring(0, offset) + text.substring(offset + 1);
+
+        return { text, needRender };
+    }
+
+    // Not Unicode aware, since things like \p{Alphabetic} or \p{L} are not supported yet
+
+    // Only pair quotes/brackets when the cursor is at
+    // end-of-line or before whitespace.
+    // Inserting `"foo` would otherwise become `""foo` and force
+    // the user to immediately delete the spurious closing char.
+    const postIsNotTouching = !/\S/.test(postInputChar);
+    if (
+        !/\\/.test(preInputChar)
+        && shouldInsertClosingPair(inputChar, preInputChar, postIsNotTouching, {
+            autoPairBracket,
+            autoPairMarkdownSyntax,
+            autoPairQuote,
+            isInInlineMath,
+            isInInlineCode,
+            type,
+        })
+    ) {
+        needRender = true;
+        text
+            = typeof event.data === 'string' && BRACKET_HASH[event.data]
+                ? text.substring(0, offset)
+                + BRACKET_HASH[inputChar]
+                + text.substring(offset)
+                : text;
+    }
+
+    // Delete the last `*` of `**` when you insert one space between `**` to create a bullet list.
+    if (
+        type === 'format'
+        && typeof event.data === 'string'
+        && /\s/.test(event.data)
+        && /^\* /.test(text)
+        && preInputChar === '*'
+        && postInputChar === '*'
+    ) {
+        text = text.substring(0, offset) + text.substring(offset + 1);
+        needRender = true;
+    }
+
+    return { text, needRender };
+}
+
+function lineBreakAutoPair(
+    event: InputEvent,
+    text: string,
+    start: INodeOffset,
+    end: INodeOffset,
+    oldStart: INodeOffset,
+    blockText: string,
+) {
+    // Just work for `Shift + Enter` to create a soft and hard line break.
+    if (
+        blockText.endsWith('\n')
+        && start.offset === text.length
+        && (event.inputType === 'insertText' || event.type === 'compositionend')
+    ) {
+        text = blockText + event.data;
+        // I don't know why firefox don't need to offset++
+        // For more info: https://github.com/marktext/muya/issues/130
+        if (!isFirefox) {
+            start.offset++;
+            end.offset++;
+        }
+    }
+    else if (
+        blockText.length === oldStart.offset
+        && blockText[oldStart.offset - 2] === '\n'
+        && event.inputType === 'deleteContentBackward'
+    ) {
+        text = blockText.substring(0, oldStart.offset - 1);
+        start.offset = text.length;
+        end.offset = text.length;
+    }
+
+    return text;
+}
+
 class Content extends TreeNode {
     public _text: string;
     public isComposed: boolean;
@@ -355,7 +577,6 @@ class Content extends TreeNode {
      * used in input handler
      * @param {input event} event
      */
-    // eslint-disable-next-line complexity
     autoPair(
         event: Event,
         text: string,
@@ -376,119 +597,18 @@ class Content extends TreeNode {
 
         if (this.text !== text) {
             if (start.offset === end.offset && event.type === 'input') {
-                const { offset } = start;
-                const { autoPairBracket, autoPairMarkdownSyntax, autoPairQuote }
-                    = this.muya.options;
-                const inputChar = text.charAt(+offset - 1);
-                const preInputChar = text.charAt(+offset - 2);
-                const prePreInputChar = text.charAt(+offset - 3);
-                const postInputChar = text.charAt(+offset);
-
-                if (event.inputType.startsWith('delete')) {
-                    // handle `deleteContentBackward` or `deleteContentForward`
-                    const deletedChar = this.text[offset];
-                    if (
-                        event.inputType === 'deleteContentBackward'
-                        && postInputChar === BRACKET_HASH[deletedChar]
-                    ) {
-                        needRender = true;
-                        text = text.substring(0, offset) + text.substring(offset + 1);
-                    }
-
-                    if (
-                        event.inputType === 'deleteContentForward'
-                        && inputChar === BACK_HASH[deletedChar]
-                    ) {
-                        needRender = true;
-                        start.offset -= 1;
-                        end.offset -= 1;
-                        text = text.substring(0, offset - 1) + text.substring(offset);
-                    }
-                }
-                else if (
-                    !event.inputType.includes('delete')
-                    && inputChar === postInputChar
-                    && ((autoPairQuote && /'/.test(inputChar))
-                        || (autoPairQuote && /"/.test(inputChar))
-                        || (autoPairBracket && /[}\])]/.test(inputChar))
-                        || (autoPairMarkdownSyntax && /\$/.test(inputChar))
-                        || (autoPairMarkdownSyntax
-                            && /[*$`~_]/.test(inputChar)
-                            && /[_*~]/.test(prePreInputChar)))
-                ) {
-                    needRender = true;
-                    text = text.substring(0, offset) + text.substring(offset + 1);
-                }
-                else {
-                    // Not Unicode aware, since things like \p{Alphabetic} or \p{L} are not supported yet
-
-                    // Only pair quotes/brackets when the cursor is at
-                    // end-of-line or before whitespace.
-                    // Inserting `"foo` would otherwise become `""foo` and force
-                    // the user to immediately delete the spurious closing char.
-                    const postIsNotTouching = !/\S/.test(postInputChar);
-                    if (
-                        !/\\/.test(preInputChar)
-                        && ((autoPairQuote
-                            && /'/.test(inputChar)
-                            && postIsNotTouching
-                            && !/[a-z\d]/i.test(preInputChar))
-                        || (autoPairQuote && /"/.test(inputChar) && postIsNotTouching)
-                        || (autoPairBracket && /[{[(]/.test(inputChar) && postIsNotTouching)
-                        || (type === 'format'
-                            && !isInInlineMath
-                            && !isInInlineCode
-                            && autoPairMarkdownSyntax
-                            && !/[a-z0-9]/i.test(preInputChar)
-                            && /[*$`~_]/.test(inputChar)))
-                    ) {
-                        needRender = true;
-                        text
-                            = typeof event.data === 'string' && BRACKET_HASH[event.data]
-                                ? text.substring(0, offset)
-                                + BRACKET_HASH[inputChar]
-                                + text.substring(offset)
-                                : text;
-                    }
-
-                    // Delete the last `*` of `**` when you insert one space between `**` to create a bullet list.
-                    if (
-                        type === 'format'
-                        && typeof event.data === 'string'
-                        && /\s/.test(event.data)
-                        && /^\* /.test(text)
-                        && preInputChar === '*'
-                        && postInputChar === '*'
-                    ) {
-                        text = text.substring(0, offset) + text.substring(offset + 1);
-                        needRender = true;
-                    }
-                }
+                const collapsed = collapsedInputAutoPair(event, text, start, end, {
+                    blockText: this.text,
+                    options: this.muya.options,
+                    isInInlineMath,
+                    isInInlineCode,
+                    type,
+                });
+                text = collapsed.text;
+                needRender = collapsed.needRender || needRender;
             }
 
-            // Just work for `Shift + Enter` to create a soft and hard line break.
-            if (
-                this.text.endsWith('\n')
-                && start.offset === text.length
-                && (event.inputType === 'insertText' || event.type === 'compositionend')
-            ) {
-                text = this.text + event.data;
-                // I don't know why firefox don't need to offset++
-                // For more info: https://github.com/marktext/muya/issues/130
-                if (!isFirefox) {
-                    start.offset++;
-                    end.offset++;
-                }
-            }
-            else if (
-                this.text.length === oldStart.offset
-                && this.text[oldStart.offset - 2] === '\n'
-                && event.inputType === 'deleteContentBackward'
-            ) {
-                text = this.text.substring(0, oldStart.offset - 1);
-                start.offset = text.length;
-                end.offset = text.length;
-            }
+            text = lineBreakAutoPair(event, text, start, end, oldStart, this.text);
         }
 
         return { text, needRender };
@@ -557,38 +677,8 @@ class Content extends TreeNode {
             return;
 
         // TODO: move codes bellow to muya.ui ?
-        if (
-            this.muya.ui.shownFloat.size > 0
-            && (event.key === EVENT_KEYS.Enter
-                || event.key === EVENT_KEYS.Escape
-                || event.key === EVENT_KEYS.Tab
-                || event.key === EVENT_KEYS.ArrowUp
-                || event.key === EVENT_KEYS.ArrowDown)
-        ) {
-            let needPreventDefault = false;
-
-            for (const tool of this.muya.ui.shownFloat) {
-                if (
-                    tool.name === 'mu-format-picker'
-                    || tool.name === 'mu-table-picker'
-                    || tool.name === 'mu-quick-insert'
-                    || tool.name === 'mu-emoji-picker'
-                    || tool.name === 'mu-front-menu'
-                    || tool.name === 'mu-list-picker'
-                    || tool.name === 'mu-image-selector'
-                    || tool.name === 'mu-table-column-tools'
-                    || tool.name === 'mu-table-bar-tools'
-                ) {
-                    needPreventDefault = true;
-                    break;
-                }
-            }
-
-            if (needPreventDefault)
-                event.preventDefault();
-
+        if (this._handleShownFloatKeydown(event))
             return;
-        }
 
         switch (event.key) {
             case EVENT_KEYS.Backspace:
@@ -624,6 +714,33 @@ class Content extends TreeNode {
                 break;
         }
     };
+
+    private _handleShownFloatKeydown(event: KeyboardEvent): boolean {
+        if (
+            this.muya.ui.shownFloat.size > 0
+            && (event.key === EVENT_KEYS.Enter
+                || event.key === EVENT_KEYS.Escape
+                || event.key === EVENT_KEYS.Tab
+                || event.key === EVENT_KEYS.ArrowUp
+                || event.key === EVENT_KEYS.ArrowDown)
+        ) {
+            let needPreventDefault = false;
+
+            for (const tool of this.muya.ui.shownFloat) {
+                if (FLOAT_PREVENT_DEFAULT_NAMES.has(tool.name)) {
+                    needPreventDefault = true;
+                    break;
+                }
+            }
+
+            if (needPreventDefault)
+                event.preventDefault();
+
+            return true;
+        }
+
+        return false;
+    }
 
     blurHandler() {
         this.scrollPage?.handleBlurFromContent(this);

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -58,6 +58,39 @@ const INLINE_UPDATE_FRAGMENTS = [
 
 const INLINE_UPDATE_REG = new RegExp(INLINE_UPDATE_FRAGMENTS.join('|'), 'i');
 
+// Offset of the cursor relative to a symmetric/asymmetric marker pair
+// (strong/em/code/math/html_tag). `open`/`close` are the opening/closing
+// marker lengths; for the symmetric inline markers they are equal.
+function markeredOffset(dis: number, len: number, open: number, close: number) {
+    if (dis < 0)
+        return 0;
+    if (dis < open)
+        return -dis;
+    if (dis <= len - close)
+        return -open;
+    if (dis <= len)
+        return len - dis - open - close;
+    return -open - close;
+}
+
+function linkOffset(dis: number, anchorLen: number) {
+    if (dis < 1)
+        return 0;
+    if (dis <= 1 + anchorLen)
+        return -1;
+    return anchorLen - dis;
+}
+
+function imageOffset(dis: number, altLen: number) {
+    if (dis < 1)
+        return 0;
+    if (dis < 2)
+        return -1;
+    if (dis <= 2 + altLen)
+        return -2;
+    return altLen - dis;
+}
+
 function getOffset(offset: number, token: Token) {
     const {
         range: { start, end },
@@ -76,70 +109,26 @@ function getOffset(offset: number, token: Token) {
         case 'inline_code':
 
         case 'inline_math': {
-            const MARKER_LEN = type === 'strong' || type === 'del' ? 2 : 1;
-            if (dis < 0)
-                return 0;
-            if (dis >= 0 && dis < MARKER_LEN)
-                return -dis;
-            if (dis >= MARKER_LEN && dis <= len - MARKER_LEN)
-                return -MARKER_LEN;
-            if (dis > len - MARKER_LEN && dis <= len)
-                return len - dis - 2 * MARKER_LEN;
-            if (dis > len)
-                return -2 * MARKER_LEN;
-
-            break;
+            const markerLen = type === 'strong' || type === 'del' ? 2 : 1;
+            return markeredOffset(dis, len, markerLen, markerLen);
         }
 
         case 'html_tag': {
             const { tag } = token;
             // handle underline, sup, sub
-            const OPEN_MARKER_LEN = FORMAT_TAG_MAP[tag].open.length;
-            const CLOSE_MARKER_LEN = FORMAT_TAG_MAP[tag].close.length;
-
-            if (dis < 0)
-                return 0;
-            if (dis >= 0 && dis < OPEN_MARKER_LEN)
-                return -dis;
-            if (dis >= OPEN_MARKER_LEN && dis <= len - CLOSE_MARKER_LEN)
-                return -OPEN_MARKER_LEN;
-            if (dis > len - CLOSE_MARKER_LEN && dis <= len)
-                return len - dis - OPEN_MARKER_LEN - CLOSE_MARKER_LEN;
-            if (dis > len)
-                return -OPEN_MARKER_LEN - CLOSE_MARKER_LEN;
-
-            break;
+            return markeredOffset(
+                dis,
+                len,
+                FORMAT_TAG_MAP[tag].open.length,
+                FORMAT_TAG_MAP[tag].close.length,
+            );
         }
 
-        case 'link': {
-            const { anchor } = token;
-            const MARKER_LEN = 1;
+        case 'link':
+            return linkOffset(dis, token.anchor.length);
 
-            if (dis < MARKER_LEN)
-                return 0;
-            if (dis >= MARKER_LEN && dis <= MARKER_LEN + anchor.length)
-                return -1;
-            if (dis > MARKER_LEN + anchor.length)
-                return anchor.length - dis;
-
-            break;
-        }
-
-        case 'image': {
-            const { alt } = token;
-            const MARKER_LEN = 1;
-
-            if (dis < MARKER_LEN)
-                return 0;
-            if (dis >= MARKER_LEN && dis < MARKER_LEN * 2)
-                return -1;
-            if (dis >= MARKER_LEN * 2 && dis <= MARKER_LEN * 2 + alt.length)
-                return -2;
-            if (dis > MARKER_LEN * 2 + alt.length)
-                return alt.length - dis;
-
-            break;
-        }
+        case 'image':
+            return imageOffset(dis, token.alt.length);
     }
 }
 

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -1,5 +1,5 @@
 import type { Muya } from '../../../index';
-import type { ImageToken, LinkToken, Token } from '../../../inlineRenderer/types';
+import type { CodeEmojiMathToken, HTMLTagToken, ImageToken, LinkToken, ReferenceLinkToken, Token } from '../../../inlineRenderer/types';
 import type { IRenderCursor } from '../../../selection/types';
 import type {
     IBlockQuoteState,
@@ -53,6 +53,79 @@ const BOTH_SIDES_FORMATS = [
     'html_tag',
     'inline_math',
 ];
+
+interface IEndFormatHit {
+    offset: number;
+}
+
+type TEndFormatHandler = (token: Token, offset: number) => Nullable<IEndFormatHit>;
+
+function endHitStrongLike(token: Token, offset: number): Nullable<IEndFormatHit> {
+    const { end } = token.range;
+    const { marker } = token as CodeEmojiMathToken;
+    if (marker && offset === end - marker.length)
+        return { offset: marker.length };
+
+    return null;
+}
+
+function endHitImageLink(token: Token, offset: number): Nullable<IEndFormatHit> {
+    const { end } = token.range;
+    const { backlash } = token as ImageToken;
+    const srcAndTitle = (token as ImageToken).srcAndTitle;
+    const hrefAndTitle = (token as LinkToken).hrefAndTitle;
+    const linkTitleLen = (srcAndTitle || hrefAndTitle).length;
+    const secondLashLen
+        = backlash && backlash.second ? backlash.second.length : 0;
+    if (offset === end - 3 - (linkTitleLen + secondLashLen))
+        return { offset: 2 };
+    if (offset === end - 1)
+        return { offset: 1 };
+
+    return null;
+}
+
+function endHitReference(token: Token, offset: number): Nullable<IEndFormatHit> {
+    const { end } = token.range;
+    const { backlash, isFullLink, label } = token as ReferenceLinkToken;
+    const labelLen = label ? label.length : 0;
+    const secondLashLen
+        = backlash && backlash.second ? backlash.second.length : 0;
+    if (isFullLink) {
+        if (offset === end - 3 - labelLen - secondLashLen)
+            return { offset: 2 };
+        if (offset === end - 1)
+            return { offset: 1 };
+        return null;
+    }
+    if (offset === end - 1)
+        return { offset: 1 };
+
+    return null;
+}
+
+function endHitHtmlTag(token: Token, offset: number): Nullable<IEndFormatHit> {
+    const { end } = token.range;
+    const { closeTag } = token as HTMLTagToken;
+    if (closeTag && offset === end - closeTag.length)
+        return { offset: closeTag.length };
+
+    return null;
+}
+
+const END_FORMAT_HANDLERS: Record<string, TEndFormatHandler> = {
+    strong: endHitStrongLike,
+    em: endHitStrongLike,
+    inline_code: endHitStrongLike,
+    emoji: endHitStrongLike,
+    del: endHitStrongLike,
+    inline_math: endHitStrongLike,
+    image: endHitImageLink,
+    link: endHitImageLink,
+    reference_image: endHitReference,
+    reference_link: endHitReference,
+    html_tag: endHitHtmlTag,
+};
 
 function parseTableHeader(text: string) {
     const rowHeader = [];
@@ -743,7 +816,6 @@ class ParagraphContent extends Format {
         });
         let result = null;
 
-        // eslint-disable-next-line complexity
         const walkTokens = (ts: Token[]) => {
             for (const token of ts) {
                 const { type, range } = token;
@@ -754,102 +826,12 @@ class ParagraphContent extends Format {
                     && offset > start
                     && offset < end
                 ) {
-                    switch (type) {
-                        case 'strong': // fall through
+                    const handler = END_FORMAT_HANDLERS[type];
+                    const hit = handler ? handler(token, offset) : null;
+                    if (hit) {
+                        result = hit;
 
-                        case 'em': // fall through
-
-                        case 'inline_code': // fall through
-
-                        case 'emoji': // fall through
-
-                        case 'del': // fall through
-
-                        case 'inline_math': {
-                            const { marker } = token;
-                            if (marker && offset === end - marker.length) {
-                                result = {
-                                    offset: marker.length,
-                                };
-
-                                return;
-                            }
-
-                            break;
-                        }
-
-                        case 'image': // fall through
-
-                        case 'link': {
-                            const { backlash } = token;
-                            const srcAndTitle = (token as ImageToken).srcAndTitle;
-                            const hrefAndTitle = (token as LinkToken).hrefAndTitle;
-                            const linkTitleLen = (srcAndTitle || hrefAndTitle).length;
-                            const secondLashLen
-                                = backlash && backlash.second ? backlash.second.length : 0;
-                            if (offset === end - 3 - (linkTitleLen + secondLashLen)) {
-                                result = {
-                                    offset: 2,
-                                };
-
-                                return;
-                            }
-                            else if (offset === end - 1) {
-                                result = {
-                                    offset: 1,
-                                };
-
-                                return;
-                            }
-                            break;
-                        }
-
-                        case 'reference_image': // fall through
-
-                        case 'reference_link': {
-                            const { backlash, isFullLink, label } = token;
-                            const labelLen = label ? label.length : 0;
-                            const secondLashLen
-                                = backlash && backlash.second ? backlash.second.length : 0;
-                            if (isFullLink) {
-                                if (offset === end - 3 - labelLen - secondLashLen) {
-                                    result = {
-                                        offset: 2,
-                                    };
-
-                                    return;
-                                }
-                                else if (offset === end - 1) {
-                                    result = {
-                                        offset: 1,
-                                    };
-
-                                    return;
-                                }
-                            }
-                            else if (offset === end - 1) {
-                                result = {
-                                    offset: 1,
-                                };
-
-                                return;
-                            }
-                            break;
-                        }
-
-                        case 'html_tag': {
-                            const { closeTag } = token;
-                            if (closeTag && offset === end - closeTag.length) {
-                                result = {
-                                    offset: closeTag.length,
-                                };
-
-                                return;
-                            }
-                            break;
-                        }
-                        default:
-                            break;
+                        return;
                     }
                 }
 

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -24,6 +24,212 @@ import { attachLinkMouseHandlers } from './linkMouseEvents';
 
 const debug = logger('editor:');
 
+// The pick/drop walkers operate on live block-tree nodes (ScrollPage,
+// Parent, Content). The tree's instance methods (queryBlock, find,
+// insertBefore, etc.) are not all exposed on a single TS type, and
+// ot-json1 op descents are dynamically shaped — so we type these as
+// BlockNode (loose structural alias) inside the inner walkers and let
+// the runtime branches do the actual narrowing.
+type BlockNode = {
+    queryBlock?: (path: (string | number)[]) => BlockNode | undefined;
+    find?: (key: number | string) => BlockNode;
+    remove?: (source: string) => void;
+    replaceWith?: (newBlock: BlockNode, source: string) => void;
+    insertBefore?: (newBlock: BlockNode, ref: BlockNode, source: string) => void;
+    update?: (value?: unknown, source?: string) => void;
+    blockName?: string;
+    align?: string;
+    _text?: string;
+    text?: string;
+    meta?: { lang?: string; type?: string };
+    parent?: BlockNode;
+} | undefined;
+
+function descend(
+    subDoc: BlockNode,
+    descent: JSONOpList,
+    stack: BlockNode[],
+): { subDoc: BlockNode; i: number } {
+    let i = 0;
+
+    for (; i < descent.length; i++) {
+        const d = descent[i];
+        if (Array.isArray(d))
+            break;
+        if (typeof d === 'object')
+            continue;
+        stack.push(subDoc);
+        // Its valid to descend into a null space - just we can't pick there.
+        subDoc = subDoc == null ? undefined : subDoc.queryBlock?.([d]);
+    }
+
+    return { subDoc, i };
+}
+
+function restore(
+    subDoc: BlockNode,
+    descent: JSONOpList,
+    stack: BlockNode[],
+    i: number,
+): BlockNode {
+    // Then back again.
+    for (--i; i >= 0; i--) {
+        const d = descent[i];
+        if (typeof d !== 'object') {
+            const container = stack.pop();
+            if (
+                subDoc
+                === (container == null ? undefined : container.queryBlock?.([d as string | number]))
+            ) {
+                subDoc = container;
+            }
+            else {
+                if (subDoc === undefined) {
+                    // TODO: handler typeof d === 'string'
+                    if (typeof d === 'number')
+                        container?.find?.(d)?.remove?.('api');
+                    subDoc = container;
+                }
+                else {
+                    if (typeof d === 'number')
+                        container?.find?.(d)?.replaceWith?.(subDoc, 'api');
+                    subDoc = container;
+                }
+            }
+        }
+        else if (!Array.isArray(d) && hasPick(d)) {
+            subDoc = undefined;
+        }
+    }
+
+    return subDoc;
+}
+
+// Phase 1: Pick. Returns updated subDocument.
+function pick(subDoc: BlockNode, descent: JSONOpList): BlockNode {
+    const stack: BlockNode[] = [];
+
+    const descended = descend(subDoc, descent, stack);
+    subDoc = descended.subDoc;
+    const i = descended.i;
+
+    // Children. These need to be traversed in reverse order here.
+    for (let j = descent.length - 1; j >= i; j--)
+        subDoc = pick(subDoc, descent[j] as JSONOpList);
+
+    return restore(subDoc, descent, stack, i);
+}
+
+function drop(root: BlockNode, descent: JSONOpList, muya: Muya): BlockNode {
+    let subDoc = root;
+    let i = 0; // For reading
+    let m = 0;
+    const rootContainer: { root: BlockNode } = { root }; // This is an avoidable allocation.
+    let container: BlockNode | { root: BlockNode } = rootContainer;
+    let key: string | number = 'root'; // For writing
+
+    function mut() {
+        for (; m < i; m++) {
+            const d = descent[m];
+            if (typeof d === 'object')
+                continue;
+            if (key === 'root') {
+                const wrap = container as { root: BlockNode };
+                container = wrap.root;
+            }
+            else {
+                container = (container as BlockNode)?.queryBlock?.([key]);
+            }
+            key = d as string | number;
+        }
+    }
+
+    function applyInsert(comp: JSONOpComponent) {
+        // Insert
+        mut();
+        const cur = container as BlockNode;
+        const ref = cur?.find?.(key);
+        if (typeof key === 'number') {
+            const insertedState = comp.i as { name: string };
+            const newBlock = ScrollPage.loadBlock(insertedState.name).create(muya, insertedState) as BlockNode;
+            if (cur && ref && newBlock)
+                cur.insertBefore?.(newBlock, ref, 'api');
+
+            subDoc = newBlock;
+        }
+        else {
+            switch (key) {
+                case 'checked': {
+                    ref?.update?.(comp.i, 'api');
+                    break;
+                }
+
+                case 'meta':
+                    // Do nothing.
+                    break;
+
+                default:
+                    debug.warn(`Unknown operation path ${key}`);
+                    break;
+            }
+        }
+    }
+
+    function applyTextEdit(es: NonNullable<JSONOpComponent['es']>) {
+        // Edit. Ok because its illegal to drop inside mixed region
+        mut();
+        const sd = subDoc!;
+        if (sd.blockName === 'table.cell') {
+            sd.align = otText.type.apply(sd.align ?? '', es) as string;
+        }
+        else if (sd.blockName === 'language-input') {
+            sd._text = otText.type.apply(sd.text ?? '', es) as string;
+            if (sd.parent?.meta)
+                sd.parent.meta.lang = sd.text;
+            sd.update?.();
+        }
+        else if (sd.blockName === 'code-block') {
+            // Handle modify code block type.
+            if (sd.meta)
+                sd.meta.type = otText.type.apply(sd.meta.type ?? '', es) as string;
+        }
+        else {
+            sd._text = otText.type.apply(sd.text ?? '', es) as string;
+            sd.update?.();
+        }
+    }
+
+    for (; i < descent.length; i++) {
+        const d = descent[i];
+
+        if (Array.isArray(d)) {
+            const child = drop(subDoc, d, muya);
+            if (child !== subDoc && child !== undefined) {
+                mut();
+                // It maybe never go into this if statement.
+                if (key === 'root')
+                    (container as { root: BlockNode }).root = child;
+                else
+                    (container as Record<string, BlockNode>)[key] = child;
+                subDoc = child;
+            }
+        }
+        else if (typeof d === 'object') {
+            const comp = d as JSONOpComponent;
+            if (comp.i !== undefined)
+                applyInsert(comp);
+
+            if (comp.es)
+                applyTextEdit(comp.es);
+        }
+        else {
+            subDoc = subDoc != null ? subDoc.queryBlock?.([d]) : undefined;
+        }
+    }
+
+    return rootContainer.root;
+}
+
 export class Editor {
     jsonState: JSONState;
     inlineRenderer: InlineRenderer;
@@ -196,188 +402,9 @@ export class Editor {
         if (operations === null)
             return;
 
-        // The pick/drop walkers operate on live block-tree nodes (ScrollPage,
-        // Parent, Content). The tree's instance methods (queryBlock, find,
-        // insertBefore, etc.) are not all exposed on a single TS type, and
-        // ot-json1 op descents are dynamically shaped — so we type these as
-        // BlockNode (loose structural alias) inside the inner walkers and let
-        // the runtime branches do the actual narrowing.
-        type BlockNode = {
-            queryBlock?: (path: (string | number)[]) => BlockNode | undefined;
-            find?: (key: number | string) => BlockNode;
-            remove?: (source: string) => void;
-            replaceWith?: (newBlock: BlockNode, source: string) => void;
-            insertBefore?: (newBlock: BlockNode, ref: BlockNode, source: string) => void;
-            update?: (value?: unknown, source?: string) => void;
-            blockName?: string;
-            align?: string;
-            _text?: string;
-            text?: string;
-            meta?: { lang?: string; type?: string };
-            parent?: BlockNode;
-        } | undefined;
-
-        // Phase 1: Pick. Returns updated subDocument.
-        function pick(subDoc: BlockNode, descent: JSONOpList): BlockNode {
-            const stack: BlockNode[] = [];
-
-            let i = 0;
-
-            for (; i < descent.length; i++) {
-                const d = descent[i];
-                if (Array.isArray(d))
-                    break;
-                if (typeof d === 'object')
-                    continue;
-                stack.push(subDoc);
-                // Its valid to descend into a null space - just we can't pick there.
-                subDoc = subDoc == null ? undefined : subDoc.queryBlock?.([d]);
-            }
-
-            // Children. These need to be traversed in reverse order here.
-            for (let j = descent.length - 1; j >= i; j--)
-                subDoc = pick(subDoc, descent[j] as JSONOpList);
-
-            // Then back again.
-            for (--i; i >= 0; i--) {
-                const d = descent[i];
-                if (typeof d !== 'object') {
-                    const container = stack.pop();
-                    if (
-                        subDoc
-                        === (container == null ? undefined : container.queryBlock?.([d as string | number]))
-                    ) {
-                        subDoc = container;
-                    }
-                    else {
-                        if (subDoc === undefined) {
-                            // TODO: handler typeof d === 'string'
-                            if (typeof d === 'number')
-                                container?.find?.(d)?.remove?.('api');
-                            subDoc = container;
-                        }
-                        else {
-                            if (typeof d === 'number')
-                                container?.find?.(d)?.replaceWith?.(subDoc, 'api');
-                            subDoc = container;
-                        }
-                    }
-                }
-                else if (!Array.isArray(d) && hasPick(d)) {
-                    subDoc = undefined;
-                }
-            }
-
-            return subDoc;
-        }
-
         const snapshot = pick(this.scrollPage as BlockNode, operations);
 
-        function drop(root: BlockNode, descent: JSONOpList): BlockNode {
-            let subDoc = root;
-            let i = 0; // For reading
-            let m = 0;
-            const rootContainer: { root: BlockNode } = { root }; // This is an avoidable allocation.
-            let container: BlockNode | { root: BlockNode } = rootContainer;
-            let key: string | number = 'root'; // For writing
-
-            function mut() {
-                for (; m < i; m++) {
-                    const d = descent[m];
-                    if (typeof d === 'object')
-                        continue;
-                    if (key === 'root') {
-                        const wrap = container as { root: BlockNode };
-                        container = wrap.root;
-                    }
-                    else {
-                        container = (container as BlockNode)?.queryBlock?.([key]);
-                    }
-                    key = d as string | number;
-                }
-            }
-
-            for (; i < descent.length; i++) {
-                const d = descent[i];
-
-                if (Array.isArray(d)) {
-                    const child = drop(subDoc, d);
-                    if (child !== subDoc && child !== undefined) {
-                        mut();
-                        // It maybe never go into this if statement.
-                        if (key === 'root')
-                            (container as { root: BlockNode }).root = child;
-                        else
-                            (container as Record<string, BlockNode>)[key] = child;
-                        subDoc = child;
-                    }
-                }
-                else if (typeof d === 'object') {
-                    const comp = d as JSONOpComponent;
-                    if (comp.i !== undefined) {
-                        // Insert
-                        mut();
-                        const cur = container as BlockNode;
-                        const ref = cur?.find?.(key);
-                        if (typeof key === 'number') {
-                            const insertedState = comp.i as { name: string };
-                            const newBlock = ScrollPage.loadBlock(insertedState.name).create(muya, insertedState) as BlockNode;
-                            if (cur && ref && newBlock)
-                                cur.insertBefore?.(newBlock, ref, 'api');
-
-                            subDoc = newBlock;
-                        }
-                        else {
-                            switch (key) {
-                                case 'checked': {
-                                    ref?.update?.(comp.i, 'api');
-                                    break;
-                                }
-
-                                case 'meta':
-                                    // Do nothing.
-                                    break;
-
-                                default:
-                                    debug.warn(`Unknown operation path ${key}`);
-                                    break;
-                            }
-                        }
-                    }
-
-                    if (comp.es) {
-                        // Edit. Ok because its illegal to drop inside mixed region
-                        mut();
-                        const sd = subDoc!;
-                        if (sd.blockName === 'table.cell') {
-                            sd.align = otText.type.apply(sd.align ?? '', comp.es) as string;
-                        }
-                        else if (sd.blockName === 'language-input') {
-                            sd._text = otText.type.apply(sd.text ?? '', comp.es) as string;
-                            if (sd.parent?.meta)
-                                sd.parent.meta.lang = sd.text;
-                            sd.update?.();
-                        }
-                        else if (sd.blockName === 'code-block') {
-                            // Handle modify code block type.
-                            if (sd.meta)
-                                sd.meta.type = otText.type.apply(sd.meta.type ?? '', comp.es) as string;
-                        }
-                        else {
-                            sd._text = otText.type.apply(sd.text ?? '', comp.es) as string;
-                            sd.update?.();
-                        }
-                    }
-                }
-                else {
-                    subDoc = subDoc != null ? subDoc.queryBlock?.([d]) : undefined;
-                }
-            }
-
-            return rootContainer.root;
-        }
-
-        drop(snapshot, operations);
+        drop(snapshot, operations, muya);
 
         this._restoreSelection(selection);
     }

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable complexity */
-/* eslint-disable max-lines-per-function */
 import type { BeginRules, InlineRules } from './rules';
 import type {
     ITokenizerFacOptions,
@@ -22,300 +20,340 @@ import {
 const disallowedHtmlTag
     = /title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext/i;
 
-function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: InlineRules, pos = 0, top: boolean, labels: Labels, options: ITokenizerFacOptions) {
-    const originSrc = src;
-    const tokens: Token[] = [];
-    let pending = '';
-    let pendingStartPos = pos;
-    const { superSubScript, footnote } = options;
-    const pushPending = () => {
-        if (pending) {
-            tokens.push({
-                type: 'text',
-                parent: tokens,
-                raw: pending,
-                content: pending,
-                range: {
-                    start: pendingStartPos,
-                    end: pos,
-                },
-            });
-        }
+// Mutable cursor + accumulator threaded through every inline-rule handler.
+// `src`/`pos` advance as input is consumed; `pending`/`pendingStartPos`
+// accumulate plain text between matched tokens; `tokens` collects the output.
+interface ILexState {
+    originSrc: string;
+    src: string;
+    pos: number;
+    pending: string;
+    pendingStartPos: number;
+    tokens: Token[];
+    inlineRules: InlineRules;
+    labels: Labels;
+    options: ITokenizerFacOptions;
+    top: boolean;
+    superSubScript: boolean;
+    footnote: boolean;
+}
 
-        pendingStartPos = pos;
-        pending = '';
-    };
+function pushPending(state: ILexState) {
+    if (state.pending) {
+        state.tokens.push({
+            type: 'text',
+            parent: state.tokens,
+            raw: state.pending,
+            content: state.pending,
+            range: {
+                start: state.pendingStartPos,
+                end: state.pos,
+            },
+        });
+    }
 
-    if (beginRules && pos === 0) {
-        const beginRuleKeys = [
-            'header',
-            'hr',
-            'code_fence',
-            'multiple_math',
-        ] as const;
+    state.pendingStartPos = state.pos;
+    state.pending = '';
+}
 
-        for (const ruleName of beginRuleKeys) {
-            const to = beginRules[ruleName].exec(src);
+function consumeBeginRules(state: ILexState, beginRules: BeginRules) {
+    const beginRuleKeys = [
+        'header',
+        'hr',
+        'code_fence',
+        'multiple_math',
+    ] as const;
 
-            if (to) {
-                const token = {
-                    type: ruleName,
-                    raw: to[0],
-                    parent: tokens,
-                    marker: to[1],
-                    content: to[2] || '',
-                    backlash: to[3] || '',
-                    range: {
-                        start: pos,
-                        end: pos + to[0].length,
-                    },
-                };
-                tokens.push(token);
-                src = src.substring(to[0].length);
-                pos = pos + to[0].length;
-                break;
-            }
-        }
-        const def = beginRules.reference_definition.exec(src);
-        if (def && isLengthEven(def[3])) {
+    for (const ruleName of beginRuleKeys) {
+        const to = beginRules[ruleName].exec(state.src);
+
+        if (to) {
             const token = {
-                type: 'reference_definition' as const,
-                parent: tokens,
-                leftBracket: def[1],
-                label: def[2],
-                backlash: def[3] || '',
-                rightBracket: def[4],
-                leftHrefMarker: def[5] || '',
-                href: def[6],
-                rightHrefMarker: def[7] || '',
-                leftTitleSpace: def[8],
-                titleMarker: def[9] || '',
-                title: def[10] || '',
-                rightTitleSpace: def[11] || '',
-                raw: def[0],
+                type: ruleName,
+                raw: to[0],
+                parent: state.tokens,
+                marker: to[1],
+                content: to[2] || '',
+                backlash: to[3] || '',
                 range: {
-                    start: pos,
-                    end: pos + def[0].length,
+                    start: state.pos,
+                    end: state.pos + to[0].length,
                 },
             };
-            tokens.push(token);
-            src = src.substring(def[0].length);
-            pos = pos + def[0].length;
+            state.tokens.push(token);
+            state.src = state.src.substring(to[0].length);
+            state.pos = state.pos + to[0].length;
+            break;
+        }
+    }
+    const def = beginRules.reference_definition.exec(state.src);
+    if (def && isLengthEven(def[3])) {
+        const token = {
+            type: 'reference_definition' as const,
+            parent: state.tokens,
+            leftBracket: def[1],
+            label: def[2],
+            backlash: def[3] || '',
+            rightBracket: def[4],
+            leftHrefMarker: def[5] || '',
+            href: def[6],
+            rightHrefMarker: def[7] || '',
+            leftTitleSpace: def[8],
+            titleMarker: def[9] || '',
+            title: def[10] || '',
+            rightTitleSpace: def[11] || '',
+            raw: def[0],
+            range: {
+                start: state.pos,
+                end: state.pos + def[0].length,
+            },
+        };
+        state.tokens.push(token);
+        state.src = state.src.substring(def[0].length);
+        state.pos = state.pos + def[0].length;
+    }
+}
+
+// backlash
+function tryBacklash(state: ILexState): boolean {
+    const backTo = state.inlineRules.backlash.exec(state.src);
+    if (!backTo)
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'backlash',
+        raw: backTo[1],
+        marker: backTo[1],
+        parent: state.tokens,
+        content: '',
+        range: {
+            start: state.pos,
+            end: state.pos + backTo[1].length,
+        },
+    });
+    state.pending += state.pending + backTo[2];
+    state.pendingStartPos = state.pos + backTo[1].length;
+    state.src = state.src.substring(backTo[0].length);
+    state.pos = state.pos + backTo[0].length;
+
+    return true;
+}
+
+// strong | em
+function tryStrongEm(state: ILexState): boolean {
+    const emRules = ['strong', 'em'] as const;
+
+    for (const rule of emRules) {
+        const to = state.inlineRules[rule].exec(state.src);
+        if (to && isLengthEven(to[3])) {
+            const isValid = validateEmphasize(
+                state.src,
+                to[0].length,
+                to[1],
+                state.pending,
+                validateRules,
+            );
+            if (isValid) {
+                pushPending(state);
+                const range = {
+                    start: state.pos,
+                    end: state.pos + to[0].length,
+                };
+                const marker = to[1];
+                state.tokens.push({
+                    type: rule,
+                    raw: to[0],
+                    range,
+                    marker,
+                    parent: state.tokens,
+                    children: tokenizerFac(
+                        to[2],
+                        null,
+                        state.inlineRules,
+                        state.pos + to[1].length,
+                        false,
+                        state.labels,
+                        state.options,
+                    ),
+                    backlash: to[3],
+                });
+                state.src = state.src.substring(to[0].length);
+                state.pos = state.pos + to[0].length;
+
+                return true;
+            }
+
+            return false;
         }
     }
 
-    while (src.length) {
-    // backlash
-        const backTo = inlineRules.backlash.exec(src);
-        if (backTo) {
-            pushPending();
-            tokens.push({
-                type: 'backlash',
-                raw: backTo[1],
-                marker: backTo[1],
-                parent: tokens,
-                content: '',
-                range: {
-                    start: pos,
-                    end: pos + backTo[1].length,
-                },
-            });
-            pending += pending + backTo[2];
-            pendingStartPos = pos + backTo[1].length;
-            src = src.substring(backTo[0].length);
-            pos = pos + backTo[0].length;
-            continue;
-        }
-        // strong | em
-        const emRules = ['strong', 'em'] as const;
-        let inChunk;
+    return false;
+}
 
-        for (const rule of emRules) {
-            const to = inlineRules[rule].exec(src);
-            if (to && isLengthEven(to[3])) {
-                const isValid = validateEmphasize(
-                    src,
-                    to[0].length,
-                    to[1],
-                    pending,
-                    validateRules,
-                );
-                if (isValid) {
-                    inChunk = true;
-                    pushPending();
-                    const range = {
-                        start: pos,
-                        end: pos + to[0].length,
-                    };
-                    const marker = to[1];
-                    tokens.push({
-                        type: rule,
-                        raw: to[0],
-                        range,
-                        marker,
-                        parent: tokens,
-                        children: tokenizerFac(
-                            to[2],
-                            null,
-                            inlineRules,
-                            pos + to[1].length,
-                            false,
-                            labels,
-                            options,
-                        ),
-                        backlash: to[3],
-                    });
-                    src = src.substring(to[0].length);
-                    pos = pos + to[0].length;
-                }
-                break;
+// emoji | inline_code | del | inline_math
+function tryChunks(state: ILexState): boolean {
+    const chunks = ['inline_code', 'del', 'emoji', 'inline_math'] as const;
+
+    for (const rule of chunks) {
+        const to = state.inlineRules[rule].exec(state.src);
+        if (to && isLengthEven(to[3])) {
+            if (
+                rule === 'emoji'
+                && !lowerPriority(state.src, to[0].length, validateRules)
+            ) {
+                return false;
             }
-        }
-        if (inChunk)
-            continue;
-
-        // emoji | inline_code | del | inline_math
-        const chunks = ['inline_code', 'del', 'emoji', 'inline_math'] as const;
-
-        for (const rule of chunks) {
-            const to = inlineRules[rule].exec(src);
-            if (to && isLengthEven(to[3])) {
-                if (
-                    rule === 'emoji'
-                    && !lowerPriority(src, to[0].length, validateRules)
-                ) {
-                    break;
-                }
-                inChunk = true;
-                pushPending();
-                const range = {
-                    start: pos,
-                    end: pos + to[0].length,
-                };
-                const marker = to[1];
-                if (
-                    rule === 'inline_code'
-                    || rule === 'emoji'
-                    || rule === 'inline_math'
-                ) {
-                    tokens.push({
-                        type: rule,
-                        raw: to[0],
-                        range,
-                        marker,
-                        parent: tokens,
-                        content: to[2],
-                        backlash: to[3],
-                    });
-                }
-                else {
-                    tokens.push({
-                        type: rule,
-                        raw: to[0],
-                        range,
-                        marker,
-                        parent: tokens,
-                        children: tokenizerFac(
-                            to[2],
-                            null,
-                            inlineRules,
-                            pos + to[1].length,
-                            false,
-                            labels,
-                            options,
-                        ),
-                        backlash: to[3],
-                    });
-                }
-                src = src.substring(to[0].length);
-                pos = pos + to[0].length;
-                break;
-            }
-        }
-        if (inChunk)
-            continue;
-        // superscript and subscript
-        if (superSubScript) {
-            const superSubTo
-                = inlineRules.superscript.exec(src) || inlineRules.subscript.exec(src);
-            if (superSubTo) {
-                pushPending();
-                tokens.push({
-                    type: 'super_sub_script',
-                    raw: superSubTo[0],
-                    marker: superSubTo[1],
-                    range: {
-                        start: pos,
-                        end: pos + superSubTo[0].length,
-                    },
-                    parent: tokens,
-                    content: superSubTo[2],
+            pushPending(state);
+            const range = {
+                start: state.pos,
+                end: state.pos + to[0].length,
+            };
+            const marker = to[1];
+            if (
+                rule === 'inline_code'
+                || rule === 'emoji'
+                || rule === 'inline_math'
+            ) {
+                state.tokens.push({
+                    type: rule,
+                    raw: to[0],
+                    range,
+                    marker,
+                    parent: state.tokens,
+                    content: to[2],
+                    backlash: to[3],
                 });
-                src = src.substring(superSubTo[0].length);
-                pos = pos + superSubTo[0].length;
-                continue;
             }
-        }
-
-        // footnote identifier
-        if (pos !== 0 && footnote) {
-            const footnoteTo = inlineRules.footnote_identifier.exec(src);
-            if (footnoteTo) {
-                pushPending();
-                tokens.push({
-                    type: 'footnote_identifier',
-                    raw: footnoteTo[0],
-                    marker: footnoteTo[1],
-                    range: {
-                        start: pos,
-                        end: pos + footnoteTo[0].length,
-                    },
-                    parent: tokens,
-                    content: footnoteTo[2],
+            else {
+                state.tokens.push({
+                    type: rule,
+                    raw: to[0],
+                    range,
+                    marker,
+                    parent: state.tokens,
+                    children: tokenizerFac(
+                        to[2],
+                        null,
+                        state.inlineRules,
+                        state.pos + to[1].length,
+                        false,
+                        state.labels,
+                        state.options,
+                    ),
+                    backlash: to[3],
                 });
-                src = src.substring(footnoteTo[0].length);
-                pos = pos + footnoteTo[0].length;
-                continue;
             }
+            state.src = state.src.substring(to[0].length);
+            state.pos = state.pos + to[0].length;
+
+            return true;
         }
-        // image
-        const imageTo = inlineRules.image.exec(src);
-        correctUrl(imageTo);
-        if (imageTo && isLengthEven(imageTo[3]) && isLengthEven(imageTo[5])) {
-            const { src: imageSrc, title } = parseSrcAndTitle(imageTo[4]);
-            pushPending();
-            tokens.push({
-                type: 'image',
-                raw: imageTo[0],
-                marker: imageTo[1],
-                srcAndTitle: imageTo[4],
-                // This `attrs` used for render image.
-                attrs: {
-                    src: imageSrc + encodeURI(imageTo[5]),
-                    title,
-                    alt: imageTo[2] + encodeURI(imageTo[3]),
-                },
-                src: imageSrc,
-                title,
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + imageTo[0].length,
-                },
-                alt: imageTo[2],
-                backlash: {
-                    first: imageTo[3],
-                    second: imageTo[5],
-                },
-            });
-            src = src.substring(imageTo[0].length);
-            pos = pos + imageTo[0].length;
-            continue;
-        }
-        // link
-        const linkTo = inlineRules.link.exec(src);
-        correctUrl(linkTo);
-        if (
+    }
+
+    return false;
+}
+
+// superscript and subscript
+function trySuperSubScript(state: ILexState): boolean {
+    if (!state.superSubScript)
+        return false;
+
+    const superSubTo
+        = state.inlineRules.superscript.exec(state.src) || state.inlineRules.subscript.exec(state.src);
+    if (!superSubTo)
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'super_sub_script',
+        raw: superSubTo[0],
+        marker: superSubTo[1],
+        range: {
+            start: state.pos,
+            end: state.pos + superSubTo[0].length,
+        },
+        parent: state.tokens,
+        content: superSubTo[2],
+    });
+    state.src = state.src.substring(superSubTo[0].length);
+    state.pos = state.pos + superSubTo[0].length;
+
+    return true;
+}
+
+// footnote identifier
+function tryFootnote(state: ILexState): boolean {
+    if (state.pos === 0 || !state.footnote)
+        return false;
+
+    const footnoteTo = state.inlineRules.footnote_identifier.exec(state.src);
+    if (!footnoteTo)
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'footnote_identifier',
+        raw: footnoteTo[0],
+        marker: footnoteTo[1],
+        range: {
+            start: state.pos,
+            end: state.pos + footnoteTo[0].length,
+        },
+        parent: state.tokens,
+        content: footnoteTo[2],
+    });
+    state.src = state.src.substring(footnoteTo[0].length);
+    state.pos = state.pos + footnoteTo[0].length;
+
+    return true;
+}
+
+// image
+function tryImage(state: ILexState): boolean {
+    const imageTo = state.inlineRules.image.exec(state.src);
+    correctUrl(imageTo);
+    if (!(imageTo && isLengthEven(imageTo[3]) && isLengthEven(imageTo[5])))
+        return false;
+
+    const { src: imageSrc, title } = parseSrcAndTitle(imageTo[4]);
+    pushPending(state);
+    state.tokens.push({
+        type: 'image',
+        raw: imageTo[0],
+        marker: imageTo[1],
+        srcAndTitle: imageTo[4],
+        // This `attrs` used for render image.
+        attrs: {
+            src: imageSrc + encodeURI(imageTo[5]),
+            title,
+            alt: imageTo[2] + encodeURI(imageTo[3]),
+        },
+        src: imageSrc,
+        title,
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + imageTo[0].length,
+        },
+        alt: imageTo[2],
+        backlash: {
+            first: imageTo[3],
+            second: imageTo[5],
+        },
+    });
+    state.src = state.src.substring(imageTo[0].length);
+    state.pos = state.pos + imageTo[0].length;
+
+    return true;
+}
+
+// link
+function tryLink(state: ILexState): boolean {
+    const linkTo = state.inlineRules.link.exec(state.src);
+    correctUrl(linkTo);
+    if (
+        !(
             linkTo
             && isLengthEven(linkTo[3])
             && isLengthEven(linkTo[5])
@@ -323,321 +361,426 @@ function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: I
             // than links. If a higher-priority inline rule matches a span
             // that extends past the tentative link's range, defer to it.
             // Covers CM 0.29 examples 520 (HTML tag) and 521 (code span).
-            && lowerPriority(src, linkTo[0].length, validateRules)
-        ) {
-            const { src: href, title } = parseSrcAndTitle(linkTo[4]);
-            pushPending();
-            tokens.push({
-                type: 'link',
-                raw: linkTo[0],
-                marker: linkTo[1],
-                hrefAndTitle: linkTo[4],
-                href,
-                title,
-                parent: tokens,
-                anchor: linkTo[2],
-                range: {
-                    start: pos,
-                    end: pos + linkTo[0].length,
-                },
-                children: tokenizerFac(
-                    linkTo[2],
-                    null,
-                    inlineRules,
-                    pos + linkTo[1].length,
-                    false,
-                    labels,
-                    options,
-                ),
-                backlash: {
-                    first: linkTo[3],
-                    second: linkTo[5],
-                },
-            });
+            && lowerPriority(state.src, linkTo[0].length, validateRules)
+        )
+    ) {
+        return false;
+    }
 
-            src = src.substring(linkTo[0].length);
-            pos = pos + linkTo[0].length;
-            continue;
-        }
+    const { src: href, title } = parseSrcAndTitle(linkTo[4]);
+    pushPending(state);
+    state.tokens.push({
+        type: 'link',
+        raw: linkTo[0],
+        marker: linkTo[1],
+        hrefAndTitle: linkTo[4],
+        href,
+        title,
+        parent: state.tokens,
+        anchor: linkTo[2],
+        range: {
+            start: state.pos,
+            end: state.pos + linkTo[0].length,
+        },
+        children: tokenizerFac(
+            linkTo[2],
+            null,
+            state.inlineRules,
+            state.pos + linkTo[1].length,
+            false,
+            state.labels,
+            state.options,
+        ),
+        backlash: {
+            first: linkTo[3],
+            second: linkTo[5],
+        },
+    });
 
-        const rLinkTo = inlineRules.reference_link.exec(src);
-        if (
+    state.src = state.src.substring(linkTo[0].length);
+    state.pos = state.pos + linkTo[0].length;
+
+    return true;
+}
+
+function tryReferenceLink(state: ILexState): boolean {
+    const rLinkTo = state.inlineRules.reference_link.exec(state.src);
+    if (
+        !(
             rLinkTo
             // CommonMark §6.5: link labels match case-insensitively. The
             // labels Map is populated by `collectReferenceDefinitions` with
             // lowercased keys, so normalize the candidate before lookup.
-            && labels.has((rLinkTo[3] || rLinkTo[1]).toLowerCase())
+            && state.labels.has((rLinkTo[3] || rLinkTo[1]).toLowerCase())
             && isLengthEven(rLinkTo[2])
             && isLengthEven(rLinkTo[4])
-            && lowerPriority(src, rLinkTo[0].length, validateRules)
-        ) {
-            pushPending();
-            tokens.push({
-                type: 'reference_link',
-                raw: rLinkTo[0],
-                isFullLink: !!rLinkTo[3],
-                parent: tokens,
-                anchor: rLinkTo[1],
-                backlash: {
-                    first: rLinkTo[2],
-                    second: rLinkTo[4] || '',
-                },
-                label: rLinkTo[3] || rLinkTo[1],
-                range: {
-                    start: pos,
-                    end: pos + rLinkTo[0].length,
-                },
-                children: tokenizerFac(
-                    rLinkTo[1],
-                    null,
-                    inlineRules,
-                    pos + 1,
-                    false,
-                    labels,
-                    options,
-                ),
-            });
-
-            src = src.substring(rLinkTo[0].length);
-            pos = pos + rLinkTo[0].length;
-            continue;
-        }
-
-        const rImageTo = inlineRules.reference_image.exec(src);
-        if (
-            rImageTo
-            && labels.has((rImageTo[3] || rImageTo[1]).toLowerCase())
-            && isLengthEven(rImageTo[2])
-            && isLengthEven(rImageTo[4])
-        ) {
-            pushPending();
-
-            tokens.push({
-                type: 'reference_image',
-                raw: rImageTo[0],
-                isFullLink: !!rImageTo[3],
-                parent: tokens,
-                alt: rImageTo[1],
-                backlash: {
-                    first: rImageTo[2],
-                    second: rImageTo[4] || '',
-                },
-                label: rImageTo[3] || rImageTo[1],
-                range: {
-                    start: pos,
-                    end: pos + rImageTo[0].length,
-                },
-            });
-
-            src = src.substring(rImageTo[0].length);
-            pos = pos + rImageTo[0].length;
-            continue;
-        }
-
-        // html escape
-        const htmlEscapeTo = inlineRules.html_escape.exec(src);
-        if (htmlEscapeTo) {
-            const len = htmlEscapeTo[0].length;
-            pushPending();
-            tokens.push({
-                type: 'html_escape',
-                raw: htmlEscapeTo[0],
-                escapeCharacter: htmlEscapeTo[1],
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + len,
-                },
-            });
-            src = src.substring(len);
-            pos = pos + len;
-            continue;
-        }
-
-        // auto link extension
-        const autoLinkExtTo = inlineRules.auto_link_extension.exec(src);
-        if (
-            autoLinkExtTo
-            && top
-            && (pos === 0 || /[* _~(]/.test(originSrc[pos - 1]))
-        ) {
-            pushPending();
-            tokens.push({
-                type: 'auto_link_extension',
-                raw: autoLinkExtTo[0],
-                www: autoLinkExtTo[1],
-                url: autoLinkExtTo[2],
-                email: autoLinkExtTo[3],
-                linkType: autoLinkExtTo[1] ? 'www' : autoLinkExtTo[2] ? 'url' : 'email',
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + autoLinkExtTo[0].length,
-                },
-            });
-            src = src.substring(autoLinkExtTo[0].length);
-            pos = pos + autoLinkExtTo[0].length;
-            continue;
-        }
-
-        // auto link
-        const autoLTo = inlineRules.auto_link.exec(src);
-        if (autoLTo) {
-            pushPending();
-            tokens.push({
-                type: 'auto_link',
-                raw: autoLTo[0],
-                href: autoLTo[1],
-                email: autoLTo[2],
-                isLink: !!autoLTo[1], // It is a link or email.
-                marker: '<',
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + autoLTo[0].length,
-                },
-            });
-            src = src.substring(autoLTo[0].length);
-            pos = pos + autoLTo[0].length;
-            continue;
-        }
-
-        // html-tag
-        const htmlTo = inlineRules.html_tag.exec(src);
-        let attrs;
-        // handle comment
-        if (htmlTo && htmlTo[1] && !htmlTo[3]) {
-            const len = htmlTo[0].length;
-            pushPending();
-            tokens.push({
-                type: 'html_tag',
-                raw: htmlTo[0],
-                tag: '<!---->',
-                openTag: htmlTo[1],
-                parent: tokens,
-                attrs: {},
-                range: {
-                    start: pos,
-                    end: pos + len,
-                },
-            });
-            src = src.substring(len);
-            pos = pos + len;
-            continue;
-        }
-
-        if (
-            htmlTo
-            && !disallowedHtmlTag.test(htmlTo[3])
-            // eslint-disable-next-line no-cond-assign
-            && (attrs = getAttributes(htmlTo[0]))
-        ) {
-            const tag = htmlTo[3];
-            const html = htmlTo[0];
-            const len = htmlTo[0].length;
-
-            pushPending();
-            tokens.push({
-                type: 'html_tag',
-                raw: html,
-                tag,
-                openTag: htmlTo[2],
-                closeTag: htmlTo[5],
-                parent: tokens,
-                attrs,
-                content: htmlTo[4],
-                children: htmlTo[4]
-                    ? tokenizerFac(
-                            htmlTo[4],
-                            null,
-                            inlineRules,
-                            pos + htmlTo[2].length,
-                            false,
-                            labels,
-                            options,
-                        )
-                    : [],
-                range: {
-                    start: pos,
-                    end: pos + len,
-                },
-            });
-            src = src.substring(len);
-            pos = pos + len;
-            continue;
-        }
-
-        // soft line break
-        const softTo = inlineRules.soft_line_break.exec(src);
-        if (softTo) {
-            const len = softTo[0].length;
-            pushPending();
-            tokens.push({
-                type: 'soft_line_break',
-                raw: softTo[0],
-                lineBreak: softTo[1],
-                isAtEnd: softTo.input.length === softTo[0].length,
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + len,
-                },
-            });
-            src = src.substring(len);
-            pos += len;
-            continue;
-        }
-        // hard line break
-        const hardTo = inlineRules.hard_line_break.exec(src);
-        if (hardTo) {
-            const len = hardTo[0].length;
-            pushPending();
-            tokens.push({
-                type: 'hard_line_break',
-                raw: hardTo[0],
-                spaces: hardTo[1], // The space in hard line break
-                lineBreak: hardTo[2], // \n
-                isAtEnd: hardTo.input.length === hardTo[0].length,
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + len,
-                },
-            });
-            src = src.substring(len);
-            pos += len;
-            continue;
-        }
-
-        // tail header
-        const tailTo = inlineRules.tail_header.exec(src);
-        if (tailTo && top) {
-            pushPending();
-            tokens.push({
-                type: 'tail_header',
-                raw: tailTo[1],
-                marker: tailTo[1],
-                parent: tokens,
-                range: {
-                    start: pos,
-                    end: pos + tailTo[1].length,
-                },
-            });
-            src = src.substring(tailTo[1].length);
-            pos += tailTo[1].length;
-            continue;
-        }
-
-        if (!pending)
-            pendingStartPos = pos;
-        pending += src[0];
-        src = src.substring(1);
-        pos++;
+            && lowerPriority(state.src, rLinkTo[0].length, validateRules)
+        )
+    ) {
+        return false;
     }
 
-    pushPending();
+    pushPending(state);
+    state.tokens.push({
+        type: 'reference_link',
+        raw: rLinkTo[0],
+        isFullLink: !!rLinkTo[3],
+        parent: state.tokens,
+        anchor: rLinkTo[1],
+        backlash: {
+            first: rLinkTo[2],
+            second: rLinkTo[4] || '',
+        },
+        label: rLinkTo[3] || rLinkTo[1],
+        range: {
+            start: state.pos,
+            end: state.pos + rLinkTo[0].length,
+        },
+        children: tokenizerFac(
+            rLinkTo[1],
+            null,
+            state.inlineRules,
+            state.pos + 1,
+            false,
+            state.labels,
+            state.options,
+        ),
+    });
 
-    return tokens;
+    state.src = state.src.substring(rLinkTo[0].length);
+    state.pos = state.pos + rLinkTo[0].length;
+
+    return true;
+}
+
+function tryReferenceImage(state: ILexState): boolean {
+    const rImageTo = state.inlineRules.reference_image.exec(state.src);
+    if (
+        !(
+            rImageTo
+            && state.labels.has((rImageTo[3] || rImageTo[1]).toLowerCase())
+            && isLengthEven(rImageTo[2])
+            && isLengthEven(rImageTo[4])
+        )
+    ) {
+        return false;
+    }
+
+    pushPending(state);
+
+    state.tokens.push({
+        type: 'reference_image',
+        raw: rImageTo[0],
+        isFullLink: !!rImageTo[3],
+        parent: state.tokens,
+        alt: rImageTo[1],
+        backlash: {
+            first: rImageTo[2],
+            second: rImageTo[4] || '',
+        },
+        label: rImageTo[3] || rImageTo[1],
+        range: {
+            start: state.pos,
+            end: state.pos + rImageTo[0].length,
+        },
+    });
+
+    state.src = state.src.substring(rImageTo[0].length);
+    state.pos = state.pos + rImageTo[0].length;
+
+    return true;
+}
+
+// html escape
+function tryHtmlEscape(state: ILexState): boolean {
+    const htmlEscapeTo = state.inlineRules.html_escape.exec(state.src);
+    if (!htmlEscapeTo)
+        return false;
+
+    const len = htmlEscapeTo[0].length;
+    pushPending(state);
+    state.tokens.push({
+        type: 'html_escape',
+        raw: htmlEscapeTo[0],
+        escapeCharacter: htmlEscapeTo[1],
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + len,
+        },
+    });
+    state.src = state.src.substring(len);
+    state.pos = state.pos + len;
+
+    return true;
+}
+
+// auto link extension
+function tryAutoLinkExtension(state: ILexState): boolean {
+    const autoLinkExtTo = state.inlineRules.auto_link_extension.exec(state.src);
+    if (
+        !(
+            autoLinkExtTo
+            && state.top
+            && (state.pos === 0 || /[* _~(]/.test(state.originSrc[state.pos - 1]))
+        )
+    ) {
+        return false;
+    }
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'auto_link_extension',
+        raw: autoLinkExtTo[0],
+        www: autoLinkExtTo[1],
+        url: autoLinkExtTo[2],
+        email: autoLinkExtTo[3],
+        linkType: autoLinkExtTo[1] ? 'www' : autoLinkExtTo[2] ? 'url' : 'email',
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + autoLinkExtTo[0].length,
+        },
+    });
+    state.src = state.src.substring(autoLinkExtTo[0].length);
+    state.pos = state.pos + autoLinkExtTo[0].length;
+
+    return true;
+}
+
+// auto link
+function tryAutoLink(state: ILexState): boolean {
+    const autoLTo = state.inlineRules.auto_link.exec(state.src);
+    if (!autoLTo)
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'auto_link',
+        raw: autoLTo[0],
+        href: autoLTo[1],
+        email: autoLTo[2],
+        isLink: !!autoLTo[1], // It is a link or email.
+        marker: '<',
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + autoLTo[0].length,
+        },
+    });
+    state.src = state.src.substring(autoLTo[0].length);
+    state.pos = state.pos + autoLTo[0].length;
+
+    return true;
+}
+
+// html-tag
+function tryHtmlTag(state: ILexState): boolean {
+    const htmlTo = state.inlineRules.html_tag.exec(state.src);
+    let attrs;
+    // handle comment
+    if (htmlTo && htmlTo[1] && !htmlTo[3]) {
+        const len = htmlTo[0].length;
+        pushPending(state);
+        state.tokens.push({
+            type: 'html_tag',
+            raw: htmlTo[0],
+            tag: '<!---->',
+            openTag: htmlTo[1],
+            parent: state.tokens,
+            attrs: {},
+            range: {
+                start: state.pos,
+                end: state.pos + len,
+            },
+        });
+        state.src = state.src.substring(len);
+        state.pos = state.pos + len;
+
+        return true;
+    }
+
+    if (
+        htmlTo
+        && !disallowedHtmlTag.test(htmlTo[3])
+        // eslint-disable-next-line no-cond-assign
+        && (attrs = getAttributes(htmlTo[0]))
+    ) {
+        const tag = htmlTo[3];
+        const html = htmlTo[0];
+        const len = htmlTo[0].length;
+
+        pushPending(state);
+        state.tokens.push({
+            type: 'html_tag',
+            raw: html,
+            tag,
+            openTag: htmlTo[2],
+            closeTag: htmlTo[5],
+            parent: state.tokens,
+            attrs,
+            content: htmlTo[4],
+            children: htmlTo[4]
+                ? tokenizerFac(
+                        htmlTo[4],
+                        null,
+                        state.inlineRules,
+                        state.pos + htmlTo[2].length,
+                        false,
+                        state.labels,
+                        state.options,
+                    )
+                : [],
+            range: {
+                start: state.pos,
+                end: state.pos + len,
+            },
+        });
+        state.src = state.src.substring(len);
+        state.pos = state.pos + len;
+
+        return true;
+    }
+
+    return false;
+}
+
+// soft line break
+function trySoftLineBreak(state: ILexState): boolean {
+    const softTo = state.inlineRules.soft_line_break.exec(state.src);
+    if (!softTo)
+        return false;
+
+    const len = softTo[0].length;
+    pushPending(state);
+    state.tokens.push({
+        type: 'soft_line_break',
+        raw: softTo[0],
+        lineBreak: softTo[1],
+        isAtEnd: softTo.input.length === softTo[0].length,
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + len,
+        },
+    });
+    state.src = state.src.substring(len);
+    state.pos += len;
+
+    return true;
+}
+
+// hard line break
+function tryHardLineBreak(state: ILexState): boolean {
+    const hardTo = state.inlineRules.hard_line_break.exec(state.src);
+    if (!hardTo)
+        return false;
+
+    const len = hardTo[0].length;
+    pushPending(state);
+    state.tokens.push({
+        type: 'hard_line_break',
+        raw: hardTo[0],
+        spaces: hardTo[1], // The space in hard line break
+        lineBreak: hardTo[2], // \n
+        isAtEnd: hardTo.input.length === hardTo[0].length,
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + len,
+        },
+    });
+    state.src = state.src.substring(len);
+    state.pos += len;
+
+    return true;
+}
+
+// tail header
+function tryTailHeader(state: ILexState): boolean {
+    const tailTo = state.inlineRules.tail_header.exec(state.src);
+    if (!(tailTo && state.top))
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'tail_header',
+        raw: tailTo[1],
+        marker: tailTo[1],
+        parent: state.tokens,
+        range: {
+            start: state.pos,
+            end: state.pos + tailTo[1].length,
+        },
+    });
+    state.src = state.src.substring(tailTo[1].length);
+    state.pos += tailTo[1].length;
+
+    return true;
+}
+
+// The fixed, priority-ordered inline-rule handler list the tokenizer loop
+// iterates. This array order IS the rule-precedence contract.
+const INLINE_HANDLERS: ReadonlyArray<(state: ILexState) => boolean> = [
+    tryBacklash,
+    tryStrongEm,
+    tryChunks,
+    trySuperSubScript,
+    tryFootnote,
+    tryImage,
+    tryLink,
+    tryReferenceLink,
+    tryReferenceImage,
+    tryHtmlEscape,
+    tryAutoLinkExtension,
+    tryAutoLink,
+    tryHtmlTag,
+    trySoftLineBreak,
+    tryHardLineBreak,
+    tryTailHeader,
+];
+
+function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: InlineRules, pos = 0, top: boolean, labels: Labels, options: ITokenizerFacOptions) {
+    const { superSubScript, footnote } = options;
+    const state: ILexState = {
+        originSrc: src,
+        src,
+        pos,
+        pending: '',
+        pendingStartPos: pos,
+        tokens: [],
+        inlineRules,
+        labels,
+        options,
+        top,
+        superSubScript,
+        footnote,
+    };
+
+    if (beginRules && state.pos === 0)
+        consumeBeginRules(state, beginRules);
+
+    while (state.src.length) {
+        let consumed = false;
+        for (const handler of INLINE_HANDLERS) {
+            if (handler(state)) {
+                consumed = true;
+                break;
+            }
+        }
+        if (consumed)
+            continue;
+
+        if (!state.pending)
+            state.pendingStartPos = state.pos;
+        state.pending += state.src[0];
+        state.src = state.src.substring(1);
+        state.pos++;
+    }
+
+    pushPending(state);
+
+    return state.tokens;
 }
 
 export function tokenizer(src: string, {

--- a/packages/muya/src/inlineRenderer/renderer/htmlTag.ts
+++ b/packages/muya/src/inlineRenderer/renderer/htmlTag.ts
@@ -1,9 +1,110 @@
 import type { VNode } from 'snabbdom';
-import type { HTMLTagToken, ImageToken, ISyntaxRenderOptions, Token } from '../types';
+import type Format from '../../block/base/format';
+import type { IRenderCursor } from '../../selection/types';
+import type { H, HTMLTagToken, ImageToken, ISyntaxRenderOptions, Token } from '../types';
 import type Renderer from './index';
 import { BLOCK_TYPE6, CLASS_NAMES } from '../../config';
 import { snakeToCamel } from '../../utils';
 import sanitize, { isValidAttribute } from '../../utils/dompurify';
+
+function renderHtmlTagChildren(
+    renderer: Renderer,
+    h: H,
+    cursor: IRenderCursor,
+    block: Format,
+    token: HTMLTagToken,
+): VNode[] | '' {
+    const { tag, children } = token;
+
+    return Array.isArray(children) && children.length && tag !== 'ruby' // important
+        ? children.reduce((acc: VNode[], to: Token) => {
+                // The original passed a `className` field here too, but
+                // receivers read `outerClass` — so the field was
+                // silently dropped under the previous `as any` cast.
+                // Preserve that runtime behavior: don't propagate it.
+                const chunk = renderer.dispatch(snakeToCamel(to.type), {
+                    h,
+                    cursor,
+                    block,
+                    token: to,
+                });
+
+                return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];
+            }, [])
+        : '';
+}
+
+function buildRawHtmlTag(
+    token: HTMLTagToken,
+    tagClassName: string,
+    openContent: (string | VNode)[],
+    closeContent: (string | VNode)[] | '',
+    anchor: VNode[] | '',
+    h: H,
+): VNode[] {
+    const { tag, attrs } = token;
+    const { start, end } = token.range;
+
+    // if  tag is a block level element, use a inline element `span` to instead.
+    // Because we can not nest a block level element in span element(line is span element)
+    // we also recommand user not use block level element in paragraph. use block element in html block.
+    // Use code !sanitize(`<${tag}>`) to filter some malicious tags. for example: <embed>.
+    let selector
+        = BLOCK_TYPE6.includes(tag) || !sanitize(`<${tag}>`) ? 'span' : tag;
+    selector += `.${CLASS_NAMES.MU_INLINE_RULE}.${CLASS_NAMES.MU_RAW_HTML}`;
+    const data = {
+        attrs: {} as Record<string, string>,
+        dataset: {
+            start: String(start),
+            end: String(end),
+            raw: token.raw,
+        },
+    };
+
+    // Disable spell checking for these tags
+    if (tag === 'code' || tag === 'kbd')
+        Object.assign(data.attrs, { spellcheck: 'false' });
+
+    if (attrs.id)
+        selector += `#${attrs.id}`;
+
+    if (attrs.class && /\S/.test(attrs.class)) {
+        const classNames = attrs.class.split(/\s+/);
+
+        for (const className of classNames)
+            selector += `.${className}`;
+    }
+
+    for (const attr of Object.keys(attrs)) {
+        if (attr !== 'id' && attr !== 'class') {
+            const attrData = attrs[attr];
+            if (attrData && isValidAttribute(tag, attr, attrData))
+                data.attrs[attr] = attrData;
+        }
+    }
+
+    return [
+        h(
+            `span.${tagClassName}.${CLASS_NAMES.MU_OUTPUT_REMOVE}`,
+            {
+                attrs: {
+                    spellcheck: 'false',
+                },
+            },
+            openContent,
+        ),
+        h(`${selector}`, data, anchor),
+        h(
+            `span.${tagClassName}.${CLASS_NAMES.MU_OUTPUT_REMOVE}`,
+            {
+                attrs: {
+                    spellcheck: 'false',
+                },
+            },
+            closeContent,
+        ),
+    ];
+}
 
 export default function htmlTag(
     this: Renderer,
@@ -15,7 +116,7 @@ export default function htmlTag(
         outerClass,
     }: ISyntaxRenderOptions & { token: HTMLTagToken },
 ) {
-    const { tag, openTag, closeTag, children, attrs } = token;
+    const { tag, openTag, closeTag, children } = token;
 
     const className = children?.length
         ? this.getClassName(outerClass, block, token, cursor)
@@ -34,23 +135,7 @@ export default function htmlTag(
         ? this.highlight(h, block, end - closeTag.length, end, token)
         : '';
 
-    const anchor
-        = Array.isArray(children) && children.length && tag !== 'ruby' // important
-            ? children.reduce((acc: VNode[], to: Token) => {
-                    // The original passed a `className` field here too, but
-                    // receivers read `outerClass` — so the field was
-                    // silently dropped under the previous `as any` cast.
-                    // Preserve that runtime behavior: don't propagate it.
-                    const chunk = this.dispatch(snakeToCamel(to.type), {
-                        h,
-                        cursor,
-                        block,
-                        token: to,
-                    });
-
-                    return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];
-                }, [])
-            : '';
+    const anchor = renderHtmlTagChildren(this, h, cursor, block, token);
 
     switch (tag) {
     // Handle html img.
@@ -85,65 +170,14 @@ export default function htmlTag(
                 });
             }
             else {
-                // if  tag is a block level element, use a inline element `span` to instead.
-                // Because we can not nest a block level element in span element(line is span element)
-                // we also recommand user not use block level element in paragraph. use block element in html block.
-                // Use code !sanitize(`<${tag}>`) to filter some malicious tags. for example: <embed>.
-                let selector
-                    = BLOCK_TYPE6.includes(tag) || !sanitize(`<${tag}>`) ? 'span' : tag;
-                selector += `.${CLASS_NAMES.MU_INLINE_RULE}.${CLASS_NAMES.MU_RAW_HTML}`;
-                const data = {
-                    attrs: {} as Record<string, string>,
-                    dataset: {
-                        start: String(start),
-                        end: String(end),
-                        raw: token.raw,
-                    },
-                };
-
-                // Disable spell checking for these tags
-                if (tag === 'code' || tag === 'kbd')
-                    Object.assign(data.attrs, { spellcheck: 'false' });
-
-                if (attrs.id)
-                    selector += `#${attrs.id}`;
-
-                if (attrs.class && /\S/.test(attrs.class)) {
-                    const classNames = attrs.class.split(/\s+/);
-
-                    for (const className of classNames)
-                        selector += `.${className}`;
-                }
-
-                for (const attr of Object.keys(attrs)) {
-                    if (attr !== 'id' && attr !== 'class') {
-                        const attrData = attrs[attr];
-                        if (attrData && isValidAttribute(tag, attr, attrData))
-                            data.attrs[attr] = attrData;
-                    }
-                }
-
-                return [
-                    h(
-                        `span.${tagClassName}.${CLASS_NAMES.MU_OUTPUT_REMOVE}`,
-                        {
-                            attrs: {
-                                spellcheck: 'false',
-                            },
-                        },
-                        openContent,
-                    ),
-                    h(`${selector}`, data, anchor),
-                    h(
-                        `span.${tagClassName}.${CLASS_NAMES.MU_OUTPUT_REMOVE}`,
-                        {
-                            attrs: {
-                                spellcheck: 'false',
-                            },
-                        },
-                        closeContent,
-                    ),
-                ];
+                return buildRawHtmlTag(
+                    token,
+                    tagClassName,
+                    openContent,
+                    closeContent,
+                    anchor,
+                    h,
+                );
             }
     }
 }

--- a/packages/muya/src/inlineRenderer/renderer/image.ts
+++ b/packages/muya/src/inlineRenderer/renderer/image.ts
@@ -1,4 +1,6 @@
 import type { VNode } from 'snabbdom';
+import type Format from '../../block/base/format';
+import type { IImageSelectionData } from '../../selection/types';
 import type { H, ImageToken, ISyntaxRenderOptions } from '../types';
 import type Renderer from './index';
 import DeleteIcon from '../../assets/icons/delete/2.png';
@@ -24,6 +26,48 @@ function renderIcon(h: H, className: string, icon: string) {
     );
 
     return h(selector, iconVnode);
+}
+
+function shouldSyncSelectedImageId(
+    selectedImage: IImageSelectionData | null,
+    src: string,
+    id: string,
+): selectedImage is IImageSelectionData {
+    return (
+        !!selectedImage
+        && selectedImage.token.attrs.src === src
+        && selectedImage.imageId !== id
+    );
+}
+
+function isSmallImage(
+    naturalWidth: number | undefined,
+    naturalHeight: number | undefined,
+) {
+    return (
+        typeof naturalWidth === 'number'
+        && typeof naturalHeight === 'number'
+        && (naturalWidth < 100 || naturalHeight < 100)
+    );
+}
+
+function isImageSelected(
+    selectedImage: IImageSelectionData | null,
+    block: Format,
+    token: ImageToken,
+    id: string,
+) {
+    if (!selectedImage)
+        return false;
+
+    const { imageId, block: selectedBlock, token: selectedToken } = selectedImage;
+
+    return (
+        imageId === `${id}_${token.range.start}`
+        && selectedBlock === block
+        && selectedToken.range.start === token.range.start
+        && selectedToken.range.end === token.range.end
+    );
 }
 
 // I don't want operate dom directly, is there any better way? need help!
@@ -102,13 +146,8 @@ export default function image(
     // the src image is still loading, so use the url Map base64.
     if (this.urlMap.has(src)) {
     // fix: it will generate a new id if the image is not loaded.
-        if (
-            selectedImage
-            && selectedImage.token.attrs.src === src
-            && selectedImage.imageId !== id
-        ) {
+        if (shouldSyncSelectedImageId(selectedImage, src, id))
             selectedImage.imageId = id;
-        }
 
         imgSrc = this.urlMap.get(src)!;
         isSuccess = true;
@@ -142,30 +181,16 @@ export default function image(
             // have (our toolbar is a floating-ui overlay), so the rule lives
             // here as data only; downstream consumers / future PRs own the
             // visual treatment.
-            if (
-                typeof naturalWidth === 'number'
-                && typeof naturalHeight === 'number'
-                && (naturalWidth < 100 || naturalHeight < 100)
-            ) {
+            if (isSmallImage(naturalWidth, naturalHeight))
                 wrapperSelector += `.${CLASS_NAMES.MU_SMALL_IMAGE}`;
-            }
         }
         else {
             wrapperSelector += `.${CLASS_NAMES.MU_IMAGE_FAIL}`;
         }
 
         // Add image selected class name.
-        if (selectedImage) {
-            const { imageId, block: SelectedImageBlock, token: selectedToken } = selectedImage;
-            if (
-                imageId === `${id}_${token.range.start}`
-                && SelectedImageBlock === block
-                && selectedToken.range.start === token.range.start
-                && selectedToken.range.end === token.range.end
-            ) {
-                wrapperSelector += `.${CLASS_NAMES.MU_INLINE_IMAGE_SELECTED}`;
-            }
-        }
+        if (isImageSelected(selectedImage, block, token, id))
+            wrapperSelector += `.${CLASS_NAMES.MU_INLINE_IMAGE_SELECTED}`;
 
         const renderImage = () => {
             const data = {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1,5 +1,6 @@
 import type Content from './block/base/content';
 import type Parent from './block/base/parent';
+import type { TBlockPath } from './block/types';
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
 import type { IIndexCursor } from './selection/offsetCursor';
@@ -742,25 +743,18 @@ export class Muya {
         if (!scrollPage)
             return;
 
-        // Accept both the `{ anchor, focus, anchorPath, focusPath }` and the
-        // `{ start, end, path }`/`block` shapes of IPublicCursorInput.
-        const anchor = cursor.anchor ?? cursor.start ?? null;
-        const focus = cursor.focus ?? cursor.end ?? anchor;
-        const anchorPath = cursor.anchorPath ?? cursor.path;
-        const focusPath = cursor.focusPath ?? cursor.path ?? anchorPath;
+        const { anchor, focus, anchorPath, focusPath }
+            = this._normalizeCursorEndpoints(cursor);
 
         if (!anchor || !focus)
             return;
 
-        // queryBlock mutates its path argument (path.shift()) — pass copies.
-        const anchorBlock
-            = cursor.anchorBlock
-                ?? cursor.block
-                ?? (anchorPath ? scrollPage.queryBlock([...anchorPath]) : null);
-        const focusBlock
-            = cursor.focusBlock
-                ?? cursor.block
-                ?? (focusPath ? scrollPage.queryBlock([...focusPath]) : null);
+        const { anchorBlock, focusBlock } = this._resolveCursorBlocks(
+            cursor,
+            scrollPage,
+            anchorPath,
+            focusPath,
+        );
 
         if (anchorBlock == null || !anchorBlock.isContent())
             return;
@@ -779,6 +773,36 @@ export class Muya {
             { offset: anchor.offset, block: anchorBlock, path: anchorBlock.path },
             { offset: focus.offset, block: focusBlock, path: focusBlock.path },
         );
+    }
+
+    // Accept both the `{ anchor, focus, anchorPath, focusPath }` and the
+    // `{ start, end, path }`/`block` shapes of IPublicCursorInput.
+    private _normalizeCursorEndpoints(cursor: IPublicCursorInput) {
+        const anchor = cursor.anchor ?? cursor.start ?? null;
+        const focus = cursor.focus ?? cursor.end ?? anchor;
+        const anchorPath = cursor.anchorPath ?? cursor.path;
+        const focusPath = cursor.focusPath ?? cursor.path ?? anchorPath;
+
+        return { anchor, focus, anchorPath, focusPath };
+    }
+
+    private _resolveCursorBlocks(
+        cursor: IPublicCursorInput,
+        scrollPage: ScrollPage,
+        anchorPath: TBlockPath | undefined,
+        focusPath: TBlockPath | undefined,
+    ) {
+        // queryBlock mutates its path argument (path.shift()) — pass copies.
+        const anchorBlock
+            = cursor.anchorBlock
+                ?? cursor.block
+                ?? (anchorPath ? scrollPage.queryBlock([...anchorPath]) : null);
+        const focusBlock
+            = cursor.focusBlock
+                ?? cursor.block
+                ?? (focusPath ? scrollPage.queryBlock([...focusPath]) : null);
+
+        return { anchorBlock, focusBlock };
     }
 
     /**

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -36,6 +36,17 @@ const DEFAULT_OPTIONS = {
     frontMatter: true,
 };
 
+// Token types whose handler manipulates the `parentList` stack (push a
+// container and recurse via synthetic `block-end`), as opposed to the leaf
+// tokens that only append a state to the current level.
+const CONTAINER_TOKEN_TYPES = new Set([
+    'block-end',
+    'blockquote',
+    'list',
+    'list_item',
+    'footnote',
+]);
+
 export class MarkdownToState {
     constructor(private _options: IMarkdownToStateOptions = DEFAULT_OPTIONS) {}
 
@@ -43,7 +54,6 @@ export class MarkdownToState {
         return this._convertMarkdownToState(markdown);
     }
 
-    // eslint-disable-next-line max-lines-per-function, complexity
     private _convertMarkdownToState(markdown: string): TState[] {
         const {
             footnote = false,
@@ -65,350 +75,379 @@ export class MarkdownToState {
 
         const states: TState[] = [];
         let token: TBlockToken | undefined;
-        let state: TState;
-        let value: string;
         const parentList: TState[][] = [states];
 
         // eslint-disable-next-line no-cond-assign
         while ((token = tokens.shift())) {
-            switch (token.type) {
-                // Marks the end of the children's traversal and a return to the previous level
-                case 'block-end': {
-                    // Fix #1735 the blockquote maybe empty. like bellow:
-                    // >
-                    // bar
-                    if (parentList[0].length === 0 && token.tokenType === 'blockquote') {
-                        state = {
-                            name: 'paragraph' as const,
-                            text: '',
-                        };
-                        parentList[0].push(state);
-                    }
-                    parentList.shift();
-                    break;
-                }
-
-                case 'frontmatter': {
-                    const { lang, style, text } = token;
-                    value = text.replace(/^\s+/, '').replace(/\s$/, '');
-
-                    state = {
-                        name: 'frontmatter' as const,
-                        meta: {
-                            lang,
-                            style,
-                        },
-                        text: value,
-                    };
-
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'hr': {
-                    state = {
-                        name: 'thematic-break' as const,
-                        text: token.raw.replace(/\n+$/, ''),
-                    };
-
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'heading': {
-                    const { headingStyle, depth, text, marker } = token;
-                    value = headingStyle === 'atx'
-                        ? `${'#'.repeat(+depth)} ${text}`
-                        : text;
-
-                    if (headingStyle === 'atx') {
-                        const atxState: IAtxHeadingState = {
-                            name: 'atx-heading',
-                            meta: { level: depth },
-                            text: value,
-                        };
-                        state = atxState;
-                    }
-                    else {
-                        const setextState: ISetextHeadingState = {
-                            name: 'setext-heading',
-                            meta: { level: depth, underline: marker },
-                            text: value,
-                        };
-                        state = setextState;
-                    }
-
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'code': {
-                    const { codeBlockStyle, text, lang: infoString = '' } = token;
-
-                    // GH#697, markedjs#1387 — strip everything past the first
-                    // whitespace; `\S*` matches the empty string so this is
-                    // always non-null even for `infoString === ''`.
-                    const lang = (infoString || '').match(/\S*/)?.[0] ?? '';
-
-                    value = text;
-                    // Fix: #1265.
-                    if (
-                        trimUnnecessaryCodeBlockEmptyLines
-                        && (value.endsWith('\n') || value.startsWith('\n'))
-                    ) {
-                        value = value.replace(/\n+$/, '').replace(/^\n+/, '');
-                    }
-
-                    const diagramMatch = /^(mermaid|vega-lite|plantuml|flowchart|sequence)$/.exec(lang);
-                    if (diagramMatch) {
-                        const diagramType = diagramMatch[1] as 'mermaid' | 'vega-lite' | 'plantuml' | 'flowchart' | 'sequence';
-                        state = {
-                            name: 'diagram' as const,
-                            text: value,
-                            meta: {
-                                type: diagramType,
-                                lang: diagramType === 'vega-lite' ? 'json' : 'yaml',
-                            },
-                        };
-                    }
-                    else {
-                        // walkTokens (utils/marked/walkTokens.ts) writes
-                        // codeBlockStyle = 'fenced' for fenced blocks and
-                        // leaves 'indented' for indented blocks. marked's
-                        // type widens the field to `'indented' | undefined`,
-                        // but `'fenced'` reaches us at runtime via the
-                        // walkTokens assignment — hence the cast.
-                        const isFenced = (codeBlockStyle as 'indented' | 'fenced' | undefined) === 'fenced';
-                        state = {
-                            name: 'code-block' as const,
-                            meta: {
-                                type: isFenced ? 'fenced' : 'indented',
-                                lang,
-                            },
-                            text: value,
-                        };
-                    }
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'table': {
-                    const { header, align, rows } = token;
-                    const tableState: ITableState = {
-                        name: 'table',
-                        children: [],
-                    };
-
-                    tableState.children.push({
-                        name: 'table.row',
-                        children: header.map((h, i) => ({
-                            name: 'table.cell' as const,
-                            meta: { align: align[i] || 'none' },
-                            text: restoreTableEscapeCharacters(h.text),
-                        })),
-                    });
-
-                    tableState.children.push(
-                        ...rows.map(row => ({
-                            name: 'table.row' as const,
-                            children: row.map((c, i) => ({
-                                name: 'table.cell' as const,
-                                meta: { align: align[i] || 'none' },
-                                text: restoreTableEscapeCharacters(c.text),
-                            })),
-                        })),
-                    );
-
-                    state = tableState;
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'html': {
-                    const text = token.text.trim();
-                    // TODO: Treat html state which only contains one img as paragraph, we maybe add image state in the future.
-                    const isSingleImage = /^<img[^<>]+>$/.test(text);
-                    if (isSingleImage) {
-                        state = {
-                            name: 'paragraph' as const,
-                            text,
-                        };
-                        parentList[0].push(state);
-                    }
-                    else {
-                        state = {
-                            name: 'html-block' as const,
-                            text,
-                        };
-                        parentList[0].push(state);
-                    }
-                    break;
-                }
-
-                case 'multiplemath': {
-                    const text = token.text.trim();
-                    const { mathStyle = '' } = token;
-                    const state = {
-                        name: 'math-block' as const,
-                        text,
-                        meta: { mathStyle },
-                    };
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'text': {
-                    value = token.text;
-                    while (tokens[0]?.type === 'text') {
-                        const next = tokens.shift() as Extract<TBlockToken, { type: 'text' }>;
-                        value += `\n${next.text}`;
-                    }
-                    state = {
-                        name: 'paragraph',
-                        text: value,
-                    };
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'paragraph': {
-                    value = token.text;
-                    state = {
-                        name: 'paragraph' as const,
-                        text: value,
-                    };
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'blockquote': {
-                    state = {
-                        name: 'block-quote' as const,
-                        children: [],
-                    };
-                    parentList[0].push(state);
-                    parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'blockquote' });
-                    tokens.unshift(...(token.tokens as TBlockToken[]));
-                    break;
-                }
-
-                case 'list': {
-                    const { listType, loose, start } = token;
-                    const bulletMarkerOrDelimiter
-                        = token.items[0].bulletMarkerOrDelimiter;
-
-                    let listState: IOrderListState | IBulletListState | ITaskListState;
-                    if (listType === 'order') {
-                        listState = {
-                            name: 'order-list',
-                            meta: {
-                                loose,
-                                start: /^\d+$/.test(String(start)) ? Number(start) : 1,
-                                delimiter: bulletMarkerOrDelimiter || '.',
-                            },
-                            children: [],
-                        };
-                    }
-                    else if (listType === 'task') {
-                        listState = {
-                            name: 'task-list',
-                            meta: {
-                                loose,
-                                marker: bulletMarkerOrDelimiter || '-',
-                            },
-                            children: [],
-                        };
-                    }
-                    else {
-                        listState = {
-                            name: 'bullet-list',
-                            meta: {
-                                loose,
-                                marker: bulletMarkerOrDelimiter || '-',
-                            },
-                            children: [],
-                        };
-                    }
-
-                    state = listState;
-                    parentList[0].push(state);
-                    parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'list' });
-                    tokens.unshift(...(token.items as TBlockToken[]));
-                    break;
-                }
-
-                case 'list_item': {
-                    const { listItemType, checked } = token;
-                    let itemState: IListItemState | ITaskListItemState;
-                    if (listItemType === 'task') {
-                        itemState = {
-                            name: 'task-list-item',
-                            meta: { checked: Boolean(checked) },
-                            children: [],
-                        };
-                    }
-                    else {
-                        itemState = {
-                            name: 'list-item',
-                            children: [],
-                        };
-                    }
-
-                    state = itemState;
-                    parentList[0].push(state);
-                    parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'list-item' });
-                    tokens.unshift(...(token.tokens as TBlockToken[]));
-                    break;
-                }
-
-                case 'space': {
-                    break;
-                }
-
-                case 'def': {
-                    // Marked v16 hoists `[label]: url "title"` reference
-                    // definitions to block-level `def` tokens. Lower them back
-                    // to paragraph state nodes so the rest of the pipeline —
-                    // `InlineRenderer.collectReferenceDefinitions` (regex scan
-                    // over paragraph text) and round-trip serialization —
-                    // keeps working without a dedicated state node.
-                    // Aligns with marktext's "definition is paragraph text"
-                    // model. See plan section 13 (PR-16).
-                    state = {
-                        name: 'paragraph' as const,
-                        text: token.raw.replace(/\n+$/, ''),
-                    };
-                    parentList[0].push(state);
-                    break;
-                }
-
-                case 'footnote': {
-                    // The footnote extension (utils/marked/extensions/footnote.ts)
-                    // emits a parent token whose `tokens` array holds nested
-                    // block tokens. Mirror that into a `footnote` container
-                    // state and recurse via tokens.unshift / block-end.
-                    const { identifier } = token;
-                    state = {
-                        name: 'footnote' as const,
-                        meta: { identifier },
-                        children: [],
-                    };
-                    parentList[0].push(state);
-                    parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'footnote' });
-                    tokens.unshift(...(token.tokens as TBlockToken[]));
-                    break;
-                }
-
-                default:
-                    debug.warn(`Unknown type ${token.type}`);
-                    break;
-            }
+            if (CONTAINER_TOKEN_TYPES.has(token.type))
+                this._handleContainerToken(token, parentList, tokens);
+            else
+                this._handleLeafToken(token, parentList, tokens, trimUnnecessaryCodeBlockEmptyLines);
         }
 
         return states.length ? states : [{ name: 'paragraph', text: '' }];
+    }
+
+    private _handleContainerToken(
+        token: TBlockToken,
+        parentList: TState[][],
+        tokens: TBlockToken[],
+    ) {
+        let state: TState;
+        switch (token.type) {
+            // Marks the end of the children's traversal and a return to the previous level
+            case 'block-end': {
+                // Fix #1735 the blockquote maybe empty. like bellow:
+                // >
+                // bar
+                if (parentList[0].length === 0 && token.tokenType === 'blockquote') {
+                    state = {
+                        name: 'paragraph' as const,
+                        text: '',
+                    };
+                    parentList[0].push(state);
+                }
+                parentList.shift();
+                break;
+            }
+
+            case 'blockquote': {
+                state = {
+                    name: 'block-quote' as const,
+                    children: [],
+                };
+                parentList[0].push(state);
+                parentList.unshift(state.children);
+                tokens.unshift({ type: 'block-end', tokenType: 'blockquote' });
+                tokens.unshift(...(token.tokens as TBlockToken[]));
+                break;
+            }
+
+            case 'list': {
+                const { listType, loose, start } = token;
+                const bulletMarkerOrDelimiter
+                    = token.items[0].bulletMarkerOrDelimiter;
+
+                let listState: IOrderListState | IBulletListState | ITaskListState;
+                if (listType === 'order') {
+                    listState = {
+                        name: 'order-list',
+                        meta: {
+                            loose,
+                            start: /^\d+$/.test(String(start)) ? Number(start) : 1,
+                            delimiter: bulletMarkerOrDelimiter || '.',
+                        },
+                        children: [],
+                    };
+                }
+                else if (listType === 'task') {
+                    listState = {
+                        name: 'task-list',
+                        meta: {
+                            loose,
+                            marker: bulletMarkerOrDelimiter || '-',
+                        },
+                        children: [],
+                    };
+                }
+                else {
+                    listState = {
+                        name: 'bullet-list',
+                        meta: {
+                            loose,
+                            marker: bulletMarkerOrDelimiter || '-',
+                        },
+                        children: [],
+                    };
+                }
+
+                state = listState;
+                parentList[0].push(state);
+                parentList.unshift(state.children);
+                tokens.unshift({ type: 'block-end', tokenType: 'list' });
+                tokens.unshift(...(token.items as TBlockToken[]));
+                break;
+            }
+
+            case 'list_item': {
+                const { listItemType, checked } = token;
+                let itemState: IListItemState | ITaskListItemState;
+                if (listItemType === 'task') {
+                    itemState = {
+                        name: 'task-list-item',
+                        meta: { checked: Boolean(checked) },
+                        children: [],
+                    };
+                }
+                else {
+                    itemState = {
+                        name: 'list-item',
+                        children: [],
+                    };
+                }
+
+                state = itemState;
+                parentList[0].push(state);
+                parentList.unshift(state.children);
+                tokens.unshift({ type: 'block-end', tokenType: 'list-item' });
+                tokens.unshift(...(token.tokens as TBlockToken[]));
+                break;
+            }
+
+            case 'footnote': {
+                // The footnote extension (utils/marked/extensions/footnote.ts)
+                // emits a parent token whose `tokens` array holds nested
+                // block tokens. Mirror that into a `footnote` container
+                // state and recurse via tokens.unshift / block-end.
+                const { identifier } = token;
+                state = {
+                    name: 'footnote' as const,
+                    meta: { identifier },
+                    children: [],
+                };
+                parentList[0].push(state);
+                parentList.unshift(state.children);
+                tokens.unshift({ type: 'block-end', tokenType: 'footnote' });
+                tokens.unshift(...(token.tokens as TBlockToken[]));
+                break;
+            }
+        }
+    }
+
+    private _handleLeafToken(
+        token: TBlockToken,
+        parentList: TState[][],
+        tokens: TBlockToken[],
+        trimUnnecessaryCodeBlockEmptyLines: boolean,
+    ) {
+        let state: TState;
+        let value: string;
+        switch (token.type) {
+            case 'frontmatter': {
+                const { lang, style, text } = token;
+                value = text.replace(/^\s+/, '').replace(/\s$/, '');
+
+                state = {
+                    name: 'frontmatter' as const,
+                    meta: {
+                        lang,
+                        style,
+                    },
+                    text: value,
+                };
+
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'hr': {
+                state = {
+                    name: 'thematic-break' as const,
+                    text: token.raw.replace(/\n+$/, ''),
+                };
+
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'heading': {
+                const { headingStyle, depth, text, marker } = token;
+                value = headingStyle === 'atx'
+                    ? `${'#'.repeat(+depth)} ${text}`
+                    : text;
+
+                if (headingStyle === 'atx') {
+                    const atxState: IAtxHeadingState = {
+                        name: 'atx-heading',
+                        meta: { level: depth },
+                        text: value,
+                    };
+                    state = atxState;
+                }
+                else {
+                    const setextState: ISetextHeadingState = {
+                        name: 'setext-heading',
+                        meta: { level: depth, underline: marker },
+                        text: value,
+                    };
+                    state = setextState;
+                }
+
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'code': {
+                const { codeBlockStyle, text, lang: infoString = '' } = token;
+                parentList[0].push(
+                    this._buildCodeState(text, infoString, codeBlockStyle, trimUnnecessaryCodeBlockEmptyLines),
+                );
+                break;
+            }
+
+            case 'table': {
+                const { header, align, rows } = token;
+                const tableState: ITableState = {
+                    name: 'table',
+                    children: [],
+                };
+
+                tableState.children.push({
+                    name: 'table.row',
+                    children: header.map((h, i) => ({
+                        name: 'table.cell' as const,
+                        meta: { align: align[i] || 'none' },
+                        text: restoreTableEscapeCharacters(h.text),
+                    })),
+                });
+
+                tableState.children.push(
+                    ...rows.map(row => ({
+                        name: 'table.row' as const,
+                        children: row.map((c, i) => ({
+                            name: 'table.cell' as const,
+                            meta: { align: align[i] || 'none' },
+                            text: restoreTableEscapeCharacters(c.text),
+                        })),
+                    })),
+                );
+
+                state = tableState;
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'html': {
+                const text = token.text.trim();
+                // TODO: Treat html state which only contains one img as paragraph, we maybe add image state in the future.
+                const isSingleImage = /^<img[^<>]+>$/.test(text);
+                if (isSingleImage) {
+                    state = {
+                        name: 'paragraph' as const,
+                        text,
+                    };
+                    parentList[0].push(state);
+                }
+                else {
+                    state = {
+                        name: 'html-block' as const,
+                        text,
+                    };
+                    parentList[0].push(state);
+                }
+                break;
+            }
+
+            case 'multiplemath': {
+                const text = token.text.trim();
+                const { mathStyle = '' } = token;
+                const state = {
+                    name: 'math-block' as const,
+                    text,
+                    meta: { mathStyle },
+                };
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'text': {
+                value = token.text;
+                while (tokens[0]?.type === 'text') {
+                    const next = tokens.shift() as Extract<TBlockToken, { type: 'text' }>;
+                    value += `\n${next.text}`;
+                }
+                state = {
+                    name: 'paragraph',
+                    text: value,
+                };
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'paragraph': {
+                value = token.text;
+                state = {
+                    name: 'paragraph' as const,
+                    text: value,
+                };
+                parentList[0].push(state);
+                break;
+            }
+
+            case 'space': {
+                break;
+            }
+
+            case 'def': {
+                // Marked v16 hoists `[label]: url "title"` reference
+                // definitions to block-level `def` tokens. Lower them back
+                // to paragraph state nodes so the rest of the pipeline —
+                // `InlineRenderer.collectReferenceDefinitions` (regex scan
+                // over paragraph text) and round-trip serialization —
+                // keeps working without a dedicated state node.
+                // Aligns with marktext's "definition is paragraph text"
+                // model. See plan section 13 (PR-16).
+                state = {
+                    name: 'paragraph' as const,
+                    text: token.raw.replace(/\n+$/, ''),
+                };
+                parentList[0].push(state);
+                break;
+            }
+
+            default:
+                debug.warn(`Unknown type ${token.type}`);
+                break;
+        }
+    }
+
+    private _buildCodeState(
+        text: string,
+        infoString: string,
+        codeBlockStyle: 'indented' | undefined,
+        trimUnnecessaryCodeBlockEmptyLines: boolean,
+    ): TState {
+        // GH#697, markedjs#1387 — strip everything past the first
+        // whitespace; `\S*` matches the empty string so this is
+        // always non-null even for `infoString === ''`.
+        const lang = (infoString || '').match(/\S*/)?.[0] ?? '';
+
+        let value = text;
+        // Fix: #1265.
+        if (
+            trimUnnecessaryCodeBlockEmptyLines
+            && (value.endsWith('\n') || value.startsWith('\n'))
+        ) {
+            value = value.replace(/\n+$/, '').replace(/^\n+/, '');
+        }
+
+        const diagramMatch = /^(mermaid|vega-lite|plantuml|flowchart|sequence)$/.exec(lang);
+        if (diagramMatch) {
+            const diagramType = diagramMatch[1] as 'mermaid' | 'vega-lite' | 'plantuml' | 'flowchart' | 'sequence';
+            return {
+                name: 'diagram' as const,
+                text: value,
+                meta: {
+                    type: diagramType,
+                    lang: diagramType === 'vega-lite' ? 'json' : 'yaml',
+                },
+            };
+        }
+
+        // walkTokens (utils/marked/walkTokens.ts) writes
+        // codeBlockStyle = 'fenced' for fenced blocks and
+        // leaves 'indented' for indented blocks. marked's
+        // type widens the field to `'indented' | undefined`,
+        // but `'fenced'` reaches us at runtime via the
+        // walkTokens assignment — hence the cast.
+        const isFenced = (codeBlockStyle as 'indented' | 'fenced' | undefined) === 'fenced';
+        return {
+            name: 'code-block' as const,
+            meta: {
+                type: isFenced ? 'fenced' : 'indented',
+                lang,
+            },
+            text: value,
+        };
     }
 }

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -32,6 +32,7 @@ import type {
 import { deepClone } from '../utils';
 
 import logger from '../utils/logger';
+import { isAnyListState } from './types';
 
 const debug = logger('export markdown: ');
 function escapeText(str: string) {
@@ -91,7 +92,7 @@ export default class ExportMarkdown {
         indent = '',
         listIndent = '',
     ): string {
-        const result = [];
+        const result: string[] = [];
         // helper for CommonMark 264
         let lastListBullet = '';
 
@@ -104,116 +105,137 @@ export default class ExportMarkdown {
                 lastListBullet = '';
             }
 
-            switch (state.name) {
-                case 'frontmatter':
-                    result.push(this.serializeFrontMatter(state));
-                    break;
-
-                case 'paragraph':
-
-                case 'thematic-break':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeTextParagraph(state, indent));
-                    break;
-
-                case 'atx-heading':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeAtxHeading(state, indent));
-                    break;
-
-                case 'setext-heading':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeSetextHeading(state, indent));
-                    break;
-
-                case 'code-block':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeCodeBlock(state, indent));
-                    break;
-
-                case 'html-block':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeHtmlBlock(state, indent));
-                    break;
-
-                case 'math-block':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeMathBlock(state, indent));
-                    break;
-
-                case 'diagram':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeDiagramBlock(state, indent));
-                    break;
-
-                case 'block-quote':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeBlockquote(state, indent));
-                    break;
-
-                case 'table':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeTable(state, indent));
-                    break;
-
-                case 'footnote':
-                    this.insertLineBreak(result, indent);
-                    result.push(this.serializeFootnote(state, indent));
-                    break;
-
-                case 'order-list':
-
-                case 'bullet-list':
-
-                case 'task-list': {
-                    let insertNewLine = this._isLooseParentList;
-                    this._isLooseParentList = true;
-                    const { meta } = state;
-
-                    // Start a new list without separation due changing the bullet or ordered list delimiter starts a new list.
-                    const bulletMarkerOrDelimiter
-                        = 'delimiter' in meta ? meta.delimiter : meta.marker;
-
-                    if (lastListBullet && lastListBullet !== bulletMarkerOrDelimiter)
-                        insertNewLine = false;
-
-                    lastListBullet = bulletMarkerOrDelimiter;
-
-                    if (insertNewLine)
-                        this.insertLineBreak(result, indent);
-
-                    this._listType.push(deepClone(meta));
-                    result.push(this.serializeList(state, indent, listIndent));
-                    this._listType.pop();
-                    break;
-                }
-
-                case 'list-item':
-
-                case 'task-list-item': {
-                    const { loose } = this._listType[this._listType.length - 1];
-
-                    // helper variable to correct the first tight item in a nested list
-                    this._isLooseParentList = loose;
-                    if (loose)
-                        this.insertLineBreak(result, indent);
-
-                    result.push(this.serializeListItem(state, indent + listIndent));
-                    this._isLooseParentList = true;
-                    break;
-                }
-
-                default: {
-                    debug.warn(
-                        'convertStatesToMarkdown: Unknown state type:',
-                        state.name,
-                    );
-                    break;
-                }
+            if (isAnyListState(state)) {
+                lastListBullet = this._serializeListBlock(
+                    state,
+                    result,
+                    indent,
+                    listIndent,
+                    lastListBullet,
+                );
+            }
+            else if (state.name === 'list-item' || state.name === 'task-list-item') {
+                this._serializeListItemBlock(state, result, indent, listIndent);
+            }
+            else {
+                this._serializeSimpleBlock(state, result, indent);
             }
         }
 
         return result.join('');
+    }
+
+    private _serializeSimpleBlock(state: TState, result: string[], indent: string) {
+        switch (state.name) {
+            case 'frontmatter':
+                result.push(this.serializeFrontMatter(state));
+                break;
+
+            case 'paragraph':
+
+            case 'thematic-break':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeTextParagraph(state, indent));
+                break;
+
+            case 'atx-heading':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeAtxHeading(state, indent));
+                break;
+
+            case 'setext-heading':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeSetextHeading(state, indent));
+                break;
+
+            case 'code-block':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeCodeBlock(state, indent));
+                break;
+
+            case 'html-block':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeHtmlBlock(state, indent));
+                break;
+
+            case 'math-block':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeMathBlock(state, indent));
+                break;
+
+            case 'diagram':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeDiagramBlock(state, indent));
+                break;
+
+            case 'block-quote':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeBlockquote(state, indent));
+                break;
+
+            case 'table':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeTable(state, indent));
+                break;
+
+            case 'footnote':
+                this.insertLineBreak(result, indent);
+                result.push(this.serializeFootnote(state, indent));
+                break;
+
+            default: {
+                debug.warn(
+                    'convertStatesToMarkdown: Unknown state type:',
+                    state.name,
+                );
+                break;
+            }
+        }
+    }
+
+    private _serializeListBlock(
+        state: IOrderListState | IBulletListState | ITaskListState,
+        result: string[],
+        indent: string,
+        listIndent: string,
+        lastListBullet: string,
+    ): string {
+        let insertNewLine = this._isLooseParentList;
+        this._isLooseParentList = true;
+        const { meta } = state;
+
+        // Start a new list without separation due changing the bullet or ordered list delimiter starts a new list.
+        const bulletMarkerOrDelimiter
+            = 'delimiter' in meta ? meta.delimiter : meta.marker;
+
+        if (lastListBullet && lastListBullet !== bulletMarkerOrDelimiter)
+            insertNewLine = false;
+
+        if (insertNewLine)
+            this.insertLineBreak(result, indent);
+
+        this._listType.push(deepClone(meta));
+        result.push(this.serializeList(state, indent, listIndent));
+        this._listType.pop();
+
+        return bulletMarkerOrDelimiter;
+    }
+
+    private _serializeListItemBlock(
+        state: IListItemState | ITaskListItemState,
+        result: string[],
+        indent: string,
+        listIndent: string,
+    ) {
+        const { loose } = this._listType[this._listType.length - 1];
+
+        // helper variable to correct the first tight item in a nested list
+        this._isLooseParentList = loose;
+        if (loose)
+            this.insertLineBreak(result, indent);
+
+        result.push(this.serializeListItem(state, indent + listIndent));
+        this._isLooseParentList = true;
     }
 
     insertLineBreak(result: unknown[], indent: string) {

--- a/packages/muya/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/muya/src/ui/paragraphFrontMenu/index.ts
@@ -192,175 +192,12 @@ export class ParagraphFrontMenu extends BaseFloat {
         if (!this._block)
             return;
 
-        const { _block: block, muya } = this;
-        const { editor } = muya;
+        const { _block: block } = this;
         const oldState = block.getState();
-        let cursorBlock = null;
-        let state = null;
-        const { bulletListMarker, orderListDelimiter } = muya.options;
 
-        if (/duplicate|new|delete/.test(label)) {
-            switch (label) {
-                case 'duplicate': {
-                    state = deepClone(oldState);
-                    const dupBlock = ScrollPage.loadBlock(state.name).create(muya, state);
-                    block.parent!.insertAfter(dupBlock, block);
-                    cursorBlock = dupBlock.lastContentInDescendant();
-                    break;
-                }
-
-                case 'new': {
-                    state = deepClone(emptyStates.paragraph);
-                    const newBlock = ScrollPage.loadBlock('paragraph').create(
-                        muya,
-                        state,
-                    );
-                    block.parent!.insertAfter(newBlock, block);
-                    cursorBlock = newBlock.lastContentInDescendant();
-                    break;
-                }
-
-                case 'delete': {
-                    if (block.prev) {
-                        cursorBlock = block.prev.lastContentInDescendant();
-                    }
-                    else if (block.next) {
-                        cursorBlock = block.next.firstContentInDescendant();
-                    }
-                    else {
-                        state = deepClone(emptyStates.paragraph);
-                        const newBlock = ScrollPage.loadBlock('paragraph').create(
-                            muya,
-                            state,
-                        );
-                        block.parent!.insertAfter(newBlock, block);
-                        cursorBlock = newBlock.lastContentInDescendant();
-                    }
-                    block.remove();
-                }
-            }
-        }
-        else {
-            switch (block.blockName) {
-                case 'paragraph':
-                    // fall through
-                case 'atx-heading': {
-                    if (block.blockName === 'paragraph' && block.blockName === label)
-                        break;
-
-                    const headingLevel = isAtxHeadingState(oldState) ? oldState.meta.level : null;
-                    if (
-                        block.blockName === 'atx-heading'
-                        && headingLevel !== null
-                        && label.split(' ')[1] === String(headingLevel)
-                    ) {
-                        break;
-                    }
-
-                    const rawText = 'text' in oldState ? oldState.text : '';
-                    const text
-                        = block.blockName === 'paragraph'
-                            ? rawText
-                            : rawText.replace(/^ {0,3}#{1,6}(?:\s+|$)/, '');
-                    replaceBlockByLabel({
-                        block,
-                        label,
-                        muya,
-                        text,
-                    });
-                    break;
-                }
-
-                case 'order-list':
-                    // fall through
-                case 'bullet-list':
-                    // fall through
-                case 'task-list': {
-                    if (!isAnyListState(oldState))
-                        break;
-
-                    // Clicking the active list type toggles the list off,
-                    // unwrapping every item back into plain paragraphs (matches
-                    // the command-palette/menu `reset-to-paragraph` behaviour).
-                    if (block.blockName === label) {
-                        muya.resetToParagraph(block);
-                        break;
-                    }
-
-                    // The conversion between order/bullet/task lists re-shapes both
-                    // the parent `meta` and each item's `meta` (only task-list-items
-                    // carry meta). Rebuild a fresh state of the target shape rather
-                    // than mutating the old one in place — the in-place form requires
-                    // discriminant-changing casts that TS can't track.
-                    const sourceMeta = oldState.meta;
-                    const loose = sourceMeta.loose;
-                    const delimiter = 'delimiter' in sourceMeta
-                        ? sourceMeta.delimiter
-                        : orderListDelimiter;
-                    const marker = 'marker' in sourceMeta
-                        ? sourceMeta.marker
-                        : bulletListMarker;
-
-                    const childContents: TState[][] = oldState.children.map(
-                        li => deepClone(li.children),
-                    );
-
-                    if (label === 'task-list') {
-                        const newState: ITaskListState = {
-                            name: 'task-list',
-                            meta: { marker: marker ?? bulletListMarker, loose: !!loose },
-                            children: childContents.map(children => ({
-                                name: 'task-list-item',
-                                meta: { checked: false },
-                                children,
-                            })),
-                        };
-                        state = newState;
-                    }
-                    else if (label === 'order-list') {
-                        const newState: IOrderListState = {
-                            name: 'order-list',
-                            meta: { delimiter, loose: !!loose, start: 1 },
-                            children: childContents.map(children => ({
-                                name: 'list-item',
-                                children,
-                            })),
-                        };
-                        state = newState;
-                    }
-                    else {
-                        const newState: IBulletListState = {
-                            name: 'bullet-list',
-                            meta: { marker: marker ?? bulletListMarker, loose: !!loose },
-                            children: childContents.map(children => ({
-                                name: 'list-item',
-                                children,
-                            })),
-                        };
-                        state = newState;
-                    }
-                    // TODO: @JOCS, remove use this.selection directly.
-                    const { anchorPath, anchor, focus, isSelectionInSameBlock }
-                        = editor.selection;
-                    const listBlock = ScrollPage.loadBlock(label).create(muya, state);
-                    block.replaceWith(listBlock);
-                    const guessCursorBlock
-                        = muya.editor.scrollPage?.queryBlock(anchorPath);
-                    if (guessCursorBlock && isSelectionInSameBlock) {
-                        const begin = Math.min(anchor!.offset, focus!.offset);
-                        const end = Math.max(anchor!.offset, focus!.offset);
-                        // Make guessCursorBlock active. queryBlock returns the
-                        // closest block at the given path; for an inline path
-                        // it's a Content leaf (which has setCursor).
-                        (guessCursorBlock as Content).setCursor(begin, end, true);
-                    }
-                    else {
-                        cursorBlock = listBlock.firstContentInDescendant();
-                    }
-                    break;
-                }
-            }
-        }
+        const cursorBlock = /duplicate|new|delete/.test(label)
+            ? this._applyMetaAction(label, block, oldState)
+            : this._turnIntoBlock(label, block, oldState);
 
         if (cursorBlock) {
             // mock cursorBlock focus
@@ -368,5 +205,185 @@ export class ParagraphFrontMenu extends BaseFloat {
         }
         // Delay hide to avoid dispatch enter handler
         setTimeout(this.hide.bind(this));
+    }
+
+    private _applyMetaAction(label: string, block: Parent, oldState: TState) {
+        const { muya } = this;
+        switch (label) {
+            case 'duplicate': {
+                const state = deepClone(oldState);
+                const dupBlock = ScrollPage.loadBlock(state.name).create(muya, state);
+                block.parent!.insertAfter(dupBlock, block);
+                return dupBlock.lastContentInDescendant();
+            }
+
+            case 'new': {
+                const state = deepClone(emptyStates.paragraph);
+                const newBlock = ScrollPage.loadBlock('paragraph').create(
+                    muya,
+                    state,
+                );
+                block.parent!.insertAfter(newBlock, block);
+                return newBlock.lastContentInDescendant();
+            }
+
+            case 'delete': {
+                let cursorBlock = null;
+                if (block.prev) {
+                    cursorBlock = block.prev.lastContentInDescendant();
+                }
+                else if (block.next) {
+                    cursorBlock = block.next.firstContentInDescendant();
+                }
+                else {
+                    const state = deepClone(emptyStates.paragraph);
+                    const newBlock = ScrollPage.loadBlock('paragraph').create(
+                        muya,
+                        state,
+                    );
+                    block.parent!.insertAfter(newBlock, block);
+                    cursorBlock = newBlock.lastContentInDescendant();
+                }
+                block.remove();
+
+                return cursorBlock;
+            }
+
+            default:
+                return null;
+        }
+    }
+
+    private _turnIntoBlock(label: string, block: Parent, oldState: TState) {
+        const { muya } = this;
+        switch (block.blockName) {
+            case 'paragraph':
+                // fall through
+            case 'atx-heading': {
+                if (block.blockName === 'paragraph' && block.blockName === label)
+                    return null;
+
+                const headingLevel = isAtxHeadingState(oldState) ? oldState.meta.level : null;
+                if (
+                    block.blockName === 'atx-heading'
+                    && headingLevel !== null
+                    && label.split(' ')[1] === String(headingLevel)
+                ) {
+                    return null;
+                }
+
+                const rawText = 'text' in oldState ? oldState.text : '';
+                const text
+                    = block.blockName === 'paragraph'
+                        ? rawText
+                        : rawText.replace(/^ {0,3}#{1,6}(?:\s+|$)/, '');
+                replaceBlockByLabel({
+                    block,
+                    label,
+                    muya,
+                    text,
+                });
+
+                return null;
+            }
+
+            case 'order-list':
+                // fall through
+            case 'bullet-list':
+                // fall through
+            case 'task-list':
+                return this._turnIntoList(label, block, oldState);
+
+            default:
+                return null;
+        }
+    }
+
+    private _turnIntoList(label: string, block: Parent, oldState: TState) {
+        const { muya } = this;
+        const { editor } = muya;
+        const { bulletListMarker, orderListDelimiter } = muya.options;
+
+        if (!isAnyListState(oldState))
+            return null;
+
+        // Clicking the active list type toggles the list off,
+        // unwrapping every item back into plain paragraphs (matches
+        // the command-palette/menu `reset-to-paragraph` behaviour).
+        if (block.blockName === label) {
+            muya.resetToParagraph(block);
+
+            return null;
+        }
+
+        // The conversion between order/bullet/task lists re-shapes both
+        // the parent `meta` and each item's `meta` (only task-list-items
+        // carry meta). Rebuild a fresh state of the target shape rather
+        // than mutating the old one in place — the in-place form requires
+        // discriminant-changing casts that TS can't track.
+        const sourceMeta = oldState.meta;
+        const loose = sourceMeta.loose;
+        const delimiter = 'delimiter' in sourceMeta
+            ? sourceMeta.delimiter
+            : orderListDelimiter;
+        const marker = 'marker' in sourceMeta
+            ? sourceMeta.marker
+            : bulletListMarker;
+
+        const childContents: TState[][] = oldState.children.map(
+            li => deepClone(li.children),
+        );
+
+        let state: ITaskListState | IOrderListState | IBulletListState;
+        if (label === 'task-list') {
+            state = {
+                name: 'task-list',
+                meta: { marker: marker ?? bulletListMarker, loose: !!loose },
+                children: childContents.map(children => ({
+                    name: 'task-list-item',
+                    meta: { checked: false },
+                    children,
+                })),
+            };
+        }
+        else if (label === 'order-list') {
+            state = {
+                name: 'order-list',
+                meta: { delimiter, loose: !!loose, start: 1 },
+                children: childContents.map(children => ({
+                    name: 'list-item',
+                    children,
+                })),
+            };
+        }
+        else {
+            state = {
+                name: 'bullet-list',
+                meta: { marker: marker ?? bulletListMarker, loose: !!loose },
+                children: childContents.map(children => ({
+                    name: 'list-item',
+                    children,
+                })),
+            };
+        }
+        // TODO: @JOCS, remove use this.selection directly.
+        const { anchorPath, anchor, focus, isSelectionInSameBlock }
+            = editor.selection;
+        const listBlock = ScrollPage.loadBlock(label).create(muya, state);
+        block.replaceWith(listBlock);
+        const guessCursorBlock
+            = muya.editor.scrollPage?.queryBlock(anchorPath);
+        if (guessCursorBlock && isSelectionInSameBlock) {
+            const begin = Math.min(anchor!.offset, focus!.offset);
+            const end = Math.max(anchor!.offset, focus!.offset);
+            // Make guessCursorBlock active. queryBlock returns the
+            // closest block at the given path; for an inline path
+            // it's a Content leaf (which has setCursor).
+            (guessCursorBlock as Content).setCursor(begin, end, true);
+
+            return null;
+        }
+
+        return listBlock.firstContentInDescendant();
     }
 }

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -443,21 +443,120 @@ export function showTablePicker(muya: Muya, block: Parent) {
     eventCenter.emit('muya-table-picker', { row: -1, column: -1 }, reference, handler);
 }
 
+type TLeafReplacementLabel
+    = | 'paragraph'
+        | 'thematic-break'
+        | 'math-block'
+        | 'html-block'
+        | 'code-block'
+        | 'block-quote';
+
+function buildLeafBlock(label: TLeafReplacementLabel, muya: Muya, text: string) {
+    const cloned = deepClone(emptyStates[label]);
+    if (cloned.name === 'paragraph') {
+        cloned.text = text;
+    }
+    else if (cloned.name === 'block-quote') {
+        const inner = cloned.children[0];
+        if (isParagraphState(inner))
+            inner.text = text;
+    }
+
+    return ScrollPage.loadBlock(label).create(muya, cloned);
+}
+
+function buildHeadingBlock(label: string, muya: Muya, text: string) {
+    const headingState = deepClone(emptyStates['atx-heading']);
+
+    const [blockName, level] = label.split(' ');
+    headingState.meta.level = +level;
+    headingState.text = `${'#'.repeat(+level)} ${text}`;
+
+    return ScrollPage.loadBlock(blockName).create(muya, headingState);
+}
+
+function buildOrderListBlock(muya: Muya, text: string) {
+    const { preferLooseListItem, orderListDelimiter } = muya.options;
+    const orderState = deepClone(emptyStates['order-list']);
+    orderState.meta.loose = preferLooseListItem;
+    orderState.meta.delimiter = orderListDelimiter;
+    const firstChild = orderState.children[0].children[0];
+    if (text && isParagraphState(firstChild))
+        firstChild.text = text;
+
+    return ScrollPage.loadBlock('order-list').create(muya, orderState);
+}
+
+function buildListBlock(label: 'bullet-list' | 'task-list', muya: Muya, text: string) {
+    const { preferLooseListItem, bulletListMarker } = muya.options;
+    const listState = deepClone(emptyStates[label]);
+    listState.meta.loose = preferLooseListItem;
+    listState.meta.marker = bulletListMarker;
+    const firstChild = listState.children[0].children[0];
+    if (text && isParagraphState(firstChild))
+        firstChild.text = text;
+
+    return ScrollPage.loadBlock(label).create(muya, listState);
+}
+
+function buildDiagramBlock(label: string, muya: Muya) {
+    const diagramState = deepClone(emptyStates.diagram);
+
+    const [name, type] = label.split(' ');
+    if (
+        type === 'mermaid'
+        || type === 'plantuml'
+        || type === 'vega-lite'
+        || type === 'flowchart'
+        || type === 'sequence'
+    ) {
+        diagramState.meta.type = type;
+        diagramState.meta.lang = type === 'vega-lite' ? 'json' : 'yaml';
+    }
+
+    return ScrollPage.loadBlock(name).create(muya, diagramState);
+}
+
+function buildReplacementBlock(label: string, muya: Muya, text: string) {
+    if (label.startsWith('atx-heading '))
+        return buildHeadingBlock(label, muya, text);
+    if (label.startsWith('diagram '))
+        return buildDiagramBlock(label, muya);
+
+    switch (label) {
+        case 'paragraph':
+            // fall through
+        case 'thematic-break':
+            // fall through
+        case 'math-block':
+            // fall through
+        case 'html-block':
+            // fall through
+        case 'code-block':
+            // fall through
+        case 'block-quote':
+            return buildLeafBlock(label, muya, text);
+
+        case 'order-list':
+            return buildOrderListBlock(muya, text);
+
+        case 'bullet-list':
+            // fall through
+        case 'task-list':
+            return buildListBlock(label, muya, text);
+
+        default:
+            debug.log('Unknown label in quick insert');
+            return null;
+    }
+}
+
 export function replaceBlockByLabel({ block, muya, label, text = '' }: {
     block: Parent;
     muya: Muya;
     label: string;
     text?: string;
 }) {
-    const {
-        preferLooseListItem,
-        bulletListMarker,
-        orderListDelimiter,
-    } = muya.options;
-    let newBlock = null;
-    let state = null;
-    let cursorBlock = null;
-
     // Front matter is only valid as the document's first block, so the
     // quick-insert "Front Matter" entry must NOT replace the cursor block in
     // place (which destroyed its content and produced invalid mid-document
@@ -490,112 +589,7 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
         return;
     }
 
-    switch (label) {
-        case 'paragraph':
-            // fall through
-        case 'thematic-break':
-            // fall through
-        case 'math-block':
-            // fall through
-        case 'html-block':
-            // fall through
-        case 'code-block':
-            // fall through
-        case 'block-quote': {
-            const cloned = deepClone(emptyStates[label]);
-            if (cloned.name === 'paragraph') {
-                cloned.text = text;
-            }
-            else if (cloned.name === 'block-quote') {
-                const inner = cloned.children[0];
-                if (isParagraphState(inner))
-                    inner.text = text;
-            }
-            state = cloned;
-            newBlock = ScrollPage.loadBlock(label).create(muya, state);
-            break;
-        }
-
-        case 'atx-heading 1':
-            // fall through
-        case 'atx-heading 2':
-            // fall through
-        case 'atx-heading 3':
-            // fall through
-        case 'atx-heading 4':
-            // fall through
-        case 'atx-heading 5':
-            // fall through
-        case 'atx-heading 6': {
-            const headingState = deepClone(emptyStates['atx-heading']);
-
-            const [blockName, level] = label.split(' ');
-            headingState.meta.level = +level;
-            headingState.text = `${'#'.repeat(+level)} ${text}`;
-            state = headingState;
-            newBlock = ScrollPage.loadBlock(blockName).create(muya, state);
-            break;
-        }
-
-        case 'order-list': {
-            const orderState = deepClone(emptyStates[label]);
-            orderState.meta.loose = preferLooseListItem;
-            orderState.meta.delimiter = orderListDelimiter;
-            const firstChild = orderState.children[0].children[0];
-            if (text && isParagraphState(firstChild))
-                firstChild.text = text;
-
-            state = orderState;
-            newBlock = ScrollPage.loadBlock(label).create(muya, state);
-            break;
-        }
-
-        case 'bullet-list':
-            // fall through
-        case 'task-list': {
-            const listState = deepClone(emptyStates[label]);
-            listState.meta.loose = preferLooseListItem;
-            listState.meta.marker = bulletListMarker;
-            const firstChild = listState.children[0].children[0];
-            if (text && isParagraphState(firstChild))
-                firstChild.text = text;
-
-            state = listState;
-            newBlock = ScrollPage.loadBlock(label).create(muya, state);
-            break;
-        }
-
-        case 'diagram vega-lite':
-            // fall through
-        case 'diagram mermaid':
-            // fall through
-        case 'diagram plantuml':
-            // fall through
-        case 'diagram flowchart':
-            // fall through
-        case 'diagram sequence': {
-            const diagramState = deepClone(emptyStates.diagram);
-
-            const [name, type] = label.split(' ');
-            if (
-                type === 'mermaid'
-                || type === 'plantuml'
-                || type === 'vega-lite'
-                || type === 'flowchart'
-                || type === 'sequence'
-            ) {
-                diagramState.meta.type = type;
-                diagramState.meta.lang = type === 'vega-lite' ? 'json' : 'yaml';
-            }
-            state = diagramState;
-            newBlock = ScrollPage.loadBlock(name).create(muya, state);
-            break;
-        }
-
-        default:
-            debug.log('Unknown label in quick insert');
-            break;
-    }
+    const newBlock = buildReplacementBlock(label, muya, text);
 
     block.replaceWith(newBlock);
     if (label === 'thematic-break') {
@@ -604,11 +598,11 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
             deepClone(emptyStates.paragraph),
         );
         newBlock.parent.insertAfter(nextParagraphBlock, newBlock);
-        cursorBlock = nextParagraphBlock.firstContentInDescendant();
+        const cursorBlock = nextParagraphBlock.firstContentInDescendant();
         cursorBlock.setCursor(0, 0, true);
     }
     else {
-        cursorBlock = newBlock.firstContentInDescendant();
+        const cursorBlock = newBlock.firstContentInDescendant();
         // Set the cursor between <div>\n\n</div> when create html-block
         const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
         cursorBlock.setCursor(offset, offset, true);

--- a/packages/muya/src/ui/tableDragBar/index.ts
+++ b/packages/muya/src/ui/tableDragBar/index.ts
@@ -100,6 +100,62 @@ const bottomOptions = {
     showArrow: false,
 };
 
+function isInMovedRange(
+    i: number,
+    index: number,
+    curIndex: number,
+    isPositive: boolean,
+) {
+    return isPositive
+        ? i > index && i <= curIndex
+        : i >= curIndex && i < index;
+}
+
+function switchTransform(
+    i: number,
+    index: number,
+    curIndex: number,
+    aspect: number,
+    axis: 'translateX' | 'translateY',
+    isPositive: boolean,
+): string | null {
+    if (isInMovedRange(i, index, curIndex, isPositive))
+        return `${axis}(${isPositive ? -aspect : aspect}px)`;
+    if (i !== index)
+        return `${axis}(0px)`;
+
+    return null;
+}
+
+function applyBottomSwitch(
+    cells: HTMLTableCellElement[][],
+    len: number,
+    compute: (i: number) => string | null,
+) {
+    for (const row of cells) {
+        for (let i = 0; i < len; i++) {
+            const transform = compute(i);
+            if (transform !== null)
+                row[i].style.transform = transform;
+        }
+    }
+}
+
+function applyRightSwitch(
+    cells: HTMLTableCellElement[][],
+    len: number,
+    compute: (i: number) => string | null,
+) {
+    for (let i = 0; i < len; i++) {
+        const transform = compute(i);
+        if (transform === null)
+            continue;
+
+        for (const cell of cells[i])
+            cell.style.transform = transform;
+    }
+}
+
 export class TableDragBar extends BaseFloat {
     static pluginName = 'tableDragBar';
     private _block: TableBodyCell | null = null;
@@ -339,58 +395,15 @@ export class TableDragBar extends BaseFloat {
         const { index, offset, curIndex, barType, aspects, cells } = this._dragInfo;
         const aspect = aspects[index];
         const len = aspects.length;
+        const isPositive = offset > 0;
+        const axis = barType === 'bottom' ? 'translateX' : 'translateY';
+        const compute = (i: number) =>
+            switchTransform(i, index, curIndex, aspect, axis, isPositive);
 
-        let i;
-        if (offset > 0) {
-            if (barType === 'bottom') {
-                for (const row of cells) {
-                    for (i = 0; i < len; i++) {
-                        const cell = row[i];
-                        if (i > index && i <= curIndex)
-                            cell.style.transform = `translateX(${-aspect}px)`;
-                        else if (i !== index)
-                            cell.style.transform = 'translateX(0px)';
-                    }
-                }
-            }
-            else {
-                for (i = 0; i < len; i++) {
-                    const row = cells[i];
-
-                    for (const cell of row) {
-                        if (i > index && i <= curIndex)
-                            cell.style.transform = `translateY(${-aspect}px)`;
-                        else if (i !== index)
-                            cell.style.transform = 'translateY(0px)';
-                    }
-                }
-            }
-        }
-        else {
-            if (barType === 'bottom') {
-                for (const row of cells) {
-                    for (i = 0; i < len; i++) {
-                        const cell = row[i];
-                        if (i >= curIndex && i < index)
-                            cell.style.transform = `translateX(${aspect}px)`;
-                        else if (i !== index)
-                            cell.style.transform = 'translateX(0px)';
-                    }
-                }
-            }
-            else {
-                for (i = 0; i < len; i++) {
-                    const row = cells[i];
-
-                    for (const cell of row) {
-                        if (i >= curIndex && i < index)
-                            cell.style.transform = `translateY(${aspect}px)`;
-                        else if (i !== index)
-                            cell.style.transform = 'translateY(0px)';
-                    }
-                }
-            }
-        }
+        if (barType === 'bottom')
+            applyBottomSwitch(cells, len, compute);
+        else
+            applyRightSwitch(cells, len, compute);
     };
 
     setDropTargetStyle = () => {

--- a/packages/muya/src/utils/marked/extensions/cjkEmStrong.ts
+++ b/packages/muya/src/utils/marked/extensions/cjkEmStrong.ts
@@ -104,13 +104,102 @@ interface ITokenizerThis {
     lexer: { inlineTokens: (src: string) => Tokens.Generic[] };
 }
 
+// The right-delimiter scan + CommonMark "rule of 3" balancing, lifted out of
+// `cjkAwareEmStrong` so each carries its own complexity budget. `opener` is the
+// already-matched left-delimiter run; the loop walks the masked source for the
+// matching closer and returns the em/strong token (or undefined when none
+// balances). Logic mirrors marked@16's emStrong scan exactly.
+function scanEmphasisRun(
+    src: string,
+    maskedSrc: string,
+    opener: RegExpExecArray,
+    inline: IEmStrongRules,
+    lexer: ITokenizerThis['lexer'],
+): Tokens.Em | Tokens.Strong | undefined {
+    // Unicode codepoints can be 1 or 2 chars wide.
+    const lLength = [...opener[0]].length - 1;
+    let rDelim;
+    let rLength;
+    let delimTotal = lLength;
+    let midDelimTotal = 0;
+
+    const endReg
+        = opener[0][0] === '*'
+            ? inline.emStrongRDelimAst
+            : inline.emStrongRDelimUnd;
+    endReg.lastIndex = 0;
+
+    // Clip maskedSrc to the opener so the right-delimiter scan starts
+    // immediately after the opening run (marked passes the masked,
+    // already-skipped variant of `src`).
+    maskedSrc = maskedSrc.slice(-1 * src.length + lLength);
+
+    let match: RegExpExecArray | null;
+    // eslint-disable-next-line no-cond-assign
+    while ((match = endReg.exec(maskedSrc)) != null) {
+        rDelim
+            = match[1]
+                || match[2]
+                || match[3]
+                || match[4]
+                || match[5]
+                || match[6];
+
+        if (!rDelim)
+            continue;
+
+        rLength = [...rDelim].length;
+
+        if (match[3] || match[4]) {
+            // Found another opener — push the requirement deeper.
+            delimTotal += rLength;
+            continue;
+        }
+        else if ((match[5] || match[6]) && lLength % 3 && !((lLength + rLength) % 3)) {
+            // Rule of 3 — a delimiter run usable as both opener and
+            // closer can't close here.
+            midDelimTotal += rLength;
+            continue;
+        }
+
+        delimTotal -= rLength;
+        if (delimTotal > 0)
+            continue;
+
+        rLength = Math.min(rLength, rLength + delimTotal + midDelimTotal);
+
+        const lastCharLength = [...match[0]][0].length;
+        const raw = src.slice(0, lLength + match.index + lastCharLength + rLength);
+
+        if (Math.min(lLength, rLength) % 2) {
+            const text = raw.slice(1, -1);
+            return {
+                type: 'em',
+                raw,
+                text,
+                tokens: lexer.inlineTokens(text),
+            } as Tokens.Em;
+        }
+
+        const text = raw.slice(2, -2);
+        return {
+            type: 'strong',
+            raw,
+            text,
+            tokens: lexer.inlineTokens(text),
+        } as Tokens.Strong;
+    }
+
+    return undefined;
+}
+
 /**
- * A faithful re-implementation of marked@16's `Tokenizer.emStrong`, identical
- * to the upstream body apart from swapping in the CJK-widened flanking rules
- * for the duration of the call. The rules are restored in a `finally` so the
- * shared `_Tokenizer.rules` object is never left mutated for other tokenizers.
+ * A faithful re-implementation of marked@16's `Tokenizer.emStrong`, swapping in
+ * the CJK-widened flanking rules for the duration of the call. The rules are
+ * restored in a `finally` so the shared `_Tokenizer.rules` object is never left
+ * mutated for other tokenizers. The right-delimiter scan lives in
+ * `scanEmphasisRun`; the behavior is unchanged from upstream marked.
  */
-// eslint-disable-next-line complexity -- verbatim copy of marked's emStrong body
 function cjkAwareEmStrong(
     this: ITokenizerThis,
     src: string,
@@ -134,7 +223,7 @@ function cjkAwareEmStrong(
     other.unicodeAlphaNumeric = unicodeAlphaNumeric;
 
     try {
-        let match = inline.emStrongLDelim.exec(src);
+        const match = inline.emStrongLDelim.exec(src);
         if (!match)
             return undefined;
 
@@ -147,80 +236,8 @@ function cjkAwareEmStrong(
 
         const nextChar = match[1] || match[2] || '';
 
-        if (!nextChar || !prevChar || inline.punctuation.exec(prevChar)) {
-            // Unicode codepoints can be 1 or 2 chars wide.
-            const lLength = [...match[0]].length - 1;
-            let rDelim;
-            let rLength;
-            let delimTotal = lLength;
-            let midDelimTotal = 0;
-
-            const endReg
-                = match[0][0] === '*'
-                    ? inline.emStrongRDelimAst
-                    : inline.emStrongRDelimUnd;
-            endReg.lastIndex = 0;
-
-            // Clip maskedSrc to the opener so the right-delimiter scan starts
-            // immediately after the opening run (marked passes the masked,
-            // already-skipped variant of `src`).
-            maskedSrc = maskedSrc.slice(-1 * src.length + lLength);
-
-            // eslint-disable-next-line no-cond-assign
-            while ((match = endReg.exec(maskedSrc)) != null) {
-                rDelim
-                    = match[1]
-                        || match[2]
-                        || match[3]
-                        || match[4]
-                        || match[5]
-                        || match[6];
-
-                if (!rDelim)
-                    continue;
-
-                rLength = [...rDelim].length;
-
-                if (match[3] || match[4]) {
-                    // Found another opener — push the requirement deeper.
-                    delimTotal += rLength;
-                    continue;
-                }
-                else if ((match[5] || match[6]) && lLength % 3 && !((lLength + rLength) % 3)) {
-                    // Rule of 3 — a delimiter run usable as both opener and
-                    // closer can't close here.
-                    midDelimTotal += rLength;
-                    continue;
-                }
-
-                delimTotal -= rLength;
-                if (delimTotal > 0)
-                    continue;
-
-                rLength = Math.min(rLength, rLength + delimTotal + midDelimTotal);
-
-                const lastCharLength = [...match[0]][0].length;
-                const raw = src.slice(0, lLength + match.index + lastCharLength + rLength);
-
-                if (Math.min(lLength, rLength) % 2) {
-                    const text = raw.slice(1, -1);
-                    return {
-                        type: 'em',
-                        raw,
-                        text,
-                        tokens: this.lexer.inlineTokens(text),
-                    } as Tokens.Em;
-                }
-
-                const text = raw.slice(2, -2);
-                return {
-                    type: 'strong',
-                    raw,
-                    text,
-                    tokens: this.lexer.inlineTokens(text),
-                } as Tokens.Strong;
-            }
-        }
+        if (!nextChar || !prevChar || inline.punctuation.exec(prevChar))
+            return scanEmphasisRun(src, maskedSrc, match, inline, this.lexer);
 
         return undefined;
     }


### PR DESCRIPTION
## Summary

Resolves every ESLint `complexity` warning in `packages/muya` (the `@muyajs/core` engine). 16 functions exceeded the `complexity ≤ 20` cap — 11 firing warnings plus 5 hidden behind `eslint-disable` comments. Each is refactored below the cap by extracting helpers / replacing branch-heavy switches with dispatch tables or membership routing, and **every `eslint-disable complexity` / `max-lines-per-function` comment is removed**.

All changes are behavior-preserving — control-flow order, short-circuit semantics, mutation timing, and outputs are unchanged.

## Functions brought under the cap

| Function | File | Before |
|---|---|---|
| `tokenizerFac` | `inlineRenderer/lexer.ts` | 80 |
| `autoPair` | `block/base/content.ts` | 61 |
| `_convertMarkdownToState` | `state/markdownToState.ts` | 49 |
| `replaceBlockByLabel` | `ui/paragraphQuickInsertMenu/config.ts` | 41 |
| `getOffset` | `block/base/format.ts` | 37 |
| `drop` | `editor/index.ts` | 34 |
| `walkTokens` | `block/content/paragraphContent/index.ts` | 34 |
| `selectItem` | `ui/paragraphFrontMenu/index.ts` | 33 |
| `keydownHandler` | `block/base/content.ts` | 29 |
| `convertStatesToMarkdown` | `state/stateToMarkdown.ts` | 29 |
| `cjkAwareEmStrong` | `utils/marked/extensions/cjkEmStrong.ts` | 26 |
| `pick` | `editor/index.ts` | 25 |
| `htmlTag` / `image` | `inlineRenderer/renderer/` | 25 |
| `setSwitchStyle` | `ui/tableDragBar/index.ts` | 25 |
| `setCursor` | `muya.ts` | 22 |

Split into 12 focused, single-purpose commits (one per area).

## Verification

- **Unit tests:** 983 passed
- **CommonMark / GFM conformance:** 1347 passed
- **E2E (Chromium, real browser):** 173 passed
- **Typecheck (`tsc --noEmit`):** clean
- **Circular deps (madge):** none
- **Lint:** 0 errors; warning count back to the pre-existing baseline (8 `ts/naming-convention` + 4 `regexp/optimal-lookaround-quantifier`) — **0 `complexity` / `max-lines-per-function`** warnings
- An independent adversarial behavior-preservation review over all 14 changed files reported no observable behavior change.

## Notes

- `editor/index.ts`: the `ot-json1` pick/drop walk was hoisted from inside `updateContents` to module scope so `updateContents` stays under `max-lines-per-function` (200). `drop` now takes `muya` as a parameter.
- `cjkAwareEmStrong` was previously kept as a verbatim copy of marked@16's `emStrong` body; its right-delimiter scan is now factored into `scanEmphasisRun`. The logic is byte-for-byte equivalent (CJK flanking + spec suites green); it no longer diffs 1:1 against the upstream `emStrong` source.
- `replaceBlockByLabel` now dispatches `atx-heading`/`diagram` labels by prefix. This is broader than the original exact-label switch, but no reachable call site emits an out-of-range label (verified; the e2e "typing 7 hashes stays a paragraph" case confirms it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)