### PR TITLE
refactor(muya): mark block-tree internals private/protected

### DIFF
--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -317,19 +317,19 @@ function lineBreakAutoPair(
 
 class Content extends TreeNode {
     private _text: string;
-    public isComposed: boolean;
+    protected isComposed: boolean;
 
     static override blockName = 'content';
 
-    get hasSelection() {
+    protected get hasSelection() {
         return !!this.getCursor();
     }
 
-    get selection() {
+    protected get selection() {
         return this.muya.editor.selection;
     }
 
-    get inlineRenderer() {
+    protected get inlineRenderer() {
         return this.muya.editor.inlineRenderer;
     }
 
@@ -363,7 +363,7 @@ class Content extends TreeNode {
         }
     }
 
-    get isCollapsed() {
+    protected get isCollapsed() {
         const { isCollapsed } = this.getCursor() ?? {};
 
         return isCollapsed;
@@ -614,7 +614,7 @@ class Content extends TreeNode {
         return { text, needRender };
     }
 
-    insertTab() {
+    protected insertTab() {
         const { muya, text } = this;
         const { tabSize } = muya.options;
         const tabCharacter = String.fromCharCode(160).repeat(tabSize);
@@ -760,20 +760,6 @@ class Content extends TreeNode {
         }
 
         return ancestors;
-    }
-
-    getCommonAncestors(block: Content) {
-        const myAncestors = this.getAncestors();
-        const blockAncestors = block.getAncestors();
-
-        const commonAncestors = [];
-
-        for (const a of myAncestors) {
-            if (blockAncestors.includes(a))
-                commonAncestors.push(a);
-        }
-
-        return commonAncestors;
     }
 
     override remove(source = 'user') {

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -705,7 +705,7 @@ class Format extends Content {
                 break;
 
             case !!taskList:
-                this.convertToTaskList();
+                this._convertToTaskList();
                 break;
 
             case !!atxHeading:
@@ -868,10 +868,10 @@ class Format extends Content {
         // convert `[*-+] \[[xX ]\] ` to task list.
         const TASK_LIST_REG = /^\[[x ]\] {1,4}/i;
         if (TASK_LIST_REG.test(firstContent.text))
-            firstContent.convertToTaskList();
+            firstContent._convertToTaskList();
     }
 
-    convertToTaskList() {
+    private _convertToTaskList() {
         const { text, parent, muya, hasSelection } = this;
         const { preferLooseListItem } = muya.options;
         const listItem = parent!.parent!;
@@ -1251,7 +1251,7 @@ class Format extends Content {
     }
 
     // Paragraph
-    convertToParagraph(force = false) {
+    protected convertToParagraph(force = false) {
         if (
             !force
             && (this.parent!.blockName === 'setext-heading'
@@ -1472,7 +1472,7 @@ class Format extends Content {
         needRemovedBlock!.remove();
     }
 
-    shiftEnterHandler(event: Event): void {
+    protected shiftEnterHandler(event: Event): void {
         event.preventDefault();
         event.stopPropagation();
 

--- a/packages/muya/src/block/base/parent.ts
+++ b/packages/muya/src/block/base/parent.ts
@@ -48,7 +48,7 @@ class Parent extends TreeNode {
         return this.children.tail;
     }
 
-    get isContainerBlock() {
+    protected get isContainerBlock() {
         // `task-list-item` is intentionally omitted: it shares the
         // `task-list` prefix and would be matched by the alternative above.
         return /block-quote|order-list|bullet-list|task-list|list-item/.test(
@@ -62,7 +62,7 @@ class Parent extends TreeNode {
         return [];
     }
 
-    getJsonPath() {
+    private _getJsonPath() {
         const { path } = this;
         if (this.isContainerBlock)
             path.pop();
@@ -122,7 +122,7 @@ class Parent extends TreeNode {
         // push operations
         if (source === 'user') {
             (args as Parent[]).forEach((node) => {
-                const path = node.getJsonPath();
+                const path = node._getJsonPath();
                 const state = node.getState();
                 this.jsonState.insertOperation(path, state);
             });
@@ -133,7 +133,7 @@ class Parent extends TreeNode {
      * This method will only be used when initialization.
      * @param  {...any} nodes attachment blocks
      */
-    appendAttachment(...nodes: Parent[]) {
+    protected appendAttachment(...nodes: Parent[]) {
         nodes.forEach((node) => {
             node.parent = this;
             const { domNode } = node;
@@ -198,7 +198,7 @@ class Parent extends TreeNode {
 
         if (source === 'user') {
             // dispatch json1 operation
-            const path = newNode.getJsonPath();
+            const path = newNode._getJsonPath();
             const state = newNode.getState();
             this.jsonState.insertOperation(path, state);
         }
@@ -215,7 +215,7 @@ class Parent extends TreeNode {
     override remove(source = 'user') {
         if (source === 'user') {
             // dispatch json1 operation
-            const path = this.getJsonPath();
+            const path = this._getJsonPath();
             this.jsonState.removeOperation(path);
         }
 
@@ -224,7 +224,7 @@ class Parent extends TreeNode {
         return this;
     }
 
-    empty() {
+    protected empty() {
         this.forEach((child) => {
             this.removeChild(child, 'api');
         });

--- a/packages/muya/src/block/base/treeNode.ts
+++ b/packages/muya/src/block/base/treeNode.ts
@@ -27,7 +27,7 @@ class TreeNode implements ILinkedNode {
 
     static blockName = 'tree.node';
 
-    get static(): IConstructor<TreeNode> {
+    protected get static(): IConstructor<TreeNode> {
         // `this.constructor` is `Function` in lib.d.ts; subclasses' generated
         // constructors carry the static `blockName` etc., but TS can't see
         // through `Function` to the subclass shape.

--- a/packages/muya/src/block/commonMark/codeBlock/code.ts
+++ b/packages/muya/src/block/commonMark/codeBlock/code.ts
@@ -75,8 +75,8 @@ class Code extends Parent {
         this.attributes = { spellcheck: 'false' };
         this._withLineNumbers = withLineNumbers;
         this.createDomNode();
-        this.createCopyNode();
-        this.listen();
+        this._createCopyNode();
+        this._listen();
     }
 
     override getState(): TState {
@@ -89,7 +89,7 @@ class Code extends Parent {
     // diagram / html), also create an empty line-numbers wrapper and cache
     // its element so CodeBlockContent.update() can sync rows without a
     // querySelector per keystroke.
-    createCopyNode() {
+    private _createCopyNode() {
         const { i18n, options } = this.muya;
         const withLineNumbers = options.codeBlockLineNumbers && this._withLineNumbers;
         let html = toHTML(renderCopyButton(i18n));
@@ -101,7 +101,7 @@ class Code extends Parent {
             : null;
     }
 
-    listen() {
+    private _listen() {
         const { editor } = this.muya;
 
         if (this.domNode == null)

--- a/packages/muya/src/block/commonMark/headingCopyLink/index.ts
+++ b/packages/muya/src/block/commonMark/headingCopyLink/index.ts
@@ -59,10 +59,10 @@ class HeadingCopyLink extends TreeNode {
         img.setAttribute('alt', '');
         this.domNode!.appendChild(img);
 
-        this.listen();
+        this._listen();
     }
 
-    listen() {
+    private _listen() {
         const { domNode, muya } = this;
         const { eventCenter } = muya;
 
@@ -105,14 +105,14 @@ class HeadingCopyLink extends TreeNode {
         });
     }
 
-    detachDOMEvents() {
+    private _detachDOMEvents() {
         for (const id of this._eventIds)
             this.muya.eventCenter.detachDOMEvent(id);
     }
 
     override remove(_source: string) {
         super.remove();
-        this.detachDOMEvents();
+        this._detachDOMEvents();
 
         return this;
     }

--- a/packages/muya/src/block/commonMark/html/htmlPreview.ts
+++ b/packages/muya/src/block/commonMark/html/htmlPreview.ts
@@ -9,7 +9,7 @@ import Parent from '../../base/parent';
 const debug = logger('htmlPreview:');
 
 class HTMLPreview extends Parent {
-    public html: string;
+    private _html: string;
 
     static override blockName = 'html-preview';
 
@@ -27,7 +27,7 @@ class HTMLPreview extends Parent {
     constructor(muya: Muya, { text }: IHtmlBlockState) {
         super(muya);
         this.tagName = 'div';
-        this.html = text;
+        this._html = text;
         this.classList = [CLASS_NAMES.MU_HTML_PREVIEW];
         this.attributes = {
             spellcheck: 'false',
@@ -37,9 +37,9 @@ class HTMLPreview extends Parent {
         this.update();
     }
 
-    update(html = this.html) {
-        if (this.html !== html)
-            this.html = html;
+    update(html = this._html) {
+        if (this._html !== html)
+            this._html = html;
 
         const { disableHtml } = this.muya.options;
         const htmlContent = sanitize(html, PREVIEW_DOMPURIFY_CONFIG, disableHtml) as string;

--- a/packages/muya/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
@@ -23,7 +23,7 @@ import CodeBlockContent from '../index';
 
 interface IFakeCell {
     text: string;
-    lang: string;
+    _lang: string;
     cursor: { start: number; end: number };
     getCursor: () => { start: { offset: number }; end: { offset: number } };
     setCursor: (start: number, end: number, _selected?: boolean) => void;
@@ -37,7 +37,7 @@ function makeFakeCodeContent(initial: {
 }): IFakeCell {
     return {
         text: initial.text,
-        lang: initial.lang,
+        _lang: initial.lang,
         cursor: { start: initial.cursorAt, end: initial.cursorAt },
         getCursor() {
             return {

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -82,7 +82,7 @@ function hasStateMeta(
 }
 
 class CodeBlockContent extends Content {
-    public initialLang: string;
+    private _initialLang: string;
     public override parent: Code | null = null;
 
     static override blockName = 'codeblock.content';
@@ -93,21 +93,21 @@ class CodeBlockContent extends Content {
         return content;
     }
 
-    get lang() {
-        const { codeContainer } = this;
+    private get _lang() {
+        const { _codeContainer: codeContainer } = this;
 
-        return codeContainer ? codeContainer.lang : this.initialLang;
+        return codeContainer ? codeContainer.lang : this._initialLang;
     }
 
     /**
      * Always be the `pre` element
      */
-    get codeContainer() {
+    private get _codeContainer() {
         return this.parent?.parent;
     }
 
     get outContainer() {
-        const { codeContainer } = this;
+        const { _codeContainer: codeContainer } = this;
 
         return /code-block|frontmatter/.test(codeContainer!.blockName)
             ? codeContainer
@@ -117,9 +117,9 @@ class CodeBlockContent extends Content {
     constructor(muya: Muya, state: CodeContentState) {
         super(muya, state.text);
         if (hasStateMeta(state))
-            this.initialLang = state.meta.lang;
+            this._initialLang = state.meta.lang;
         else
-            this.initialLang = LANG_HASH[state.name];
+            this._initialLang = LANG_HASH[state.name];
 
         this.classList = [...this.classList, 'mu-codeblock-content'];
         // Used for empty status prompts
@@ -133,13 +133,13 @@ class CodeBlockContent extends Content {
     }
 
     // Some block has a preview container, like math, diagram, html, should update the preview if the text changed.
-    updatePreviewIfHave(text: string) {
+    private _updatePreviewIfHave(text: string) {
         if (this.outContainer?.attachments?.length)
             (this.outContainer?.attachments?.head as HTMLPreview).update(text);
     }
 
     override update(_cursor?: IRenderCursor, highlights = []) {
-        const { lang, text } = this;
+        const { _lang: lang, text } = this;
         // transform alias to original language
         const fullLengthLang = transformAliasToOrigin([lang])[0];
         const domNode = this.domNode!;
@@ -206,7 +206,7 @@ class CodeBlockContent extends Content {
         );
         this.text = text;
 
-        this.updatePreviewIfHave(text);
+        this._updatePreviewIfHave(text);
 
         if (needRender) {
             this.setCursor(start!.offset, end!.offset, true);
@@ -269,7 +269,7 @@ class CodeBlockContent extends Content {
     override tabHandler(event: KeyboardEvent): void {
         event.preventDefault();
         const { start, end } = this.getCursor()!;
-        const { lang, text } = this;
+        const { _lang: lang, text } = this;
         const isMarkupCodeContent = /markup|html|xml|svg|mathml/.test(lang);
 
         if (isMarkupCodeContent) {
@@ -368,7 +368,7 @@ class CodeBlockContent extends Content {
             event.preventDefault();
             const { text } = this;
             this.text = text.substring(0, start.offset - 1) + text.substring(start.offset);
-            this.updatePreviewIfHave(this.text);
+            this._updatePreviewIfHave(this.text);
             return this.setCursor(--start.offset, --end.offset, true);
         }
         // The following code is aimed at ensuring compatibility with Firefox.
@@ -377,7 +377,7 @@ class CodeBlockContent extends Content {
         // the backspace key is pressed in Firefox. Therefore, we need to manually
         // simulate the backspace key in order to set the cursor position correctly.
         if (start.offset === end.offset) {
-            const { lang, text } = this;
+            const { _lang: lang, text } = this;
             // transform alias to original language
             const fullLengthLang = transformAliasToOrigin([lang])[0];
             if (fullLengthLang && /\S/.test(text) && loadedLanguages.has(fullLengthLang)) {
@@ -403,7 +403,7 @@ class CodeBlockContent extends Content {
                 if (needRender) {
                     event.preventDefault();
                     this.text = code;
-                    this.updatePreviewIfHave(this.text);
+                    this._updatePreviewIfHave(this.text);
                     return this.setCursor(--start.offset, --end.offset, true);
                 }
             }

--- a/packages/muya/src/block/content/langInputContent/__tests__/handlers.spec.ts
+++ b/packages/muya/src/block/content/langInputContent/__tests__/handlers.spec.ts
@@ -68,7 +68,7 @@ describe('langInputContent.backspaceHandler', () => {
                 start: { offset: 1 },
                 end: { offset: 1 },
             })),
-            updateLanguage: vi.fn(),
+            _updateLanguage: vi.fn(),
             previousContentInContext: vi.fn(() => null),
         };
         const event = makeFakeEvent();
@@ -79,7 +79,7 @@ describe('langInputContent.backspaceHandler', () => {
         );
 
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
-        expect(fakeThis.updateLanguage).toHaveBeenCalledWith('');
+        expect(fakeThis._updateLanguage).toHaveBeenCalledWith('');
         // The {1,1} branch does not also enter the {0,0} branch.
         expect(fakeThis.previousContentInContext).not.toHaveBeenCalled();
     });
@@ -95,7 +95,7 @@ describe('langInputContent.backspaceHandler', () => {
                 start: { offset: 0 },
                 end: { offset: 0 },
             })),
-            updateLanguage: vi.fn(),
+            _updateLanguage: vi.fn(),
             previousContentInContext: vi.fn(() => previousBlock),
         };
         const event = makeFakeEvent();
@@ -109,7 +109,7 @@ describe('langInputContent.backspaceHandler', () => {
         const offset = previousBlock.text.length;
         expect(previousBlock.setCursor).toHaveBeenCalledWith(offset, offset, true);
         // The {0,0} branch must not trigger the single-char updateLanguage path.
-        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+        expect(fakeThis._updateLanguage).not.toHaveBeenCalled();
     });
 
     it('cursor {0,0} with NO previousContentInContext → preventDefault, no caret move, no throw', () => {
@@ -119,7 +119,7 @@ describe('langInputContent.backspaceHandler', () => {
                 start: { offset: 0 },
                 end: { offset: 0 },
             })),
-            updateLanguage: vi.fn(),
+            _updateLanguage: vi.fn(),
             previousContentInContext: vi.fn(() => null),
         };
         const event = makeFakeEvent();
@@ -133,7 +133,7 @@ describe('langInputContent.backspaceHandler', () => {
 
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
         expect(fakeThis.previousContentInContext).toHaveBeenCalledTimes(1);
-        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+        expect(fakeThis._updateLanguage).not.toHaveBeenCalled();
     });
 
     it('cursor in the middle (e.g. {1,1} text length > 1) → neither branch fires, no preventDefault', () => {
@@ -143,7 +143,7 @@ describe('langInputContent.backspaceHandler', () => {
                 start: { offset: 1 },
                 end: { offset: 1 },
             })),
-            updateLanguage: vi.fn(),
+            _updateLanguage: vi.fn(),
             previousContentInContext: vi.fn(() => null),
         };
         const event = makeFakeEvent();
@@ -154,7 +154,7 @@ describe('langInputContent.backspaceHandler', () => {
         );
 
         expect(event.preventDefault).not.toHaveBeenCalled();
-        expect(fakeThis.updateLanguage).not.toHaveBeenCalled();
+        expect(fakeThis._updateLanguage).not.toHaveBeenCalled();
         expect(fakeThis.previousContentInContext).not.toHaveBeenCalled();
     });
 });

--- a/packages/muya/src/block/content/langInputContent/index.ts
+++ b/packages/muya/src/block/content/langInputContent/index.ts
@@ -36,7 +36,7 @@ class LangInputContent extends Content {
      * Update this block lang and parent's lang, and show/hide language selector.
      * @param lang
      */
-    updateLanguage(lang: string) {
+    private _updateLanguage(lang: string) {
         const { start, end } = this.getCursor()!;
         this.text = lang;
         this.parent!.lang = lang;
@@ -49,7 +49,7 @@ class LangInputContent extends Content {
     override inputHandler() {
         const textContent = this.domNode!.textContent ?? '';
         const lang = textContent.split(/\s+/)[0];
-        this.updateLanguage(lang);
+        this._updateLanguage(lang);
     }
 
     override enterHandler(event: Event) {
@@ -67,7 +67,7 @@ class LangInputContent extends Content {
         if (start.offset === 1 && end.offset === 1 && text.length === 1) {
             event.preventDefault();
             const lang = '';
-            this.updateLanguage(lang);
+            this._updateLanguage(lang);
         }
         if (start.offset === 0 && end.offset === 0) {
             event.preventDefault();

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -789,7 +789,7 @@ class ParagraphContent extends Format {
         cursorBlock?.setCursor(start.offset, end.offset, true);
     }
 
-    override insertTab() {
+    protected override insertTab() {
         const { muya, text } = this;
         const { tabSize } = muya.options;
         const tabCharacter = String.fromCharCode(160).repeat(tabSize);

--- a/packages/muya/src/block/content/tableCell/index.ts
+++ b/packages/muya/src/block/content/tableCell/index.ts
@@ -10,7 +10,7 @@ import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
 
 class TableCellContent extends Format {
-    public hasZeroWidthSpaceAtBeginning: boolean = false;
+    private _hasZeroWidthSpaceAtBeginning: boolean = false;
 
     static override blockName = 'table.cell.content';
 
@@ -24,15 +24,15 @@ class TableCellContent extends Format {
         return this.closestBlock('table') as Table;
     }
 
-    get tableInner() {
+    private get _tableInner() {
         return this.closestBlock('table.inner') as TableInner;
     }
 
-    get row() {
+    private get _row() {
         return this.closestBlock('table.row') as Row;
     }
 
-    get cell() {
+    private get _cell() {
         return this.closestBlock('table.cell') as Cell;
     }
 
@@ -50,19 +50,19 @@ class TableCellContent extends Format {
         return this.inlineRenderer.patch(this, cursor, highlights);
     }
 
-    findNextRow() {
-        const { row } = this;
+    private _findNextRow() {
+        const { _row: row } = this;
 
         return row.next || null;
     }
 
-    findPreviousRow() {
-        const { row } = this;
+    private _findPreviousRow() {
+        const { _row: row } = this;
 
         return row.prev || null;
     }
 
-    shiftEnter(event: Event) {
+    private _shiftEnter(event: Event) {
         event.preventDefault();
 
         const { start, end } = this.getCursor()!;
@@ -76,21 +76,21 @@ class TableCellContent extends Format {
         this.setCursor(offset, offset, true);
     }
 
-    commandEnter(event: Event) {
+    private _commandEnter(event: Event) {
         event.preventDefault();
 
-        const offset = this.tableInner.offset(this.row);
+        const offset = this._tableInner.offset(this._row);
         const cursorBlock = this.table.insertRow(
             offset + 1, /* Because insert after the current row */
         );
         cursorBlock.setCursor(0, 0);
     }
 
-    normalEnter(event: Event) {
+    private _normalEnter(event: Event) {
         event.preventDefault();
 
-        const nextRow = this.findNextRow();
-        const { row } = this;
+        const nextRow = this._findNextRow();
+        const { _row: row } = this;
         let cursorBlock = null;
         if (nextRow) {
             cursorBlock = nextRow.firstContentInDescendant();
@@ -125,20 +125,20 @@ class TableCellContent extends Format {
             return;
 
         if (event.shiftKey)
-            return this.shiftEnter(event);
+            return this._shiftEnter(event);
         else if ((isOsx && event.metaKey) || (!isOsx && event.ctrlKey))
-            return this.commandEnter(event);
+            return this._commandEnter(event);
         else
-            return this.normalEnter(event);
+            return this._normalEnter(event);
     }
 
     override arrowHandler(event: Event) {
         if (!isKeyboardEvent(event))
             return;
 
-        const previousRow = this.findPreviousRow();
-        const nextRow = this.findNextRow();
-        const { table, cell, row } = this;
+        const previousRow = this._findPreviousRow();
+        const nextRow = this._findNextRow();
+        const { table, _cell: cell, _row: row } = this;
         const offset = row.offset(cell);
         const tablePrevContent = table.prev
             ? table.prev.lastContentInDescendant()
@@ -259,11 +259,11 @@ class TableCellContent extends Format {
     override composeHandler(event: Event) {
         super.composeHandler(event);
         if (event.type === 'compositionstart' && this.text === '') {
-            this.hasZeroWidthSpaceAtBeginning = true;
+            this._hasZeroWidthSpaceAtBeginning = true;
             this.domNode!.textContent = '\u200B';
         }
-        else if (event.type === 'compositionend' && this.hasZeroWidthSpaceAtBeginning) {
-            this.hasZeroWidthSpaceAtBeginning = false;
+        else if (event.type === 'compositionend' && this._hasZeroWidthSpaceAtBeginning) {
+            this._hasZeroWidthSpaceAtBeginning = false;
             const { text } = this;
             const offset = text.length - 1;
             this.text = text.substring(0, offset);

--- a/packages/muya/src/block/extra/diagram/diagramPreview.ts
+++ b/packages/muya/src/block/extra/diagram/diagramPreview.ts
@@ -72,8 +72,8 @@ async function renderDiagram({
 }
 
 class DiagramPreview extends Parent {
-    public code: string;
-    public type: string;
+    private _code: string;
+    private _type: string;
     static override blockName = 'diagram-preview';
 
     static create(muya: Muya, state: IDiagramState) {
@@ -90,15 +90,15 @@ class DiagramPreview extends Parent {
     constructor(muya: Muya, { text, meta }: IDiagramState) {
         super(muya);
         this.tagName = 'div';
-        this.code = text;
-        this.type = meta.type;
+        this._code = text;
+        this._type = meta.type;
         this.classList = ['mu-diagram-preview'];
         this.attributes = {
             spellcheck: 'false',
             contenteditable: 'false',
         };
         this.createDomNode();
-        this.attachDOMEvents();
+        this._attachDOMEvents();
         this.update();
     }
 
@@ -107,7 +107,7 @@ class DiagramPreview extends Parent {
         return {} as TState;
     }
 
-    attachDOMEvents() {
+    private _attachDOMEvents() {
         const clickObservable = fromEvent(this.domNode!, 'click');
         clickObservable.subscribe(this.clickHandler.bind(this));
     }
@@ -123,15 +123,15 @@ class DiagramPreview extends Parent {
         cursorBlock?.setCursor(0, 0);
     }
 
-    async update(code = this.code) {
+    async update(code = this._code) {
         const { i18n } = this.muya;
-        if (this.code !== code)
-            this.code = code;
+        if (this._code !== code)
+            this._code = code;
 
         if (code) {
             this.domNode!.innerHTML = i18n.t('Loading...');
             const { mermaidTheme, vegaTheme, plantumlServer, sequenceTheme } = this.muya.options;
-            const { type } = this;
+            const { _type: type } = this;
 
             try {
                 await renderDiagram({

--- a/packages/muya/src/block/extra/footnote/index.ts
+++ b/packages/muya/src/block/extra/footnote/index.ts
@@ -58,7 +58,7 @@ class Footnote extends Parent {
         return [...pPath, offset, 'children'];
     }
 
-    override get isContainerBlock() {
+    protected override get isContainerBlock() {
         return true;
     }
 

--- a/packages/muya/src/block/extra/math/mathPreview.ts
+++ b/packages/muya/src/block/extra/math/mathPreview.ts
@@ -10,7 +10,7 @@ import 'katex/dist/contrib/mhchem.min.js';
 const debug = logger('mathPreview:');
 
 class MathPreview extends Parent {
-    public math: string;
+    private _math: string;
 
     static override blockName = 'math-preview';
 
@@ -28,14 +28,14 @@ class MathPreview extends Parent {
     constructor(muya: Muya, { text }: IMathBlockState) {
         super(muya);
         this.tagName = 'div';
-        this.math = text;
+        this._math = text;
         this.classList = ['mu-math-preview'];
         this.attributes = {
             spellcheck: 'false',
             contenteditable: 'false',
         };
         this.createDomNode();
-        this.attachDOMEvents();
+        this._attachDOMEvents();
         this.update();
     }
 
@@ -44,7 +44,7 @@ class MathPreview extends Parent {
         return {} as TState;
     }
 
-    attachDOMEvents() {
+    private _attachDOMEvents() {
         const clickObservable = fromEvent(this.domNode!, 'click');
         clickObservable.subscribe(this.clickHandler.bind(this));
     }
@@ -57,9 +57,9 @@ class MathPreview extends Parent {
         cursorBlock?.setCursor(0, 0);
     }
 
-    update(math = this.math) {
-        if (this.math !== math)
-            this.math = math;
+    update(math = this._math) {
+        if (this._math !== math)
+            this._math = math;
 
         const { i18n } = this.muya;
 

--- a/packages/muya/src/block/gfm/table/index.ts
+++ b/packages/muya/src/block/gfm/table/index.ts
@@ -115,7 +115,7 @@ class Table extends Parent {
         return (this.firstChild as Parent & { queryBlock: (p: TBlockPath) => Parent | Content | undefined }).queryBlock(path);
     }
 
-    override empty() {
+    protected override empty() {
         if (this.isEmpty())
             return;
 

--- a/packages/muya/src/block/gfm/taskListCheckbox/index.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/index.ts
@@ -233,14 +233,14 @@ class TaskListCheckbox extends TreeNode {
             this.domNode.checked = checked;
     }
 
-    detachDOMEvents() {
+    private _detachDOMEvents() {
         for (const id of this._eventIds)
             this.muya.eventCenter.detachDOMEvent(id);
     }
 
     override remove(_source: string) {
         super.remove();
-        this.detachDOMEvents();
+        this._detachDOMEvents();
 
         return this;
     }

--- a/packages/muya/src/block/scrollPage/index.ts
+++ b/packages/muya/src/block/scrollPage/index.ts
@@ -27,11 +27,11 @@ export class ScrollPage extends Parent {
     // makes sense for Parent. Content leaves register themselves through
     // their containing Parent's create flow and don't go through
     // `loadBlock(...).create()` externally.
-    static registeredBlocks = new Map<string, IConstructor<Parent>>();
+    private static _registeredBlocks = new Map<string, IConstructor<Parent>>();
 
     static register(Block: IConstructor<TreeNode>) {
         const { blockName } = Block;
-        this.registeredBlocks.set(blockName, Block as IConstructor<Parent>);
+        this._registeredBlocks.set(blockName, Block as IConstructor<Parent>);
     }
 
     // Returns the registered constructor. Asserts non-undefined for
@@ -40,7 +40,7 @@ export class ScrollPage extends Parent {
     // Mismatched names hit the warn branch and the caller crashes at
     // `.create()` — matches the original loose contract.
     static loadBlock(blockName: string): IConstructor<Parent> {
-        const block = this.registeredBlocks.get(blockName);
+        const block = this._registeredBlocks.get(blockName);
 
         if (!block)
             debug.warn(`block:${blockName} is not existed.`);


### PR DESCRIPTION
## What

Third of the staged member-visibility series (stacked on #4537). Narrows block-hierarchy members:
- **`private`** (with `_` prefix) for members used only within their declaring class — across `TreeNode`, `Parent`, `Content`, `Format`, `ScrollPage`, and the concrete blocks (`Code`, `HeadingCopyLink`, `HTMLPreview`, `CodeBlockContent`, `LangInputContent`, `TableCellContent`, `TaskListCheckbox`, `DiagramPreview`, `MathPreview`).
- **`protected`** for base members used only by subclasses (`Parent.empty/appendAttachment/isContainerBlock`, `Content.isComposed/hasSelection/selection/inlineRenderer/isCollapsed/insertTab`, `Format.convertToParagraph/shiftEnterHandler`, `TreeNode.static`), and the matching overrides (`Table.empty`, `ParagraphContent.insertTab`, `Footnote.isContainerBlock`).

Also removes `Content.getCommonAncestors` — privatizing it surfaced that it has **zero callers** anywhere in the monorepo (dead code).

Event handlers, the tree protocol (`getState`/`create`/`queryBlock`/…), `TaskListCheckbox.syncDom` (called by a module-level helper) and the `ot-json1`-typed structural-access points stay public — `tsc` enforces this.

## Why

Reduces the block tree's accidental public surface; `private`/`protected` access is now verified by `tsc`.

## Verification
- `pnpm -C packages/muya lint` — 0 errors
- `pnpm -C packages/muya lint:types` — passes
- `pnpm -C packages/muya test` — 983 passed (two structural-mock specs updated to the new private names)
- `pnpm -C packages/muya test:spec` — 1347 passed

> Stacked on #4537 → #4535. Review/merge those first; this PR retargets to `develop` once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)