### PR TITLE
fix(muya): replace selected image on paste + language-input paste parity

### DIFF
--- a/packages/muya/src/block/content/langInputContent/index.ts
+++ b/packages/muya/src/block/content/langInputContent/index.ts
@@ -46,6 +46,13 @@ class LangInputContent extends Content {
         this.muya.eventCenter.emit('content-change', { block: this });
     }
 
+    // Public entry for setting the language programmatically (e.g. pasting into
+    // the language input), so the code block re-highlights and `parent.lang`
+    // updates; the DOM input handlers use `_updateLanguage` directly.
+    updateLanguage(lang: string): void {
+        this._updateLanguage(lang);
+    }
+
     override inputHandler() {
         const textContent = this.domNode!.textContent ?? '';
         const lang = textContent.split(/\s+/)[0];

--- a/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteImageLoading.spec.ts
@@ -86,9 +86,9 @@ describe('pasteHandler image paste — loading placeholder then replace (sub-ite
 
         const done = clipboard.pasteHandler(makePasteEvent());
 
-        // Give the microtasks up to the `await imageAction` a chance to run.
-        await Promise.resolve();
-        await Promise.resolve();
+        // The placeholder is spliced in synchronously just before `imageAction`
+        // is awaited; wait until that call to avoid coupling to microtask counts.
+        await vi.waitFor(() => expect(imageAction).toHaveBeenCalled());
 
         // A placeholder image markdown must already be present in the anchor.
         expect(anchorBlock.text).toMatch(/!\[[^\]]*\]\([^)]+\)/);

--- a/packages/muya/src/clipboard/__tests__/pasteLanguageInput.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteLanguageInput.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs takes the FIRST line of a paste as the code block language and
+// propagates it (re-highlight / language selector), rather than concatenating
+// every line into the language identifier.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    // Returns a thenable so `CodeBlock.set lang` -> loadLanguage(value).then(...)
+    // does not throw under the stubbed prism.
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentBlocks(muya: Muya): Content[] {
+    const out: Content[] = [];
+    let c: Content | null = muya.editor.scrollPage!.firstContentInDescendant();
+    while (c) {
+        out.push(c);
+        c = c.nextContentInContext() ?? null;
+    }
+    return out;
+}
+
+function pasteEvent(text: string) {
+    return {
+        preventDefault() {},
+        stopPropagation() {},
+        clipboardData: { getData: (t: string) => (t === 'text/plain' ? text : ''), files: [], items: [] },
+    } as unknown as ClipboardEvent;
+}
+
+async function pasteInto(muya: Muya, block: Content, text: string): Promise<string> {
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: 0, block, path },
+        focus: { offset: 0, block, path },
+        isCollapsed: true,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+    await muya.editor.clipboard.pasteHandler(pasteEvent(text), text, '');
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('paste — into a code block language input (muyajs parity)', () => {
+    it('uses only the first line as the language and propagates it', async () => {
+        const muya = bootMuya('```\ncode line\n```\n');
+        const langInput = contentBlocks(muya).find(b => b.blockName === 'language-input')!;
+
+        const md = await pasteInto(muya, langInput, 'js\nignored second line');
+
+        expect(md).toBe('```js\ncode line\n```\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pasteReplaceImage.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteReplaceImage.spec.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+
+import type Format from '../../block/base/format';
+import type { ImageToken } from '../../inlineRenderer/types';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs `pasteImage` replaces a selected inline image when an image is pasted,
+// instead of inserting a second image at a (now collapsed) text cursor.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown, ...options } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function selectWholeImage(muya: Muya): Format {
+    const block = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+    const raw = block.text;
+    const token = {
+        type: 'image',
+        raw,
+        range: { start: 0, end: raw.length },
+    } as unknown as ImageToken;
+    muya.editor.selection.selectImage({ token, imageId: 'sel-img', block });
+
+    // happy-dom doesn't round-trip the range that `setCursor` writes, so stub
+    // `getSelection` to the image's range — what a real browser would report
+    // after the replace path selects the old image.
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: 0, block, path },
+        focus: { offset: raw.length, block, path },
+        isCollapsed: false,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+    return block;
+}
+
+function pasteEvent() {
+    return {
+        preventDefault() {},
+        stopPropagation() {},
+        clipboardData: { getData: () => '', files: [], items: [] },
+    } as unknown as ClipboardEvent;
+}
+
+describe('paste — replace a selected inline image (muyajs parity)', () => {
+    it('pasting an image while one is selected replaces it', async () => {
+        const muya = bootMuya('![old](https://example.com/old.png)\n', {
+            clipboardFilePath: () => Promise.resolve('/tmp/new.png'),
+        });
+        selectWholeImage(muya);
+
+        await muya.editor.clipboard.pasteHandler(pasteEvent(), '', '');
+        await new Promise(r => setTimeout(r, 40));
+
+        expect(muya.getMarkdown()).toBe('![](/tmp/new.png)\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pasteReplaceImage.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteReplaceImage.spec.ts
@@ -92,4 +92,51 @@ describe('paste — replace a selected inline image (muyajs parity)', () => {
 
         expect(muya.getMarkdown()).toBe('![](/tmp/new.png)\n');
     });
+
+    it('replaces by the token range even when the DOM selection clamps to one position', async () => {
+        // Real browsers collapse a text selection spanning the atomic
+        // (contenteditable=false) image to a single position — this is what
+        // broke replacing a resized `<img>`: the splice consumed only the
+        // leading character and orphaned the rest of the tag. The replace must
+        // use the image token's range, not the clamped DOM selection.
+        const muya = bootMuya('![old](https://example.com/old.png)\n', {
+            clipboardFilePath: () => Promise.resolve('/tmp/new.png'),
+        });
+        const block = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+        const raw = block.text;
+        muya.editor.selection.selectImage({
+            token: { type: 'image', raw, range: { start: 0, end: raw.length } } as unknown as ImageToken,
+            imageId: 'sel-img',
+            block,
+        });
+        const path = block.path;
+        muya.editor.selection.getSelection = () => ({
+            anchor: { offset: 0, block, path },
+            focus: { offset: 1, block, path }, // clamped across the atomic image
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.FORWARD,
+            type: SelectionCaretType.RANGE,
+        });
+
+        await muya.editor.clipboard.pasteHandler(pasteEvent(), '', '');
+        await new Promise(r => setTimeout(r, 40));
+
+        // The WHOLE image is replaced, not just the first character.
+        expect(muya.getMarkdown()).toBe('![](/tmp/new.png)\n');
+    });
+
+    it('leaves the replaced image selected so the toolbar / resize bar follow it', async () => {
+        const muya = bootMuya('![old](https://example.com/old.png)\n', {
+            clipboardFilePath: () => Promise.resolve('/tmp/new.png'),
+        });
+        selectWholeImage(muya);
+
+        await muya.editor.clipboard.pasteHandler(pasteEvent(), '', '');
+        await new Promise(r => setTimeout(r, 40));
+
+        const selected = muya.editor.selection.image;
+        expect(selected).not.toBeNull();
+        expect(selected!.token.attrs.src).toContain('/tmp/new.png');
+    });
 });

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -6,6 +6,7 @@ import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
 import CodeBlockContent from '../block/content/codeBlockContent';
+import LangInputContent from '../block/content/langInputContent';
 import { ScrollPage } from '../block/scrollPage';
 import { URL_REG } from '../config';
 import HtmlToMarkdown from '../state/htmlToMarkdown';
@@ -13,7 +14,7 @@ import { MarkdownToState } from '../state/markdownToState';
 import { isParagraphState } from '../state/types';
 import { getClipboardImageFile, getCopyTextType, isStandaloneTableHtml, normalizePastedHTML } from '../utils/paste';
 import { mergePasteIntoHeading } from './mergePasteIntoHeading';
-import { tryPasteImage } from './pasteImage';
+import { tryPasteImage, tryReplaceSelectedImage } from './pasteImage';
 import { PasteType } from './types';
 
 // Everything the per-anchor paste handlers need from the synchronous snapshot
@@ -261,9 +262,25 @@ function applyLiteralPaste(
         return;
     }
 
-    if (anchorBlock.blockName === 'language-input')
-        markdown = markdown.replace(/\n/g, '');
-    else if (anchorBlock.blockName === 'table.cell.content')
+    // language-input: only the first line is the language; propagate it to the
+    // code block (re-highlight + language selector) rather than splicing raw.
+    if (anchorBlock.blockName === 'language-input') {
+        const firstLine = initialMarkdown.split('\n')[0];
+        const newLang
+            = content.substring(0, start.offset)
+                + firstLine
+                + content.substring(end.offset);
+        const offset = start.offset + firstLine.length;
+        if (anchorBlock instanceof LangInputContent)
+            anchorBlock.updateLanguage(newLang);
+        else
+            anchorBlock.text = newLang;
+        anchorBlock.setCursor(offset, offset, true);
+
+        return;
+    }
+
+    if (anchorBlock.blockName === 'table.cell.content')
         markdown = markdown.replace(/\n/g, '<br/>');
 
     anchorBlock.text
@@ -338,6 +355,13 @@ interface IPasteData {
 async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void> {
     const { muya } = clipboard;
     const { bulletListMarker } = muya.options;
+
+    // A selected inline image collapses the text selection, so handle the
+    // "paste an image over a selected image" replace before reading the
+    // (now absent) text selection.
+    if (clipboard.selection.image && await tryReplaceSelectedImage(clipboard, data.imageFile))
+        return;
+
     const selection = clipboard.selection.getSelection();
     if (!selection)
         return;

--- a/packages/muya/src/clipboard/pasteImage.ts
+++ b/packages/muya/src/clipboard/pasteImage.ts
@@ -1,8 +1,11 @@
 import type Content from '../block/base/content';
+import type Format from '../block/base/format';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
+import { CLASS_NAMES } from '../config';
 import { SelectionType } from '../selection/types';
 import { getUniqueId } from '../utils';
+import { getImageInfo } from '../utils/image';
 import { readFileAsDataURL, resolveClipboardImagePath } from '../utils/paste';
 
 /**
@@ -143,6 +146,141 @@ export async function tryPasteImage(
 }
 
 /**
+ * Splice `![alt](src)` over the character range `[start, end)` of `block`,
+ * replacing whatever inline image text lived there — a markdown `![]()` OR a
+ * resized html `<img ...>`. Splicing by the token's range directly (instead of
+ * selecting the image and reading the DOM cursor back) is what muyajs does: a
+ * DOM text-selection spanning the atomic `contenteditable=false` image clamps
+ * to a single position, which would replace only the leading `<` and orphan the
+ * rest of the tag.
+ */
+function spliceImageText(
+    block: Content,
+    range: { start: number; end: number },
+    src: string,
+    alt = '',
+): string {
+    const escapedSrc = src
+        .replace(/ /g, encodeURI(' '))
+        .replace(/#/g, encodeURIComponent('#'));
+    const imageText = `![${alt}](${escapedSrc})`;
+
+    block.text
+        = block.text.substring(0, range.start)
+            + imageText
+            + block.text.substring(range.end);
+
+    const offset = range.start + imageText.length;
+    block.setCursor(offset, offset, true);
+
+    return imageText;
+}
+
+// Find the rendered wrapper of the image whose token starts at `startOffset`
+// (same lookup the inline-image click path uses). The block was re-rendered
+// synchronously by the `setCursor(..., true)` in `spliceImageText` /
+// `replacePlaceholderImage`, so the wrapper is already in the DOM.
+function findImageWrapper(block: Format, startOffset: number): Nullable<HTMLElement> {
+    const { domNode } = block;
+    if (domNode == null)
+        return null;
+
+    const images = domNode.querySelectorAll<HTMLElement>(`.${CLASS_NAMES.MU_INLINE_IMAGE}`);
+    let wrapper: Nullable<HTMLElement> = images[images.length - 1] ?? null;
+    for (const image of images) {
+        if (getImageInfo(image).token.range.start === startOffset) {
+            wrapper = image;
+            break;
+        }
+    }
+
+    return wrapper;
+}
+
+// Float the image toolbar + resize bar over `wrapper`, mirroring the loaded-image
+// branch of `ImageSelection._handleClickInlineImage`. The controls anchor to the
+// image container's box, so this must run only once the image has loaded.
+function positionImageControls(clipboard: Clipboard, block: Format, wrapper: HTMLElement): void {
+    const imageContainer = wrapper.querySelector(`.${CLASS_NAMES.MU_IMAGE_CONTAINER}`);
+    if (imageContainer == null)
+        return;
+
+    const imageInfo = getImageInfo(wrapper);
+    const rect = imageContainer.getBoundingClientRect();
+    const reference = {
+        getBoundingClientRect: () => rect,
+        width: wrapper.offsetWidth,
+        height: wrapper.offsetHeight,
+    };
+    const { eventCenter } = clipboard.muya;
+    eventCenter.emit('muya-image-toolbar', { block, reference, imageInfo });
+    eventCenter.emit('muya-transformer', { block, reference: imageContainer, imageInfo });
+}
+
+// Re-select the replaced image and float its controls over it. The image is
+// selected synchronously so it stays the active selection; the toolbar / resize
+// bar are positioned only once the image has loaded — they anchor to the loaded
+// image box, which is 0-sized (and has no `<img>`) until `loadImageAsync` fills
+// it in, which never re-emits the positioning events on its own.
+function reselectImageAt(clipboard: Clipboard, block: Format, startOffset: number): void {
+    const wrapper = findImageWrapper(block, startOffset);
+    if (wrapper == null)
+        return;
+
+    clipboard.muya.editor.selection.selectImage(
+        Object.assign({}, getImageInfo(wrapper), { block }),
+    );
+    block.update();
+
+    if (typeof requestAnimationFrame !== 'function')
+        return;
+
+    let attempts = 60;
+    const positionWhenLoaded = (): void => {
+        const current = findImageWrapper(block, startOffset);
+        if (current?.querySelector('img')) {
+            positionImageControls(clipboard, block, current);
+
+            return;
+        }
+        if (--attempts > 0)
+            requestAnimationFrame(positionWhenLoaded);
+    };
+    requestAnimationFrame(positionWhenLoaded);
+}
+
+// Replace the image spanning `range` with the pasted `src`, routing through the
+// embedder's `imageAction` (with a `loading-<id>` placeholder) the same way
+// {@link insertImageSrc} does for a fresh insert. The new image is left selected
+// so the floating image controls follow it.
+async function replaceImageAt(
+    clipboard: Clipboard,
+    block: Format,
+    range: { start: number; end: number },
+    src: string,
+): Promise<void> {
+    const { imageAction } = clipboard.muya.options;
+
+    if (!imageAction) {
+        spliceImageText(block, range, src);
+        reselectImageAt(clipboard, block, range.start);
+
+        return;
+    }
+
+    const id = `loading-${getUniqueId()}`;
+    const placeholderText = spliceImageText(block, range, src, id);
+
+    let finalSrc = src;
+    const resolved = await imageAction({ src, alt: '', title: '' });
+    if (resolved)
+        finalSrc = resolved;
+
+    replacePlaceholderImage(block, placeholderText, finalSrc);
+    reselectImageAt(clipboard, block, range.start);
+}
+
+/**
  * Pasting an image while an inline image is selected replaces that image
  * (muyajs `pasteImage` selectedImage branch) instead of inserting a new one.
  * Returns `true` when it replaced the selected image.
@@ -159,10 +297,11 @@ export async function tryReplaceSelectedImage(
     if (src == null)
         return false;
 
+    // Replace by the image token's character range directly — never via a DOM
+    // text selection, which clamps across the atomic image and mangles the tag.
     const { block, token } = selectedImage;
     clipboard.selection.activate(SelectionType.TEXT);
-    block.setCursor(token.range.start, token.range.end, true);
-    await insertImageSrc(clipboard, block, src);
+    await replaceImageAt(clipboard, block, token.range, src);
 
     return true;
 }

--- a/packages/muya/src/clipboard/pasteImage.ts
+++ b/packages/muya/src/clipboard/pasteImage.ts
@@ -1,6 +1,7 @@
 import type Content from '../block/base/content';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
+import { SelectionType } from '../selection/types';
 import { getUniqueId } from '../utils';
 import { readFileAsDataURL, resolveClipboardImagePath } from '../utils/paste';
 
@@ -103,33 +104,65 @@ async function insertImageSrc(
     replacePlaceholderImage(anchorBlock, placeholderText, finalSrc);
 }
 
+// Resolve a pasted image to an `src`: a clipboard FILE path (via the
+// `clipboardFilePath` hook) first, then an in-memory bitmap File read as a
+// base64 `data:` URL. Returns null when the clipboard carries no image.
+async function resolveImageSrc(
+    clipboard: Clipboard,
+    imageFile: Nullable<File>,
+): Promise<Nullable<string>> {
+    const imagePath = await resolveClipboardImagePath(
+        clipboard.muya.options.clipboardFilePath,
+    );
+    if (imagePath)
+        return imagePath;
+
+    if (imageFile)
+        return readFileAsDataURL(imageFile);
+
+    return null;
+}
+
 /**
- * Insert a pasted image when the clipboard carries one. Tries a resolved
- * clipboard FILE path first (via the `clipboardFilePath` hook), then
- * an in-memory bitmap File (read as a base64 `data:` URL). Returns
- * `true` when an image was inserted so the caller skips the text/HTML
- * paste, `false` to fall through.
+ * Insert a pasted image when the clipboard carries one. Returns `true` when an
+ * image was inserted so the caller skips the text/HTML paste, `false` to fall
+ * through.
  */
 export async function tryPasteImage(
     clipboard: Clipboard,
     anchorBlock: Content,
     imageFile: Nullable<File>,
 ): Promise<boolean> {
-    const imagePath = await resolveClipboardImagePath(
-        clipboard.muya.options.clipboardFilePath,
-    );
-    if (imagePath) {
-        await insertImageSrc(clipboard, anchorBlock, imagePath);
-        return true;
-    }
+    const src = await resolveImageSrc(clipboard, imageFile);
+    if (src == null)
+        return false;
 
-    if (imageFile) {
-        const dataUrl = await readFileAsDataURL(imageFile);
-        if (dataUrl) {
-            await insertImageSrc(clipboard, anchorBlock, dataUrl);
-            return true;
-        }
-    }
+    await insertImageSrc(clipboard, anchorBlock, src);
 
-    return false;
+    return true;
+}
+
+/**
+ * Pasting an image while an inline image is selected replaces that image
+ * (muyajs `pasteImage` selectedImage branch) instead of inserting a new one.
+ * Returns `true` when it replaced the selected image.
+ */
+export async function tryReplaceSelectedImage(
+    clipboard: Clipboard,
+    imageFile: Nullable<File>,
+): Promise<boolean> {
+    const selectedImage = clipboard.selection.image;
+    if (selectedImage == null)
+        return false;
+
+    const src = await resolveImageSrc(clipboard, imageFile);
+    if (src == null)
+        return false;
+
+    const { block, token } = selectedImage;
+    clipboard.selection.activate(SelectionType.TEXT);
+    block.setCursor(token.range.start, token.range.end, true);
+    await insertImageSrc(clipboard, block, src);
+
+    return true;
 }


### PR DESCRIPTION
## Summary

Third PR in the clipboard parity series (stacked on #4542 — paste block merge). Two paste-into-special-context fixes:

- **Replace a selected image on paste (A9).** Selecting an inline image collapses the text selection, so the old code returned early (no anchor) and the pasted image went nowhere / was inserted at a stray cursor. We now check for a selected image before reading the text selection and replace it in place (muyajs `pasteImage` selectedImage branch).
- **Language-input paste (A7).** Pasting into a code block's language identifier now takes only the **first line** as the language and propagates it via `LangInputContent.updateLanguage` (re-highlight + language selector refresh), instead of concatenating every pasted line and never propagating.

`pasteImage`'s src resolution is factored into a shared `resolveImageSrc`, used by both `tryPasteImage` and the new `tryReplaceSelectedImage`.

Deferred: the **plain-text-paste of block-level HTML** case (A8) — its "literal text" semantics are inherently leaky through the markdown round-trip and the trigger (block HTML present in `text/plain` only, under Paste-as-Plain-Text) is rare. Flagged for a decision.

> Stacked on #4542; review/merge that first. Base will be retargeted to `develop` once it lands.

## Tests

- New `pasteReplaceImage.spec.ts` and `pasteLanguageInput.spec.ts` (real `Muya`, asserting on `getMarkdown()`).
- `pasteImageLoading.spec.ts`: replaced a microtask-count-coupled intermediate check with `vi.waitFor(imageAction called)` — the `resolveImageSrc` refactor adds one async hop; observable placeholder→swap behavior is unchanged.
- Full muya unit suite passes (only the known worktree `css?inline` failures remain). `tsc`, `eslint`, `madge --circular` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)