### PR TITLE
refactor(muya): mark UI float-tool internals private

### DIFF
--- a/packages/muya/src/ui/baseFloat/index.ts
+++ b/packages/muya/src/ui/baseFloat/index.ts
@@ -24,12 +24,12 @@ function defaultOptions() {
 const BUTTON_GROUP = ['mu-table-drag-bar', 'mu-front-button'];
 
 abstract class BaseFloat {
-    public options: IBaseOptions;
+    protected options: IBaseOptions;
     public status: boolean = false;
     public floatBox: HTMLElement | null = null;
     public container: HTMLElement | null = null;
-    public lastScrollTop: number | null = null;
-    public cb: (...args: unknown[]) => void = noop;
+    private _lastScrollTop: number | null = null;
+    protected cb: (...args: unknown[]) => void = noop;
 
     private _cleanup: (() => void) | null = null;
     private _resizeObserver: ResizeObserver | null = null;
@@ -91,8 +91,8 @@ abstract class BaseFloat {
         const scrollHandler = (event: Event) => {
             if (!isHTMLElement(event.target))
                 return;
-            if (typeof this.lastScrollTop !== 'number') {
-                this.lastScrollTop = event.target.scrollTop;
+            if (typeof this._lastScrollTop !== 'number') {
+                this._lastScrollTop = event.target.scrollTop;
 
                 return;
             }
@@ -100,7 +100,7 @@ abstract class BaseFloat {
             // only when scroll distance great than 50px, then hide the float box.
             if (
                 this.status
-                && Math.abs(event.target.scrollTop - this.lastScrollTop) > 50
+                && Math.abs(event.target.scrollTop - this._lastScrollTop) > 50
             ) {
                 this.hide();
             }
@@ -137,7 +137,7 @@ abstract class BaseFloat {
         }
 
         this.cb = noop;
-        this.lastScrollTop = null;
+        this._lastScrollTop = null;
 
         if (BUTTON_GROUP.includes(this.name))
             eventCenter.emit('muya-float-button', this, false);

--- a/packages/muya/src/ui/baseScrollFloat/index.ts
+++ b/packages/muya/src/ui/baseScrollFloat/index.ts
@@ -6,23 +6,23 @@ import BaseFloat from '../baseFloat';
 
 abstract class BaseScrollFloat extends BaseFloat {
     public scrollElement: HTMLElement | null = null;
-    public reference: Element | ReferenceElement | null = null;
+    private _reference: Element | ReferenceElement | null = null;
     public activeItem: unknown | null = null;
     public renderArray: unknown[] = [];
 
     constructor(muya: Muya, name: string, options = {}) {
         super(muya, name, options);
-        this.createScrollElement();
+        this._createScrollElement();
     }
 
-    createScrollElement() {
+    private _createScrollElement() {
         const { container } = this;
         const scrollElement = document.createElement('div');
         container!.appendChild(scrollElement);
         this.scrollElement = scrollElement;
     }
 
-    activeEleScrollIntoView(ele: HTMLElement) {
+    protected activeEleScrollIntoView(ele: HTMLElement) {
         if (ele) {
             ele.scrollIntoView({
                 behavior: 'smooth',
@@ -64,7 +64,7 @@ abstract class BaseScrollFloat extends BaseFloat {
 
     override hide() {
         super.hide();
-        this.reference = null;
+        this._reference = null;
     }
 
     override show(reference: Element | ReferenceElement, cb: (...args: never[]) => void = noop) {
@@ -73,11 +73,11 @@ abstract class BaseScrollFloat extends BaseFloat {
         this.cb = cb as (...args: unknown[]) => void;
 
         if (reference instanceof HTMLElement) {
-            if (this.reference && this.reference === reference && this.status)
+            if (this._reference && this._reference === reference && this.status)
                 return;
         }
 
-        this.reference = reference;
+        this._reference = reference;
         super.show(reference, cb);
     }
 

--- a/packages/muya/src/ui/imageResizeBar/index.ts
+++ b/packages/muya/src/ui/imageResizeBar/index.ts
@@ -34,10 +34,10 @@ export class ImageResizeBar {
         container.classList.add('mu-transformer');
         document.body.appendChild(container);
 
-        this.listen();
+        this._listen();
     }
 
-    listen() {
+    private _listen() {
         const { eventCenter, domNode } = this.muya;
 
         const scrollHandler = (event: Event) => {
@@ -65,7 +65,7 @@ export class ImageResizeBar {
                 this._block = block;
                 this._imageInfo = imageInfo;
                 setTimeout(() => {
-                    this.render();
+                    this._render();
                 });
             }
             else {
@@ -77,22 +77,22 @@ export class ImageResizeBar {
         eventCenter.attachDOMEvent(findScrollContainer(domNode), 'scroll', scrollHandler);
         eventCenter.attachDOMEvent(this._container, 'dragstart', event =>
             event.preventDefault());
-        eventCenter.attachDOMEvent(document.body, 'mousedown', this.mouseDown);
+        eventCenter.attachDOMEvent(document.body, 'mousedown', this._mouseDown);
     }
 
-    render() {
+    private _render() {
         const { eventCenter } = this.muya;
         if (this._status)
             this.hide();
 
         this._status = true;
 
-        this.createElements();
-        this.update();
+        this._createElements();
+        this._update();
         eventCenter.emit('muya-float', this, true);
     }
 
-    createElements() {
+    private _createElements() {
         VERTICAL_BAR.forEach((c) => {
             const bar = document.createElement('div');
             bar.classList.add('bar');
@@ -102,7 +102,7 @@ export class ImageResizeBar {
         });
     }
 
-    update() {
+    private _update() {
         const rect = this._reference!.getBoundingClientRect();
         VERTICAL_BAR.forEach((c) => {
             const bar: HTMLDivElement = this._container.querySelector(`.${c}`)!;
@@ -121,7 +121,7 @@ export class ImageResizeBar {
         });
     }
 
-    mouseDown = (event: Event) => {
+    private _mouseDown = (event: Event) => {
         if (!isHTMLElement(event.target) || !event.target.closest('.bar'))
             return;
 
@@ -131,12 +131,12 @@ export class ImageResizeBar {
         const mouseMoveId = eventCenter.attachDOMEvent(
             document.body,
             'mousemove',
-            this.mouseMove,
+            this._mouseMove,
         );
         const mouseUpId = eventCenter.attachDOMEvent(
             document.body,
             'mouseup',
-            this.mouseUp,
+            this._mouseUp,
         );
         this._resizing = true;
         // Hide image toolbar
@@ -144,7 +144,7 @@ export class ImageResizeBar {
         this._eventId.push(mouseMoveId, mouseUpId);
     };
 
-    mouseMove = (event: Event) => {
+    private _mouseMove = (event: Event) => {
         if (!isMouseEvent(event))
             return;
 
@@ -177,10 +177,10 @@ export class ImageResizeBar {
         width = Number.parseInt(String(width));
         this._width = width;
         image.setAttribute('width', String(width));
-        this.update();
+        this._update();
     };
 
-    mouseUp = (event: Event) => {
+    private _mouseUp = (event: Event) => {
         event.preventDefault();
         const { eventCenter } = this.muya;
         if (this._eventId.length) {

--- a/packages/muya/src/ui/imageToolbar/index.ts
+++ b/packages/muya/src/ui/imageToolbar/index.ts
@@ -55,7 +55,7 @@ export class ImageToolBar extends BaseFloat {
                 this._imageInfo = imageInfo;
                 setTimeout(() => {
                     this.show(reference);
-                    this.render();
+                    this._render();
                 }, 0);
             }
             else {
@@ -64,7 +64,7 @@ export class ImageToolBar extends BaseFloat {
         });
     }
 
-    render() {
+    private _render() {
         const { _icons: icons, _oldVNode: oldVNode, _toolbarContainer: toolbarContainer, _imageInfo: imageInfo } = this;
         const { i18n } = this.muya;
         const { attrs } = imageInfo!.token;
@@ -101,7 +101,7 @@ export class ImageToolBar extends BaseFloat {
                     },
                     on: {
                         click: (event) => {
-                            this.selectItem(event, i);
+                            this._selectItem(event, i);
                         },
                     },
                 },
@@ -119,7 +119,7 @@ export class ImageToolBar extends BaseFloat {
         this._oldVNode = vnode;
     }
 
-    selectItem(event: Event, item: Icon) {
+    private _selectItem(event: Event, item: Icon) {
         event.preventDefault();
         event.stopPropagation();
 

--- a/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -17,9 +17,23 @@ import LinkTools from '../index';
 // then poke `selectItem` directly to verify each branch dispatches to
 // the right collaborator.
 
+// White-box view onto LinkTools' private render state, which these tests
+// inject directly to exercise `selectItem`'s dispatch branches.
+interface ILinkToolsView {
+    _linkBlock: Format | null;
+    _linkInfo: {
+        href?: string;
+        text?: string;
+        raw?: string;
+        range?: { start: number; end: number } | null;
+    } | null;
+    selectItem: (event: Event, item: { type: string; icon: string }) => void;
+    destroy: () => void;
+}
+
 interface ITestSession {
     muya: Muya;
-    tools: LinkTools;
+    tools: ILinkToolsView;
     domNode: HTMLElement;
 }
 
@@ -44,7 +58,7 @@ interface ILinkToolsTestOptions {
 
 function bootLinkTools(options: ILinkToolsTestOptions = {}): ITestSession {
     const { muya, domNode } = makeFakeMuya();
-    const tools = new LinkTools(muya, options);
+    const tools = new LinkTools(muya, options) as unknown as ILinkToolsView;
     const session = { muya, tools, domNode };
     sessions.push(session);
     return session;
@@ -76,8 +90,8 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
         const blockUnlink = vi.fn();
         // linkBlock is typed as Format | null; the fake only implements
         // `unlink` (the only method selectItem calls).
-        tools.linkBlock = { unlink: blockUnlink } as unknown as Format;
-        tools.linkInfo = {
+        tools._linkBlock = { unlink: blockUnlink } as unknown as Format;
+        tools._linkInfo = {
             href: 'https://example.com',
             text: 'hi',
             raw: '[hi](https://example.com)',
@@ -95,8 +109,8 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
 
     it('unlink: no-ops when block is missing (defensive)', () => {
         const { tools } = bootLinkTools();
-        tools.linkBlock = null;
-        tools.linkInfo = { href: 'x', text: 'y', range: { start: 0, end: 1 } };
+        tools._linkBlock = null;
+        tools._linkInfo = { href: 'x', text: 'y', range: { start: 0, end: 1 } };
 
         // Should not throw.
         tools.selectItem(makeFakeEvent(), { type: 'unlink', icon: '' });
@@ -107,8 +121,8 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
         const blockUnlink = vi.fn();
         // linkBlock is typed as Format | null; the fake only implements
         // `unlink` (the only method selectItem calls).
-        tools.linkBlock = { unlink: blockUnlink } as unknown as Format;
-        tools.linkInfo = { href: 'x', text: 'y', range: null };
+        tools._linkBlock = { unlink: blockUnlink } as unknown as Format;
+        tools._linkInfo = { href: 'x', text: 'y', range: null };
 
         tools.selectItem(makeFakeEvent(), { type: 'unlink', icon: '' });
 
@@ -120,7 +134,7 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
         const { tools } = bootLinkTools({ jumpClick });
 
         const linkInfo = { href: 'https://example.com' };
-        tools.linkInfo = linkInfo;
+        tools._linkInfo = linkInfo;
 
         tools.selectItem(makeFakeEvent(), { type: 'jump', icon: '' });
 

--- a/packages/muya/src/ui/linkTools/index.ts
+++ b/packages/muya/src/ui/linkTools/index.ts
@@ -42,19 +42,19 @@ class LinkTools extends BaseFloat {
     static pluginName = 'linkTools';
 
     public override options: ILinkToolsOptions;
-    public oldVNode: VNode | null = null;
-    public linkInfo: ILinkInfo | null = null;
-    public linkBlock: Format | null = null;
-    public icons: LinkToolIcon[] = iconsConfig;
-    public hideTimer: ReturnType<typeof setTimeout> | null = null;
-    public linkContainer: HTMLElement;
+    private _oldVNode: VNode | null = null;
+    private _linkInfo: ILinkInfo | null = null;
+    private _linkBlock: Format | null = null;
+    private _icons: LinkToolIcon[] = iconsConfig;
+    private _hideTimer: ReturnType<typeof setTimeout> | null = null;
+    private _linkContainer: HTMLElement;
 
     constructor(muya: Muya, options: Partial<ILinkToolsOptions> = {}) {
         const name = 'mu-link-tools';
         const opts: ILinkToolsOptions = Object.assign({}, defaultOptions, options);
         super(muya, name, opts);
         this.options = opts;
-        const linkContainer = (this.linkContainer = document.createElement('div'));
+        const linkContainer = (this._linkContainer = document.createElement('div'));
         this.container!.appendChild(linkContainer);
         // Add a per-instance class on the floatBox so the parent
         // `.mu-float-wrapper` is identifiable in DOM and reachable by
@@ -68,26 +68,26 @@ class LinkTools extends BaseFloat {
         super.listen();
         eventCenter.subscribe('muya-link-tools', ({ reference, linkInfo, block }: ILinkToolsEventPayload) => {
             if (reference) {
-                this.linkInfo = linkInfo ?? null;
-                this.linkBlock = block ?? null;
+                this._linkInfo = linkInfo ?? null;
+                this._linkBlock = block ?? null;
                 setTimeout(() => {
                     this.show(reference);
                     this.render();
                 }, 0);
             }
             else {
-                if (this.hideTimer)
-                    clearTimeout(this.hideTimer);
+                if (this._hideTimer)
+                    clearTimeout(this._hideTimer);
 
-                this.hideTimer = setTimeout(() => {
+                this._hideTimer = setTimeout(() => {
                     this.hide();
                 }, 500);
             }
         });
 
         const mouseOverHandler = () => {
-            if (this.hideTimer)
-                clearTimeout(this.hideTimer);
+            if (this._hideTimer)
+                clearTimeout(this._hideTimer);
         };
 
         const mouseOutHandler = () => {
@@ -99,7 +99,7 @@ class LinkTools extends BaseFloat {
     }
 
     render() {
-        const { icons, oldVNode, linkContainer } = this;
+        const { _icons: icons, _oldVNode: oldVNode, _linkContainer: linkContainer } = this;
         const children = icons.map((i) => {
             let icon: VNode | undefined;
             let iconWrapperSelector: string | undefined;
@@ -143,7 +143,7 @@ class LinkTools extends BaseFloat {
         else
             patch(linkContainer, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     selectItem(event: Event, item: LinkToolIcon) {
@@ -151,8 +151,8 @@ class LinkTools extends BaseFloat {
         event.stopPropagation();
         switch (item.type) {
             case 'unlink': {
-                const block = this.linkBlock;
-                const linkInfo = this.linkInfo;
+                const block = this._linkBlock;
+                const linkInfo = this._linkInfo;
                 if (block && linkInfo && linkInfo.range) {
                     block.unlink({
                         range: linkInfo.range,
@@ -164,7 +164,7 @@ class LinkTools extends BaseFloat {
             }
 
             case 'jump':
-                this.options.jumpClick?.(this.linkInfo);
+                this.options.jumpClick?.(this._linkInfo);
                 this.hide();
                 break;
         }

--- a/packages/muya/src/ui/paragraphFrontButton/index.ts
+++ b/packages/muya/src/ui/paragraphFrontButton/index.ts
@@ -50,7 +50,7 @@ function isOrderOrBulletList(block: Parent): block is OrderList | BulletList {
 
 export class ParagraphFrontButton {
     public name: string = 'mu-front-button';
-    public resizeObserver: ResizeObserver | null = null;
+    private _resizeObserver: ResizeObserver | null = null;
     private _options: IBaseOptions;
     private _block: Parent | null = null;
     private _oldVNode: VNode | null = null;
@@ -88,7 +88,7 @@ export class ParagraphFrontButton {
 
         // Since the size of the container is not fixed and changes according to the change of content,
         // the floatBox needs to set the size according to the container size
-        const resizeObserver = (this.resizeObserver = new ResizeObserver(() => {
+        const resizeObserver = (this._resizeObserver = new ResizeObserver(() => {
             // Use requestAnimationFrame to avoid "ResizeObserver loop completed" warning
             requestAnimationFrame(() => {
                 const { offsetWidth, offsetHeight } = container;
@@ -147,29 +147,29 @@ export class ParagraphFrontButton {
             });
         };
 
-        eventCenter.attachDOMEvent(container, 'mousedown', this.dragBarMouseDown);
-        eventCenter.attachDOMEvent(container, 'mouseup', this.dragBarMouseUp);
+        eventCenter.attachDOMEvent(container, 'mousedown', this._dragBarMouseDown);
+        eventCenter.attachDOMEvent(container, 'mouseup', this._dragBarMouseUp);
         eventCenter.attachDOMEvent(document, 'mousemove', mousemoveHandler);
         eventCenter.attachDOMEvent(container, 'click', clickHandler);
     }
 
-    dragBarMouseDown = (event: Event) => {
+    private _dragBarMouseDown = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
         this._dragTimer = setTimeout(() => {
-            this.startDrag();
+            this._startDrag();
             this._dragTimer = null;
         }, 300);
     };
 
-    dragBarMouseUp = () => {
+    private _dragBarMouseUp = () => {
         if (this._dragTimer) {
             clearTimeout(this._dragTimer);
             this._dragTimer = null;
         }
     };
 
-    mouseMove = (event: Event) => {
+    private _mouseMove = (event: Event) => {
         if (!this._dragInfo || !isMouseEvent(event))
             return;
 
@@ -185,7 +185,7 @@ export class ParagraphFrontButton {
                 ele[BLOCK_DOM_PROPERTY]
                 && (ele[BLOCK_DOM_PROPERTY] as Parent).isOutMostBlock,
         );
-        this.moveShadow(event);
+        this._moveShadow(event);
 
         if (
             outMostElement
@@ -195,7 +195,7 @@ export class ParagraphFrontButton {
             const block = outMostElement[BLOCK_DOM_PROPERTY];
             const rect = outMostElement.getBoundingClientRect();
             const position = verticalPositionInRect(event, rect);
-            this.createStyledGhost(rect, position);
+            this._createStyledGhost(rect, position);
 
             Object.assign(this._dragInfo, {
                 target: block,
@@ -212,7 +212,7 @@ export class ParagraphFrontButton {
         }
     };
 
-    mouseUp = (event: Event) => {
+    private _mouseUp = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
 
@@ -223,7 +223,7 @@ export class ParagraphFrontButton {
         if (this._ghost)
             this._ghost.remove();
 
-        this.destroyShadow();
+        this._destroyShadow();
         document.body.style.cursor = 'auto';
         this._dragTimer = null;
         const { block, target, position } = this._dragInfo || {};
@@ -259,7 +259,7 @@ export class ParagraphFrontButton {
         this._dragInfo = null;
     };
 
-    startDrag = () => {
+    private _startDrag = () => {
         const { _block: block } = this;
         // Frontmatter should not be drag.
         if (!block || block.blockName === 'frontmatter')
@@ -269,7 +269,7 @@ export class ParagraphFrontButton {
         this._dragInfo = {
             block,
         };
-        this.createStyledShadow();
+        this._createStyledShadow();
         this.hide();
         const { eventCenter } = this.muya;
 
@@ -279,13 +279,13 @@ export class ParagraphFrontButton {
             eventCenter.attachDOMEvent(
                 document,
                 'mousemove',
-                throttle(this.mouseMove, 100),
+                throttle(this._mouseMove, 100),
             ),
-            eventCenter.attachDOMEvent(document, 'mouseup', this.mouseUp),
+            eventCenter.attachDOMEvent(document, 'mouseup', this._mouseUp),
         ];
     };
 
-    createStyledGhost(rect: DOMRect, position: 'down' | 'up') {
+    private _createStyledGhost(rect: DOMRect, position: 'down' | 'up') {
         let ghost = this._ghost;
         if (!ghost) {
             ghost = document.createElement('div');
@@ -301,7 +301,7 @@ export class ParagraphFrontButton {
         });
     }
 
-    createStyledShadow() {
+    private _createStyledShadow() {
         const { domNode } = this._block!;
         const { width, top, left } = domNode!.getBoundingClientRect();
         const shadow = document.createElement('div');
@@ -316,7 +316,7 @@ export class ParagraphFrontButton {
         this._shadow = shadow;
     }
 
-    moveShadow(event: Event) {
+    private _moveShadow(event: Event) {
         const { _shadow: shadow } = this;
         // The shadow already be removed.
         if (!shadow || !isMouseEvent(event))
@@ -328,7 +328,7 @@ export class ParagraphFrontButton {
         });
     }
 
-    destroyShadow() {
+    private _destroyShadow() {
         const { _shadow: shadow } = this;
         if (shadow) {
             shadow.remove();
@@ -438,8 +438,8 @@ export class ParagraphFrontButton {
     }
 
     destroy() {
-        if (this._container && this.resizeObserver)
-            this.resizeObserver.unobserve(this._container);
+        if (this._container && this._resizeObserver)
+            this._resizeObserver.unobserve(this._container);
 
         if (this._cleanup) {
             this._cleanup();

--- a/packages/muya/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/muya/src/ui/paragraphFrontMenu/index.ts
@@ -49,7 +49,6 @@ const defaultOptions = {
 
 export class ParagraphFrontMenu extends BaseFloat {
     static pluginName = 'frontMenu';
-    public reference: HTMLDivElement | null = null;
     private _oldVNode: VNode | null = null;
     private _block: Parent | null = null;
     private _frontMenuContainer: HTMLDivElement = document.createElement('div');
@@ -76,7 +75,6 @@ export class ParagraphFrontMenu extends BaseFloat {
         eventCenter.subscribe('muya-front-menu', ({ reference, block }) => {
             if (reference) {
                 this._block = block;
-                this.reference = reference;
 
                 setTimeout(() => {
                     this.show(reference);
@@ -87,14 +85,13 @@ export class ParagraphFrontMenu extends BaseFloat {
 
         const enterLeaveHandler = () => {
             this.hide();
-            this.reference = null;
             this._block = null;
         };
 
         eventCenter.attachDOMEvent(container!, 'mouseleave', enterLeaveHandler);
     }
 
-    renderSubMenu(subMenu: IQuickInsertMenuItem['children']) {
+    private _renderSubMenu(subMenu: IQuickInsertMenuItem['children']) {
         const { _block: block } = this;
         const { i18n } = this.muya;
         const children = subMenu.map((menuItem) => {
@@ -173,7 +170,7 @@ export class ParagraphFrontMenu extends BaseFloat {
         if (subMenu.length) {
             const line = h('li.divider');
             children.unshift(line);
-            children.unshift(this.renderSubMenu(subMenu));
+            children.unshift(this._renderSubMenu(subMenu));
         }
 
         const vnode = h('ul', children);

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
@@ -56,11 +56,22 @@ function bootMuya(markdown: string): Muya {
 
 // Boot the editor over a single empty paragraph and hand back the menu with its
 // `block` already pointed at the paragraph's content leaf.
-function bootMenu(): { muya: Muya; menu: ParagraphQuickInsertMenu } {
+// White-box view onto the menu's private `_block` field and `_search` method,
+// which these characterization tests drive directly.
+interface IMenuView {
+    _block: ParagraphContent | null;
+    _search: (text: string) => void;
+    renderData: ParagraphQuickInsertMenu['renderData'];
+    renderArray: ParagraphQuickInsertMenu['renderArray'];
+    scrollElement: ParagraphQuickInsertMenu['scrollElement'];
+    activeItem: ParagraphQuickInsertMenu['activeItem'];
+}
+
+function bootMenu(): { muya: Muya; menu: IMenuView } {
     const muya = bootMuya('\n');
-    const menu = new ParagraphQuickInsertMenu(muya);
+    const menu = new ParagraphQuickInsertMenu(muya) as unknown as IMenuView;
     const first = muya.editor.scrollPage!.firstContentInDescendant()!;
-    menu.block = first as unknown as ParagraphContent;
+    menu._block = first as unknown as ParagraphContent;
 
     return { muya, menu };
 }
@@ -69,7 +80,7 @@ describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () =>
     it('search("") returns the full menu config (frontmatter included on an empty doc-start paragraph)', () => {
         const { menu } = bootMenu();
 
-        menu.search('');
+        menu._search('');
 
         const sectionNames = menu.renderData.map(d => d.name);
         expect(sectionNames).toEqual([
@@ -94,7 +105,7 @@ describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () =>
         const { menu } = bootMenu();
 
         // '代码块' is the zh-CN translation of 'Code Block'.
-        menu.search('代码');
+        menu._search('代码');
 
         expect(menu.renderData.map(d => d.name)).toEqual(['advanced blocks']);
         const matched = menu.renderData[0].children;
@@ -109,7 +120,7 @@ describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () =>
         const { menu } = bootMenu();
 
         // '表格' is the zh-CN translation of 'Table Block'.
-        menu.search('表格');
+        menu._search('表格');
 
         // 'table' (advanced blocks) is the exact match and sorts first.
         expect(menu.renderData[0].name).toBe('advanced blocks');
@@ -124,7 +135,7 @@ describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () =>
 
         // The character '表' appears in '表格' (Table Block, advanced blocks) and
         // in '任务列表'/etc. (list blocks), so two sections match.
-        menu.search('表');
+        menu._search('表');
 
         expect(menu.renderData.length).toBeGreaterThan(1);
         // 'advanced blocks' (table, best score) sorts ahead of 'list blocks'.
@@ -140,7 +151,7 @@ describe('paragraphQuickInsertMenu search() — zh-CN localized matching', () =>
     it('search("zzzzz") yields empty renderData', () => {
         const { menu } = bootMenu();
 
-        menu.search('zzzzz');
+        menu._search('zzzzz');
 
         expect(menu.renderData).toEqual([]);
         expect(menu.renderArray).toEqual([]);
@@ -152,7 +163,7 @@ describe('paragraphQuickInsertMenu render() — DOM output', () => {
         const { menu } = bootMenu();
 
         // search() calls render() internally; the no-result node lands in the DOM.
-        menu.search('zzzzz');
+        menu._search('zzzzz');
 
         const noResult = menu.scrollElement!.querySelector('.no-result');
         expect(noResult).not.toBeNull();
@@ -165,7 +176,7 @@ describe('paragraphQuickInsertMenu render() — DOM output', () => {
     it('a match renders one <section> per matched group with exactly one .item.active', () => {
         const { menu } = bootMenu();
 
-        menu.search('表');
+        menu._search('表');
 
         const sections = menu.scrollElement!.querySelectorAll('section');
         expect(sections.length).toBe(menu.renderData.length);
@@ -180,7 +191,7 @@ describe('paragraphQuickInsertMenu render() — DOM output', () => {
     it('renderArray is the flattened children of every matched section', () => {
         const { menu } = bootMenu();
 
-        menu.search('列表');
+        menu._search('列表');
 
         const flattened = menu.renderData.flatMap(d => d.children);
         expect(menu.renderArray).toEqual(flattened);

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
@@ -33,7 +33,7 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
     static pluginName = 'quickInsert';
 
     public oldVNode: VNode | null = null;
-    public block: ParagraphContent | null = null;
+    private _block: ParagraphContent | null = null;
     public override activeItem: IQuickInsertMenuItem['children'][number] | null = null;
     public override renderArray: IQuickInsertMenuItem['children'] = [];
     private _renderData: IQuickInsertMenuItem[] = [];
@@ -81,9 +81,9 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
                 domNode!.removeAttribute('placeholder');
 
             if (needToShowQuickInsert) {
-                this.block = block;
+                this._block = block;
                 this.show(domNode);
-                this.search(text.substring(1)); // remove `/` char
+                this._search(text.substring(1)); // remove `/` char
             }
             else {
                 this.hide();
@@ -183,8 +183,8 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
         this.oldVNode = vnode;
     }
 
-    search(text: string) {
-        const { muya, block } = this;
+    private _search(text: string) {
+        const { muya, _block: block } = this;
         const { i18n } = muya;
         const canInsertFrontMatter = checkCanInsertFrontMatter(muya, block!);
         const menuConfig = deepClone(MENU_CONFIG);
@@ -229,7 +229,7 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
     }
 
     override selectItem({ label }: IQuickInsertMenuItem['children'][number]) {
-        const { block, muya } = this;
+        const { _block: block, muya } = this;
         replaceBlockByLabel({
             label,
             block: block!.parent!,

--- a/packages/muya/src/ui/tableChessboard/index.ts
+++ b/packages/muya/src/ui/tableChessboard/index.ts
@@ -44,7 +44,7 @@ class TablePicker extends BaseFloat {
         super.listen();
         eventCenter.subscribe('muya-table-picker', (data, reference, cb) => {
             if (!this.status) {
-                this.showPicker(data, reference, cb);
+                this._showPicker(data, reference, cb);
                 this.render();
             }
             else {
@@ -112,7 +112,7 @@ class TablePicker extends BaseFloat {
                 },
                 on: {
                     keyup: (event: KeyboardEvent) => {
-                        this.keyupHandler(event, 'row');
+                        this._keyupHandler(event, 'row');
                     },
                 },
             }),
@@ -124,7 +124,7 @@ class TablePicker extends BaseFloat {
                 },
                 on: {
                     keyup: (event: KeyboardEvent) => {
-                        this.keyupHandler(event, 'column');
+                        this._keyupHandler(event, 'column');
                     },
                 },
             }),
@@ -151,7 +151,7 @@ class TablePicker extends BaseFloat {
         this._oldVNode = vnode;
     }
 
-    keyupHandler(event: KeyboardEvent, type: 'row' | 'column') {
+    private _keyupHandler(event: KeyboardEvent, type: 'row' | 'column') {
         let number = +this._select![type];
         const value = isHTMLInputElement(event.target) ? +event.target.value : Number.NaN;
         if (event.key === EVENT_KEYS.ArrowUp)
@@ -169,7 +169,7 @@ class TablePicker extends BaseFloat {
         }
     }
 
-    showPicker(current: ICheckerCount, reference: ReferenceElement, cb: (row: number, column: number) => void) {
+    private _showPicker(current: ICheckerCount, reference: ReferenceElement, cb: (row: number, column: number) => void) {
     // current { row, column } zero base
         this._current = current;
         // Clone so footer-input edits mutating `_select` never corrupt the

--- a/packages/muya/src/ui/tableColumnToolbar/index.ts
+++ b/packages/muya/src/ui/tableColumnToolbar/index.ts
@@ -23,10 +23,10 @@ const defaultOptions = {
 };
 
 export class TableColumnToolbar extends BaseFloat {
-    public oldVNode: VNode | null = null;
-    public block: CellBlock | null = null;
-    public icons: TableColumnToolIcon[] = icons;
-    public toolsContainer: HTMLDivElement = document.createElement('div');
+    private _oldVNode: VNode | null = null;
+    private _block: CellBlock | null = null;
+    private _icons: TableColumnToolIcon[] = icons;
+    private _toolsContainer: HTMLDivElement = document.createElement('div');
 
     static pluginName = 'tableColumnTools';
 
@@ -35,7 +35,7 @@ export class TableColumnToolbar extends BaseFloat {
         const opts = Object.assign({}, defaultOptions, options);
         super(muya, name, opts);
         this.options = opts;
-        this.container!.appendChild(this.toolsContainer);
+        this.container!.appendChild(this._toolsContainer);
         this.floatBox!.classList.add('mu-table-column-tools-container');
         this.listen();
     }
@@ -72,7 +72,7 @@ export class TableColumnToolbar extends BaseFloat {
                         && ele[BLOCK_DOM_PROPERTY].blockName === 'table.cell',
                 );
                 const cellBlock = tableCellEle![BLOCK_DOM_PROPERTY];
-                this.block = cellBlock as CellBlock;
+                this._block = cellBlock as CellBlock;
                 this.show(tableCellEle!);
                 this.render();
             }
@@ -85,7 +85,7 @@ export class TableColumnToolbar extends BaseFloat {
     }
 
     render() {
-        const { icons, oldVNode, toolsContainer, block } = this;
+        const { _icons: icons, _oldVNode: oldVNode, _toolsContainer: toolsContainer, _block: block } = this;
         const { i18n } = this.muya;
         const children = icons.map((i) => {
             const iconWrapperSelector = 'div.icon-wrapper';
@@ -134,21 +134,21 @@ export class TableColumnToolbar extends BaseFloat {
         else
             patch(toolsContainer, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     selectItem(event: Event, item: TableColumnToolIcon) {
         event.preventDefault();
         event.stopPropagation();
 
-        const { block } = this;
+        const { _block: block } = this;
         // Block is not null, just in case
         if (!block || !block.parent)
             return;
 
         const offset = block.parent.offset(block);
         const { table, row } = block;
-        const columnCount = row.offset(this.block!);
+        const columnCount = row.offset(this._block!);
 
         switch (item.type) {
             case 'remove': {

--- a/packages/muya/src/ui/tableDragBar/index.ts
+++ b/packages/muya/src/ui/tableDragBar/index.ts
@@ -215,7 +215,7 @@ export class TableDragBar extends BaseFloat {
                 this._barType = barType;
                 this._block = cellBlock;
                 this.show(tableCellEl!);
-                this.render(barType);
+                this._render(barType);
             }
             else {
                 this.hide();
@@ -223,20 +223,20 @@ export class TableDragBar extends BaseFloat {
         });
 
         eventCenter.attachDOMEvent(document.body, 'mousemove', handler);
-        eventCenter.attachDOMEvent(container!, 'mousedown', this.mousedown);
-        eventCenter.attachDOMEvent(container!, 'mouseup', this.mouseup);
+        eventCenter.attachDOMEvent(container!, 'mousedown', this._mousedown);
+        eventCenter.attachDOMEvent(container!, 'mouseup', this._mouseup);
     }
 
-    mousedown = (event: Event) => {
+    private _mousedown = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
         this._mouseTimer = setTimeout(() => {
-            this.startDrag(event);
+            this._startDrag(event);
             this._mouseTimer = null;
         }, 300);
     };
 
-    mouseup = (event: Event) => {
+    private _mouseup = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
         const { container, _barType: barType } = this;
@@ -259,7 +259,7 @@ export class TableDragBar extends BaseFloat {
         }
     };
 
-    startDrag(event: Event) {
+    private _startDrag(event: Event) {
         event.preventDefault();
         if (!isMouseEvent(event) || !this._block || !this._barType)
             return;
@@ -291,12 +291,12 @@ export class TableDragBar extends BaseFloat {
         }
 
         this._dragEventIds.push(
-            eventCenter.attachDOMEvent(document, 'mousemove', this.docMousemove),
-            eventCenter.attachDOMEvent(document, 'mouseup', this.docMouseup),
+            eventCenter.attachDOMEvent(document, 'mousemove', this._docMousemove),
+            eventCenter.attachDOMEvent(document, 'mouseup', this._docMouseup),
         );
     }
 
-    docMousemove = (event: Event) => {
+    private _docMousemove = (event: Event) => {
         if (!this._dragInfo || !isMouseEvent(event))
             return;
 
@@ -308,12 +308,12 @@ export class TableDragBar extends BaseFloat {
             return;
 
         this._isDragTableBar = true;
-        this.calculateCurIndex();
-        this.setDragTargetStyle();
-        this.setSwitchStyle();
+        this._calculateCurIndex();
+        this._setDragTargetStyle();
+        this._setSwitchStyle();
     };
 
-    docMouseup = (event: Event) => {
+    private _docMouseup = (event: Event) => {
         event.preventDefault();
 
         const { eventCenter } = this.muya;
@@ -325,16 +325,16 @@ export class TableDragBar extends BaseFloat {
         if (!this._isDragTableBar)
             return;
 
-        this.setDropTargetStyle();
+        this._setDropTargetStyle();
 
         // The drop animation need 300ms.
         setTimeout(() => {
-            this.switchTableData();
-            this.resetDragTableBar();
+            this._switchTableData();
+            this._resetDragTableBar();
         }, 300);
     };
 
-    calculateCurIndex = () => {
+    private _calculateCurIndex = () => {
         if (!this._dragInfo)
             return;
 
@@ -375,7 +375,7 @@ export class TableDragBar extends BaseFloat {
         this._dragInfo.curIndex = Math.max(0, Math.min(curIndex, len - 1));
     };
 
-    setDragTargetStyle = () => {
+    private _setDragTargetStyle = () => {
         const { offset, barType, dragCells } = this._dragInfo!;
 
         for (const cell of dragCells) {
@@ -388,7 +388,7 @@ export class TableDragBar extends BaseFloat {
         }
     };
 
-    setSwitchStyle = () => {
+    private _setSwitchStyle = () => {
         if (!this._dragInfo)
             return;
 
@@ -406,7 +406,7 @@ export class TableDragBar extends BaseFloat {
             applyRightSwitch(cells, len, compute);
     };
 
-    setDropTargetStyle = () => {
+    private _setDropTargetStyle = () => {
         if (!this._dragInfo)
             return;
 
@@ -432,7 +432,7 @@ export class TableDragBar extends BaseFloat {
         }
     };
 
-    switchTableData = () => {
+    private _switchTableData = () => {
         if (!this._dragInfo)
             return;
 
@@ -520,12 +520,12 @@ export class TableDragBar extends BaseFloat {
         }
     };
 
-    resetDragTableBar = () => {
+    private _resetDragTableBar = () => {
         this._dragInfo = null;
         this._isDragTableBar = false;
     };
 
-    render(barType: BarType) {
+    private _render(barType: BarType) {
         this.container!.dataset.drag = barType;
     }
 }

--- a/packages/muya/src/ui/tooltip/index.ts
+++ b/packages/muya/src/ui/tooltip/index.ts
@@ -26,11 +26,11 @@ class Tooltip {
         eventCenter.attachDOMEvent(
             domNode,
             'mouseover',
-            this.mouseOver.bind(this),
+            this._mouseOver.bind(this),
         );
     }
 
-    mouseOver(event) {
+    private _mouseOver(event) {
         const { target } = event;
         const toolTipTarget = target.closest('[data-tooltip]');
         const { eventCenter } = this._muya;
@@ -50,7 +50,7 @@ class Tooltip {
 
             const timer = setInterval(() => {
                 if (!document.body.contains(toolTipTarget)) {
-                    this.mouseLeave({ target: toolTipTarget });
+                    this._mouseLeave({ target: toolTipTarget });
                     clearInterval(timer);
                 }
             }, 300);
@@ -58,12 +58,12 @@ class Tooltip {
             eventCenter.attachDOMEvent(
                 toolTipTarget,
                 'mouseleave',
-                this.mouseLeave.bind(this),
+                this._mouseLeave.bind(this),
             );
         }
     }
 
-    mouseLeave(event) {
+    private _mouseLeave(event) {
         const { target } = event;
         if (this._cache.has(target)) {
             const tooltipEle = this._cache.get(target);

--- a/packages/muya/src/ui/ui.ts
+++ b/packages/muya/src/ui/ui.ts
@@ -3,20 +3,20 @@ import type BaseFloat from './baseFloat';
 
 export class Ui {
     public shownFloat: Set<BaseFloat> = new Set();
-    public shownButton: Set<BaseFloat> = new Set();
+    private _shownButton: Set<BaseFloat> = new Set();
 
     constructor(public muya: Muya) {
-        this.listen();
+        this._listen();
     }
 
-    listen() {
+    private _listen() {
     // cache shown float box
         this.muya.eventCenter.subscribe('muya-float', (tool, status) => {
             status ? this.shownFloat.add(tool) : this.shownFloat.delete(tool);
         });
         // cache shown btn
         this.muya.eventCenter.subscribe('muya-float-button', (tool, status) => {
-            status ? this.shownButton.add(tool) : this.shownButton.delete(tool);
+            status ? this._shownButton.add(tool) : this._shownButton.delete(tool);
         });
     }
 
@@ -24,7 +24,7 @@ export class Ui {
         for (const tool of this.shownFloat)
             tool.hide();
 
-        for (const btn of this.shownButton)
+        for (const btn of this._shownButton)
             btn.hide();
     }
 }


### PR DESCRIPTION
## What

Final PR of the staged member-visibility series (stacked on #4538). Narrows UI float/tool members used only within their declaring class to `private` (with `_` prefix): `BaseFloat`, `BaseScrollFloat`, `Ui`, `Tooltip`, `ImageResizeBar`, `ImageToolBar`, `LinkTools`, `ParagraphFrontButton`, `ParagraphFrontMenu`, `ParagraphQuickInsertMenu`, `TablePicker`, `TableColumnToolbar`, `TableDragBar`.

`tsc` + lint shaped the result:
- **`protected`** for the non-overridden base members `BaseFloat.options/cb` and `BaseScrollFloat.activeEleScrollIntoView`.
- The overridable lifecycle/abstract methods (`listen`/`init`/`render`/`getItemElement`) stay **public** — they're overridden across ~16 float subclasses, so keeping the whole chain public is consistent (vs. protected base + widened-public overrides).
- `EmojiSelector.renderObj` stays a public accessor over its private `_renderObj` backing field (renaming would collide).
- Removed `ParagraphFrontMenu`'s write-only `reference` field (dead state).

Two white-box specs (`linkTools`, quick-insert `search`) get small typed internal views to reach the now-private state.

## Verification
- `pnpm -C packages/muya lint` — 0 errors
- `pnpm -C packages/muya lint:types` — passes
- `pnpm -C packages/muya test` — 983 passed
- `pnpm -C packages/muya test:spec` — 1347 passed

> Stacked on #4538 → #4537 → #4535. Review/merge those first; this PR retargets to `develop` once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)