### PR TITLE
fix(muya): collapse code block to paragraph on cross-block cut from its language line (#918)

### DIFF
--- a/packages/muya/src/clipboard/__tests__/cutLanguageInput918.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/cutLanguageInput918.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// #918: a cross-block cut whose selection starts inside a code fence's
+// language-input line must collapse the start code block to a paragraph
+// holding the merged text, rather than corrupting the code block (the old
+// path spliced the merged text into the language identifier and left an
+// inconsistent block tree).
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentBlocks(muya: Muya): Content[] {
+    const out: Content[] = [];
+    let c: Content | null = muya.editor.scrollPage!.firstContentInDescendant();
+    while (c) {
+        out.push(c);
+        c = c.nextContentInContext() ?? null;
+    }
+    return out;
+}
+
+function stubSelection(muya: Muya, a: Content, aOff: number, f: Content, fOff: number) {
+    // Capture paths eagerly — the cut detaches the start code block, and a
+    // re-entrant getSelection would otherwise read a null parent off it.
+    const aPath = a.path;
+    const fPath = f.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: aOff, block: a, path: aPath },
+        focus: { offset: fOff, block: f, path: fPath },
+        isCollapsed: false,
+        isSelectionInSameBlock: a === f,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+async function cutAndRead(muya: Muya): Promise<string> {
+    muya.editor.clipboard.cutHandler();
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('track C — cross-block cut starting in a code fence language line (#918)', () => {
+    it('collapses the code block to a paragraph holding the merged text', async () => {
+        const muya = bootMuya('```js\nconst x = 1\n```\n\nhello world\n');
+        const blocks = contentBlocks(muya);
+        const langInput = blocks.find(b => b.blockName === 'language-input')!;
+        const para = blocks[blocks.length - 1];
+        // 'js'@1 -> 'j' merged with 'hello world'@5 -> ' world'.
+        stubSelection(muya, langInput, 1, para, 5);
+        expect(await cutAndRead(muya)).toBe('j world\n');
+    });
+});

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -56,6 +56,20 @@ function resetToEmptyParagraph(clipboard: Clipboard): void {
     cursorBlock?.setCursor(0, 0, true);
 }
 
+// Seat the caret and re-evaluate the block's type from its new text — a cut can
+// add or remove a block-leading marker (`# `, `- `, …).
+function setCursorAndConvert(block: Content, offset: number): void {
+    block.setCursor(offset, offset, true);
+    if (block instanceof Format)
+        block.checkInlineUpdate();
+}
+
+// Collapse the document to a single empty paragraph once a cut empties it.
+function resetIfEmpty(clipboard: Clipboard): void {
+    if (clipboard.scrollPage?.length() === 0)
+        resetToEmptyParagraph(clipboard);
+}
+
 // Empty every cell content leaf from `start` up to and including `after`,
 // keeping the table grid intact.
 function emptyCellContentsUntil(
@@ -369,9 +383,7 @@ export function cutSelection(clipboard: Clipboard): void {
         anchorBlock.text
             = text.substring(0, startOffset) + text.substring(endOffset);
 
-        anchorBlock.setCursor(startOffset, startOffset, true);
-        if (anchorBlock instanceof Format)
-            anchorBlock.checkInlineUpdate();
+        setCursorAndConvert(anchorBlock, startOffset);
 
         return;
     }
@@ -408,13 +420,8 @@ export function cutSelection(clipboard: Clipboard): void {
 
     removeBlocks(startBlock, endBlock);
 
-    startBlock.setCursor(startOffset, startOffset, true);
-    if (startBlock instanceof Format)
-        startBlock.checkInlineUpdate();
-
-    if (clipboard.scrollPage?.length() === 0) {
-        resetToEmptyParagraph(clipboard);
-    }
+    setCursorAndConvert(startBlock, startOffset);
+    resetIfEmpty(clipboard);
 }
 
 // #918: collapse the start code block (whose language line begins the
@@ -442,8 +449,7 @@ function collapseLanguageInputCut(
 
     paragraph.firstContentInDescendant()?.setCursor(startOffset, startOffset, true);
 
-    if (clipboard.scrollPage?.length() === 0)
-        resetToEmptyParagraph(clipboard);
+    resetIfEmpty(clipboard);
 }
 
 // Keyboard delete over a frozen table selection (two-stage, muyajs parity):

--- a/packages/muya/src/clipboard/cut.ts
+++ b/packages/muya/src/clipboard/cut.ts
@@ -388,6 +388,15 @@ export function cutSelection(clipboard: Clipboard): void {
         return;
     }
 
+    // #918: a cross-block cut that starts inside a code fence's language line
+    // collapses the start code block to a paragraph holding the merged text,
+    // rather than corrupting the code block's language with the merged content.
+    if (startBlock.blockName === 'language-input') {
+        collapseLanguageInputCut(clipboard, startBlock, endBlock, startOffset, endOffset);
+
+        return;
+    }
+
     // Leaf-level merge: keep the
     // start head and the end tail in the start content block, then remove
     // only the structure strictly between the two leaves (and the emptied
@@ -406,6 +415,35 @@ export function cutSelection(clipboard: Clipboard): void {
     if (clipboard.scrollPage?.length() === 0) {
         resetToEmptyParagraph(clipboard);
     }
+}
+
+// #918: collapse the start code block (whose language line begins the
+// selection) into a paragraph carrying the merged head + end-tail text, then
+// remove the spanned structure.
+function collapseLanguageInputCut(
+    clipboard: Clipboard,
+    startBlock: Content,
+    endBlock: Content,
+    startOffset: number,
+    endOffset: number,
+): void {
+    const mergedText
+        = startBlock.text.substring(0, startOffset)
+            + endBlock.text.substring(endOffset);
+    const codeBlock = startBlock.outMostBlock;
+
+    removeBlocks(startBlock, endBlock);
+
+    const paragraph = ScrollPage.loadBlock('paragraph').create(clipboard.muya, {
+        name: 'paragraph',
+        text: mergedText,
+    });
+    codeBlock?.replaceWith(paragraph);
+
+    paragraph.firstContentInDescendant()?.setCursor(startOffset, startOffset, true);
+
+    if (clipboard.scrollPage?.length() === 0)
+        resetToEmptyParagraph(clipboard);
 }
 
 // Keyboard delete over a frozen table selection (two-stage, muyajs parity):


### PR DESCRIPTION
Follow-up to #4540 (cut/delete parity), split out per review. Fixes the #918 edge: a cross-block cut/delete whose selection starts inside a code fence's language-input line and extends into a following block. Previously the generic leaf-merge spliced the merged text into the language identifier and left an inconsistent block tree (subsequent path/lang access threw). Mirroring muyajs, the start code block is now collapsed into a paragraph holding the merged head + end-tail text, and the spanned structure is removed.

Stacked on #4540; review/merge that first. Base will be retargeted to develop once it lands.

Tests: new cutLanguageInput918.spec.ts (real Muya). Full muya unit suite passes (only known worktree css?inline failures). tsc, eslint, madge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)