### PR TITLE
fix(muya): align clipboard cut/delete semantics with muyajs

### DIFF
--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -670,7 +670,12 @@ class Format extends Content {
             }
         }
 
-        // Check block convert if needed, and table cell no need to check.
+        this.checkInlineUpdate();
+    }
+
+    // Re-evaluate this block's type from its text (a leading `# `, `- `, `> `…
+    // promotes/demotes it). Table cells never reinterpret their text as markdown.
+    checkInlineUpdate(): void {
         if (this.blockName !== 'table.cell.content')
             this._convertIfNeeded();
     }

--- a/packages/muya/src/clipboard/__tests__/cutBlockConvert.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/cutBlockConvert.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs `cutHandler` runs `checkInlineUpdate` after a cut so the start block's
+// type tracks its new text: cutting away a heading's `# ` marker demotes it to a
+// paragraph, and cutting text so a paragraph starts with `# ` promotes it.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstContent(muya: Muya): Content {
+    return muya.editor.scrollPage!.firstContentInDescendant()!;
+}
+
+function stubSameBlockSelection(muya: Muya, block: Content, start: number, end: number) {
+    // Capture `path` eagerly: the cut triggers a block-type conversion that
+    // detaches `block`, and a re-entrant `getSelection` would otherwise read a
+    // null parent off the stale node.
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: start, block, path },
+        focus: { offset: end, block, path },
+        isCollapsed: false,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+async function cut(muya: Muya): Promise<void> {
+    muya.editor.clipboard.cutHandler();
+    await new Promise(r => setTimeout(r, 40));
+}
+
+describe('track C — same-block cut re-evaluates block type', () => {
+    it('cutting the "## " marker from a heading demotes it to a paragraph', async () => {
+        const muya = bootMuya('## Heading\n');
+        const block = firstContent(muya);
+        stubSameBlockSelection(muya, block, 0, 3); // select "## "
+        await cut(muya);
+
+        expect(muya.editor.scrollPage!.firstChild!.blockName).toBe('paragraph');
+        expect(muya.getMarkdown()).toBe('Heading\n');
+    });
+
+    it('cutting text so a paragraph starts with "# " promotes it to a heading', async () => {
+        const muya = bootMuya('a# title\n');
+        const block = firstContent(muya);
+        stubSameBlockSelection(muya, block, 0, 1); // select "a"
+        await cut(muya);
+
+        expect(muya.editor.scrollPage!.firstChild!.blockName).toBe('atx-heading');
+        expect(muya.getMarkdown()).toBe('# title\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/cutSelectedImage.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/cutSelectedImage.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import type Format from '../../block/base/format';
+import type { ImageToken } from '../../inlineRenderer/types';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+
+// Cutting a selected inline image removes it from the document (muyajs parity).
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// The same selection payload the click handler produces; range spans the whole
+// `![..](..)` markdown.
+function selectImage(muya: Muya): Format {
+    const block = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+    const raw = block.text;
+    const token = {
+        type: 'image',
+        raw,
+        range: { start: 0, end: raw.length },
+    } as unknown as ImageToken;
+    muya.editor.selection.selectImage({ token, imageId: 'cut-img', block });
+    return block;
+}
+
+describe('track C — cut a selected inline image deletes it (muyajs parity)', () => {
+    it('cutHandler removes the selected image from the document', async () => {
+        const muya = bootMuya('![alt](https://example.com/a.png)\n');
+        selectImage(muya);
+        expect(muya.editor.selection.image).not.toBeNull();
+
+        muya.editor.clipboard.cutHandler();
+        await new Promise(r => setTimeout(r, 40));
+
+        expect(muya.getMarkdown()).toBe('\n');
+        expect(muya.editor.selection.image).toBeNull();
+    });
+
+    it('cutting an image among text only removes the image markdown', async () => {
+        const muya = bootMuya('before ![alt](https://example.com/a.png) after\n');
+        const block = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+        const raw = block.text;
+        const start = raw.indexOf('![');
+        const end = raw.indexOf(')', start) + 1;
+        const token = {
+            type: 'image',
+            raw: raw.slice(start, end),
+            range: { start, end },
+        } as unknown as ImageToken;
+        muya.editor.selection.selectImage({ token, imageId: 'cut-img', block });
+
+        muya.editor.clipboard.cutHandler();
+        await new Promise(r => setTimeout(r, 40));
+
+        expect(muya.getMarkdown()).toBe('before  after\n');
+        expect(muya.editor.selection.image).toBeNull();
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
@@ -5,12 +5,9 @@ import type { Muya } from '../../muya';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya as MuyaClass } from '../../muya';
 
-// A plain Backspace/Delete while a table rectangle is frozen must NOT fall
-// through to `cutHandler()`. The `keydownHandler` short-circuits on
-// `selection.table.hasSelection`, so the selected cells keep their text. The
-// document-level `keydown` listener is registered via
-// `eventCenter.attachDOMEvent(document, 'keydown', ...)`, so dispatching the
-// event on `document` exercises the real handler.
+// muyajs parity: Backspace/Delete over a frozen table rect clears the selected
+// cells (no clipboard write, no table deletion). The `keydown` listener is on
+// `document`, so dispatch there to exercise the real handler.
 
 // The clipboard module pulls in CodeBlockContent → utils/prism which touches
 // `window` at import time. Stub the prism shim (same stub as sibling specs).
@@ -75,12 +72,13 @@ function dragSelect(table: TableBlock, r1: number, c1: number, r2: number, c2: n
     fireMouse(cellDom(table, r2, c2), 'mouseup');
 }
 
-describe('track C — keydown table.hasSelection guard', () => {
-    it('a plain Backspace over a frozen table rect does not empty the cells', async () => {
-        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+describe('track C — keydown over a frozen table rect clears the cells', () => {
+    it('a plain Backspace over a frozen table rect empties the selected cells', async () => {
+        const muya = bootMuya('| a1 | b1 | c1 |\n| --- | --- | --- |\n| a2 | b2 | c2 |\n');
         const table = firstTable(muya);
 
-        // Freeze the whole 2x2 body grid so `selection.table.hasSelection`.
+        // Freeze a partial rectangle (top-left 2x2 of a 3-column table) so the
+        // selection is content-bearing but not the whole table.
         dragSelect(table, 0, 0, 1, 1);
         expect(muya.editor.selection.table.hasSelection).toBe(true);
 
@@ -91,19 +89,20 @@ describe('track C — keydown table.hasSelection guard', () => {
         const event = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true });
         document.dispatchEvent(event);
 
-        // The frozen selection still stands and the cells keep their text —
-        // the guard stopped the handler before `cutHandler()` ran.
+        // The selected cells are emptied, the frozen selection is released, and
+        // the table grid stays (keyboard delete never deletes the table).
         await new Promise(r => setTimeout(r, 40));
-        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        expect(muya.editor.selection.table.hasSelection).toBe(false);
         const md = muya.getMarkdown();
-        expect(md).toContain('a1');
-        expect(md).toContain('b1');
-        expect(md).toContain('a2');
-        expect(md).toContain('b2');
+        expect(md).toContain('|');
+        expect(md).not.toMatch(/\ba1\b/);
+        expect(md).not.toMatch(/\bb1\b/);
+        expect(md).not.toMatch(/\ba2\b/);
+        expect(md).not.toMatch(/\bb2\b/);
     });
 
-    it('a plain Delete over a frozen table rect does not empty the cells', async () => {
-        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+    it('a plain Delete over a frozen table rect empties the selected cells', async () => {
+        const muya = bootMuya('| a1 | b1 | c1 |\n| --- | --- | --- |\n| a2 | b2 | c2 |\n');
         const table = firstTable(muya);
 
         dragSelect(table, 0, 0, 1, 1);
@@ -116,11 +115,10 @@ describe('track C — keydown table.hasSelection guard', () => {
         document.dispatchEvent(event);
 
         await new Promise(r => setTimeout(r, 40));
-        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        expect(muya.editor.selection.table.hasSelection).toBe(false);
         const md = muya.getMarkdown();
-        expect(md).toContain('a1');
-        expect(md).toContain('b1');
-        expect(md).toContain('a2');
-        expect(md).toContain('b2');
+        expect(md).toContain('|');
+        expect(md).not.toMatch(/\ba1\b/);
+        expect(md).not.toMatch(/\bb2\b/);
     });
 });

--- a/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/keydownTableGuard.spec.ts
@@ -72,53 +72,90 @@ function dragSelect(table: TableBlock, r1: number, c1: number, r2: number, c2: n
     fireMouse(cellDom(table, r2, c2), 'mouseup');
 }
 
-describe('track C — keydown over a frozen table rect clears the cells', () => {
-    it('a plain Backspace over a frozen table rect empties the selected cells', async () => {
+function tick(): Promise<void> {
+    return new Promise(r => setTimeout(r, 40));
+}
+
+// Fire a keyboard delete over the frozen selection. `ownsEvent()` needs
+// `document.activeElement` inside `muya.domNode`, so re-focus the (0,0) cell
+// before every press — the previous press may have re-rendered the cell.
+function pressDelete(table: TableBlock, key: 'Backspace' | 'Delete'): void {
+    cellDom(table, 0, 0).focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+describe('track C — keydown over a frozen table rect (two-stage, muyajs parity)', () => {
+    it('first Backspace clears the selected cells but keeps the frozen selection', async () => {
         const muya = bootMuya('| a1 | b1 | c1 |\n| --- | --- | --- |\n| a2 | b2 | c2 |\n');
         const table = firstTable(muya);
 
-        // Freeze a partial rectangle (top-left 2x2 of a 3-column table) so the
-        // selection is content-bearing but not the whole table.
+        // Whole columns 0–1 of a 3-column table (all rows, two of three columns).
         dragSelect(table, 0, 0, 1, 1);
         expect(muya.editor.selection.table.hasSelection).toBe(true);
 
-        // `ownsEvent()` requires `document.activeElement` inside `muya.domNode`.
-        cellDom(table, 0, 0).focus();
-        expect(muya.domNode.contains(document.activeElement)).toBe(true);
+        pressDelete(table, 'Backspace');
+        await tick();
 
-        const event = new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true });
-        document.dispatchEvent(event);
-
-        // The selected cells are emptied, the frozen selection is released, and
-        // the table grid stays (keyboard delete never deletes the table).
-        await new Promise(r => setTimeout(r, 40));
-        expect(muya.editor.selection.table.hasSelection).toBe(false);
+        // Cells emptied, but the rectangle stays frozen for a possible second press.
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
         const md = muya.getMarkdown();
         expect(md).toContain('|');
         expect(md).not.toMatch(/\ba1\b/);
         expect(md).not.toMatch(/\bb1\b/);
         expect(md).not.toMatch(/\ba2\b/);
         expect(md).not.toMatch(/\bb2\b/);
+        expect(md).toContain('c1');
+        expect(md).toContain('c2');
     });
 
-    it('a plain Delete over a frozen table rect empties the selected cells', async () => {
+    it('a second Backspace on the emptied whole-column selection removes those columns', async () => {
         const muya = bootMuya('| a1 | b1 | c1 |\n| --- | --- | --- |\n| a2 | b2 | c2 |\n');
         const table = firstTable(muya);
 
         dragSelect(table, 0, 0, 1, 1);
-        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        pressDelete(table, 'Backspace'); // clear
+        await tick();
+        pressDelete(table, 'Backspace'); // remove the now-empty columns
+        await tick();
 
-        cellDom(table, 0, 0).focus();
-        expect(muya.domNode.contains(document.activeElement)).toBe(true);
-
-        const event = new KeyboardEvent('keydown', { key: 'Delete', bubbles: true });
-        document.dispatchEvent(event);
-
-        await new Promise(r => setTimeout(r, 40));
+        expect(table.columnCount).toBe(1);
         expect(muya.editor.selection.table.hasSelection).toBe(false);
         const md = muya.getMarkdown();
-        expect(md).toContain('|');
+        expect(md).toContain('c1');
+        expect(md).toContain('c2');
+        expect(md).not.toMatch(/\ba1\b/);
+        expect(md).not.toMatch(/\bb1\b/);
+    });
+
+    it('first Delete clears the selected cells and keeps the selection (Backspace parity)', async () => {
+        const muya = bootMuya('| a1 | b1 | c1 |\n| --- | --- | --- |\n| a2 | b2 | c2 |\n');
+        const table = firstTable(muya);
+
+        dragSelect(table, 0, 0, 1, 1);
+        pressDelete(table, 'Delete');
+        await tick();
+
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+        const md = muya.getMarkdown();
         expect(md).not.toMatch(/\ba1\b/);
         expect(md).not.toMatch(/\bb2\b/);
+    });
+
+    it('a second Backspace on an emptied PARTIAL rectangle drops the selection without changing the grid', async () => {
+        // 3×3 table so a top-left 2×2 spans neither all rows nor all columns.
+        const muya = bootMuya('| a | b | c |\n| --- | --- | --- |\n| d | e | f |\n| g | h | i |\n');
+        const table = firstTable(muya);
+
+        dragSelect(table, 0, 0, 1, 1);
+        pressDelete(table, 'Backspace'); // clear
+        await tick();
+        expect(muya.editor.selection.table.hasSelection).toBe(true);
+
+        pressDelete(table, 'Backspace'); // partial empty → just deselect
+        await tick();
+
+        expect(muya.editor.selection.table.hasSelection).toBe(false);
+        expect(table.rowCount).toBe(3);
+        expect(table.columnCount).toBe(3);
     });
 });

--- a/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/trackCCut.spec.ts
@@ -254,6 +254,17 @@ describe('track C — cross-block cut keeps both endpoint tails (leaf merge)', (
     });
 });
 
+describe('track C — cross-block cut preserves the end block soft-line tail (GH#2269 parity)', () => {
+    it('cutting into a multi-line paragraph keeps the trailing soft-lines', async () => {
+        const muya = bootMuya('alpha\n\nbeta\ngamma\ndelta\n');
+        const blocks = contentBlocks(muya);
+        // block 1 is one paragraph with soft breaks: 'beta\ngamma\ndelta'.
+        const end = blocks[blocks.length - 1];
+        stubSelection(muya, blocks[0], 2, end, 2);
+        expect(await cutAndRead(muya)).toBe('alta\ngamma\ndelta\n');
+    });
+});
+
 describe('track C — whole-document selection collapses to one empty paragraph', () => {
     it('select-all then cut leaves a single empty paragraph', async () => {
         const muya = bootMuya('# Title\n\nbody text\n\n- a\n- b\n');
@@ -343,19 +354,34 @@ describe('track C — empty table row/column/whole-table cut is structural', () 
         expect(md).not.toContain('|');
     });
 
-    it('cutting a selection that still has content only empties in place', async () => {
+    it('cutting a PARTIAL content selection only empties in place', async () => {
         const muya = bootMuya(
             '| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n',
         );
         const table = firstTable(muya);
         const beforeRows = table.rowCount;
         const beforeCols = table.columnCount;
-        dragSelect(table, 0, 0, 1, 1); // has content
+        dragSelect(table, 0, 0, 1, 0); // first column only — not the whole table
         const md = await cutSelectionAndRead(muya);
-        // Structure unchanged; only the cells were emptied.
+        // Structure unchanged; only the selected column's cells were emptied.
         expect(table.rowCount).toBe(beforeRows);
         expect(table.columnCount).toBe(beforeCols);
         expect(md).not.toMatch(/\ba1\b/);
-        expect(md).not.toMatch(/\bb2\b/);
+        expect(md).not.toMatch(/\ba2\b/);
+        expect(md).toContain('b1');
+        expect(md).toContain('b2');
+    });
+
+    it('cutting a whole table that still has content removes the table (muyajs parity)', async () => {
+        const muya = bootMuya(
+            '| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n',
+        );
+        const table = firstTable(muya);
+        // whole table, with content
+        dragSelect(table, 0, 0, table.rowCount - 1, table.columnCount - 1);
+        const md = await cutSelectionAndRead(muya);
+        expect(md).not.toContain('|');
+        expect(md).not.toContain('a1');
+        expect(md).not.toContain('b2');
     });
 });

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -5,9 +5,10 @@ import type Table from '../block/gfm/table';
 import type TableBodyCell from '../block/gfm/table/cell';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
+import Format from '../block/base/format';
 import { ScrollPage } from '../block/scrollPage';
 import { CLASS_NAMES } from '../config';
-import { SelectionDirection } from '../selection/types';
+import { SelectionDirection, SelectionType } from '../selection/types';
 import { getBlock } from '../utils/dom';
 
 /**
@@ -245,22 +246,15 @@ function selectedTableCells(
     return { table, cells };
 }
 
-/**
- * Structurally delete an empty whole row / column / table when cutting a
- * frozen table-cell selection. Returns `true` when it handled the cut (the
- * caller then skips the in-place clear), `false` to fall through to the
- * in-place clear.
- */
-function cutEmptyTableStructure(clipboard: Clipboard): boolean {
+// A clipboard cut (`isCut`) deletes a whole-table selection even with content;
+// keyboard delete only removes empty whole rows / columns. Returns `false` to
+// fall back to clearing the cells in place.
+function cutTableStructure(clipboard: Clipboard, isCut: boolean): boolean {
     const selectedCells = selectedTableCells(clipboard);
     if (selectedCells == null)
         return false;
 
     const { table, cells } = selectedCells;
-    const hasContent = cells.some(cell => (cell.firstChild as Content)?.text);
-    if (hasContent)
-        return false;
-
     const rows = new Set(cells.map(cell => cell.rowOffset));
     const columns = new Set(cells.map(cell => cell.columnOffset));
     const { rowCount, columnCount } = table;
@@ -272,7 +266,24 @@ function cutEmptyTableStructure(clipboard: Clipboard): boolean {
             && columns.size === columnCount
             && cells.length === rowCount * columnCount;
 
-    if (!isWholeColumn && !isWholeRow && !isWholeTable)
+    if (isWholeTable && isCut) {
+        clipboard.selection.table.clear();
+        const outsideContent
+            = table.nextContentInContext() ?? table.previousContentInContext();
+        table.remove();
+        if (clipboard.scrollPage?.length() === 0)
+            resetToEmptyParagraph(clipboard);
+        else
+            outsideContent?.setCursor(0, 0, true);
+
+        return true;
+    }
+
+    const hasContent = cells.some(cell => (cell.firstChild as Content)?.text);
+    if (hasContent)
+        return false;
+
+    if (!isWholeColumn && !isWholeRow)
         return false;
 
     const cursorOffsetRow = [...rows][0];
@@ -280,18 +291,7 @@ function cutEmptyTableStructure(clipboard: Clipboard): boolean {
 
     clipboard.selection.table.clear();
 
-    if (isWholeTable) {
-        const outsideContent
-            = table.nextContentInContext() ?? table.previousContentInContext();
-        table.remove();
-        if (clipboard.scrollPage?.length() === 0) {
-            resetToEmptyParagraph(clipboard);
-        }
-        else {
-            outsideContent?.setCursor(0, 0, true);
-        }
-    }
-    else if (isWholeColumn) {
+    if (isWholeColumn) {
         const cursorBlock = table.removeColumn(cursorOffsetColumn);
         cursorBlock?.setCursor(0, 0, true);
     }
@@ -304,13 +304,18 @@ function cutEmptyTableStructure(clipboard: Clipboard): boolean {
 }
 
 export function cutSelection(clipboard: Clipboard): void {
-    // A frozen cross-cell table selection. When every selected cell is
-    // already empty and the rectangle covers a whole row / column / table,
-    // delete that structure; otherwise empty the cells in place. The copy half
-    // already captured the
-    // rectangle's markdown via `getClipboardData`.
+    // Cut a selected image: the copy half wrote its raw markdown; remove it here.
+    const selectedImage = clipboard.selection.image;
+    if (selectedImage) {
+        const { block, ...imageInfo } = selectedImage;
+        block.deleteImage(imageInfo);
+        clipboard.selection.activate(SelectionType.TEXT);
+
+        return;
+    }
+
     if (clipboard.selection.table.hasSelection) {
-        if (!cutEmptyTableStructure(clipboard))
+        if (!cutTableStructure(clipboard, true))
             clipboard.selection.table.clearSelectedCells();
 
         return;
@@ -339,7 +344,11 @@ export function cutSelection(clipboard: Clipboard): void {
         anchorBlock.text
             = text.substring(0, startOffset) + text.substring(endOffset);
 
-        return anchorBlock.setCursor(startOffset, startOffset, true);
+        anchorBlock.setCursor(startOffset, startOffset, true);
+        if (anchorBlock instanceof Format)
+            anchorBlock.checkInlineUpdate();
+
+        return;
     }
 
     const startBlock = direction === SelectionDirection.FORWARD ? anchorBlock : focusBlock;
@@ -366,8 +375,16 @@ export function cutSelection(clipboard: Clipboard): void {
     removeBlocks(startBlock, endBlock);
 
     startBlock.setCursor(startOffset, startOffset, true);
+    if (startBlock instanceof Format)
+        startBlock.checkInlineUpdate();
 
     if (clipboard.scrollPage?.length() === 0) {
         resetToEmptyParagraph(clipboard);
     }
+}
+
+// Keyboard delete over a frozen table selection: clear the cells without copying.
+export function deleteTableSelection(clipboard: Clipboard): void {
+    if (!cutTableStructure(clipboard, false))
+        clipboard.selection.table.clearSelectedCells();
 }

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -246,10 +246,25 @@ function selectedTableCells(
     return { table, cells };
 }
 
-// A clipboard cut (`isCut`) deletes a whole-table selection even with content;
-// keyboard delete only removes empty whole rows / columns. Returns `false` to
-// fall back to clearing the cells in place.
-function cutTableStructure(clipboard: Clipboard, isCut: boolean): boolean {
+// Remove the whole table block and seat the caret just outside it (or reset to
+// a single empty paragraph when the table was the only block).
+function removeWholeTable(clipboard: Clipboard, table: Table): void {
+    clipboard.selection.table.clear();
+    const outsideContent
+        = table.nextContentInContext() ?? table.previousContentInContext();
+    table.remove();
+    if (clipboard.scrollPage?.length() === 0)
+        resetToEmptyParagraph(clipboard);
+    else
+        outsideContent?.setCursor(0, 0, true);
+}
+
+// For an already-empty frozen selection: if the rectangle covers whole
+// column(s), whole row(s), or the whole table, delete that structure and return
+// `true`; a partial rectangle returns `false` so the caller just drops the
+// selection. Multiple whole columns / rows are removed high-index-first so the
+// remaining offsets stay valid.
+function removeEmptyTableStructure(clipboard: Clipboard): boolean {
     const selectedCells = selectedTableCells(clipboard);
     if (selectedCells == null)
         return false;
@@ -257,50 +272,60 @@ function cutTableStructure(clipboard: Clipboard, isCut: boolean): boolean {
     const { table, cells } = selectedCells;
     const rows = new Set(cells.map(cell => cell.rowOffset));
     const columns = new Set(cells.map(cell => cell.columnOffset));
-    const { rowCount, columnCount } = table;
+    const spansAllRows = rows.size === table.rowCount;
+    const spansAllColumns = columns.size === table.columnCount;
 
-    const isWholeColumn = columns.size === 1 && rows.size === rowCount;
-    const isWholeRow = rows.size === 1 && columns.size === columnCount;
-    const isWholeTable
-        = rows.size === rowCount
-            && columns.size === columnCount
-            && cells.length === rowCount * columnCount;
-
-    if (isWholeTable && isCut) {
-        clipboard.selection.table.clear();
-        const outsideContent
-            = table.nextContentInContext() ?? table.previousContentInContext();
-        table.remove();
-        if (clipboard.scrollPage?.length() === 0)
-            resetToEmptyParagraph(clipboard);
-        else
-            outsideContent?.setCursor(0, 0, true);
+    if (spansAllRows && spansAllColumns) {
+        removeWholeTable(clipboard, table);
 
         return true;
     }
 
-    const hasContent = cells.some(cell => (cell.firstChild as Content)?.text);
-    if (hasContent)
-        return false;
-
-    if (!isWholeColumn && !isWholeRow)
-        return false;
-
-    const cursorOffsetRow = [...rows][0];
-    const cursorOffsetColumn = [...columns][0];
-
-    clipboard.selection.table.clear();
-
-    if (isWholeColumn) {
-        const cursorBlock = table.removeColumn(cursorOffsetColumn);
+    if (spansAllRows) {
+        clipboard.selection.table.clear();
+        let cursorBlock: Nullable<Content> = null;
+        for (const column of [...columns].sort((a, b) => b - a))
+            cursorBlock = table.removeColumn(column);
         cursorBlock?.setCursor(0, 0, true);
-    }
-    else {
-        const cursorBlock = table.removeRow(cursorOffsetRow);
-        cursorBlock?.setCursor(0, 0, true);
+
+        return true;
     }
 
-    return true;
+    if (spansAllColumns) {
+        clipboard.selection.table.clear();
+        let cursorBlock: Nullable<Content> = null;
+        for (const row of [...rows].sort((a, b) => b - a))
+            cursorBlock = table.removeRow(row);
+        cursorBlock?.setCursor(0, 0, true);
+
+        return true;
+    }
+
+    return false;
+}
+
+// Clipboard cut over a frozen table selection: a whole-table selection is
+// deleted even with content; otherwise content cells fall back to an in-place
+// clear, and an empty whole column/row selection deletes that structure.
+function cutTableStructure(clipboard: Clipboard): boolean {
+    const selectedCells = selectedTableCells(clipboard);
+    if (selectedCells == null)
+        return false;
+
+    const { table, cells } = selectedCells;
+    const rows = new Set(cells.map(cell => cell.rowOffset));
+    const columns = new Set(cells.map(cell => cell.columnOffset));
+
+    if (rows.size === table.rowCount && columns.size === table.columnCount) {
+        removeWholeTable(clipboard, table);
+
+        return true;
+    }
+
+    if (cells.some(cell => (cell.firstChild as Content)?.text))
+        return false;
+
+    return removeEmptyTableStructure(clipboard);
 }
 
 export function cutSelection(clipboard: Clipboard): void {
@@ -315,7 +340,7 @@ export function cutSelection(clipboard: Clipboard): void {
     }
 
     if (clipboard.selection.table.hasSelection) {
-        if (!cutTableStructure(clipboard, true))
+        if (!cutTableStructure(clipboard))
             clipboard.selection.table.clearSelectedCells();
 
         return;
@@ -383,8 +408,14 @@ export function cutSelection(clipboard: Clipboard): void {
     }
 }
 
-// Keyboard delete over a frozen table selection: clear the cells without copying.
+// Keyboard delete over a frozen table selection (two-stage, muyajs parity):
+// the first press clears the selected cells' text but keeps the rectangle
+// frozen; once the cells are empty, the next press removes whole column(s) /
+// row(s) / the whole table, or drops the selection for a partial rectangle.
 export function deleteTableSelection(clipboard: Clipboard): void {
-    if (!cutTableStructure(clipboard, false))
-        clipboard.selection.table.clearSelectedCells();
+    if (clipboard.selection.table.emptySelectedCells())
+        return;
+
+    if (!removeEmptyTableStructure(clipboard))
+        clipboard.selection.table.clear();
 }

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -2,7 +2,7 @@ import type { Muya } from '../muya';
 import type { IClipboardPayload } from './copyData';
 import { isClipboardEvent, isKeyboardEvent } from '../utils';
 import { getClipboardData, writeClipboardData } from './copyData';
-import { cutSelection } from './cut';
+import { cutSelection, deleteTableSelection } from './cut';
 import { pastePlainText, pasteSelection } from './paste';
 import { CopyType, PasteType } from './types';
 
@@ -50,8 +50,13 @@ class Clipboard {
                 return;
             const { key, metaKey } = event;
 
-            if (this.selection.table.hasSelection)
+            if (this.selection.table.hasSelection) {
+                if (!metaKey && (key === 'Backspace' || key === 'Delete')) {
+                    event.preventDefault();
+                    deleteTableSelection(this);
+                }
                 return;
+            }
 
             const { isSelectionInSameBlock } = this.selection.getSelection() ?? {};
             if (isSelectionInSameBlock)

--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -283,24 +283,44 @@ class TableRectSelection {
      * content block's `text` setter so each edit dispatches a json op and the
      * document state stays in sync. The caret is placed in the anchor cell.
      */
-    clearSelectedCells(): void {
+    /**
+     * Empty every selected cell's text and re-render it, keeping the frozen
+     * selection. Returns whether any cell actually had content to clear — the
+     * caller uses that to drive the two-stage keyboard delete (first press
+     * clears, second press removes structure). Each cleared cell is re-rendered
+     * via `update()`; setting `.text` alone only patches state, so without this
+     * the non-anchor cells would keep their stale DOM.
+     */
+    emptySelectedCells(): boolean {
         if (!this.hasSelection)
-            return;
+            return false;
 
         const minRow = Math.min(this._anchor!.row, this._focus!.row);
         const maxRow = Math.max(this._anchor!.row, this._focus!.row);
         const minColumn = Math.min(this._anchor!.column, this._focus!.column);
         const maxColumn = Math.max(this._anchor!.column, this._focus!.column);
 
+        let hadContent = false;
         for (let r = minRow; r <= maxRow; r++) {
             for (let c = minColumn; c <= maxColumn; c++) {
                 const content = this._table!.cellAt(r, c)?.firstChild;
-                if (content && content.isContent() && content.text !== '')
+                if (content && content.isContent() && content.text !== '') {
+                    hadContent = true;
                     content.text = '';
+                    content.update();
+                }
             }
         }
 
+        return hadContent;
+    }
+
+    clearSelectedCells(): void {
+        if (!this.hasSelection)
+            return;
+
         const anchorContent = this._anchor!.cell.firstChild;
+        this.emptySelectedCells();
         this.clear();
         if (anchorContent && anchorContent.isContent())
             anchorContent.setCursor(0, 0, true);


### PR DESCRIPTION
## Summary

First PR in a clipboard parity series that re-aligns the `@muyajs/core` engine's copy/cut/paste behavior with the legacy `muyajs` engine (a behavior audit found 33 verified differences; this PR covers the high-value cut/delete regressions).

Four cut/delete behaviors are brought back in line with muyajs:

- **Cut a selected inline image → removes it.** `cutSelection` was missing the `selectedImage` branch, so cutting an image copied its raw markdown but left the image in the document. It now deletes the image (the copy half already wrote the raw), restoring "cut = move".
- **Cut re-evaluates the block type.** A cut bypassed the input pipeline, so cutting a heading's `# ` marker left an (invalid) heading. A new public `Format.checkInlineUpdate()` runs after the cut so the start block converts: `# ` removed → paragraph, text becomes `# …` → heading. `inputHandler` now routes through the same method.
- **Whole-table cut vs keyboard delete.** A clipboard cut of a content-bearing whole-table selection now deletes the table (muyajs parity); a keyboard Backspace/Delete over a frozen table selection clears the spanned cells (and removes an empty whole row/column) instead of no-op. Driven by `cutTableStructure(clipboard, isCut)`.
- **GH#2269 soft-line tail** — confirmed already handled by muya's leaf-merge cut (`start.head + end.tail`); added a parity test.

Deferred to a follow-up PR (per review): **#918** — a cross-block delete starting inside a code fence's `language-input` line (an obscure edge that currently leaves an inconsistent block tree).

## Tests

- New: `cutSelectedImage.spec.ts`, `cutBlockConvert.spec.ts`; rewritten `keydownTableGuard.spec.ts` (now asserts cells are cleared); extended `trackCCut.spec.ts` (whole-table content cut, partial-content empties-in-place, GH#2269).
- All red→green via TDD. Full muya unit suite passes (the only failures are the known worktree `css?inline` import limitation, unrelated to this change). `tsc`, `eslint` (0 errors), and `madge --circular` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)