### PR TITLE
refactor(muya): mark core/state/selection internals private

### DIFF
--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -21,14 +21,14 @@ class Clipboard {
 
     static create(muya: Muya) {
         const clipboard = new Clipboard(muya);
-        clipboard.listen();
+        clipboard._listen();
 
         return clipboard;
     }
 
     constructor(public muya: Muya) {}
 
-    listen() {
+    private _listen() {
         const ownsEvent = () => this.muya.hasFocus();
 
         const copyCutHandler = (event: Event) => {

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -241,15 +241,15 @@ export class Editor {
 
     private _activeContentBlock: Nullable<Content> = null;
 
-    constructor(public muya: Muya) {
-        const state = muya.options.json || muya.options.markdown || '';
+    constructor(private _muya: Muya) {
+        const state = _muya.options.json || _muya.options.markdown || '';
 
-        this.jsonState = new JSONState(muya, state);
-        this.inlineRenderer = new InlineRenderer(muya);
-        this.selection = new Selection(muya);
-        this.searchModule = new Search(muya);
-        this.clipboard = Clipboard.create(muya);
-        this.history = new History(muya);
+        this.jsonState = new JSONState(_muya, state);
+        this.inlineRenderer = new InlineRenderer(_muya);
+        this.selection = new Selection(_muya);
+        this.searchModule = new Search(_muya);
+        this.clipboard = Clipboard.create(_muya);
+        this.history = new History(_muya);
     }
 
     get activeContentBlock() {
@@ -271,7 +271,7 @@ export class Editor {
     init() {
         registerBlocks();
 
-        const { muya } = this;
+        const muya = this._muya;
         const state = this.jsonState.getState();
 
         this.scrollPage = ScrollPage.create(muya, state);
@@ -289,7 +289,7 @@ export class Editor {
     }
 
     private _dispatchEvents() {
-        const { domNode } = this.muya;
+        const { domNode } = this._muya;
 
         const eventHandler = (event: Event) => {
             const selectionResult = this.selection.getSelection();
@@ -392,7 +392,7 @@ export class Editor {
     }
 
     updateContents(operations: JSONOp, selection: Nullable<IHistorySelection>, source: string) {
-        const { muya } = this;
+        const muya = this._muya;
         // ot-json1 no-op (`null`) is forwarded to dispatch — JSONState
         // short-circuits internally so listeners still see a json-change
         // event for the no-op.

--- a/packages/muya/src/event/index.ts
+++ b/packages/muya/src/event/index.ts
@@ -14,7 +14,7 @@ class EventCenter {
     public events: IEvent[] = [];
     public listeners: IListeners = {};
 
-    get eventId() {
+    private get _eventId() {
         return `${PREFIX}${idIterator.next().value}`;
     }
 
@@ -28,10 +28,10 @@ class EventCenter {
         listener: EventListener,
         capture?: boolean | AddEventListenerOptions,
     ): string {
-        if (this.checkHasBind(target, event, listener, capture))
+        if (this._checkHasBind(target, event, listener, capture))
             return '';
 
-        const { eventId } = this;
+        const eventId = this._eventId;
         target.addEventListener(event, listener, capture);
         this.events.push({
             eventId,
@@ -140,7 +140,7 @@ class EventCenter {
     }
 
     // Determine whether the event has been bind
-    checkHasBind(
+    private _checkHasBind(
         cTarget: HTMLElement | Document,
         cEvent: string,
         cListener: EventListenerOrEventListenerObject,

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -87,16 +87,16 @@ class History {
         redo: [],
     };
 
-    get selection() {
-        return this.muya.editor.selection;
+    private get _selection() {
+        return this._muya.editor.selection;
     }
 
-    constructor(public muya: Muya, private _options: IOptions = DEFAULT_OPTIONS) {
+    constructor(private _muya: Muya, private _options: IOptions = DEFAULT_OPTIONS) {
         this._listen();
     }
 
     private _listen() {
-        this.muya.eventCenter.on(
+        this._muya.eventCenter.on(
             'json-change',
             ({
                 op,
@@ -114,7 +114,7 @@ class History {
                 if (!this._options.userOnly || source === 'user')
                     this._record(op, prevDoc);
                 else
-                    this.transform(op);
+                    this._transform(op);
             },
         );
     }
@@ -128,19 +128,19 @@ class History {
 
         this._stack[dest].push({
             operation: inverseOperation as JSONOpList,
-            selection: this.selection.getSelection(),
+            selection: this._selection.getSelection(),
             rebuild,
         });
 
         this._lastRecorded = 0;
         this._ignoreChange = true;
         if (rebuild)
-            this.muya.editor.rebuildContents(operation, selection, 'user');
+            this._muya.editor.rebuildContents(operation, selection, 'user');
         else
-            this.muya.editor.updateContents(operation, selection, 'user');
+            this._muya.editor.updateContents(operation, selection, 'user');
         this._ignoreChange = false;
 
-        this.getLastSelection();
+        this._getLastSelection();
     }
 
     clear() {
@@ -252,8 +252,8 @@ class History {
         this._lastRecorded = 0;
     }
 
-    getLastSelection() {
-        this._selectionStack.push(this.selection.getSelection());
+    private _getLastSelection() {
+        this._selectionStack.push(this._selection.getSelection());
 
         if (this._selectionStack.length > 2)
             this._selectionStack.shift();
@@ -265,7 +265,7 @@ class History {
         if (op.length === 0)
             return;
 
-        let selection = this.getLastSelection();
+        let selection = this._getLastSelection();
         this._stack.redo = [];
         let undoOperation = json1.type.invertWithDoc(op, asDoc(doc));
 
@@ -346,7 +346,7 @@ class History {
         this._change(HistoryAction.REDO, HistoryAction.UNDO);
     }
 
-    transform(op: JSONOpList) {
+    private _transform(op: JSONOpList) {
         transformStack(this._stack.undo, op);
         transformStack(this._stack.redo, op);
     }

--- a/packages/muya/src/i18n/index.ts
+++ b/packages/muya/src/i18n/index.ts
@@ -5,18 +5,19 @@ import { en } from '../locales/en';
 
 class I18n {
     public lang: string;
-    public resources: Record<string, ILocale['resource']>;
+    private _resources: Record<string, ILocale['resource']>;
 
-    constructor(public muya: Muya, object: ILocale) {
+    constructor(_muya: Muya, object: ILocale) {
         const { name, resource } = object || en;
         this.lang = name;
-        this.resources = {
+        this._resources = {
             [name]: resource,
         };
     }
 
     t(key: string): string {
-        const { lang, resources } = this;
+        const { lang } = this;
+        const resources = this._resources;
 
         return resources?.[lang]?.[key] || resources?.en?.[key] || key;
     }
@@ -24,8 +25,8 @@ class I18n {
     locale(object: ILocale) {
         const { name, resource } = object;
         this.lang = name;
-        this.resources = {
-            ...this.resources,
+        this._resources = {
+            ...this._resources,
             [name]: resource,
         };
     }

--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -19,7 +19,7 @@ class InlineRenderer {
         this.renderer = new Renderer(muya, this);
     }
 
-    tokenizer(block: Format, highlights: IHighlight[]) {
+    private _tokenizer(block: Format, highlights: IHighlight[]) {
         const { options } = this.muya;
         const { text } = block;
         const { labels } = this;
@@ -60,12 +60,12 @@ class InlineRenderer {
     }
 
     patch(block: Format, cursor?: IRenderCursor, highlights: IHighlight[] = []) {
-        this.collectReferenceDefinitions();
+        this._collectReferenceDefinitions();
         const { domNode } = block;
         if (block.isParent())
             debug.error('Patch can only handle content block');
 
-        const tokens = this.tokenizer(block, highlights);
+        const tokens = this._tokenizer(block, highlights);
         const html = this.renderer.output(
             tokens,
             block,
@@ -74,7 +74,7 @@ class InlineRenderer {
         domNode!.innerHTML = html;
     }
 
-    collectReferenceDefinitions() {
+    private _collectReferenceDefinitions() {
         const state = this.muya.editor.jsonState.getState();
         const labels = new Map();
 

--- a/packages/muya/src/inlineRenderer/renderer/index.ts
+++ b/packages/muya/src/inlineRenderer/renderer/index.ts
@@ -108,7 +108,7 @@ class Renderer {
 
     constructor(public muya: Muya, public parent: InlineRenderer) {}
 
-    checkConflicted(block: Format, token: Token, cursor: IRenderCursor = {}) {
+    private _checkConflicted(block: Format, token: Token, cursor: IRenderCursor = {}) {
         const anchor = cursor.anchor || cursor.start;
         const focus = cursor.focus || cursor.end;
         if (!anchor || !focus || (cursor.block && cursor.block !== block))
@@ -130,7 +130,7 @@ class Renderer {
     ) {
         return (
             outerClass
-            || (this.checkConflicted(block, token, cursor)
+            || (this._checkConflicted(block, token, cursor)
                 ? CLASS_NAMES.MU_GRAY
                 : CLASS_NAMES.MU_HIDE)
         );

--- a/packages/muya/src/search/index.ts
+++ b/packages/muya/src/search/index.ts
@@ -7,15 +7,15 @@ import { DEFAULT_SEARCH_OPTIONS } from '../config';
 import { buildRegexValue, matchString } from '../utils/search';
 
 export class Search {
-    public value: string = '';
+    private _value: string = '';
     public matches: IMatch[] = [];
     public index: number = -1;
 
-    get scrollPage() {
-        return this.muya.editor.scrollPage;
+    private get _scrollPage() {
+        return this._muya.editor.scrollPage;
     }
 
-    constructor(public muya: Muya) {}
+    constructor(private _muya: Muya) {}
 
     private _updateMatches(isClear = false) {
         const { matches, index } = this;
@@ -81,7 +81,8 @@ export class Search {
     replace(replaceValue: string, opt = { isSingle: true, isRegexp: false }) {
         const { isSingle, isRegexp, ...rest } = opt;
         const options = Object.assign({}, DEFAULT_SEARCH_OPTIONS, rest);
-        const { matches, value, index } = this;
+        const { matches, index } = this;
+        const value = this._value;
 
         if (matches.length) {
             if (isRegexp)
@@ -150,7 +151,7 @@ export class Search {
 
         // Highlight current search.
         if (value) {
-            this.scrollPage?.depthFirstTraverse((block: TreeNode) => {
+            this._scrollPage?.depthFirstTraverse((block: TreeNode) => {
                 if (block.isContent()) {
                     const { text } = block;
                     if (text && typeof text === 'string') {
@@ -180,7 +181,7 @@ export class Search {
             index = 0;
         }
 
-        Object.assign(this, { value, matches, index });
+        Object.assign(this, { _value: value, matches, index });
 
         this._updateMatches();
 

--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -28,12 +28,12 @@ class TableRectSelection {
 
     static create(muya: Muya): TableRectSelection {
         const instance = new TableRectSelection(muya);
-        instance.attach();
+        instance._attach();
 
         return instance;
     }
 
-    constructor(public muya: Muya) {}
+    constructor(private _muya: Muya) {}
 
     get hasSelection(): boolean {
         return this._table != null && this._anchor != null && this._focus != null;
@@ -106,8 +106,8 @@ class TableRectSelection {
         this._renderHighlight();
     }
 
-    attach(): void {
-        const { eventCenter, domNode } = this.muya;
+    private _attach(): void {
+        const { eventCenter, domNode } = this._muya;
         eventCenter.attachDOMEvent(domNode, 'mousedown', this._onMouseDown);
     }
 
@@ -129,7 +129,7 @@ class TableRectSelection {
         this._focus = position;
         this._isSelecting = false;
 
-        const { eventCenter } = this.muya;
+        const { eventCenter } = this._muya;
         this._dragEventIds.push(
             eventCenter.attachDOMEvent(document, 'mousemove', this._onMouseMove),
             eventCenter.attachDOMEvent(document, 'mouseup', this._onMouseUp),
@@ -177,9 +177,9 @@ class TableRectSelection {
 
     private _freezeNativeSelection(): void {
         document.getSelection()?.removeAllRanges();
-        this.muya.domNode.focus();
-        this.muya.editor.activeContentBlock = null;
-        this.muya.ui.hideAllFloatTools();
+        this._muya.domNode.focus();
+        this._muya.editor.activeContentBlock = null;
+        this._muya.ui.hideAllFloatTools();
     }
 
     private _suppressNativeRange(): void {
@@ -187,7 +187,7 @@ class TableRectSelection {
     }
 
     private _detachDragEvents(): void {
-        const { eventCenter } = this.muya;
+        const { eventCenter } = this._muya;
         for (const id of this._dragEventIds)
             eventCenter.detachDOMEvent(id);
 

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -71,11 +71,11 @@ class TextSelection {
         this._listenSelectActions();
     }
 
-    get scrollPage() {
+    private get _scrollPage() {
         return this._muya.editor.scrollPage;
     }
 
-    get isCollapsed() {
+    private get _isCollapsed() {
         const { anchorBlock, focusBlock, anchor, focus } = this;
 
         if (anchor == null || focus == null)
@@ -93,14 +93,14 @@ class TextSelection {
         return anchorBlock === focusBlock;
     }
 
-    get direction() {
+    private get _direction() {
         const {
             anchor,
             focus,
             anchorBlock,
             focusBlock,
             isSelectionInSameBlock,
-            isCollapsed,
+            _isCollapsed: isCollapsed,
         } = this;
         if (anchor == null || focus == null || !anchorBlock || !focusBlock)
             return SelectionDirection.NONE;
@@ -117,8 +117,8 @@ class TextSelection {
         );
     }
 
-    get type() {
-        const { anchorBlock, focusBlock, isCollapsed } = this;
+    private get _type() {
+        const { anchorBlock, focusBlock, _isCollapsed: isCollapsed } = this;
 
         return computeCaretType(anchorBlock, focusBlock, isCollapsed);
     }
@@ -135,7 +135,7 @@ class TextSelection {
     }
 
     selectAllContent() {
-        const { scrollPage } = this;
+        const { _scrollPage: scrollPage } = this;
         const aBlock = scrollPage?.firstContentInDescendant();
         const fBlock = scrollPage?.lastContentInDescendant();
 
@@ -218,7 +218,7 @@ class TextSelection {
     }
 
     private _emitSelectionChange() {
-        const { isCollapsed, isSelectionInSameBlock, direction, type } = this;
+        const { _isCollapsed: isCollapsed, isSelectionInSameBlock, _direction: direction, _type: type } = this;
         const anchorBlock = this.anchorBlock ?? null;
         const focusBlock = this.focusBlock ?? null;
 
@@ -358,7 +358,7 @@ class TextSelection {
             anchorPath,
             focusBlock,
             focusPath,
-            scrollPage,
+            _scrollPage: scrollPage,
         } = this;
 
         if (!anchor || !focus) {

--- a/packages/muya/src/selection/index.ts
+++ b/packages/muya/src/selection/index.ts
@@ -28,11 +28,11 @@ class Selection {
     private _image: ImageSelection;
     private _table: TableRectSelection;
 
-    constructor(public muya: Muya) {
-        this._text = new TextSelection(muya, this);
-        this._image = new ImageSelection(muya, this);
+    constructor(private _muya: Muya) {
+        this._text = new TextSelection(this._muya, this);
+        this._image = new ImageSelection(this._muya, this);
         this._image.attach();
-        this._table = TableRectSelection.create(muya);
+        this._table = TableRectSelection.create(this._muya);
     }
 
     get type(): SelectionType {
@@ -89,7 +89,7 @@ class Selection {
 
     selectImage(data: IImageSelectionData): void {
         this._image.selected = data;
-        this.muya.editor.activeContentBlock = null;
+        this._muya.editor.activeContentBlock = null;
         this.activate(SelectionType.IMAGE);
     }
 
@@ -102,7 +102,7 @@ class Selection {
             this._image.clear();
 
         if (type !== SelectionType.TEXT) {
-            this.muya.eventCenter.emit('selection-change', {
+            this._muya.eventCenter.emit('selection-change', {
                 kind: type,
             });
         }

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -47,11 +47,11 @@ class JSONState {
 
     private _state: TState[] = [];
 
-    constructor(public muya: Muya, stateOrMarkdown: TState[] | string) {
+    constructor(private _muya: Muya, stateOrMarkdown: TState[] | string) {
         this.setContent(stateOrMarkdown);
     }
 
-    apply(op: JSONOp) {
+    private _apply(op: JSONOp) {
         // ot-json1's noop is the literal `null`. `json1.type.apply` accepts it
         // and returns the doc unchanged — short-circuit instead so the rest of
         // the call site can treat `op` as definitely applied.
@@ -62,16 +62,16 @@ class JSONState {
 
     setContent(content: TState[] | string) {
         if (typeof content === 'object')
-            this.setState(content);
+            this._setState(content);
         else
-            this.setMarkdown(content);
+            this._setMarkdown(content);
     }
 
-    setState(state: TState[]) {
+    private _setState(state: TState[]) {
         this._state = state;
     }
 
-    setMarkdown(markdown: string) {
+    private _setMarkdown(markdown: string) {
         this._state = this.markdownToState(markdown);
     }
 
@@ -85,7 +85,7 @@ class JSONState {
             trimUnnecessaryCodeBlockEmptyLines,
             frontMatter,
             math,
-        } = this.muya.options;
+        } = this._muya.options;
 
         return new MarkdownToState({
             footnote,
@@ -192,11 +192,11 @@ class JSONState {
 
     dispatch(op: JSONOp, source = 'user' /* user, api */) {
         const prevDoc = this.getState();
-        this.apply(op);
+        this._apply(op);
         // TODO: remove doc in future
         const doc = this.getState();
         debug.log(JSON.stringify(op));
-        this.muya.eventCenter.emit('json-change', {
+        this._muya.eventCenter.emit('json-change', {
             op,
             source,
             prevDoc,
@@ -242,10 +242,10 @@ class JSONState {
                 (acc, curr) => json1.type.compose(acc, curr) as JSONOpList,
             );
             const prevDoc = this.getState();
-            this.apply(op);
+            this._apply(op);
             // TODO: remove doc in future
             const doc = this.getState();
-            this.muya.eventCenter.emit('json-change', {
+            this._muya.eventCenter.emit('json-change', {
                 op,
                 source: 'user',
                 prevDoc,

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -30,9 +30,9 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
 export class MarkdownToHtml {
     private _exportContainer: HTMLDivElement | null = null;
 
-    constructor(public markdown: string, public muya?: Muya) {}
+    constructor(public markdown: string, private _muya?: Muya) {}
 
-    async renderMermaid() {
+    private async _renderMermaid() {
         const codes = this._exportContainer!.querySelectorAll(
             'code.language-mermaid',
         );
@@ -59,15 +59,15 @@ export class MarkdownToHtml {
         await mermaid.run({
             nodes: [...this._exportContainer!.querySelectorAll('div.mermaid')],
         });
-        if (this.muya) {
+        if (this._muya) {
             mermaid.initialize({
                 securityLevel: 'strict',
-                theme: this.muya.options.mermaidTheme,
+                theme: this._muya.options.mermaidTheme,
             });
         }
     }
 
-    async renderDiagram() {
+    private async _renderDiagram() {
         const selector
             = 'code.language-vega-lite, code.language-plantuml, code.language-flowchart, code.language-sequence';
         const codes = this._exportContainer!.querySelectorAll(selector);
@@ -102,13 +102,13 @@ export class MarkdownToHtml {
             }
             else if (functionType === 'sequence') {
                 Object.assign(options, {
-                    theme: this.muya?.options.sequenceTheme ?? 'hand',
+                    theme: this._muya?.options.sequenceTheme ?? 'hand',
                 });
             }
 
             try {
                 if (functionType === 'plantuml') {
-                    const diagram = render.parse(rawCode, this.muya?.options.plantumlServer);
+                    const diagram = render.parse(rawCode, this._muya?.options.plantumlServer);
                     diagramContainer.innerHTML = '';
                     diagram.insertImgElement(diagramContainer);
                 }
@@ -163,11 +163,11 @@ export class MarkdownToHtml {
     // render pure html by marked
     async renderHtml() {
         let html = getHighlightHtml(this.markdown, {
-            superSubScript: this.muya?.options?.superSubScript ?? true,
-            footnote: this.muya?.options?.footnote ?? false,
+            superSubScript: this._muya?.options?.superSubScript ?? true,
+            footnote: this._muya?.options?.footnote ?? false,
             isGitlabCompatibilityEnabled:
-        this.muya?.options?.isGitlabCompatibilityEnabled ?? true,
-            math: this.muya?.options?.math ?? true,
+        this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
+            math: this._muya?.options?.math ?? true,
         });
 
         html = sanitize(html, EXPORT_DOMPURIFY_CONFIG, false) as string;
@@ -179,8 +179,8 @@ export class MarkdownToHtml {
         document.body.appendChild(exportContainer);
 
         // render only render the light theme of mermaid and diagram...
-        await this.renderMermaid();
-        await this.renderDiagram();
+        await this._renderMermaid();
+        await this._renderDiagram();
 
         // Inject github-compatible slug ids onto exported headings so the
         // exported document's [TOC] / `getHtmlToc` `href="#slug"` anchors

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -84,10 +84,10 @@ export default class ExportMarkdown {
     }
 
     generate(states: TState[]) {
-        return this.convertStatesToMarkdown(states);
+        return this._convertStatesToMarkdown(states);
     }
 
-    convertStatesToMarkdown(
+    private _convertStatesToMarkdown(
         states: TState[],
         indent = '',
         listIndent = '',
@@ -128,59 +128,59 @@ export default class ExportMarkdown {
     private _serializeSimpleBlock(state: TState, result: string[], indent: string) {
         switch (state.name) {
             case 'frontmatter':
-                result.push(this.serializeFrontMatter(state));
+                result.push(this._serializeFrontMatter(state));
                 break;
 
             case 'paragraph':
 
             case 'thematic-break':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeTextParagraph(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeTextParagraph(state, indent));
                 break;
 
             case 'atx-heading':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeAtxHeading(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeAtxHeading(state, indent));
                 break;
 
             case 'setext-heading':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeSetextHeading(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeSetextHeading(state, indent));
                 break;
 
             case 'code-block':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeCodeBlock(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeCodeBlock(state, indent));
                 break;
 
             case 'html-block':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeHtmlBlock(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeHtmlBlock(state, indent));
                 break;
 
             case 'math-block':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeMathBlock(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeMathBlock(state, indent));
                 break;
 
             case 'diagram':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeDiagramBlock(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeDiagramBlock(state, indent));
                 break;
 
             case 'block-quote':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeBlockquote(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeBlockquote(state, indent));
                 break;
 
             case 'table':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeTable(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeTable(state, indent));
                 break;
 
             case 'footnote':
-                this.insertLineBreak(result, indent);
-                result.push(this.serializeFootnote(state, indent));
+                this._insertLineBreak(result, indent);
+                result.push(this._serializeFootnote(state, indent));
                 break;
 
             default: {
@@ -212,10 +212,10 @@ export default class ExportMarkdown {
             insertNewLine = false;
 
         if (insertNewLine)
-            this.insertLineBreak(result, indent);
+            this._insertLineBreak(result, indent);
 
         this._listType.push(deepClone(meta));
-        result.push(this.serializeList(state, indent, listIndent));
+        result.push(this._serializeList(state, indent, listIndent));
         this._listType.pop();
 
         return bulletMarkerOrDelimiter;
@@ -232,13 +232,13 @@ export default class ExportMarkdown {
         // helper variable to correct the first tight item in a nested list
         this._isLooseParentList = loose;
         if (loose)
-            this.insertLineBreak(result, indent);
+            this._insertLineBreak(result, indent);
 
-        result.push(this.serializeListItem(state, indent + listIndent));
+        result.push(this._serializeListItem(state, indent + listIndent));
         this._isLooseParentList = true;
     }
 
-    insertLineBreak(result: unknown[], indent: string) {
+    private _insertLineBreak(result: unknown[], indent: string) {
         if (!result.length)
             return;
         // Blank lines inside a list item should be empty, not carry the
@@ -248,7 +248,7 @@ export default class ExportMarkdown {
         result.push(`${indent.replace(/ +$/, '')}\n`);
     }
 
-    serializeFrontMatter(state: IFrontmatterState) {
+    private _serializeFrontMatter(state: IFrontmatterState) {
         let startToken;
         let endToken;
         switch (state.meta.lang) {
@@ -287,7 +287,7 @@ export default class ExportMarkdown {
         return result.join('');
     }
 
-    serializeTextParagraph(
+    private _serializeTextParagraph(
         state: IParagraphState | IThematicBreakState,
         indent: string,
     ) {
@@ -297,7 +297,7 @@ export default class ExportMarkdown {
         return `${lines.map(line => `${indent}${line}`).join('\n')}\n`;
     }
 
-    serializeAtxHeading(state: IAtxHeadingState, indent: string) {
+    private _serializeAtxHeading(state: IAtxHeadingState, indent: string) {
         const { text } = state;
         const match = text.match(/(#{1,6})(.*)/);
 
@@ -306,7 +306,7 @@ export default class ExportMarkdown {
         return `${indent}${atxHeadingText}\n`;
     }
 
-    serializeSetextHeading(state: ISetextHeadingState, indent: string) {
+    private _serializeSetextHeading(state: ISetextHeadingState, indent: string) {
         const { text, meta } = state;
         const { underline } = meta;
         const lines = text.trim().split('\n');
@@ -317,7 +317,7 @@ export default class ExportMarkdown {
         );
     }
 
-    serializeCodeBlock(state: ICodeBlockState, indent: string) {
+    private _serializeCodeBlock(state: ICodeBlockState, indent: string) {
         const result = [];
         const { text, meta } = state;
         const textList = text.split('\n');
@@ -339,7 +339,7 @@ export default class ExportMarkdown {
         return result.join('');
     }
 
-    serializeHtmlBlock(state: IHtmlBlockState, indent: string) {
+    private _serializeHtmlBlock(state: IHtmlBlockState, indent: string) {
         const result = [];
         const { text } = state;
         const lines = text.split('\n');
@@ -350,7 +350,7 @@ export default class ExportMarkdown {
         return result.join('');
     }
 
-    serializeMathBlock(state: IMathBlockState, indent: string) {
+    private _serializeMathBlock(state: IMathBlockState, indent: string) {
         const result = [];
         const {
             text,
@@ -367,7 +367,7 @@ export default class ExportMarkdown {
         return result.join('');
     }
 
-    serializeDiagramBlock(state: IDiagramState, indent: string) {
+    private _serializeDiagramBlock(state: IDiagramState, indent: string) {
         const result = [];
         const {
             text,
@@ -384,14 +384,14 @@ export default class ExportMarkdown {
         return result.join('');
     }
 
-    serializeBlockquote(state: IBlockQuoteState, indent: string) {
+    private _serializeBlockquote(state: IBlockQuoteState, indent: string) {
         const { children } = state;
         const newIndent = `${indent}> `;
 
-        return this.convertStatesToMarkdown(children, newIndent);
+        return this._convertStatesToMarkdown(children, newIndent);
     }
 
-    serializeFootnote(state: IFootnoteBlockState, indent: string) {
+    private _serializeFootnote(state: IFootnoteBlockState, indent: string) {
         // Footnote definitions render as
         //   [^id]: first paragraph
         //
@@ -401,7 +401,7 @@ export default class ExportMarkdown {
         // indented by four spaces past the surrounding `indent`.
         const { meta, children } = state;
         const innerIndent = `${indent}    `;
-        const inner = this.convertStatesToMarkdown(children, innerIndent);
+        const inner = this._convertStatesToMarkdown(children, innerIndent);
         const prefix = `${indent}[^${meta.identifier}]: `;
         // Strip the inner indent off the first non-empty line so the prefix
         // sits flush, leaving subsequent lines at the four-space indent.
@@ -409,7 +409,7 @@ export default class ExportMarkdown {
         return `${prefix}${stripped}`;
     }
 
-    serializeTable(state: ITableState, indent: string) {
+    private _serializeTable(state: ITableState, indent: string) {
         const result: string[] = [];
         const row = state.children.length;
         const tableData = [];
@@ -487,17 +487,17 @@ export default class ExportMarkdown {
         return `${result.join('\n')}\n`;
     }
 
-    serializeList(
+    private _serializeList(
         state: IBulletListState | IOrderListState | ITaskListState,
         indent: string,
         listIndent: string,
     ) {
         const { children } = state;
 
-        return this.convertStatesToMarkdown(children, indent, listIndent);
+        return this._convertStatesToMarkdown(children, indent, listIndent);
     }
 
-    serializeListItem(
+    private _serializeListItem(
         state: IListItemState | ITaskListItemState,
         indent: string,
     ) {
@@ -551,7 +551,7 @@ export default class ExportMarkdown {
 
         result.push(`${indent}${itemMarker}`);
         result.push(
-            this.convertStatesToMarkdown(children, newIndent, listIndent).substring(
+            this._convertStatesToMarkdown(children, newIndent, listIndent).substring(
                 newIndent.length,
             ),
         );

--- a/packages/muya/src/utils/diagram/plantuml/index.ts
+++ b/packages/muya/src/utils/diagram/plantuml/index.ts
@@ -11,7 +11,7 @@ export default class Diagram {
      */
     static parse(input: string, plantumlServer?: string) {
         const diagram = new Diagram();
-        diagram.encode(input);
+        diagram._encode(input);
         if (plantumlServer)
             diagram.plantumlServer = plantumlServer;
 
@@ -26,7 +26,7 @@ export default class Diagram {
      * 2. Compressed using Deflate or Brotli algorithm
      * 3. Re-encoded in ASCII using a transformation close to base64
      */
-    encode(value: string) {
+    private _encode(value: string) {
         this.encodedInput = plantumlEncoder.encode(value);
     }
 


### PR DESCRIPTION
## What

Second of the staged member-visibility series (stacked on #4535). Marks members of the core engine, state, selection, inline-renderer and plantuml `Diagram` classes `private` (with the now-enforced `_` prefix) when they are used only within their declaring class.

Classes touched: `Editor`, `EventCenter`, `History`, `I18n`, `Clipboard`, `Search`, `JSONState`, `ExportMarkdown`, `MarkdownToHtml`, `Selection` / `TextSelection` / `TableRectSelection`, `InlineRenderer` / `Renderer`, `Diagram` (~46 members).

`tsc` + lint refined an initial audit list and kept these **public** on purpose:
- `JSONState.invert/compose/transform` — the intentional `ot-json1` statics for collaborative editing (documented in `packages/muya/CLAUDE.md`).
- `Renderer.dispatch/getClassName/getHighlightClassName/loadMathMap` — reached from token renderers mixed onto `Renderer.prototype` in sibling files (a TS `private` member is only accessible lexically inside the class body).
- `I18n` simply stops storing its unused `muya` reference.

## Why

Shrinks the package's accidental public surface so the API is intentional; `private` access is now verified by `tsc`.

## Verification
- `pnpm -C packages/muya lint` — 0 errors
- `pnpm -C packages/muya lint:types` — passes
- `pnpm -C packages/muya test` — 983 passed
- `pnpm -C packages/muya test:spec` — 1347 passed

> Stacked on #4535 — review/merge that first; this PR will retarget to `develop` once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)