### PR TITLE
fix(muya): render footnotes in copy-as-html / copy-as-rich clipboard HTML

### DIFF
--- a/packages/muya/src/clipboard/__tests__/copyFootnote.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyFootnote.spec.ts
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { getClipBoardHtml } from '../../utils/marked/getClipboardHtml';
+
+// Copy-as-HTML / copy-as-rich must render footnote definitions in the clipboard
+// HTML the same way the static / export render path does. muyajs passed the
+// `footnote` option into marked; muya's `getClipBoardHtml` dropped it.
+const MD = 'See the note[^1].\n\n[^1]: The footnote body.';
+
+describe('getClipBoardHtml — footnote rendering', () => {
+    it('renders footnote definitions when footnote is enabled', () => {
+        const html = getClipBoardHtml(MD, { footnote: true });
+        expect(html).toContain('footnote-block');
+    });
+
+    it('leaves footnote definitions unrendered when footnote is disabled', () => {
+        const html = getClipBoardHtml(MD, { footnote: false });
+        expect(html).not.toContain('footnote-block');
+    });
+});

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -39,13 +39,14 @@ interface ICopyOrder {
 
 function buildHtmlOptions(options: Muya['options']) {
     const {
+        footnote,
         frontMatter = true,
         math,
         isGitlabCompatibilityEnabled,
         superSubScript,
     } = options;
 
-    return { frontMatter, math, isGitlabCompatibilityEnabled, superSubScript };
+    return { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript };
 }
 
 // Collapse the three list flavours (task/order/bullet) into one slice

--- a/packages/muya/src/utils/marked/getClipboardHtml.ts
+++ b/packages/muya/src/utils/marked/getClipboardHtml.ts
@@ -3,6 +3,7 @@ import { Marked } from 'marked';
 import { EXPORT_DOMPURIFY_CONFIG } from '../../config';
 import { sanitize } from '../index';
 import cjkEmStrongExtension from './extensions/cjkEmStrong';
+import footnoteExtension from './extensions/footnote';
 import mathExtension from './extensions/math';
 import superSubScriptExtension from './extensions/superSubscript';
 import fm, { frontMatterRender } from './frontMatter';
@@ -11,7 +12,7 @@ import walkTokens from './walkTokens';
 
 export function getClipBoardHtml(src: string, options: ILexOption = {}) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
-    const { frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
+    const { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
         = options;
     let html = '';
 
@@ -40,6 +41,9 @@ export function getClipBoardHtml(src: string, options: ILexOption = {}) {
 
     if (superSubScript)
         marked.use(superSubScriptExtension());
+
+    if (footnote)
+        marked.use(footnoteExtension());
 
     if (frontMatter) {
         const { token, src: newSrc } = fm(src);


### PR DESCRIPTION
## Summary

Clipboard parity series (independent of the cut/paste PRs). `getClipBoardHtml` — used by **Copy as HTML** (rendered HTML in `text/plain`) and **Copy as Rich Text** (HTML in `text/html`) — never registered the footnote marked extension, and `buildHtmlOptions` dropped the `footnote` option. So copying a selection containing footnote definitions produced clipboard HTML with the raw `[^id]:` text instead of rendered footnotes, even though the static/export render path (`getHighlightHtml`) renders them.

Fix: thread `footnote` through `buildHtmlOptions` and `marked.use(footnoteExtension())` when it is enabled — matching `getHighlightHtml`.

## Tests

- New `copyFootnote.spec.ts`: `getClipBoardHtml` renders `footnote-block` when `footnote: true`, leaves the definition unrendered when `false`.
- Full muya unit suite passes (only the known worktree `css?inline` failures remain). `tsc`, `eslint`, `madge --circular` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)