### PR TITLE
refactor(muya): enforce `_` prefix for private members via lint

### DIFF
--- a/packages/muya/eslint.config.mjs
+++ b/packages/muya/eslint.config.mjs
@@ -3,6 +3,8 @@ import antfu from '@antfu/eslint-config';
 import parser from '@typescript-eslint/parser';
 
 function typescriptPreset() {
+    const memberSelectors = ['classProperty', 'classMethod', 'parameterProperty', 'classicAccessor', 'autoAccessor'];
+
     return {
         files: ['**/*.ts', '**/*.tsx'],
         rules: {
@@ -27,7 +29,7 @@ function typescriptPreset() {
                 },
             ],
             'ts/naming-convention': [
-                'warn',
+                'error',
                 // Interfaces' names should start with a capital 'I'.
                 {
                     selector: 'interface',
@@ -37,9 +39,16 @@ function typescriptPreset() {
                         match: true,
                     },
                 },
-                // Private fields of a class should start with an underscore '_'.
+                // `_` <=> private: this block forbids a leading `_` on every member;
+                // the private block below (more specific, so it wins regardless of
+                // order) requires it. `format: null` checks only the underscore.
                 {
-                    selector: ['classMethod', 'classProperty'],
+                    selector: memberSelectors,
+                    format: null,
+                    leadingUnderscore: 'forbid',
+                },
+                {
+                    selector: memberSelectors,
                     modifiers: ['private'],
                     format: ['camelCase'],
                     leadingUnderscore: 'require',

--- a/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
+++ b/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
@@ -76,11 +76,11 @@ function placeCursorOn(muya: Muya, text: string): Content {
     return target;
 }
 
-interface StateNode { name: string; text?: string; children?: StateNode[] }
+interface IStateNode { name: string; text?: string; children?: IStateNode[] }
 
 // Does any block at the TOP level of the document carry this text directly?
 function topLevelHasParagraph(muya: Muya, text: string): boolean {
-    return (muya.getState() as unknown as StateNode[]).some(
+    return (muya.getState() as unknown as IStateNode[]).some(
         node => node.name === 'paragraph' && node.text === text,
     );
 }

--- a/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
@@ -27,7 +27,7 @@ interface IOffset {
 // `_addFormat` is declared private on Format, so accessing it via the
 // prototype requires bypassing visibility — this structural type captures
 // the signature the helper here actually invokes.
-interface FormatProtoAddFormat {
+interface IFormatProtoAddFormat {
     _addFormat: (
         this: { text: string },
         type: string,
@@ -39,7 +39,7 @@ function applyAddFormat(text: string, start: number, end: number, type: string) 
     const fakeThis = { text } as { text: string };
     const startOffset: IOffset = { offset: start };
     const endOffset: IOffset = { offset: end };
-    (Format.prototype as unknown as FormatProtoAddFormat)._addFormat.call(fakeThis, type, {
+    (Format.prototype as unknown as IFormatProtoAddFormat)._addFormat.call(fakeThis, type, {
         start: startOffset,
         end: endOffset,
     });

--- a/packages/muya/src/block/base/__tests__/formatUnlink.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatUnlink.spec.ts
@@ -21,7 +21,7 @@ interface IFakeFormatThis {
 // `Format.prototype.unlink` is a real instance method (declared on the class)
 // but isn't picked up by the public Format type when accessed via prototype.
 // Cast to a record of methods to call it with a structural fake.
-interface FormatProtoUnlink { unlink: (this: IFakeFormatThis, info: { range: { start: number; end: number } | null; text: string }) => void }
+interface IFormatProtoUnlink { unlink: (this: IFakeFormatThis, info: { range: { start: number; end: number } | null; text: string }) => void }
 
 function applyUnlink(text: string, range: { start: number; end: number }, anchorText: string) {
     const emit = vi.fn();
@@ -31,7 +31,7 @@ function applyUnlink(text: string, range: { start: number; end: number }, anchor
         setCursor,
         muya: { eventCenter: { emit } },
     };
-    (Format.prototype as unknown as FormatProtoUnlink).unlink.call(fakeThis, { range, text: anchorText });
+    (Format.prototype as unknown as IFormatProtoUnlink).unlink.call(fakeThis, { range, text: anchorText });
     return { text: fakeThis.text as string, emit, setCursor };
 }
 
@@ -86,7 +86,7 @@ describe('format.unlink — replaces link source with visible anchor', () => {
             setCursor,
             muya: { eventCenter: { emit } },
         };
-        (Format.prototype as unknown as FormatProtoUnlink).unlink.call(fakeThis, { range: null, text: 'whatever' });
+        (Format.prototype as unknown as IFormatProtoUnlink).unlink.call(fakeThis, { range: null, text: 'whatever' });
         expect(fakeThis.text).toBe(src);
         expect(setCursor).not.toHaveBeenCalled();
         expect(emit).not.toHaveBeenCalled();

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -316,7 +316,7 @@ function lineBreakAutoPair(
 }
 
 class Content extends TreeNode {
-    public _text: string;
+    private _text: string;
     public isComposed: boolean;
 
     static override blockName = 'content';

--- a/packages/muya/src/block/content/atxHeadingContent/__tests__/enterHandler.spec.ts
+++ b/packages/muya/src/block/content/atxHeadingContent/__tests__/enterHandler.spec.ts
@@ -16,7 +16,7 @@ import AtxHeadingContent from '../index';
 // We exercise the handler directly with a structurally-typed `this` so
 // no Muya bootstrap is required.
 
-interface FakeAtxContent {
+interface IFakeAtxContent {
     text: string;
     cursor: { start: number; end: number };
     parent: {
@@ -28,7 +28,7 @@ interface FakeAtxContent {
     setCursor: (start: number, end: number, _selected?: boolean) => void;
 }
 
-function makeFakeContent(level: number, cursorAt: number): FakeAtxContent {
+function makeFakeContent(level: number, cursorAt: number): IFakeAtxContent {
     return {
         text: '# Headings',
         cursor: { start: cursorAt, end: cursorAt },

--- a/packages/muya/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
@@ -21,7 +21,7 @@ import CodeBlockContent from '../index';
 // We drive the prototype directly with a structurally typed `this` so we
 // don't need a real Muya bootstrap.
 
-interface FakeCell {
+interface IFakeCell {
     text: string;
     lang: string;
     cursor: { start: number; end: number };
@@ -34,7 +34,7 @@ function makeFakeCodeContent(initial: {
     text: string;
     lang: string;
     cursorAt: number;
-}): FakeCell {
+}): IFakeCell {
     return {
         text: initial.text,
         lang: initial.lang,

--- a/packages/muya/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
@@ -8,7 +8,7 @@ import { mergePasteIntoHeading } from '../mergePasteIntoHeading';
 // touches `text` / `update()` on the anchor and `blockName` on the wrapper,
 // so the fake objects intentionally don't satisfy the full Content / Parent
 // surface — `as unknown as Content` (etc.) makes the assertion explicit.
-function asContent(block: FakeContent): Content {
+function asContent(block: IFakeContent): Content {
     return block as unknown as Content;
 }
 function asParentWithBlockName(blockName: string): Parent {
@@ -28,14 +28,14 @@ function asParentWithBlockName(blockName: string): Parent {
 // `mergePasteIntoHeading` is the pure helper that decides whether to merge
 // and, if so, mutates the heading's text and returns the remaining states.
 
-interface FakeContent {
+interface IFakeContent {
     text: string;
     updated: boolean;
     update: () => void;
 }
 
-function content(text: string): FakeContent {
-    const block: FakeContent = {
+function content(text: string): IFakeContent {
+    const block: IFakeContent = {
         text,
         updated: false,
         update() {

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -136,7 +136,7 @@ class Clipboard {
             await pastePlainText(this, text);
     }
 
-    async _readClipboardText(): Promise<string> {
+    private async _readClipboardText(): Promise<string> {
         // Sandboxed Electron renderers can't reach the system clipboard
         // directly, so the embedder supplies a reader (e.g. an IPC bridge to
         // Electron's native `clipboard`). Fall back to the async Clipboard API

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -91,7 +91,7 @@ class History {
         return this.muya.editor.selection;
     }
 
-    constructor(public muya: Muya, private options: IOptions = DEFAULT_OPTIONS) {
+    constructor(public muya: Muya, private _options: IOptions = DEFAULT_OPTIONS) {
         this._listen();
     }
 
@@ -111,7 +111,7 @@ class History {
                 if (this._ignoreChange)
                     return;
 
-                if (!this.options.userOnly || source === 'user')
+                if (!this._options.userOnly || source === 'user')
                     this._record(op, prevDoc);
                 else
                     this.transform(op);
@@ -271,7 +271,7 @@ class History {
 
         const timestamp = Date.now();
         if (
-            this._lastRecorded + this.options.delay > timestamp
+            this._lastRecorded + this._options.delay > timestamp
             && this._stack.undo.length > 0
         ) {
             const { operation: lastOperation, selection: lastSelection }
@@ -288,7 +288,7 @@ class History {
 
         this._stack.undo.push({ operation: undoOperation, selection });
 
-        if (this._stack.undo.length > this.options.maxStack)
+        if (this._stack.undo.length > this._options.maxStack)
             this._stack.undo.shift();
     }
 
@@ -318,7 +318,7 @@ class History {
         // replacement must not absorb a later keystroke (or vice versa).
         this._lastRecorded = 0;
 
-        if (this._stack.undo.length > this.options.maxStack)
+        if (this._stack.undo.length > this._options.maxStack)
             this._stack.undo.shift();
     }
 

--- a/packages/muya/src/types/global.d.ts
+++ b/packages/muya/src/types/global.d.ts
@@ -2,6 +2,7 @@ import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
 
 declare global {
+    // eslint-disable-next-line ts/naming-convention
     interface Window {
         Prism: unknown;
         MUYA_VERSION: string;
@@ -13,6 +14,7 @@ declare global {
         DIRNAME?: string;
     }
 
+    // eslint-disable-next-line ts/naming-convention
     interface Element {
         __MUYA_BLOCK__: Content | Parent;
     }


### PR DESCRIPTION
## What

First of a staged series that hardens member-visibility conventions in `packages/muya`. This PR makes the `_`-prefix convention **enforced** and bidirectional, so a leading underscore reliably marks a `private` member.

### Lint rule (`packages/muya/eslint.config.mjs`)
- Flip `ts/naming-convention` from `warn` to **`error`**.
- Add a catch-all rule that **forbids** a leading underscore on non-private members (`format: null`, so only the underscore is policed, not casing).
- Broaden the private-member selector to also cover **parameter properties** and **accessors** (get/set).

### Violations this surfaces (all resolved here)
- Mark `Content._text` and `Clipboard._readClipboardText` `private` — they carried a `_` prefix while being public / implicit-public.
- Rename `History`'s private `options` parameter property to `_options`.
- I-prefix six test-fake interfaces (`StateNode`, `FormatProtoAddFormat`, …).
- Inline-disable the two unrenamable global lib augmentations (`Window`, `Element`) in `global.d.ts`.

## Why

The `_`-prefix-for-private convention was documented and partially configured but only a warning, and one-directional. Enforcing it (and making `_` ⇔ private) is the foundation for the follow-up PRs that mark internal members `private`/`protected`.

## Verification
- `pnpm -C packages/muya lint` — 0 errors
- `pnpm -C packages/muya lint:types` — passes
- `pnpm -C packages/muya test` — 983 passed
- `pnpm -C packages/muya test:spec` — 1347 passed (no conformance regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)