### PR TITLE
fix(muya): merge pasted paragraphs/headings inline (muyajs parity)

### DIFF
--- a/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/clipboardFilePath.spec.ts
@@ -1,7 +1,6 @@
 import type Content from '../../block/base/content';
 import type Parent from '../../block/base/parent';
 import type { Muya } from '../../muya';
-import type { TLeafState } from '../../state/types';
 import { describe, expect, it, vi } from 'vitest';
 import { ScrollPage } from '../../block/scrollPage';
 
@@ -51,6 +50,7 @@ function makeAnchorBlock(initialText = '', cursor = 0) {
             end: { offset: cursor },
         }),
         setCursor: vi.fn(),
+        update: vi.fn(),
         getAnchor: () => null,
     };
     return block as unknown as Content & { setCursor: ReturnType<typeof vi.fn> };
@@ -151,29 +151,13 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
         // that await — otherwise the detached DataTransfer would yield '' here
         // and the paste would silently insert nothing.
         //
-        // A plain-text paste into a non-literal anchor now always parses
-        // through `MarkdownToState` (Track D / sub-item 1), so the captured text
-        // lands in a created paragraph block rather than being spliced into the
-        // anchor verbatim. Mock `loadBlock` to capture the created block's state.
-        const created: TLeafState[] = [];
-        const spy = vi
-            .spyOn(ScrollPage, 'loadBlock')
-            .mockImplementation(() => ({
-                create: (_muya: unknown, state: TLeafState) => {
-                    created.push(state);
-                    return {
-                        firstContentInDescendant: () => ({
-                            text: state.text ?? '',
-                            setCursor: vi.fn(),
-                        }),
-                    };
-                },
-            }) as unknown as ReturnType<typeof ScrollPage.loadBlock>);
+        // A single pasted paragraph merges inline into the anchor (muyajs
+        // `checkPasteType` MERGE), so the captured text lands in the anchor's
+        // own text rather than a separate block.
+        const spy = vi.spyOn(ScrollPage, 'loadBlock');
 
         const clipboardFilePath = vi.fn().mockResolvedValue('');
         const anchorBlock = makeAnchorBlock('', 0);
-        // The anchor's wrapper records the created block so the empty origin
-        // paragraph cleanup can run without crashing.
         const wrapper = {
             blockName: 'paragraph',
             getState: () => ({ name: 'paragraph', text: '' }),
@@ -189,7 +173,8 @@ describe('clipboard.pasteHandler — clipboardFilePath hook', () => {
         expect(clipboardFilePath).toHaveBeenCalledOnce();
         expect(getData).toHaveBeenCalledWith('text/plain');
         // The captured text survived the async hook and reached the paste path.
-        expect(created).toEqual([{ name: 'paragraph', text: 'hello world' }]);
+        expect(anchorBlock.text).toBe('hello world');
+        expect(spy).not.toHaveBeenCalled();
 
         spy.mockRestore();
     });

--- a/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs `pasteCtrl` MERGE semantics ported into @muyajs/core: pasting a
+// paragraph into a non-empty text block merges its first paragraph inline
+// (head + pasted + tail) instead of inserting it as a separate block below;
+// the trailing text of the anchor is sewn onto the last pasted block; a
+// multi-line paragraph pasted into a heading keeps only its first line in the
+// heading; a same-type list pasted into a list item merges into that list.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+// normalizePastedHTML uses DOMPurify which needs a richer DOM than happy-dom
+// gives; we only paste plain-text markdown here, so pass the html through.
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return { ...actual, normalizePastedHTML: async (html: string) => html };
+});
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentBlocks(muya: Muya): Content[] {
+    const out: Content[] = [];
+    let c: Content | null = muya.editor.scrollPage!.firstContentInDescendant();
+    while (c) {
+        out.push(c);
+        c = c.nextContentInContext() ?? null;
+    }
+    return out;
+}
+
+function stubSelection(muya: Muya, block: Content, start: number, end: number) {
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: start, block, path },
+        focus: { offset: end, block, path },
+        isCollapsed: start === end,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+function pasteEvent(text: string) {
+    return {
+        preventDefault() {},
+        stopPropagation() {},
+        clipboardData: {
+            getData: (t: string) => (t === 'text/plain' ? text : ''),
+            files: [],
+            items: [],
+        },
+    } as unknown as ClipboardEvent;
+}
+
+async function paste(muya: Muya, block: Content, start: number, end: number, text: string): Promise<string> {
+    stubSelection(muya, block, start, end);
+    await muya.editor.clipboard.pasteHandler(pasteEvent(text), text, '');
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('paste — paragraph merges inline into a non-empty text block (A3)', () => {
+    it('pasting a paragraph at the cursor merges it into the paragraph', async () => {
+        const muya = bootMuya('foobar\n');
+        const block = contentBlocks(muya)[0];
+        expect(await paste(muya, block, 3, 3, 'hello')).toBe('foohellobar\n');
+    });
+
+    it('pasting over a selection replaces it inline (A4)', async () => {
+        const muya = bootMuya('foobar\n');
+        const block = contentBlocks(muya)[0];
+        expect(await paste(muya, block, 3, 5, 'X')).toBe('fooXr\n');
+    });
+
+    it('pasting multiple paragraphs merges the first and sews the tail onto the last', async () => {
+        const muya = bootMuya('foobar\n');
+        const block = contentBlocks(muya)[0];
+        expect(await paste(muya, block, 3, 3, 'one\n\ntwo')).toBe('fooone\n\ntwobar\n');
+    });
+});
+
+describe('paste — multi-line paragraph into a heading keeps only the first line (A6)', () => {
+    it('only the first soft-line lands in the heading, the rest become a paragraph', async () => {
+        const muya = bootMuya('# Title\n');
+        const block = contentBlocks(muya)[0]; // atx-heading content, text '# Title'
+        expect(await paste(muya, block, block.text.length, block.text.length, 'a\nb\nc')).toBe(
+            '# Titlea\n\nb\nc\n',
+        );
+    });
+});

--- a/packages/muya/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/muya/src/clipboard/mergePasteIntoHeading.ts
@@ -37,12 +37,21 @@ export function mergePasteIntoHeading(
     if (first.name !== 'paragraph')
         return states;
 
+    // A heading is a single line: only the first soft-line of the pasted
+    // paragraph stays in the heading; any following lines become a paragraph
+    // block below it.
+    const [firstLine, ...restLines] = first.text.split('\n');
+
     const original = anchorBlock.text;
     anchorBlock.text
         = original.substring(0, cursor.startOffset)
-            + first.text
+            + firstLine
             + original.substring(cursor.endOffset);
     anchorBlock.update();
 
-    return states.slice(1);
+    const remaining = states.slice(1);
+    if (restLines.length > 0)
+        remaining.unshift({ name: 'paragraph', text: restLines.join('\n') });
+
+    return remaining;
 }

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -1,6 +1,8 @@
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
 import type TreeNode from '../block/base/treeNode';
+import type { Muya } from '../muya';
+import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
 import CodeBlockContent from '../block/content/codeBlockContent';
@@ -40,18 +42,150 @@ function isSingleCellSelected(clipboard: Clipboard): boolean {
     return state.children.length === 1 && state.children[0].children.length === 1;
 }
 
-// Parse a paste into real blocks (the common anchor case): parse markdown →
-// state, splice a leading paragraph back into a heading anchor, drop the
-// selected range, insert the new blocks, remove the emptied source paragraph,
-// and seat the cursor at the end.
+// The deepest last text-bearing leaf of a parsed state (a paragraph inside a
+// list / quote), used to sew the anchor's trailing text onto the last block.
+function lastLeafState(state: TState): Nullable<{ text: string }> {
+    const node = state as { children?: TState[]; text?: string };
+    if (Array.isArray(node.children) && node.children.length > 0)
+        return lastLeafState(node.children[node.children.length - 1]);
+
+    return typeof node.text === 'string' ? (node as { text: string }) : null;
+}
+
+// Append the anchor's trailing text onto the last pasted block; return the caret
+// offset (the length before the sewn tail) inside that leaf.
+function sewTail(states: TState[], tail: string): number {
+    const leaf = lastLeafState(states[states.length - 1]);
+    if (leaf == null)
+        return 0;
+
+    const offset = leaf.text.length;
+    if (tail.length > 0)
+        leaf.text += tail;
+
+    return offset;
+}
+
+function insertStatesAfter(
+    muya: Muya,
+    wrapperBlock: Nullable<Parent>,
+    states: TState[],
+): Nullable<Parent> {
+    let wb = wrapperBlock;
+    for (const state of states) {
+        const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
+        wb?.parent?.insertAfter(newBlock, wb);
+        wb = newBlock;
+    }
+
+    return wb;
+}
+
+function removeEmptyOriginParagraph(originWrapperBlock: Nullable<Parent>): void {
+    if (originWrapperBlock?.blockName !== 'paragraph')
+        return;
+
+    const originState = originWrapperBlock.getState();
+    if (isParagraphState(originState) && originState.text === '')
+        originWrapperBlock.remove();
+}
+
+function seatCursorAtSeam(last: Nullable<Parent>, offset: number): void {
+    last?.lastContentInDescendant()?.setCursor(offset, offset, true);
+}
+
+// muyajs `checkPasteType`: a paragraph always merges inline into the anchor; a
+// heading merges (with its marker dropped) only into a non-empty anchor;
+// anything else starts a new block. Returns the inline text to merge, or null
+// for the NEWLINE path.
+function inlineMergeText(state: TState, anchorHasText: boolean): Nullable<string> {
+    switch (state.name) {
+        case 'paragraph':
+            return state.text;
+        case 'atx-heading':
+            return anchorHasText ? state.text.replace(/^ {0,3}#{1,6}\s+/, '') : null;
+        case 'setext-heading':
+            return anchorHasText ? state.text : null;
+        default:
+            return null;
+    }
+}
+
+// Heading anchor: the first line was spliced into the heading; insert the rest
+// as blocks below and seat the caret at the end of the last one.
+function pasteAfterHeading(muya: Muya, ctx: IPasteContext, remaining: TState[]): void {
+    const last = insertStatesAfter(muya, ctx.wrapperBlock, remaining);
+    removeEmptyOriginParagraph(ctx.originWrapperBlock);
+
+    const cursorBlock = last?.firstContentInDescendant();
+    const offset = cursorBlock?.text.length;
+    if (offset != null)
+        cursorBlock?.setCursor(offset, offset, true);
+}
+
+// MERGE: splice the first state's text into the anchor (head + pasted), sewing
+// the anchor's tail onto the last pasted block — or back onto the anchor when
+// the paste is a single state.
+function pasteInlineMerge(
+    muya: Muya,
+    ctx: IPasteContext,
+    states: TState[],
+    mergeText: string,
+    head: string,
+    tail: string,
+): void {
+    const { anchorBlock } = ctx;
+    const rest = states.slice(1);
+
+    if (rest.length === 0) {
+        anchorBlock.text = head + mergeText + tail;
+        anchorBlock.update();
+        const offset = head.length + mergeText.length;
+        anchorBlock.setCursor(offset, offset, true);
+
+        return;
+    }
+
+    anchorBlock.text = head + mergeText;
+    anchorBlock.update();
+    const offset = sewTail(rest, tail);
+    const last = insertStatesAfter(muya, ctx.wrapperBlock, rest);
+    seatCursorAtSeam(last, offset);
+}
+
+// NEWLINE: the first state cannot merge into the anchor — insert every state as
+// a new block, sewing the tail onto the last and dropping an emptied anchor.
+function pasteNewline(
+    muya: Muya,
+    ctx: IPasteContext,
+    states: TState[],
+    head: string,
+    tail: string,
+): void {
+    const { anchorBlock } = ctx;
+    if (anchorBlock.text !== head) {
+        anchorBlock.text = head;
+        anchorBlock.update();
+    }
+
+    const offset = sewTail(states, tail);
+    const last = insertStatesAfter(muya, ctx.wrapperBlock, states);
+    if (head.length === 0)
+        removeEmptyOriginParagraph(ctx.originWrapperBlock);
+
+    seatCursorAtSeam(last, offset);
+}
+
+// Parse a paste into real blocks. A heading anchor keeps the first line; a
+// non-heading anchor merges the first paragraph/heading inline (head + pasted +
+// tail) or, for non-mergeable content, starts new blocks below.
 function applyParsedPaste(
     clipboard: Clipboard,
     ctx: IPasteContext,
     markdown: string,
 ): void {
     const { muya } = clipboard;
-    const { anchorBlock, originWrapperBlock, start, end, content } = ctx;
-    let wrapperBlock = ctx.wrapperBlock;
+    const { anchorBlock, start, end, content } = ctx;
 
     // An empty / whitespace-only paste is a no-op; the parser would otherwise
     // emit a lone empty paragraph and churn blocks.
@@ -74,40 +208,29 @@ function applyParsedPaste(
         frontMatter,
     }).generate(markdown);
 
-    // When pasting into a heading, splice the first paragraph back into the
-    // heading text so the heading semantics survive. The helper also collapses
-    // any selection on the heading.
+    if (states.length === 0)
+        return;
+
     const remaining = mergePasteIntoHeading(
         anchorBlock,
-        wrapperBlock,
+        ctx.wrapperBlock,
         states,
         { startOffset: start.offset, endOffset: end.offset },
     );
+    if (remaining !== states) {
+        pasteAfterHeading(muya, ctx, remaining);
 
-    if (remaining === states && start.offset !== end.offset) {
-        anchorBlock.text
-            = content.substring(0, start.offset) + content.substring(end.offset);
-        anchorBlock.update();
+        return;
     }
 
-    for (const state of remaining) {
-        const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
-        wrapperBlock?.parent?.insertAfter(newBlock, wrapperBlock);
-        wrapperBlock = newBlock;
-    }
+    const head = content.substring(0, start.offset);
+    const tail = content.substring(end.offset);
+    const mergeText = inlineMergeText(states[0], head.length > 0);
 
-    // Remove empty paragraph when paste.
-    if (originWrapperBlock?.blockName === 'paragraph') {
-        const originState = originWrapperBlock.getState();
-        if (isParagraphState(originState) && originState.text === '')
-            originWrapperBlock.remove();
-    }
-
-    const cursorBlock = wrapperBlock?.firstContentInDescendant();
-    const offset = cursorBlock?.text.length;
-
-    if (offset != null)
-        cursorBlock?.setCursor(offset, offset, true);
+    if (mergeText != null)
+        pasteInlineMerge(muya, ctx, states, mergeText, head, tail);
+    else
+        pasteNewline(muya, ctx, states, head, tail);
 }
 
 // `language-input`, `table.cell.content` and `codeblock.content` never parse a


### PR DESCRIPTION
## Summary

Second PR in the clipboard parity series. Ports muyajs `pasteCtrl` MERGE/NEWLINE semantics into the state-based paste path. Previously a paste into a non-empty text block always inserted the parsed content as **separate blocks below** the cursor (so pasting `hello` into `foo|bar` produced two blocks instead of `foohellobar`).

- **Paragraph merges inline.** A pasted paragraph splices into a non-empty text anchor → `head + pasted + tail`. A heading pasted into a non-empty anchor merges the same way (marker dropped); into an *empty* anchor it still starts a block. Non-mergeable content (code/table/quote/hr) starts a new block (unchanged).
- **Selection replace.** Pasting over a selection replaces it inline.
- **Tail sewing + caret.** When a paste yields multiple blocks, the anchor's trailing text is sewn onto the last pasted block and the caret lands at the seam.
- **Multi-line into heading (A6).** A multi-line (soft-break) paragraph pasted into a heading keeps only its first line in the heading; the rest becomes a paragraph below. Previously the trailing lines were **silently dropped** (`serializeAtxHeading` only keeps the first line).

Deferred to a follow-up PR: **list-into-list merge + loose/tight reconciliation** — it needs live list-tree restructuring (navigating up to the enclosing list and appending items), distinct from the inline text merges here.

## Tests

- New `pasteBlockMerge.spec.ts` (real-`Muya` + stubbed selection, asserting on `getMarkdown()`): inline paragraph merge, selection-replace, multi-block tail-sewing, multi-line-into-heading.
- `mergePasteIntoHeading.spec.ts` (6) and `pasteHandlerParity.spec.ts` (15) still pass — the heading-merge and single-line-into-empty-paragraph behaviors are preserved.
- Updated one `clipboardFilePath.spec.ts` case: a single pasted paragraph now merges into the (empty) anchor rather than creating a separate block.
- Full muya unit suite passes (only the known worktree `css?inline` import failures remain). `tsc`, `eslint`, `madge --circular` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)