### PR TITLE
refactor(muya): rename selection enum members to UPPER_SNAKE_CASE

### DIFF
--- a/packages/muya/src/__tests__/getCursorOffset.spec.ts
+++ b/packages/muya/src/__tests__/getCursorOffset.spec.ts
@@ -92,8 +92,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
             focus: { offset: 5, block, path: [0, 'text'] },
             isCollapsed: false,
             isSelectionInSameBlock: true,
-            direction: SelectionDirection.Forward,
-            type: SelectionCaretType.Range,
+            direction: SelectionDirection.FORWARD,
+            type: SelectionCaretType.RANGE,
         };
         const sentinelState = injectStateSentinels(muya.getState(), selection);
         expect(sentinelState).not.toBeNull();
@@ -112,8 +112,8 @@ describe('muya.getCursorOffset() (Phase G — G7)', () => {
             focus: { offset: 2, block, path: [0, 'text'] }, //  after "he"
             isCollapsed: false,
             isSelectionInSameBlock: true,
-            direction: SelectionDirection.Backward,
-            type: SelectionCaretType.Range,
+            direction: SelectionDirection.BACKWARD,
+            type: SelectionCaretType.RANGE,
         };
         const sentinelState = injectStateSentinels(muya.getState(), selection);
         expect(sentinelState).not.toBeNull();

--- a/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatClickCursor.spec.ts
@@ -63,7 +63,7 @@ function firstBlock(muya: Muya): Format {
 }
 
 function directionOf(anchorOffset: number, focusOffset: number): SelectionDirection {
-    return anchorOffset < focusOffset ? SelectionDirection.Forward : SelectionDirection.Backward;
+    return anchorOffset < focusOffset ? SelectionDirection.FORWARD : SelectionDirection.BACKWARD;
 }
 
 function flushFrame(): Promise<void> {
@@ -81,7 +81,7 @@ describe('setCursor preserves a backward selection (begin > end stays backward)'
         expect(selection.anchor!.offset).toBe(7);
         expect(selection.focus!.offset).toBe(2);
         expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
-            SelectionDirection.Backward,
+            SelectionDirection.BACKWARD,
         );
     });
 
@@ -95,7 +95,7 @@ describe('setCursor preserves a backward selection (begin > end stays backward)'
         expect(selection.anchor!.offset).toBe(2);
         expect(selection.focus!.offset).toBe(7);
         expect(directionOf(selection.anchor!.offset, selection.focus!.offset)).toBe(
-            SelectionDirection.Forward,
+            SelectionDirection.FORWARD,
         );
     });
 });
@@ -117,7 +117,7 @@ describe('clickHandler forwards the backward anchor/focus (not normalized start/
             focus: { offset: 2, block: content as never, path: content.path },
             isCollapsed: false,
             isSelectionInSameBlock: true,
-            direction: SelectionDirection.Backward,
+            direction: SelectionDirection.BACKWARD,
             type: 'Range' as never,
         });
         const setCursorSpy = vi.spyOn(content, 'setCursor');

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -77,7 +77,7 @@ function stubSelection(
     aOff: number,
     f: Content,
     fOff: number,
-    direction = SelectionDirection.Forward,
+    direction = SelectionDirection.FORWARD,
 ) {
     const aPath = a.path;
     const fPath = f.path;
@@ -87,7 +87,7 @@ function stubSelection(
         isCollapsed: false,
         isSelectionInSameBlock: a === f,
         direction,
-        type: SelectionCaretType.Range,
+        type: SelectionCaretType.RANGE,
     });
 }
 

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -333,8 +333,8 @@ export function cutSelection(clipboard: Clipboard): void {
     if (isSelectionInSameBlock) {
         const { text } = anchorBlock;
         const startOffset
-            = direction === SelectionDirection.Forward ? anchor.offset : focus.offset;
-        const endOffset = direction === SelectionDirection.Forward ? focus.offset : anchor.offset;
+            = direction === SelectionDirection.FORWARD ? anchor.offset : focus.offset;
+        const endOffset = direction === SelectionDirection.FORWARD ? focus.offset : anchor.offset;
 
         anchorBlock.text
             = text.substring(0, startOffset) + text.substring(endOffset);
@@ -342,10 +342,10 @@ export function cutSelection(clipboard: Clipboard): void {
         return anchorBlock.setCursor(startOffset, startOffset, true);
     }
 
-    const startBlock = direction === SelectionDirection.Forward ? anchorBlock : focusBlock;
-    const endBlock = direction === SelectionDirection.Forward ? focusBlock : anchorBlock;
-    const startOffset = direction === SelectionDirection.Forward ? anchor.offset : focus.offset;
-    const endOffset = direction === SelectionDirection.Forward ? focus.offset : anchor.offset;
+    const startBlock = direction === SelectionDirection.FORWARD ? anchorBlock : focusBlock;
+    const endBlock = direction === SelectionDirection.FORWARD ? focusBlock : anchorBlock;
+    const startOffset = direction === SelectionDirection.FORWARD ? anchor.offset : focus.offset;
+    const endOffset = direction === SelectionDirection.FORWARD ? focus.offset : anchor.offset;
 
     // Whole-document selection collapses to a single empty paragraph.
     if (isSelectAll(clipboard, startBlock, startOffset, endBlock, endOffset)) {

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -57,7 +57,7 @@ class ImageSelection {
             event.preventDefault();
             const { block, ...imageInfo } = selected;
             block.deleteImage(imageInfo);
-            this._selection.activate(SelectionType.Text);
+            this._selection.activate(SelectionType.TEXT);
         }
     };
 

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -29,13 +29,13 @@ function computeDirection(
 ): SelectionDirection {
     if (isSelectionInSameBlock) {
         return anchorOffset < focusOffset
-            ? SelectionDirection.Forward
-            : SelectionDirection.Backward;
+            ? SelectionDirection.FORWARD
+            : SelectionDirection.BACKWARD;
     }
 
     return compareParagraphsOrder(anchorBlock.domNode!, focusBlock.domNode!)
-        ? SelectionDirection.Forward
-        : SelectionDirection.Backward;
+        ? SelectionDirection.FORWARD
+        : SelectionDirection.BACKWARD;
 }
 
 function computeCaretType(
@@ -44,9 +44,9 @@ function computeCaretType(
     isCollapsed: boolean,
 ): SelectionCaretType {
     if (!anchorBlock && !focusBlock)
-        return SelectionCaretType.None;
+        return SelectionCaretType.NONE;
 
-    return isCollapsed ? SelectionCaretType.Caret : SelectionCaretType.Range;
+    return isCollapsed ? SelectionCaretType.CARET : SelectionCaretType.RANGE;
 }
 
 class TextSelection {
@@ -103,10 +103,10 @@ class TextSelection {
             isCollapsed,
         } = this;
         if (anchor == null || focus == null || !anchorBlock || !focusBlock)
-            return SelectionDirection.None;
+            return SelectionDirection.NONE;
 
         if (isCollapsed)
-            return SelectionDirection.None;
+            return SelectionDirection.NONE;
 
         return computeDirection(
             anchorBlock,
@@ -224,7 +224,7 @@ class TextSelection {
 
         // Follow the caret (focus end) for forward selections so typewriter
         // scrolling tracks the cursor rather than the selection start.
-        const cursorCoords = getCursorCoords(direction === SelectionDirection.Forward);
+        const cursorCoords = getCursorCoords(direction === SelectionDirection.FORWARD);
         // Duck-type the Format block — a value import of Format here would
         // create a selection -> format circular dependency.
         const anchorBlockRef = anchorBlock as Format | null;
@@ -248,7 +248,7 @@ class TextSelection {
             isSelectionInSameBlock,
             direction,
             type,
-            kind: SelectionType.Text,
+            kind: SelectionType.TEXT,
             selectedImage: this._selection.image,
             cursorCoords,
             formats,

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -71,8 +71,8 @@ function mirrorLiveSelection(muya: Muya): void {
             focus: { offset: focus.offset, block: focusBlock, path: focusBlock.path },
             isCollapsed,
             isSelectionInSameBlock,
-            direction: SelectionDirection.None,
-            type: isCollapsed ? SelectionCaretType.Caret : SelectionCaretType.Range,
+            direction: SelectionDirection.NONE,
+            type: isCollapsed ? SelectionCaretType.CARET : SelectionCaretType.RANGE,
         };
     });
 }
@@ -310,8 +310,8 @@ describe('selection.selectAll honors the live selection over stale cache', () =>
             focus: { offset: 3, block: second, path: second.path },
             isCollapsed: true,
             isSelectionInSameBlock: true,
-            direction: SelectionDirection.None,
-            type: SelectionCaretType.Caret,
+            direction: SelectionDirection.NONE,
+            type: SelectionCaretType.CARET,
         });
 
         // selectAll must honor the live caret and grow to the whole second

--- a/packages/muya/src/selection/__tests__/selectionEnums.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectionEnums.spec.ts
@@ -3,11 +3,11 @@ import { SelectionCaretType, SelectionDirection } from '../types';
 
 describe('selection enums', () => {
     it('keep wire-compatible string values', () => {
-        expect(SelectionDirection.Forward).toBe('forward');
-        expect(SelectionDirection.Backward).toBe('backward');
-        expect(SelectionDirection.None).toBe('none');
-        expect(SelectionCaretType.Caret).toBe('Caret');
-        expect(SelectionCaretType.Range).toBe('Range');
-        expect(SelectionCaretType.None).toBe('None');
+        expect(SelectionDirection.FORWARD).toBe('forward');
+        expect(SelectionDirection.BACKWARD).toBe('backward');
+        expect(SelectionDirection.NONE).toBe('none');
+        expect(SelectionCaretType.CARET).toBe('Caret');
+        expect(SelectionCaretType.RANGE).toBe('Range');
+        expect(SelectionCaretType.NONE).toBe('None');
     });
 });

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -37,16 +37,16 @@ class Selection {
 
     get type(): SelectionType {
         if (this._image.selected)
-            return SelectionType.Image;
+            return SelectionType.IMAGE;
         if (this._table.hasSelection)
-            return SelectionType.Table;
-        return SelectionType.Text;
+            return SelectionType.TABLE;
+        return SelectionType.TEXT;
     }
 
     get current(): TextSelection | TableRectSelection | ImageSelection {
         switch (this.type) {
-            case SelectionType.Image: return this._image;
-            case SelectionType.Table: return this._table;
+            case SelectionType.IMAGE: return this._image;
+            case SelectionType.TABLE: return this._table;
             default: return this._text;
         }
     }
@@ -90,18 +90,18 @@ class Selection {
     selectImage(data: IImageSelectionData): void {
         this._image.selected = data;
         this.muya.editor.activeContentBlock = null;
-        this.activate(SelectionType.Image);
+        this.activate(SelectionType.IMAGE);
     }
 
     activate(type: SelectionType): void {
-        if (type !== SelectionType.Text)
+        if (type !== SelectionType.TEXT)
             this._text.collapse();
-        if (type !== SelectionType.Table)
+        if (type !== SelectionType.TABLE)
             this._table.clear();
-        if (type !== SelectionType.Image)
+        if (type !== SelectionType.IMAGE)
             this._image.clear();
 
-        if (type !== SelectionType.Text) {
+        if (type !== SelectionType.TEXT) {
             this.muya.eventCenter.emit('selection-change', {
                 kind: type,
             });

--- a/packages/muya/src/selection/types.ts
+++ b/packages/muya/src/selection/types.ts
@@ -76,21 +76,21 @@ export type IHistorySelection = Omit<ISelection, 'anchor' | 'focus'> & {
 };
 
 export enum SelectionType {
-    Text = 'text',
-    Table = 'table',
-    Image = 'image',
+    TEXT = 'text',
+    TABLE = 'table',
+    IMAGE = 'image',
 }
 
 export enum SelectionDirection {
-    None = 'none',
-    Forward = 'forward',
-    Backward = 'backward',
+    NONE = 'none',
+    FORWARD = 'forward',
+    BACKWARD = 'backward',
 }
 
 export enum SelectionCaretType {
-    None = 'None',
-    Caret = 'Caret',
-    Range = 'Range',
+    NONE = 'None',
+    CARET = 'Caret',
+    RANGE = 'Range',
 }
 
 export interface IImageSelectionData {


### PR DESCRIPTION
## Summary

Aligns the three remaining non-conforming TypeScript enums with the
`UPPER_SNAKE_CASE` member-key convention already used by `CopyType` and
`PasteType` in the muya engine.

| Enum | Old keys | New keys |
|---|---|---|
| `SelectionType` | `Text/Table/Image` | `TEXT/TABLE/IMAGE` |
| `SelectionDirection` | `None/Forward/Backward` | `NONE/FORWARD/BACKWARD` |
| `SelectionCaretType` | `None/Caret/Range` | `NONE/CARET/RANGE` |

The other enums in the repo (`CopyType`, `PasteType`, `HistoryAction`,
`UnindentType`) already follow this convention and are untouched.

**String values are intentionally unchanged** so the wire- and
DOM-compatible serialization is preserved (e.g. `SelectionDirection.FORWARD`
is still `'forward'`, `SelectionCaretType.NONE` is still `'None'`, matching
the DOM `Selection.type` values). The `selectionEnums.spec.ts` test asserting
these values still passes.

## Changes

- Rename enum member keys in `packages/muya/src/selection/types.ts`.
- Update all 9 call sites across `selection/`, `clipboard/cut.ts`, and the
  affected spec files.

## Verification

- `pnpm -C packages/muya lint:types` — passes
- `pnpm -C packages/muya lint` — 0 errors (only pre-existing unrelated warnings)
- Affected vitest suites — 21 files / 119 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)