### PR TITLE
fix(muya): merge same-type list paste + plain-text block HTML (muyajs parity)

### DIFF
--- a/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
@@ -126,4 +126,18 @@ describe('paste — multi-line paragraph into a heading keeps only the first lin
             '# Titlea\n\nb\nc\n',
         );
     });
+
+    it('pasting multiple paragraphs mid-heading sews the heading tail after the paste', async () => {
+        const muya = bootMuya('# hello world\n');
+        const block = contentBlocks(muya)[0]; // '# hello world'
+        // cursor between 'hello ' and 'world' (offset 8); 'world' must trail the
+        // whole paste, not stay in the heading.
+        expect(await paste(muya, block, 8, 8, 'A\n\nB')).toBe('# hello A\n\nBworld\n');
+    });
+
+    it('pasting a single paragraph mid-heading keeps it on the heading line', async () => {
+        const muya = bootMuya('# hello world\n');
+        const block = contentBlocks(muya)[0];
+        expect(await paste(muya, block, 8, 8, 'A')).toBe('# hello Aworld\n');
+    });
 });

--- a/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteHandlerParity.spec.ts
@@ -102,6 +102,7 @@ function makeAnchorBlock(
         getCursor: () => ({ start: { offset: cursor }, end: { offset: cursor } }),
         setCursor: vi.fn(),
         getAnchor: () => wrapper,
+        closestBlock: () => null,
         firstContentInDescendant: () => block,
         getState: () => ({ name: blockName, text: block.text }),
         update: vi.fn(),

--- a/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs `pasteCtrl` list MERGE: pasting a same-type, same-marker list into a
+// list item merges the first pasted item inline into the current item, appends
+// the remaining pasted items to the list, and reconciles loose/tight.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return { ...actual, normalizePastedHTML: async (html: string) => html };
+});
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentBlocks(muya: Muya): Content[] {
+    const out: Content[] = [];
+    let c: Content | null = muya.editor.scrollPage!.firstContentInDescendant();
+    while (c) {
+        out.push(c);
+        c = c.nextContentInContext() ?? null;
+    }
+    return out;
+}
+
+function pasteEvent(text: string) {
+    return {
+        preventDefault() {},
+        stopPropagation() {},
+        clipboardData: { getData: (t: string) => (t === 'text/plain' ? text : ''), files: [], items: [] },
+    } as unknown as ClipboardEvent;
+}
+
+async function paste(muya: Muya, block: Content, start: number, end: number, text: string): Promise<string> {
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: start, block, path },
+        focus: { offset: end, block, path },
+        isCollapsed: start === end,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+    await muya.editor.clipboard.pasteHandler(pasteEvent(text), text, '');
+    await new Promise(r => setTimeout(r, 40));
+    return muya.getMarkdown();
+}
+
+describe('paste — same-type list merges into the enclosing list (A5, muyajs parity)', () => {
+    it('merges the first pasted item inline and appends the rest', async () => {
+        const muya = bootMuya('- a\n');
+        const block = contentBlocks(muya)[0]; // list-item paragraph 'a'
+        expect(await paste(muya, block, 1, 1, '- x\n- y')).toBe('- ax\n- y\n');
+    });
+
+    it('reconciles tight + loose into a loose list', async () => {
+        const muya = bootMuya('- a\n');
+        const block = contentBlocks(muya)[0];
+        // a loose pasted list (blank line between items)
+        expect(await paste(muya, block, 1, 1, '- x\n\n- y')).toBe('- ax\n\n- y\n');
+    });
+
+    it('does not merge when the bullet marker differs', async () => {
+        const muya = bootMuya('- a\n');
+        const block = contentBlocks(muya)[0];
+        const md = await paste(muya, block, 1, 1, '* x');
+        expect(md).not.toContain('- ax');
+    });
+
+    it('merges into the cursor paragraph of a loose item, not the first paragraph', async () => {
+        // Loose item with two paragraphs; cursor in the SECOND ("second"@2).
+        const muya = bootMuya('- a\n\n  second\n');
+        const blocks = contentBlocks(muya);
+        const second = blocks.find(b => b.text === 'second')!;
+        // 'a' must survive; 'second'@2 -> 'se' + 'x', tail 'cond' sews to 'y'.
+        expect(await paste(muya, second, 2, 2, '- x\n- y')).toBe('- a\n\n  sex\n\n- ycond\n');
+    });
+
+    it('places the caret after the folded text on a single-item merge', async () => {
+        const muya = bootMuya('- abc\n');
+        const block = contentBlocks(muya)[0];
+        await paste(muya, block, 3, 3, '- X'); // end of 'abc'
+        const { selection } = muya.editor;
+        expect(muya.editor.activeContentBlock?.text).toBe('abcX');
+        expect(selection.anchor?.offset).toBe(4);
+        expect(selection.focus?.offset).toBe(4);
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pastePlainTextHtml.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pastePlainTextHtml.spec.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs `pasteAsPlainText`: block-level HTML present in text/plain is inserted
+// as literal text, not rendered into a live html-block (which is what NORMAL
+// paste does).
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return { ...actual, normalizePastedHTML: async (html: string) => html };
+});
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown, ...options } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstContent(muya: Muya): Content {
+    return muya.editor.scrollPage!.firstContentInDescendant()!;
+}
+
+describe('paste as plain text — block-level HTML is literal (A8, muyajs parity)', () => {
+    it('inserts <ul>...</ul> as literal text rather than a live html-block', async () => {
+        const html = '<ul><li>a</li><li>b</li></ul>';
+        const muya = bootMuya('foo\n', { clipboardText: () => html });
+        const block = firstContent(muya);
+        const path = block.path;
+        muya.editor.selection.getSelection = () => ({
+            anchor: { offset: 3, block, path },
+            focus: { offset: 3, block, path },
+            isCollapsed: true,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.FORWARD,
+            type: SelectionCaretType.RANGE,
+        });
+
+        await muya.editor.clipboard.pasteAsPlainText();
+        await new Promise(r => setTimeout(r, 40));
+
+        // The HTML merged into the paragraph as literal text — one block, no
+        // separate html-block.
+        expect(muya.getMarkdown()).toBe(`foo${html}\n`);
+        expect(muya.editor.scrollPage!.length()).toBe(1);
+    });
+
+    it('splits multi-line block HTML into per-line paragraphs (no raw newline in a block)', async () => {
+        const html = '<ul>\n<li>a</li>\n</ul>';
+        const muya = bootMuya('foo\n', { clipboardText: () => html });
+        const block = firstContent(muya);
+        const path = block.path;
+        muya.editor.selection.getSelection = () => ({
+            anchor: { offset: 3, block, path },
+            focus: { offset: 3, block, path },
+            isCollapsed: true,
+            isSelectionInSameBlock: true,
+            direction: SelectionDirection.FORWARD,
+            type: SelectionCaretType.RANGE,
+        });
+
+        await muya.editor.clipboard.pasteAsPlainText();
+        await new Promise(r => setTimeout(r, 40));
+
+        // First line folds into 'foo'; the remaining two lines become their own
+        // paragraphs, so the markdown round-trips stably.
+        const md = muya.getMarkdown();
+        expect(md).toBe('foo<ul>\n\n<li>a</li>\n\n</ul>\n');
+        expect(muya.editor.scrollPage!.length()).toBe(3);
+    });
+});

--- a/packages/muya/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/muya/src/clipboard/mergePasteIntoHeading.ts
@@ -39,14 +39,12 @@ export function mergePasteIntoHeading(
 
     // A heading is a single line: only the first soft-line of the pasted
     // paragraph stays in the heading; any following lines become a paragraph
-    // block below it.
+    // block below it. The anchor's tail is NOT kept here — the caller sews it
+    // onto the last pasted block instead.
     const [firstLine, ...restLines] = first.text.split('\n');
 
     const original = anchorBlock.text;
-    anchorBlock.text
-        = original.substring(0, cursor.startOffset)
-            + firstLine
-            + original.substring(cursor.endOffset);
+    anchorBlock.text = original.substring(0, cursor.startOffset) + firstLine;
     anchorBlock.update();
 
     const remaining = states.slice(1);

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -113,16 +113,26 @@ function inlineMergeText(state: TState, anchorHasText: boolean): Nullable<string
 }
 
 // Heading anchor: the first line was spliced into the heading; insert the rest
-// as blocks below and seat the caret at the end of the last one.
-function pasteAfterHeading(muya: Muya, ctx: IPasteContext, remaining: TState[]): void {
-    const last = insertStatesAfter(muya, ctx.wrapperBlock, remaining);
-    removeEmptyOriginParagraph(ctx.originWrapperBlock);
+// as blocks below. The anchor's tail is sewn onto the last pasted block so it
+// trails the whole paste (muyajs `pasteCtrl`); only when nothing follows does
+// it stay in the heading.
+function pasteAfterHeading(muya: Muya, ctx: IPasteContext, remaining: TState[], tail: string): void {
+    const { anchorBlock } = ctx;
 
-    const cursorBlock = last?.firstContentInDescendant();
-    if (cursorBlock != null) {
-        const offset = cursorBlock.text.length;
-        cursorBlock.setCursor(offset, offset, true);
+    if (remaining.length === 0) {
+        const offset = anchorBlock.text.length;
+        if (tail.length > 0) {
+            anchorBlock.text += tail;
+            anchorBlock.update();
+        }
+        anchorBlock.setCursor(offset, offset, true);
+
+        return;
     }
+
+    const sewOffset = sewTail(remaining, tail);
+    const last = insertStatesAfter(muya, ctx.wrapperBlock, remaining);
+    seatCursorAtSeam(last, sewOffset);
 }
 
 // MERGE: splice the first state's text into the anchor (head + pasted), sewing
@@ -319,6 +329,9 @@ function applyParsedPaste(
     if (states.length === 0)
         return;
 
+    const head = content.substring(0, start.offset);
+    const tail = content.substring(end.offset);
+
     const remaining = mergePasteIntoHeading(
         anchorBlock,
         ctx.wrapperBlock,
@@ -326,13 +339,10 @@ function applyParsedPaste(
         { startOffset: start.offset, endOffset: end.offset },
     );
     if (remaining !== states) {
-        pasteAfterHeading(muya, ctx, remaining);
+        pasteAfterHeading(muya, ctx, remaining, tail);
 
         return;
     }
-
-    const head = content.substring(0, start.offset);
-    const tail = content.substring(end.offset);
 
     if (tryMergeListPaste(clipboard, ctx, states, head, tail))
         return;

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -11,7 +11,7 @@ import { ScrollPage } from '../block/scrollPage';
 import { URL_REG } from '../config';
 import HtmlToMarkdown from '../state/htmlToMarkdown';
 import { MarkdownToState } from '../state/markdownToState';
-import { isParagraphState } from '../state/types';
+import { isAnyListState, isParagraphState } from '../state/types';
 import { getClipboardImageFile, getCopyTextType, isStandaloneTableHtml, normalizePastedHTML } from '../utils/paste';
 import { mergePasteIntoHeading } from './mergePasteIntoHeading';
 import { tryPasteImage, tryReplaceSelectedImage } from './pasteImage';
@@ -119,9 +119,10 @@ function pasteAfterHeading(muya: Muya, ctx: IPasteContext, remaining: TState[]):
     removeEmptyOriginParagraph(ctx.originWrapperBlock);
 
     const cursorBlock = last?.firstContentInDescendant();
-    const offset = cursorBlock?.text.length;
-    if (offset != null)
-        cursorBlock?.setCursor(offset, offset, true);
+    if (cursorBlock != null) {
+        const offset = cursorBlock.text.length;
+        cursorBlock.setCursor(offset, offset, true);
+    }
 }
 
 // MERGE: splice the first state's text into the anchor (head + pasted), sewing
@@ -177,9 +178,115 @@ function pasteNewline(
     seatCursorAtSeam(last, offset);
 }
 
+// The content leaf of the `paraIndex`-th block inside the `itemIndex`-th list
+// item — used to seat the caret after a list-merge rebuilds the list block.
+function itemParaContent(list: Parent, itemIndex: number, paraIndex: number): Nullable<Content> {
+    const item = list.find(itemIndex) as Parent | undefined;
+    const para = item?.find(paraIndex) as Parent | undefined;
+
+    return para?.firstContentInDescendant() ?? null;
+}
+
+// Same list kind + same bullet marker / order delimiter.
+function listMarkersMatch(a: TState, b: TState): boolean {
+    if (a.name === 'order-list' && b.name === 'order-list')
+        return a.meta.delimiter === b.meta.delimiter;
+    if (a.name === 'bullet-list' && b.name === 'bullet-list')
+        return a.meta.marker === b.meta.marker;
+    if (a.name === 'task-list' && b.name === 'task-list')
+        return a.meta.marker === b.meta.marker;
+
+    return false;
+}
+
+// A5: pasting a same-kind, same-marker list into a list item merges it into the
+// enclosing list (muyajs `pasteCtrl` LIST MERGE) — the first pasted item folds
+// inline into the current item, the rest append to the list, and loose/tight
+// reconcile (`a.loose || b.loose`). Returns false to fall through to a normal
+// paste (no enclosing list, or a mismatched kind/marker).
+function tryMergeListPaste(
+    clipboard: Clipboard,
+    ctx: IPasteContext,
+    states: TState[],
+    head: string,
+    tail: string,
+): boolean {
+    const firstState = states[0];
+    if (!isAnyListState(firstState))
+        return false;
+
+    const listItemName = firstState.name === 'task-list' ? 'task-list-item' : 'list-item';
+    const listItem = ctx.anchorBlock.closestBlock(listItemName);
+    const listBlock = listItem?.parent;
+    if (listItem == null || listBlock == null || listBlock.blockName !== firstState.name)
+        return false;
+
+    const listState = listBlock.getState();
+    if (!isAnyListState(listState) || !listMarkersMatch(listState, firstState))
+        return false;
+
+    const itemIndex = listBlock.offset(listItem);
+    // The cursor lives in a specific paragraph of the item — not necessarily the
+    // first (loose list items hold several blocks). Merge into that paragraph.
+    const paraIndex = ctx.wrapperBlock ? (listItem as Parent).offset(ctx.wrapperBlock) : 0;
+    const currentItem = listState.children[itemIndex];
+    const anchorPara = currentItem?.children[paraIndex];
+    if (anchorPara == null || !isParagraphState(anchorPara))
+        return false;
+
+    // Sew the anchor's tail onto the last pasted leaf; the head stays here.
+    const sewOffset = sewTail(states, tail);
+    const pastedItems = firstState.children;
+    const pastedFirst = pastedItems[0].children[0];
+
+    const mergedChildren = [...listState.children];
+    let foldedOnly = false;
+    if (isParagraphState(pastedFirst)) {
+        anchorPara.text = head + pastedFirst.text;
+        currentItem.children = [...currentItem.children, ...pastedItems[0].children.slice(1)];
+        mergedChildren.push(...pastedItems.slice(1));
+        // The whole paste folded into `anchorPara` (no extra blocks/items): the
+        // caret stays in that paragraph at the seam.
+        foldedOnly
+            = pastedItems.length === 1
+                && pastedItems[0].children.length === 1
+                && states.length === 1;
+    }
+    else {
+        anchorPara.text = head;
+        mergedChildren.push(...pastedItems);
+    }
+
+    const loose = listState.meta.loose || firstState.meta.loose;
+    const mergedListState = {
+        ...listState,
+        meta: { ...listState.meta, loose },
+        children: mergedChildren,
+    };
+
+    const newList = ScrollPage.loadBlock(mergedListState.name).create(
+        clipboard.muya,
+        mergedListState,
+    );
+    listBlock.replaceWith(newList);
+
+    if (foldedOnly) {
+        const cursor = itemParaContent(newList, itemIndex, paraIndex);
+        const offset = head.length + sewOffset;
+        cursor?.setCursor(offset, offset, true);
+    }
+    else {
+        const last = insertStatesAfter(clipboard.muya, newList, states.slice(1));
+        seatCursorAtSeam(last, sewOffset);
+    }
+
+    return true;
+}
+
 // Parse a paste into real blocks. A heading anchor keeps the first line; a
-// non-heading anchor merges the first paragraph/heading inline (head + pasted +
-// tail) or, for non-mergeable content, starts new blocks below.
+// same-kind list merges into the enclosing list; otherwise a non-heading anchor
+// merges the first paragraph/heading inline (head + pasted + tail) or, for
+// non-mergeable content, starts new blocks below.
 function applyParsedPaste(
     clipboard: Clipboard,
     ctx: IPasteContext,
@@ -226,6 +333,10 @@ function applyParsedPaste(
 
     const head = content.substring(0, start.offset);
     const tail = content.substring(end.offset);
+
+    if (tryMergeListPaste(clipboard, ctx, states, head, tail))
+        return;
+
     const mergeText = inlineMergeText(states[0], head.length > 0);
 
     if (mergeText != null)
@@ -306,6 +417,35 @@ function applyLiteralPaste(
         if (typeof updater.update === 'function')
             updater.update(anchorBlock.text);
     }
+}
+
+// A8: under Paste as Plain Text, block-level HTML is inserted as literal text
+// (muyajs `pasteAsPlainText` copyAsHtml branch) rather than a live html-block —
+// the markup stays visible as source. The first line folds into the anchor; any
+// remaining lines become their own paragraphs, so no block keeps a raw newline.
+function applyPlainTextBlockHtml(clipboard: Clipboard, ctx: IPasteContext, text: string): void {
+    const { anchorBlock, start, end, content } = ctx;
+    const head = content.substring(0, start.offset);
+    const tail = content.substring(end.offset);
+    const lines = text.trim().split('\n');
+
+    if (lines.length === 1) {
+        anchorBlock.text = head + lines[0] + tail;
+        anchorBlock.update();
+        const offset = head.length + lines[0].length;
+        anchorBlock.setCursor(offset, offset, true);
+
+        return;
+    }
+
+    anchorBlock.text = head + lines[0];
+    anchorBlock.update();
+
+    const rest = lines.slice(1).map(line => ({ name: 'paragraph' as const, text: line }));
+    const lastLine = rest[rest.length - 1];
+    lastLine.text += tail;
+    const last = insertStatesAfter(clipboard.muya, ctx.wrapperBlock, rest);
+    seatCursorAtSeam(last, lastLine.text.length - tail.length);
 }
 
 // Block-level HTML (`<ul>`/`<ol>`/`<pre>`/`<blockquote>` … — tags in
@@ -432,6 +572,11 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
             applyParsedPaste(clipboard, ctx, markdown);
         else
             applyLiteralPaste(clipboard, ctx, markdown);
+    }
+    else if (pasteType === PasteType.PASTE_AS_PLAIN_TEXT) {
+        // Paste as Plain Text inserts block-level HTML as literal text, not a
+        // live html-block (muyajs `pasteAsPlainText` copyAsHtml branch).
+        applyPlainTextBlockHtml(clipboard, ctx, text);
     }
     else {
         applyHtmlBlockPaste(clipboard, ctx, text);


### PR DESCRIPTION
Final PR in the clipboard parity series (stacked on #4543). Two muyajs-parity paste edges.

## A5 — list-into-list merge
Pasting a same-kind, same-marker list into a list item now merges it into the enclosing list (muyajs pasteCtrl LIST MERGE) instead of nesting it inside the current item: the first pasted item folds inline into the cursor's paragraph, the rest append to the list, and loose/tight reconcile (a.loose || b.loose).

## A8 — Paste as Plain Text of block HTML
Block-level HTML present in text/plain is inserted as literal text (first line folds into the anchor, remaining lines become their own paragraphs so no block keeps a raw newline) rather than a live html-block.

## Adversarial review
An adversarial multi-agent review of the first cut caught three real bugs, now fixed with regression tests:
- merging into the wrong paragraph of a *loose* list item (content loss) — now targets the cursor's actual paragraph;
- the single-item-fold caret missing head.length;
- multi-line HTML collapsing into one newline-bearing paragraph (round-trip unstable).

> Stacked on #4543 (→ #4542 → develop). Base retargets to develop as the stack lands.

## Tests
New pasteListMerge.spec.ts (5) and pastePlainTextHtml.spec.ts (2), real Muya asserting markdown + caret. Full muya unit suite passes (only the known worktree css?inline failures). tsc, eslint, madge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)