### PR TITLE
chore: translate remaining Chinese console/debug strings to English

### DIFF
--- a/packages/desktop/src/renderer/src/prefComponents/image/components/uploader/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/image/components/uploader/index.vue
@@ -213,7 +213,7 @@
             class="debug-info"
           >
             <summary>{{ t('preferences.image.uploader.debugInfo') }}</summary>
-            <pre>{{ picgoDebugInfo || '暂无调试信息' }}</pre>
+            <pre>{{ picgoDebugInfo || 'No debug info available' }}</pre>
           </details>
         </div>
       </div>
@@ -381,7 +381,7 @@ const startRealtimeDetection = () => {
             scheduleNextDetection() // Begin normal scheduling after the first detection completes
           })
           .catch((error) => {
-            console.error('初始PicGo检测失败:', error)
+            console.error('Initial PicGo detection failed:', error)
             scheduleNextDetection()
           })
       }, 3000)
@@ -397,7 +397,7 @@ const startRealtimeDetection = () => {
           scheduleNextDetection() // Begin normal scheduling after the first detection completes
         })
         .catch((error) => {
-          console.error('初始PicGo检测失败:', error)
+          console.error('Initial PicGo detection failed:', error)
           scheduleNextDetection()
         })
     }, 3000)
@@ -426,7 +426,7 @@ const startRealtimeDetection = () => {
             scheduleNextDetection() // Recursively schedule the next detection
           })
           .catch((error) => {
-            console.error('PicGo检测异常:', error)
+            console.error('PicGo detection error:', error)
             scheduleNextDetection()
           })
       } else {
@@ -699,17 +699,17 @@ const testPicgo = async (): Promise<void> => {
   lastDetectionTime.value = new Date().toISOString()
 
   const debugMessages: string[] = []
-  debugMessages.push(`检测时间: ${new Date().toLocaleString()}`)
+  debugMessages.push(`Detection time: ${new Date().toLocaleString()}`)
 
   // Add environment information
-  debugMessages.push(`平台: ${window.process?.platform || 'unknown'}`)
-  debugMessages.push('进程类型: renderer')
+  debugMessages.push(`Platform: ${window.process?.platform || 'unknown'}`)
+  debugMessages.push('Process type: renderer')
 
   if (typeof window.commandExists === 'undefined') {
-    const errorMsg = 'commandExists 未暴露到 window 对象'
+    const errorMsg = 'commandExists is not exposed on the window object'
     console.error('✗', errorMsg)
     debugMessages.push(`✗ ${errorMsg}`)
-    debugMessages.push('检查 preload 脚本是否正确加载')
+    debugMessages.push('Check whether the preload script is loaded correctly')
     picgoExists.value = false
     picgoDetectionFailed.value = true
     picgoDetectionStatus.value = t('preferences.image.uploader.picgoDetectionFailed')
@@ -718,14 +718,14 @@ const testPicgo = async (): Promise<void> => {
     return
   }
 
-  debugMessages.push('✓ commandExists 已暴露到 window 对象')
+  debugMessages.push('✓ commandExists is exposed on the window object')
 
   if (typeof window.commandExists.exists !== 'function') {
-    const errorMsg = 'commandExists.exists 方法不可用'
+    const errorMsg = 'commandExists.exists method is unavailable'
     const availableKeys = Object.keys(window.commandExists).join(', ')
     console.error('✗', errorMsg)
     debugMessages.push(`✗ ${errorMsg}`)
-    debugMessages.push(`可用方法: ${availableKeys}`)
+    debugMessages.push(`Available methods: ${availableKeys}`)
     picgoExists.value = false
     picgoDetectionFailed.value = true
     picgoDetectionStatus.value = t('preferences.image.uploader.picgoDetectionFailed')
@@ -734,45 +734,45 @@ const testPicgo = async (): Promise<void> => {
     return
   }
 
-  debugMessages.push('✓ commandExists.exists 方法可用')
+  debugMessages.push('✓ commandExists.exists method is available')
 
   try {
-    debugMessages.push('正在检测 PicGo 命令...')
+    debugMessages.push('Detecting PicGo command...')
 
     // First test some basic commands
     const nodeExists = await window.commandExists.exists('node')
     const npmExists = await window.commandExists.exists('npm')
-    debugMessages.push(`Node.js 检测: ${nodeExists ? '✓' : '✗'}`)
-    debugMessages.push(`npm 检测: ${npmExists ? '✓' : '✗'}`)
+    debugMessages.push(`Node.js detection: ${nodeExists ? '✓' : '✗'}`)
+    debugMessages.push(`npm detection: ${npmExists ? '✓' : '✗'}`)
 
     const result = await window.commandExists.exists('picgo')
-    debugMessages.push(`PicGo 检测结果: ${result}`)
+    debugMessages.push(`PicGo detection result: ${result}`)
 
     picgoExists.value = result
 
     if (result) {
-      debugMessages.push('✓ PicGo 命令检测成功')
+      debugMessages.push('✓ PicGo command detected successfully')
       picgoDetectionFailed.value = false
       picgoDetectionStatus.value = t('preferences.image.uploader.picgoInstalled')
       // Record the successful detection time
       lastSuccessTime.value = new Date().toISOString()
       consecutiveFailures.value = 0 // Reset failure count
     } else {
-      debugMessages.push('✗ PicGo 命令未找到')
-      debugMessages.push('可能原因:')
-      debugMessages.push('1. PicGo 未安装')
-      debugMessages.push('2. PATH 环境变量问题')
-      debugMessages.push('3. Electron 环境限制')
+      debugMessages.push('✗ PicGo command not found')
+      debugMessages.push('Possible causes:')
+      debugMessages.push('1. PicGo is not installed')
+      debugMessages.push('2. PATH environment variable issue')
+      debugMessages.push('3. Electron environment restriction')
       picgoDetectionFailed.value = false // Detection succeeded; PicGo is simply not installed
       picgoDetectionStatus.value = t('preferences.image.uploader.picgoNotInstalled')
     }
   } catch (error) {
-    console.error('PicGo 检测失败:', error)
+    console.error('PicGo detection failed:', error)
     const message = error instanceof Error ? error.message : String(error)
     const stack = error instanceof Error ? error.stack : undefined
-    debugMessages.push(`✗ 检测异常: ${message}`)
+    debugMessages.push(`✗ Detection error: ${message}`)
     if (stack) {
-      debugMessages.push(`错误堆栈: ${stack}`)
+      debugMessages.push(`Error stack: ${stack}`)
     }
     picgoExists.value = false
     picgoDetectionFailed.value = true

--- a/packages/desktop/src/renderer/src/prefComponents/sideBar/config.ts
+++ b/packages/desktop/src/renderer/src/prefComponents/sideBar/config.ts
@@ -178,13 +178,13 @@ export const getTranslatedSearchContent: CachedTranslator = (() => {
       try {
         translatedCategory = t(categoryKey)
       } catch (e) {
-        console.warn(`   ⚠️ 搜索分类翻译失败: ${errMessage(e)}`)
+        console.warn(`   ⚠️ Search category translation failed: ${errMessage(e)}`)
         // Try fallback to preferences.categories
         try {
           const fallbackKey = `preferences.categories.${mappedCategory}`
           translatedCategory = t(fallbackKey)
         } catch (e2) {
-          console.warn(`   ❌ 搜索分类fallback也失败: ${errMessage(e2)}`)
+          console.warn(`   ❌ Search category fallback also failed: ${errMessage(e2)}`)
           translatedCategory = categoryName
         }
       }
@@ -195,13 +195,13 @@ export const getTranslatedSearchContent: CachedTranslator = (() => {
       try {
         translatedPreference = t(itemKey)
       } catch (e) {
-        console.warn(`   ⚠️ 搜索项目翻译失败: ${errMessage(e)}`)
+        console.warn(`   ⚠️ Search item translation failed: ${errMessage(e)}`)
         // Try fallback to preferences.items
         try {
           const fallbackKey = `preferences.items.${k}`
           translatedPreference = t(fallbackKey)
         } catch (e2) {
-          console.warn(`   ❌ 搜索项目fallback也失败: ${errMessage(e2)}`)
+          console.warn(`   ❌ Search item fallback also failed: ${errMessage(e2)}`)
           translatedPreference = description.split('--')[1] || description
         }
       }
@@ -239,7 +239,7 @@ export const setupLanguageChangeListener = (): void => {
           })
         )
       } catch (e) {
-        console.warn('⚠️ 无法获取更新后的语言设置:', e)
+        console.warn('⚠️ Failed to get updated language setting:', e)
       }
     }
   }
@@ -252,7 +252,7 @@ export const setupLanguageChangeListener = (): void => {
         // Use Vue's reactive system to listen for language changes
       }
     } catch (e) {
-      console.warn('⚠️ 设置语言变化监听器失败:', e)
+      console.warn('⚠️ Failed to set up language change listener:', e)
     }
   }
 
@@ -340,11 +340,11 @@ function createDebugPopup(): HTMLDivElement {
   `
 
   const title = document.createElement('h3')
-  title.textContent = '🛠️ 调试信息'
+  title.textContent = '🛠️ Debug Info'
   title.style.cssText = 'margin: 0; color: #333;'
 
   const closeButton = document.createElement('button')
-  closeButton.textContent = '✕ 关闭'
+  closeButton.textContent = '✕ Close'
   closeButton.style.cssText = `
     background: #ff4444;
     color: white;
@@ -419,7 +419,7 @@ export const debugLanguageState = (): void => {
   }
 
   // Clear and populate debug information
-  debugContent.innerHTML = '<div id="debugDetails">正在加载调试信息...</div>'
+  debugContent.innerHTML = '<div id="debugDetails">Loading debug info...</div>'
 
   // Populate debug details
   const details = debugContent.querySelector('#debugDetails') as HTMLDivElement | null
@@ -429,39 +429,39 @@ export const debugLanguageState = (): void => {
   setTimeout(() => {
     try {
       // Show detailed information about the i18n instance
-      let debugInfo = '<h4>🔍 i18n实例详细信息:</h4>'
+      let debugInfo = '<h4>🔍 i18n instance details:</h4>'
 
       if (!window.__VUE_I18N__) {
-        debugInfo += '<p style="color:red;">❌ __VUE_I18N__ 不存在</p>'
+        debugInfo += '<p style="color:red;">❌ __VUE_I18N__ does not exist</p>'
       } else {
         const i18n = window.__VUE_I18N__
         debugInfo += `
-          <p><strong>__VUE_I18N__ 类型:</strong> ${typeof i18n}</p>
-          <p><strong>__VUE_I18N__ 键:</strong> ${Object.keys(i18n).slice(0, 10).join(', ')}</p>
-          <p><strong>global 类型:</strong> ${typeof i18n.global}</p>
+          <p><strong>__VUE_I18N__ type:</strong> ${typeof i18n}</p>
+          <p><strong>__VUE_I18N__ keys:</strong> ${Object.keys(i18n).slice(0, 10).join(', ')}</p>
+          <p><strong>global type:</strong> ${typeof i18n.global}</p>
         `
 
         // Safely display global info
         try {
           if (i18n.global) {
             const globalKeys = Object.keys(i18n.global).slice(0, 5)
-            debugInfo += `<p><strong>global 键:</strong> ${globalKeys.join(', ')}</p>`
+            debugInfo += `<p><strong>global keys:</strong> ${globalKeys.join(', ')}</p>`
 
             // Check if translation function is available
             if (typeof (i18n.global as VueI18nGlobal).t === 'function') {
-              debugInfo += '<p style="color:green;">✅ global.t 函数可用</p>'
+              debugInfo += '<p style="color:green;">✅ global.t function available</p>'
             } else {
-              debugInfo += '<p style="color:orange;">⚠️ global.t 函数不可用</p>'
+              debugInfo += '<p style="color:orange;">⚠️ global.t function unavailable</p>'
             }
           }
         } catch (e) {
-          debugInfo += `<p style="color:red;">❌ 检查global时出错: ${errMessage(e)}</p>`
+          debugInfo += `<p style="color:red;">❌ Error checking global: ${errMessage(e)}</p>`
         }
 
         // Try to get the i18n instance
         const i18nInstance = getI18nInstance()
         if (i18nInstance) {
-          debugInfo += '<p style="color:green;">✅ 成功获取i18n实例</p>'
+          debugInfo += '<p style="color:green;">✅ Successfully got i18n instance</p>'
 
           // Get the current language
           let currentLanguage = 'unknown'
@@ -472,7 +472,7 @@ export const debugLanguageState = (): void => {
             currentLanguage = inst.locale
           }
 
-          debugInfo += `<p><strong>🌍 当前语言:</strong> ${currentLanguage}</p>`
+          debugInfo += `<p><strong>🌍 Current language:</strong> ${currentLanguage}</p>`
 
           // Test translation
           try {
@@ -480,18 +480,18 @@ export const debugLanguageState = (): void => {
             const testTranslation = tFn
               ? tFn('preferences.general.window.titleBarStyle.custom')
               : ''
-            debugInfo += `<p><strong>🔄 测试翻译:</strong> ${testTranslation}</p>`
+            debugInfo += `<p><strong>🔄 Test translation:</strong> ${testTranslation}</p>`
           } catch (e) {
-            debugInfo += `<p style="color:red;"><strong>🔄 测试翻译失败:</strong> ${errMessage(e)}</p>`
+            debugInfo += `<p style="color:red;"><strong>🔄 Test translation failed:</strong> ${errMessage(e)}</p>`
           }
         } else {
-          debugInfo += '<p style="color:red;">❌ 无法获取有效的i18n实例</p>'
+          debugInfo += '<p style="color:red;">❌ Could not get a valid i18n instance</p>'
         }
       }
 
       details.innerHTML = debugInfo
     } catch (e) {
-      details.innerHTML = `<p style="color:red;">❌ 调试失败: ${errMessage(e)}</p>`
+      details.innerHTML = `<p style="color:red;">❌ Debug failed: ${errMessage(e)}</p>`
     }
   }, 500)
 }

--- a/packages/muya/src/state/renderToStaticHTML.ts
+++ b/packages/muya/src/state/renderToStaticHTML.ts
@@ -97,7 +97,7 @@ function transformFootnotes(html: string): string {
     let body = html.replace(FOOTNOTE_DEF_RE, (_, id: string, inner: string) => {
         // First definition wins for duplicate identifiers — matches the way
         // pandoc / GFM linkrefs treat repeated labels and what the plan asks
-        // for (Section 十, risk #2).
+        // for (Section 10, risk #2).
         if (!definitions.has(id))
             definitions.set(id, inner);
         return '';


### PR DESCRIPTION
## Summary

Audits the codebase for Chinese text in non-internationalized locations (console logs, comments, and hardcoded debug UI) and converts it to English. Translation/locale files and CJK test fixtures are intentionally left untouched.

### Desktop (`chore(desktop)`)
- `prefComponents/sideBar/config.ts` — the i18n search-debug tooling emitted Chinese `console.warn` messages and built an entire debug popup (titles, close button, all `innerHTML` labels) in Chinese. All converted to English.
- `prefComponents/image/components/uploader/index.vue` — the PicGo detection flow logged Chinese `console.error` messages and pushed ~20 Chinese lines into the debug `<pre>` panel, plus a Chinese empty-state string. All converted to English.

### Muya (`chore(muya)`)
- `state/renderToStaticHTML.ts` — a footnote comment referenced `Section 十`; rewritten as `Section 10`.

## Deliberately left as-is (legitimate CJK, not stray text)
- `CJK_REG` Unicode-range regexes in `muyajs`/`muya` — functional code, not text.
- `中文**"加粗"**中文` comment examples — the literal CJK string *is* the test case for the CJK em/strong rule (marktext#4307); surrounding comments are already English.
- `<ruby>北京<rt>Beijing</rt></ruby>` in muya examples — demo data showcasing the ruby feature.
- Language-picker `简体中文 / 繁體中文 / 日本語` `<option>` labels in muya example/e2e host pages — endonyms shown in their own script.

## Notes
- String-only changes; no behavior change.
- `eslint` passes clean on the changed desktop files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)