### PR TITLE
feat: align Paragraph/Format menus with muyajs behavior on @muyajs/core (+3 upgrades)

### DIFF
--- a/packages/desktop/src/main/menu/actions/paragraph.ts
+++ b/packages/desktop/src/main/menu/actions/paragraph.ts
@@ -181,6 +181,7 @@ interface SelectionState {
   isMultiline?: boolean
   isCodeFences?: boolean
   isCodeContent?: boolean
+  hasFrontMatter?: boolean
 }
 
 const setCheckedMenuItem = (
@@ -269,5 +270,11 @@ export const updateSelectionMenus = (
   // Disable loose list item.
   if (!affiliation.ul && !affiliation.ol) {
     setMultipleStatus(applicationMenu, ['looseListItemMenuItem'], false)
+  }
+
+  // Front matter may exist at most once per document; disable the menu item
+  // whenever the document already has one.
+  if (state.hasFrontMatter) {
+    setMultipleStatus(applicationMenu, ['frontMatterMenuItem'], false)
   }
 }

--- a/packages/desktop/src/main/menu/actions/paragraph.ts
+++ b/packages/desktop/src/main/menu/actions/paragraph.ts
@@ -4,20 +4,14 @@ import type { CommandManager } from '../../commands'
 
 type Win = BrowserWindow | null | undefined
 
-const DISABLE_LABELS: readonly string[] = [
-  // paragraph menu items
-  'heading1MenuItem',
-  'heading2MenuItem',
-  'heading3MenuItem',
-  'heading4MenuItem',
-  'heading5MenuItem',
-  'heading6MenuItem',
-  'upgradeHeadingMenuItem',
-  'degradeHeadingMenuItem',
-  'tableMenuItem',
-  // formats menu items
-  'hyperlinkMenuItem',
-  'imageMenuItem'
+// Paragraph-menu items that can actually be executed across a multi-block
+// selection; everything else is disabled when the selection spans blocks.
+const CROSS_BLOCK_ENABLED_PARAGRAPH: readonly string[] = [
+  'codeFencesMenuItem',
+  'quoteBlockMenuItem',
+  'orderListMenuItem',
+  'bulletListMenuItem',
+  'taskListMenuItem'
 ]
 
 const MENU_ID_MAP: Readonly<Record<string, string>> = Object.freeze({
@@ -261,10 +255,17 @@ export const updateSelectionMenus = (
       }
     }
   } else if (isMultiline) {
+    // Format: link/image are meaningless across a multi-block selection.
     formatMenuItem.submenu!.items
-      .filter((item: MenuItem) => item.id && DISABLE_LABELS.includes(item.id))
+      .filter((item: MenuItem) => item.id === 'hyperlinkMenuItem' || item.id === 'imageMenuItem')
       .forEach((item: MenuItem) => (item.enabled = false))
-    setMultipleStatus(applicationMenu, DISABLE_LABELS, false)
+    // Paragraph: enable only the items that have a defined cross-block action.
+    const paragraphMenu = applicationMenu.getMenuItemById('paragraphMenuEntry')!
+    paragraphMenu.submenu!.items.forEach((item: MenuItem) => {
+      if (item.id) {
+        item.enabled = CROSS_BLOCK_ENABLED_PARAGRAPH.includes(item.id)
+      }
+    })
   }
 
   // Disable loose list item.

--- a/packages/desktop/src/main/menu/actions/paragraph.ts
+++ b/packages/desktop/src/main/menu/actions/paragraph.ts
@@ -28,7 +28,7 @@ const MENU_ID_MAP: Readonly<Record<string, string>> = Object.freeze({
   quoteBlockMenuItem: 'blockquote',
   orderListMenuItem: 'ol',
   bulletListMenuItem: 'ul',
-  // taskListMenuItem: 'ul',
+  taskListMenuItem: 'task',
   paragraphMenuItem: 'p',
   horizontalLineMenuItem: 'hr',
   frontMatterMenuItem: 'frontmatter' // 'pre'
@@ -180,7 +180,7 @@ interface SelectionState {
 
 const setCheckedMenuItem = (
   applicationMenu: Menu,
-  { affiliation, isTable, isLooseListItem, isTaskList }: SelectionState
+  { affiliation, isTable, isLooseListItem }: SelectionState
 ): void => {
   const paragraphMenuItem = applicationMenu.getMenuItemById('paragraphMenuEntry')!
   paragraphMenuItem.submenu!.items.forEach((item: MenuItem) => (item.checked = false))
@@ -191,16 +191,13 @@ const setCheckedMenuItem = (
       item.checked = !!isLooseListItem
     } else if (
       Object.keys(affiliation).some((b) => {
-        if (b === 'ul' && isTaskList) {
-          if (item.id === 'taskListMenuItem') {
-            return true
-          }
-          return false
-        } else if (isTable && item.id === 'tableMenuItem') {
+        if (isTable && item.id === 'tableMenuItem') {
           return true
         } else if (item.id === 'codeFencesMenuItem' && /code$/.test(b)) {
           return true
         }
+        // Each list kind is its own affiliation key (ol / ul / task), so a
+        // nested chain checks every level via the id map.
         return b === MENU_ID_MAP[item.id]
       })
     ) {
@@ -269,8 +266,8 @@ export const updateSelectionMenus = (
     })
   }
 
-  // Disable loose list item.
-  if (!affiliation.ul && !affiliation.ol) {
+  // Disable loose list item when not inside any list (bullet / ordered / task).
+  if (!affiliation.ul && !affiliation.ol && !affiliation.task) {
     setMultipleStatus(applicationMenu, ['looseListItemMenuItem'], false)
   }
 

--- a/packages/desktop/src/main/menu/actions/paragraph.ts
+++ b/packages/desktop/src/main/menu/actions/paragraph.ts
@@ -246,13 +246,14 @@ export const updateSelectionMenus = (
   if (isCodeFences) {
     setParagraphMenuItemStatus(applicationMenu, false)
 
-    // A code line is selected.
-    if (isCodeContent) {
-      formatMenuItem.submenu!.items.forEach((item: MenuItem) => (item.enabled = false))
+    // Non-formattable code-like content (code/math/html/frontmatter/diagram):
+    // disable every format item. Tables never reach here (they return early via
+    // isDisabled) so table cells keep formatting.
+    formatMenuItem.submenu!.items.forEach((item: MenuItem) => (item.enabled = false))
 
-      if (Object.keys(affiliation).some((b) => /code$/.test(b))) {
-        setMultipleStatus(applicationMenu, ['codeFencesMenuItem'], true)
-      }
+    // A code line is selected — re-enable the code-fence toggle.
+    if (isCodeContent && Object.keys(affiliation).some((b) => /code$/.test(b))) {
+      setMultipleStatus(applicationMenu, ['codeFencesMenuItem'], true)
     }
   } else if (isMultiline) {
     // Format: link/image are meaningless across a multi-block selection.

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -359,7 +359,8 @@ const CONTAINER_FUNCTION_TYPE: Record<string, string> = {
   frontmatter: 'frontmatter',
   table: 'table',
   'html-block': 'html',
-  'math-block': 'multiplemath'
+  'math-block': 'multiplemath',
+  diagram: 'diagram'
 }
 
 interface EngineAffiliationEntry {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1814,7 +1814,9 @@ onMounted(() => {
     }
     editorStore.SELECTION_CHANGE({
       ...adaptSelectionChange(changes),
-      hasFrontMatter: editor.value?.getState()?.[0]?.name === 'frontmatter'
+      // Read the live block tree (O(1)) rather than getState(), which deep-clones
+      // the whole document — this runs on every cursor move.
+      hasFrontMatter: editor.value?.editor?.scrollPage?.firstChild?.blockName === 'frontmatter'
     })
     // The active inline formats now ride along on selection-change (replacing
     // the old separate `selectionFormats` event) — drive the format menu/toolbar

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1316,6 +1316,22 @@ const handlePrintServiceClearup = () => {
   printer!.clearup()
 }
 
+// Push the current selection to the application-menu / toolbar state. Called on
+// every muya selection-change, and again right after a paragraph action: a no-op
+// action (e.g. "Paragraph" inside a list/quote) fires no selection-change, so the
+// clicked checkbox menu item's auto-toggled OS checkmark would otherwise linger.
+const pushSelectionMenuState = (changes: MuyaChange) => {
+  editorStore.SELECTION_CHANGE({
+    ...adaptSelectionChange(changes),
+    // Read the live block tree (O(1)) rather than getState(), which deep-clones
+    // the whole document — this runs on every cursor move.
+    hasFrontMatter: editor.value?.editor?.scrollPage?.firstChild?.blockName === 'frontmatter'
+  })
+  // The active inline formats ride along on selection-change — drive the format
+  // menu/toolbar state from them.
+  editorStore.SELECTION_FORMATS((changes.formats ?? []) as SelectionFormatLike[])
+}
+
 const handleEditParagraph = (type: unknown) => {
   if (type === 'table') {
     tableChecker.rows = 4
@@ -1326,6 +1342,12 @@ const handleEditParagraph = (type: unknown) => {
     })
   } else if (editor.value) {
     editor.value.updateParagraph(type)
+    // Re-sync the menu so a no-op action (e.g. "Paragraph" inside a list/quote)
+    // does not leave the clicked checkbox item checked. A real conversion fires
+    // its own selection-change, which resyncs again.
+    if (selectionChange.value) {
+      pushSelectionMenuState(selectionChange.value as MuyaChange)
+    }
   }
 }
 
@@ -1812,16 +1834,7 @@ onMounted(() => {
     if (currentFile.value?.id && editor.value) {
       editorStore.PERSIST_CURSOR(currentFile.value.id, serializeCursor(editor.value.getSelection()))
     }
-    editorStore.SELECTION_CHANGE({
-      ...adaptSelectionChange(changes),
-      // Read the live block tree (O(1)) rather than getState(), which deep-clones
-      // the whole document — this runs on every cursor move.
-      hasFrontMatter: editor.value?.editor?.scrollPage?.firstChild?.blockName === 'frontmatter'
-    })
-    // The active inline formats now ride along on selection-change (replacing
-    // the old separate `selectionFormats` event) — drive the format menu/toolbar
-    // state from them.
-    editorStore.SELECTION_FORMATS((changes.formats ?? []) as SelectionFormatLike[])
+    pushSelectionMenuState(changes)
   })
 
   document.addEventListener('keyup', keyup)

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1811,7 +1811,10 @@ onMounted(() => {
     if (currentFile.value?.id && editor.value) {
       editorStore.PERSIST_CURSOR(currentFile.value.id, serializeCursor(editor.value.getSelection()))
     }
-    editorStore.SELECTION_CHANGE(adaptSelectionChange(changes))
+    editorStore.SELECTION_CHANGE({
+      ...adaptSelectionChange(changes),
+      hasFrontMatter: editor.value?.getState()?.[0]?.name === 'frontmatter'
+    })
     // The active inline formats now ride along on selection-change (replacing
     // the old separate `selectionFormats` event) — drive the format menu/toolbar
     // state from them.

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -118,6 +118,7 @@ interface SelectionChange {
   start: { key: string; offset: number; block?: { text?: string; functionType?: string }; type?: string }
   end: { key: string; offset: number; block?: { functionType?: string }; type?: string }
   affiliation?: AffiliationEntry[]
+  hasFrontMatter?: boolean
 }
 
 interface SelectionFormat {
@@ -1800,6 +1801,7 @@ interface ApplicationMenuState {
   isCodeFences: boolean
   isCodeContent: boolean
   isTable: boolean
+  hasFrontMatter: boolean
   affiliation: Record<string, boolean>
 }
 
@@ -1812,7 +1814,8 @@ interface ApplicationMenuState {
 const createApplicationMenuState = ({
   start,
   end,
-  affiliation
+  affiliation,
+  hasFrontMatter
 }: SelectionChange): ApplicationMenuState => {
   const state: ApplicationMenuState = {
     isDisabled: false,
@@ -1827,6 +1830,7 @@ const createApplicationMenuState = ({
     isCodeContent: false,
     // Whether the selection contains a table.
     isTable: false,
+    hasFrontMatter: !!hasFrontMatter,
     // Contains keys about the selection type(s) (string, boolean) like "ul: true".
     affiliation: {}
   }

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1883,6 +1883,11 @@ const createApplicationMenuState = ({
         state.isTable = true
         state.isDisabled = true
         state.affiliation[b.type] = true
+      } else if (b.functionType === 'diagram') {
+        // Diagrams are atomic, non-formattable blocks: disable the whole
+        // paragraph + format menus like a code fence, but they are not tables.
+        state.isCodeFences = true
+        state.affiliation[b.functionType] = true
       }
       break
     } else if (isMultiline && /^h{1,6}$/.test(b.type)) {

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1854,20 +1854,17 @@ const createApplicationMenuState = ({
     }
   }
 
-  // Query list information.
-  if (aff.length >= 1 && /ul|ol/.test(aff[0].type)) {
-    const listBlock = aff[0]
-    state.affiliation[listBlock.type] = true
+  // The list the cursor is actually inside is the INNERMOST list in the
+  // affiliation chain. The chain is outermost-first, so it is the last ul/ol
+  // entry — keying off aff[0] would pick the outermost list and miss a deeply
+  // nested one (also beyond the depth-3 scan below).
+  const innerList = [...aff].reverse().find((b) => b.type === 'ul' || b.type === 'ol')
+  if (innerList) {
+    state.affiliation[innerList.type] = true
     // The engine's affiliation entry carries the loose flag on the list block
     // itself (derived from `meta.loose`), not via a `children` chain.
-    state.isLooseListItem = !!listBlock.isLooseListItem
-    state.isTaskList = listBlock.listType === 'task'
-  } else if (aff.length >= 3 && aff[1].type === 'li') {
-    const listItem = aff[1]
-    const listType = listItem.listItemType === 'order' ? 'ol' : 'ul'
-    state.affiliation[listType] = true
-    state.isLooseListItem = !!listItem.isLooseListItem
-    state.isTaskList = listItem.listItemType === 'task'
+    state.isLooseListItem = !!innerList.isLooseListItem
+    state.isTaskList = innerList.listType === 'task'
   }
 
   // Search with block depth 3 (e.g. "ul -> li -> p" where p is the actually paragraph inside the list (item)).
@@ -1894,7 +1891,9 @@ const createApplicationMenuState = ({
       // Multiple block elements are selected.
       state.affiliation = {}
       break
-    } else {
+    } else if (b.type !== 'ul' && b.type !== 'ol') {
+      // Lists are handled above (innermost only); the depth-limited scan must
+      // not re-add an outer list type and check two list kinds at once.
       if (!state.affiliation[b.type]) {
         state.affiliation[b.type] = true
       }

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1854,13 +1854,17 @@ const createApplicationMenuState = ({
     }
   }
 
-  // The list the cursor is actually inside is the INNERMOST list in the
-  // affiliation chain. The chain is outermost-first, so it is the last ul/ol
-  // entry — keying off aff[0] would pick the outermost list and miss a deeply
-  // nested one (also beyond the depth-3 scan below).
-  const innerList = [...aff].reverse().find((b) => b.type === 'ul' || b.type === 'ol')
+  // Check every list level in the affiliation chain — nested lists show all
+  // levels (e.g. a ul wrapping an ol checks both). Scanning the full chain (not
+  // just the depth-3 loop below) keeps a deeply nested inner list checked. The
+  // loose/task flags come from the INNERMOST list (the one the cursor is in);
+  // the chain is outermost-first, so that is the last ul/ol entry.
+  const listEntries = aff.filter((b) => b.type === 'ul' || b.type === 'ol')
+  for (const entry of listEntries) {
+    state.affiliation[entry.type] = true
+  }
+  const innerList = listEntries[listEntries.length - 1]
   if (innerList) {
-    state.affiliation[innerList.type] = true
     // The engine's affiliation entry carries the loose flag on the list block
     // itself (derived from `meta.loose`), not via a `children` chain.
     state.isLooseListItem = !!innerList.isLooseListItem

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1861,7 +1861,10 @@ const createApplicationMenuState = ({
   // the chain is outermost-first, so that is the last ul/ol entry.
   const listEntries = aff.filter((b) => b.type === 'ul' || b.type === 'ol')
   for (const entry of listEntries) {
-    state.affiliation[entry.type] = true
+    // Task and bullet lists are both `type: 'ul'`; distinguish by listType so a
+    // chain with several kinds (e.g. ol > task > ul) checks each list menu item.
+    const kind = entry.type === 'ol' ? 'ol' : entry.listType === 'task' ? 'task' : 'ul'
+    state.affiliation[kind] = true
   }
   const innerList = listEntries[listEntries.length - 1]
   if (innerList) {

--- a/packages/desktop/test/unit/specs/application-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/application-menu-state.spec.ts
@@ -56,7 +56,7 @@ describe('createApplicationMenuState via SELECTION_CHANGE', () => {
     expect(state.isTable).toBe(false)
   })
 
-  it('checks only the innermost list (ordered) for a deeply nested ul > ul > ol', () => {
+  it('checks every list level for a deeply nested ul > ul > ol (flags from innermost)', () => {
     const state = menuStateFor({
       start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
       end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
@@ -70,8 +70,10 @@ describe('createApplicationMenuState via SELECTION_CHANGE', () => {
         { type: 'p', blockName: 'paragraph' }
       ]
     }) as unknown as { affiliation: Record<string, boolean>; isTaskList: boolean }
+    // Both nested list levels are checked; the deeply nested ol is no longer
+    // dropped by the depth-3 scan.
     expect(state.affiliation.ol).toBe(true)
-    expect(state.affiliation.ul).toBeFalsy()
+    expect(state.affiliation.ul).toBe(true)
     expect(state.isTaskList).toBe(false)
   })
 })

--- a/packages/desktop/test/unit/specs/application-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/application-menu-state.spec.ts
@@ -55,4 +55,23 @@ describe('createApplicationMenuState via SELECTION_CHANGE', () => {
     expect(state.isCodeFences).toBe(true)
     expect(state.isTable).toBe(false)
   })
+
+  it('checks only the innermost list (ordered) for a deeply nested ul > ul > ol', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      affiliation: [
+        { type: 'ul', blockName: 'bullet-list', listType: 'bullet' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'ul', blockName: 'bullet-list', listType: 'bullet' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'ol', blockName: 'order-list', listType: 'order' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'p', blockName: 'paragraph' }
+      ]
+    }) as unknown as { affiliation: Record<string, boolean>; isTaskList: boolean }
+    expect(state.affiliation.ol).toBe(true)
+    expect(state.affiliation.ul).toBeFalsy()
+    expect(state.isTaskList).toBe(false)
+  })
 })

--- a/packages/desktop/test/unit/specs/application-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/application-menu-state.spec.ts
@@ -1,0 +1,58 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `@/store/editor` (via `@/config`) reads `window.path.sep` at module load and
+// the store sends IPC through `window.electron`; stub the preload surface first.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      marktext?: { env: { windowId: number } }
+      electron?: { clipboard: { writeText: (s: string) => void }; ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void } }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.marktext ??= { env: { windowId: 1 } }
+  w.window.electron ??= { clipboard: { writeText: () => {} }, ipcRenderer: { send: () => {}, on: () => {} } }
+})
+
+vi.mock('@/services/notification', () => ({ default: { notify: vi.fn(), name: 'notify' } }))
+
+const { useEditorStore } = await import('@/store/editor')
+
+// createApplicationMenuState is module-private; assert it via the IPC payload
+// the SELECTION_CHANGE action sends.
+function menuStateFor(changes: unknown) {
+  const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+  const store = useEditorStore()
+  store.SELECTION_CHANGE(changes as never)
+  const call = [...sendSpy.mock.calls].reverse().find((c) => c[0] === 'mt::editor-selection-changed')
+  return call?.[2] as { isCodeFences: boolean; isTable: boolean }
+}
+
+describe('createApplicationMenuState via SELECTION_CHANGE', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('marks a math/html/frontmatter selection as code-fences', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'pre', block: { functionType: 'codeContent' } },
+      end: { key: 'a', offset: 0, type: 'pre', block: { functionType: 'codeContent' } },
+      affiliation: [{ type: 'pre', blockName: 'math-block', functionType: 'multiplemath' }]
+    })
+    expect(state.isCodeFences).toBe(true)
+  })
+
+  it('marks a diagram selection as code-fences and not a table', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: {} },
+      end: { key: 'a', offset: 0, type: 'span', block: {} },
+      affiliation: [{ type: 'figure', blockName: 'diagram', functionType: 'diagram' }]
+    })
+    expect(state.isCodeFences).toBe(true)
+    expect(state.isTable).toBe(false)
+  })
+})

--- a/packages/desktop/test/unit/specs/application-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/application-menu-state.spec.ts
@@ -76,4 +76,23 @@ describe('createApplicationMenuState via SELECTION_CHANGE', () => {
     expect(state.affiliation.ul).toBe(true)
     expect(state.isTaskList).toBe(false)
   })
+
+  it('checks ordered + task + bullet for ol > task > ul (cursor in the bullet list)', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      affiliation: [
+        { type: 'ol', blockName: 'order-list', listType: 'order' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'ul', blockName: 'task-list', listType: 'task' },
+        { type: 'li', blockName: 'task-list-item' },
+        { type: 'ul', blockName: 'bullet-list', listType: 'bullet' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'p', blockName: 'paragraph' }
+      ]
+    }) as unknown as { affiliation: Record<string, boolean> }
+    expect(state.affiliation.ol).toBe(true)
+    expect(state.affiliation.task).toBe(true)
+    expect(state.affiliation.ul).toBe(true)
+  })
 })

--- a/packages/desktop/test/unit/specs/application-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/application-menu-state.spec.ts
@@ -96,3 +96,51 @@ describe('createApplicationMenuState via SELECTION_CHANGE', () => {
     expect(state.affiliation.ul).toBe(true)
   })
 })
+
+// The "Paragraph" menu item is checked via affiliation.p. Inside a list/quote
+// the leaf IS a paragraph but the item must NOT be checked (the user is in a
+// list/quote, not a bare paragraph); the cleanup drops `p` whenever another
+// block key is present. This is the true state a no-op Paragraph click resyncs
+// back to (it never has a real effect there — parity with muyajs).
+describe('createApplicationMenuState — Paragraph checked-state in containers', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it('does NOT check Paragraph for a caret inside a list item', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      affiliation: [
+        { type: 'ul', blockName: 'bullet-list', listType: 'bullet' },
+        { type: 'li', blockName: 'list-item' },
+        { type: 'p', blockName: 'paragraph' }
+      ]
+    }) as unknown as { affiliation: Record<string, boolean> }
+    expect(state.affiliation.p).toBeFalsy()
+    expect(state.affiliation.ul).toBe(true)
+  })
+
+  it('does NOT check Paragraph for a caret inside a block-quote', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      affiliation: [
+        { type: 'blockquote', blockName: 'block-quote' },
+        { type: 'p', blockName: 'paragraph' }
+      ]
+    }) as unknown as { affiliation: Record<string, boolean> }
+    expect(state.affiliation.p).toBeFalsy()
+    expect(state.affiliation.blockquote).toBe(true)
+  })
+
+  it('DOES check Paragraph for a bare top-level paragraph', () => {
+    const state = menuStateFor({
+      start: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      end: { key: 'a', offset: 0, type: 'span', block: { functionType: 'paragraphContent' } },
+      affiliation: [{ type: 'p', blockName: 'paragraph' }]
+    }) as unknown as { affiliation: Record<string, boolean> }
+    expect(state.affiliation.p).toBe(true)
+  })
+})

--- a/packages/desktop/test/unit/specs/selection-menus.spec.ts
+++ b/packages/desktop/test/unit/specs/selection-menus.spec.ts
@@ -65,24 +65,6 @@ type FakeMenu = ReturnType<typeof makeMenu>
 const enabledIds = (items: FakeMenu['paragraphItems']) =>
   items.filter((i) => i.enabled).map((i) => i.id)
 
-const disabledIds = (items: FakeMenu['paragraphItems']) =>
-  items.filter((i) => !i.enabled).map((i) => i.id)
-
-// The set the source disables for multiline selections (DISABLE_LABELS).
-const DISABLE_LABELS = [
-  'heading1MenuItem',
-  'heading2MenuItem',
-  'heading3MenuItem',
-  'heading4MenuItem',
-  'heading5MenuItem',
-  'heading6MenuItem',
-  'upgradeHeadingMenuItem',
-  'degradeHeadingMenuItem',
-  'tableMenuItem',
-  'hyperlinkMenuItem',
-  'imageMenuItem'
-]
-
 describe('updateSelectionMenus', () => {
   it('disables every Paragraph submenu item when the selection is disabled (table/multi-block)', () => {
     const menu = makeMenu()
@@ -101,25 +83,19 @@ describe('updateSelectionMenus', () => {
     expect(menu.formatItems.every((i) => i.enabled === true)).toBe(true)
   })
 
-  it('disables hyperlink/image (Format) and heading/table (Paragraph) for a multiline selection', () => {
+  it('enables only the honest set in Paragraph and disables link/image in Format for a multiline selection', () => {
     const menu = makeMenu()
 
     updateSelectionMenus(menu as unknown as Menu, { affiliation: {}, isMultiline: true })
 
-    // Format menu: only the DISABLE_LABELS entries it owns are disabled.
-    const formatItem = (id: string) => menu.formatItems.find((i) => i.id === id)!
-    expect(formatItem('hyperlinkMenuItem').enabled).toBe(false)
-    expect(formatItem('imageMenuItem').enabled).toBe(false)
-    expect(formatItem('strongMenuItem').enabled).toBe(true)
-    expect(formatItem('emphasisMenuItem').enabled).toBe(true)
-
-    // Paragraph menu: the DISABLE_LABELS heading/table entries are disabled.
-    const paraDisabled = disabledIds(menu.paragraphItems)
-    const expectedParaDisabled = DISABLE_LABELS.filter((id) => PARAGRAPH_MENU_IDS.includes(id))
-    // Plus the loose-list-item is disabled because affiliation has no ul/ol.
-    expect(paraDisabled.sort()).toEqual(
-      [...expectedParaDisabled, 'looseListItemMenuItem'].sort()
+    // Paragraph: only code/quote/ordered/bullet/task are actionable across blocks.
+    expect(enabledIds(menu.paragraphItems).sort()).toEqual(
+      ['bulletListMenuItem', 'codeFencesMenuItem', 'orderListMenuItem', 'quoteBlockMenuItem', 'taskListMenuItem'].sort()
     )
+
+    // Format: only link/image are disabled.
+    const formatDisabled = menu.formatItems.filter((i) => !i.enabled).map((i) => i.id)
+    expect(formatDisabled.sort()).toEqual(['hyperlinkMenuItem', 'imageMenuItem'].sort())
   })
 
   it('disables every Format submenu item for code content and re-enables codeFences (Paragraph)', () => {

--- a/packages/desktop/test/unit/specs/selection-menus.spec.ts
+++ b/packages/desktop/test/unit/specs/selection-menus.spec.ts
@@ -169,3 +169,23 @@ describe('updateSelectionMenus', () => {
     expect(checked).toEqual(['heading1MenuItem'])
   })
 })
+
+describe('updateSelectionMenus — front matter', () => {
+  it('disables Front Matter when the document already has front matter', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { p: true }, hasFrontMatter: true })
+
+    const fm = menu.paragraphItems.find((i) => i.id === 'frontMatterMenuItem')!
+    expect(fm.enabled).toBe(false)
+  })
+
+  it('keeps Front Matter enabled when the document has none', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { p: true }, hasFrontMatter: false })
+
+    const fm = menu.paragraphItems.find((i) => i.id === 'frontMatterMenuItem')!
+    expect(fm.enabled).toBe(true)
+  })
+})

--- a/packages/desktop/test/unit/specs/selection-menus.spec.ts
+++ b/packages/desktop/test/unit/specs/selection-menus.spec.ts
@@ -165,3 +165,21 @@ describe('updateSelectionMenus — front matter', () => {
     expect(fm.enabled).toBe(true)
   })
 })
+
+describe('updateSelectionMenus — format disabled in non-formattable blocks', () => {
+  it('disables all format items in a code-fence block even without code content (math/html/frontmatter/diagram)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { multiplemath: true }, isCodeFences: true })
+
+    expect(menu.formatItems.every((i) => i.enabled === false)).toBe(true)
+  })
+
+  it('keeps format items enabled inside a table (disabled paragraph, not code)', () => {
+    const menu = makeMenu()
+
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { figure: true }, isTable: true, isDisabled: true })
+
+    expect(menu.formatItems.every((i) => i.enabled === true)).toBe(true)
+  })
+})

--- a/packages/desktop/test/unit/specs/selection-menus.spec.ts
+++ b/packages/desktop/test/unit/specs/selection-menus.spec.ts
@@ -183,3 +183,27 @@ describe('updateSelectionMenus — format disabled in non-formattable blocks', (
     expect(menu.formatItems.every((i) => i.enabled === true)).toBe(true)
   })
 })
+
+describe('updateSelectionMenus — list kinds', () => {
+  it('checks the task list (not bullet) for a task affiliation', () => {
+    const menu = makeMenu()
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { task: true } })
+    const ids = menu.paragraphItems.filter((i) => i.checked).map((i) => i.id)
+    expect(ids).toContain('taskListMenuItem')
+    expect(ids).not.toContain('bulletListMenuItem')
+  })
+
+  it('checks ordered + bullet + task for a nested ol/task/ul affiliation', () => {
+    const menu = makeMenu()
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { ol: true, task: true, ul: true } })
+    const ids = menu.paragraphItems.filter((i) => i.checked).map((i) => i.id).sort()
+    expect(ids).toEqual(['bulletListMenuItem', 'orderListMenuItem', 'taskListMenuItem'].sort())
+  })
+
+  it('keeps loose-list-item enabled inside a task list', () => {
+    const menu = makeMenu()
+    updateSelectionMenus(menu as unknown as Menu, { affiliation: { task: true } })
+    const loose = menu.paragraphItems.find((i) => i.id === 'looseListItemMenuItem')!
+    expect(loose.enabled).toBe(true)
+  })
+})

--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -151,6 +151,45 @@ describe('muya.createTable()', () => {
             expect(b.children.every(row => row.children.length === 2)).toBe(true); // floor(2.9)
         });
     });
+
+    it('inserts the table BELOW a non-empty heading instead of replacing it', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya, 4); // caret inside the heading text
+        muya.createTable({ rows: 2, columns: 2 });
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(2);
+            expect(s[0].name).toBe('atx-heading'); // heading kept
+            expect(s[1].name).toBe('table'); // table directly below
+        });
+        // the new table gets focus (caret in its first cell)
+        const sel = muya.editor.selection.getSelection();
+        expect(sel!.anchor.block.blockName).toBe('table.cell.content');
+    });
+
+    it('inserts the table BELOW a non-empty paragraph instead of replacing it', async () => {
+        const muya = bootMuya('hello\n');
+        placeCursorOnFirstBlock(muya, 5);
+        muya.createTable({ rows: 2, columns: 2 });
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(2);
+            expect(s[0].name).toBe('paragraph');
+            expect((s[0] as { text: string }).text).toBe('hello');
+            expect(s[1].name).toBe('table');
+        });
+    });
+
+    it('replaces a non-empty block in place when { replace: true } (grid picker path)', async () => {
+        const muya = bootMuya('/table\n'); // a non-empty quick-insert trigger line
+        placeCursorOnFirstBlock(muya, 6);
+        muya.createTable({ rows: 2, columns: 2 }, { replace: true });
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(1); // trigger consumed, not left behind
+            expect(s[0].name).toBe('table');
+        });
+    });
 });
 
 describe('muya.insertImage()', () => {

--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -190,6 +190,22 @@ describe('muya.createTable()', () => {
             expect(s[0].name).toBe('table');
         });
     });
+
+    it('inserts the table right after the paragraph INSIDE a list item, not after the list', async () => {
+        const muya = bootMuya('- item text\n');
+        placeCursorOnFirstBlock(muya, 4);
+        muya.createTable({ rows: 2, columns: 2 });
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            // a single top-level bullet-list — the table did NOT land after it
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('bullet-list');
+            const item = (s[0] as { children: { children: { name: string }[] }[] }).children[0];
+            expect(item.children.map(c => c.name)).toEqual(['paragraph', 'table']);
+        });
+        // the nested table still serializes without throwing
+        expect(() => muya.getMarkdown()).not.toThrow();
+    });
 });
 
 describe('muya.insertImage()', () => {

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -110,4 +110,17 @@ describe('cross-block paragraph wrapping', () => {
         expect(sel.anchorBlock!.text).toBe('alpha');
         expect(sel.focusBlock!.text).toBe('bravo');
     });
+
+    it('preserves markdown syntax when wrapping a cross-block selection into a code block', async () => {
+        const muya = boot('# Title\n\nbody\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('pre');
+        await vi.waitFor(() => {
+            const s = muya.getState() as unknown as IStateBlock[];
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('code-block');
+            expect(s[0].text).toContain('# Title');
+            expect(s[0].text).toContain('body');
+        });
+    });
 });

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -123,4 +123,21 @@ describe('cross-block paragraph wrapping', () => {
             expect(s[0].text).toContain('body');
         });
     });
+
+    it('preserves a multi-block selection across wrap then unwrap (paragraph + list)', async () => {
+        const muya = boot('alpha\n\n- bravo\n'); // a paragraph and an unordered list
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('ol-order'); // wrap both into an ordered list
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('order-list'));
+
+        muya.updateParagraph('ol-order'); // click ordered again -> unwrap
+        await vi.waitFor(() => {
+            const s = muya.getState() as unknown as IStateBlock[];
+            expect(s.some(b => b.name === 'order-list')).toBe(false);
+        });
+        // the original span (alpha .. bravo) is restored
+        const sel = muya.editor.selection;
+        expect(sel.anchorBlock!.text).toBe('alpha');
+        expect(sel.focusBlock!.text).toBe('bravo');
+    });
 });

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -65,4 +65,17 @@ describe('cross-block paragraph wrapping', () => {
             expect(s[0].children.length).toBe(2);
         });
     });
+
+    it('wraps selected paragraphs into a single block-quote', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('blockquote');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('block-quote');
+            expect(s[0].children.length).toBe(2);
+            expect(s[0].children[0].text).toBe('alpha');
+            expect(s[0].children[1].text).toBe('bravo');
+        });
+    });
 });

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+const hosts: HTMLElement[] = [];
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+afterEach(() => {
+    while (hosts.length)
+        hosts.pop()!.remove();
+});
+function boot(md: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown: md } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    hosts.push(muya.domNode);
+    return muya;
+}
+// Select a range spanning the first two top-level paragraphs.
+function selectFirstTwoBlocks(muya: Muya) {
+    const sp = muya.editor.scrollPage!;
+    const first = sp.firstContentInDescendant()!;
+    const second = sp.firstChild!.next!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = second;
+    muya.editor.selection.setSelection(
+        { offset: 0, block: first, path: first.path },
+        { offset: second.text.length, block: second, path: second.path },
+    );
+}
+
+describe('cross-block paragraph wrapping', () => {
+    it('wraps selected paragraphs into a bullet list (one item per block)', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('bullet-list');
+            expect(s[0].children.length).toBe(2);
+            expect(s[0].children[0].children[0].text).toBe('alpha');
+            expect(s[0].children[1].children[0].text).toBe('bravo');
+        });
+    });
+
+    it('wraps selected paragraphs into an ordered list', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('ol-order');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('order-list');
+            expect(s[0].children.length).toBe(2);
+        });
+    });
+
+    it('wraps selected paragraphs into a task list', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('ul-task');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('task-list');
+            expect(s[0].children.length).toBe(2);
+        });
+    });
+});

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
+import type Parent from '../block/base/parent';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../muya';
+
+interface IStateBlock { name: string; text: string; children: IStateBlock[] }
 
 const hosts: HTMLElement[] = [];
 beforeEach(() => {
@@ -22,7 +25,7 @@ function boot(md: string): Muya {
 function selectFirstTwoBlocks(muya: Muya) {
     const sp = muya.editor.scrollPage!;
     const first = sp.firstContentInDescendant()!;
-    const second = sp.firstChild!.next!.firstContentInDescendant()!;
+    const second = (sp.firstChild!.next as Parent).firstContentInDescendant()!;
     muya.editor.activeContentBlock = second;
     muya.editor.selection.setSelection(
         { offset: 0, block: first, path: first.path },
@@ -36,7 +39,7 @@ describe('cross-block paragraph wrapping', () => {
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('ul-bullet');
         await vi.waitFor(() => {
-            const s = muya.getState();
+            const s = muya.getState() as unknown as IStateBlock[];
             expect(s[0].name).toBe('bullet-list');
             expect(s[0].children.length).toBe(2);
             expect(s[0].children[0].children[0].text).toBe('alpha');
@@ -49,7 +52,7 @@ describe('cross-block paragraph wrapping', () => {
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('ol-order');
         await vi.waitFor(() => {
-            const s = muya.getState();
+            const s = muya.getState() as unknown as IStateBlock[];
             expect(s[0].name).toBe('order-list');
             expect(s[0].children.length).toBe(2);
         });
@@ -60,7 +63,7 @@ describe('cross-block paragraph wrapping', () => {
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('ul-task');
         await vi.waitFor(() => {
-            const s = muya.getState();
+            const s = muya.getState() as unknown as IStateBlock[];
             expect(s[0].name).toBe('task-list');
             expect(s[0].children.length).toBe(2);
         });
@@ -71,7 +74,7 @@ describe('cross-block paragraph wrapping', () => {
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('blockquote');
         await vi.waitFor(() => {
-            const s = muya.getState();
+            const s = muya.getState() as unknown as IStateBlock[];
             expect(s[0].name).toBe('block-quote');
             expect(s[0].children.length).toBe(2);
             expect(s[0].children[0].text).toBe('alpha');
@@ -84,7 +87,7 @@ describe('cross-block paragraph wrapping', () => {
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('pre');
         await vi.waitFor(() => {
-            const s = muya.getState();
+            const s = muya.getState() as unknown as IStateBlock[];
             expect(s.length).toBe(1);
             expect(s[0].name).toBe('code-block');
             const text = (s[0].text ?? '') as string;

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -92,4 +92,19 @@ describe('cross-block paragraph wrapping', () => {
             expect(text).toContain('bravo');
         });
     });
+
+    it('keeps the selection spanning the wrapped content after list wrap', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('bullet-list');
+        });
+        // happy-dom collapses the live DOM selection, so assert via the cached
+        // endpoints that setSelection records (the same ones the menu round-trip
+        // relies on).
+        const sel = muya.editor.selection;
+        expect(sel.anchorBlock!.text).toBe('alpha');
+        expect(sel.focusBlock!.text).toBe('bravo');
+    });
 });

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -78,4 +78,18 @@ describe('cross-block paragraph wrapping', () => {
             expect(s[0].children[1].text).toBe('bravo');
         });
     });
+
+    it('joins selected paragraphs into a single code block', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        selectFirstTwoBlocks(muya);
+        muya.updateParagraph('pre');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('code-block');
+            const text = (s[0].text ?? '') as string;
+            expect(text).toContain('alpha');
+            expect(text).toContain('bravo');
+        });
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -99,6 +99,22 @@ describe('updateParagraph same-block menu model', () => {
         expect(muya.editor.selection.anchor?.offset).toBe(3);
     });
 
+    it('preserves a range selection across paragraph -> list -> paragraph', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = placeCursorOnFirstBlock(muya);
+        content.setCursor(2, 6, true); // select offsets [2, 6)
+
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('bullet-list'));
+        expect(muya.editor.selection.anchor?.offset).toBe(2);
+        expect(muya.editor.selection.focus?.offset).toBe(6);
+
+        muya.updateParagraph('ul-bullet'); // toggle back to paragraph
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('paragraph'));
+        expect(muya.editor.selection.anchor?.offset).toBe(2);
+        expect(muya.editor.selection.focus?.offset).toBe(6);
+    });
+
     it('inserts a thematic break below a non-empty paragraph', async () => {
         const muya = bootMuya('hello\n');
         placeCursorOnFirstBlock(muya);

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -300,6 +300,15 @@ describe('updateParagraph toggle-off active types', () => {
         expect(muya.editor.selection.anchor?.offset).toBe(5); // -1 for the removed '#'
     });
 
+    it('clears the markers when the Paragraph menu item resets a thematic break', async () => {
+        const muya = bootMuya('---\n');
+        placeCursorOnFirstBlock(muya); // content text is the "---" marker
+        muya.updateParagraph('paragraph'); // reset the hr leaf
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('paragraph'));
+        expect((muya.getState()[0] as { text: string }).text).toBe(''); // empty, no "---"
+        expect(muya.editor.selection.anchorBlock?.text).toBe('');
+    });
+
     it('keeps the caret when the Paragraph menu item resets a heading leaf', async () => {
         const muya = bootMuya('## Title\n');
         const content = placeCursorOnFirstBlock(muya); // content text is "## Title"

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -284,4 +284,14 @@ describe('updateParagraph toggle-off active types', () => {
         });
         expect(muya.editor.selection.anchor?.offset).toBe(5); // -1 for the removed '#'
     });
+
+    it('keeps the caret when the Paragraph menu item resets a heading leaf', async () => {
+        const muya = bootMuya('## Title\n');
+        const content = placeCursorOnFirstBlock(muya); // content text is "## Title"
+        content.setCursor(6, 6, true); // after "## Tit"
+        muya.updateParagraph('paragraph'); // reset the heading leaf -> "Title"
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('paragraph'));
+        expect(muya.editor.selection.anchorBlock?.text).toBe('Title');
+        expect(muya.editor.selection.anchor?.offset).toBe(3); // 6 - len("## ")
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -260,4 +260,28 @@ describe('updateParagraph toggle-off active types', () => {
         expect(muya.editor.selection.anchorBlock?.text).toBe('# Title');
         expect(muya.editor.selection.anchor?.offset).toBe(5); // 3 + len("# ")
     });
+
+    it('keeps the caret when degrading a heading level (## -> ###)', async () => {
+        const muya = bootMuya('## Title\n');
+        const content = placeCursorOnFirstBlock(muya);
+        content.setCursor(6, 6, true); // after "## Tit"
+        muya.updateParagraph('degrade heading'); // h2 -> h3
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect((s[0] as { meta: { level: number } }).meta.level).toBe(3);
+        });
+        expect(muya.editor.selection.anchor?.offset).toBe(7); // +1 for the extra '#'
+    });
+
+    it('keeps the caret when upgrading a heading level (## -> #)', async () => {
+        const muya = bootMuya('## Title\n');
+        const content = placeCursorOnFirstBlock(muya);
+        content.setCursor(6, 6, true); // after "## Tit"
+        muya.updateParagraph('upgrade heading'); // h2 -> h1
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect((s[0] as { meta: { level: number } }).meta.level).toBe(1);
+        });
+        expect(muya.editor.selection.anchor?.offset).toBe(5); // -1 for the removed '#'
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -139,6 +139,21 @@ describe('updateParagraph same-block menu model', () => {
         });
     });
 
+    it('inserts a thematic break + trailing empty paragraph below a non-empty heading (heading kept)', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('hr');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(3);
+            expect(s[0].name).toBe('atx-heading');
+            expect((s[0] as { text: string }).text).toBe('# Title'); // heading kept
+            expect(s[1].name).toBe('thematic-break'); // rule below it
+            expect(s[2].name).toBe('paragraph');
+            expect((s[2] as { text: string }).text).toBe(''); // trailing empty paragraph
+        });
+    });
+
     it('unwraps an enclosing block-quote (with a heading inside) instead of nesting one', async () => {
         const muya = bootMuya('> # Title\n');
         placeCursorOnFirstBlock(muya);

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -219,4 +219,24 @@ describe('updateParagraph toggle-off active types', () => {
         expect(muya.editor.selection.anchorBlock?.text).toBe('bravo');
         expect(muya.editor.selection.anchor?.offset).toBe(3);
     });
+
+    it('keeps the caret position (accounting for "# ") when toggling a heading to a paragraph', async () => {
+        const muya = bootMuya('# Title\n');
+        const content = placeCursorOnFirstBlock(muya); // content text is "# Title"
+        content.setCursor(5, 5, true); // after "# Tit"
+        muya.updateParagraph('heading 1'); // toggle heading off -> "Title"
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('paragraph'));
+        expect(muya.editor.selection.anchorBlock?.text).toBe('Title');
+        expect(muya.editor.selection.anchor?.offset).toBe(3); // 5 - len("# ")
+    });
+
+    it('keeps the caret position (accounting for "# ") when converting a paragraph to a heading', async () => {
+        const muya = bootMuya('Title\n');
+        const content = placeCursorOnFirstBlock(muya);
+        content.setCursor(3, 3, true); // after "Tit"
+        muya.updateParagraph('heading 1'); // -> "# Title"
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('atx-heading'));
+        expect(muya.editor.selection.anchorBlock?.text).toBe('# Title');
+        expect(muya.editor.selection.anchor?.offset).toBe(5); // 3 + len("# ")
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -201,12 +201,14 @@ describe('updateParagraph toggle-off active types', () => {
         });
     });
 
-    it('toggles a thematic break back to a paragraph when clicked from within', async () => {
+    it('toggles a thematic break to an EMPTY paragraph (drops the --- markers)', async () => {
         const muya = bootMuya('---\n');
         placeCursorOnFirstBlock(muya);
         muya.updateParagraph('hr');
         await vi.waitFor(() => {
-            expect(muya.getState()[0].name).toBe('paragraph');
+            const s = muya.getState();
+            expect(s[0].name).toBe('paragraph');
+            expect((s[0] as { text: string }).text).toBe('');
         });
     });
 

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -84,4 +84,41 @@ describe('updateParagraph same-block menu model', () => {
             expect((s[0] as { text: string }).text).toContain('code here');
         });
     });
+
+    it('preserves the caret offset across paragraph -> list -> paragraph', async () => {
+        const muya = bootMuya('hello world\n');
+        const content = placeCursorOnFirstBlock(muya);
+        content.setCursor(3, 3, true);
+
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('bullet-list'));
+        expect(muya.editor.selection.anchor?.offset).toBe(3);
+
+        muya.updateParagraph('ul-bullet'); // toggle back to paragraph
+        await vi.waitFor(() => expect(muya.getState()[0].name).toBe('paragraph'));
+        expect(muya.editor.selection.anchor?.offset).toBe(3);
+    });
+
+    it('inserts a thematic break below a non-empty paragraph', async () => {
+        const muya = bootMuya('hello\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('hr');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(2);
+            expect(s[0].name).toBe('paragraph');
+            expect((s[0] as { text: string }).text).toBe('hello');
+            expect(s[1].name).toBe('thematic-break');
+        });
+    });
+
+    it('unwraps an enclosing block-quote (with a heading inside) instead of nesting one', async () => {
+        const muya = bootMuya('> # Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('blockquote');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('atx-heading');
+        });
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+const bootedHosts: HTMLElement[] = [];
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+function placeCursorOnFirstBlock(muya: Muya) {
+    const first = muya.editor.scrollPage!.firstContentInDescendant()!;
+    muya.editor.activeContentBlock = first;
+    first.setCursor(0, 0, true);
+    return first;
+}
+
+describe('updateParagraph same-block menu model', () => {
+    it('converts a non-empty paragraph to a heading in place (convertible)', async () => {
+        const muya = bootMuya('hello world\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('heading 1');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('atx-heading');
+        });
+    });
+
+    it('inserts a new code block BELOW a non-empty paragraph (non-convertible, original kept)', async () => {
+        const muya = bootMuya('hello\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('pre'); // 'pre' -> code-block; not in canTurnIntoMenu(paragraph)
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(2);
+            expect(s[0].name).toBe('paragraph');
+            expect((s[0] as { text: string }).text).toBe('hello');
+            expect(s[1].name).toBe('code-block');
+        });
+    });
+
+    it('replaces an EMPTY paragraph in place for a non-convertible type', async () => {
+        const muya = bootMuya('\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('pre');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('code-block');
+        });
+    });
+
+    it('converts the list item paragraph (immediate), leaving the list intact', async () => {
+        const muya = bootMuya('- item one\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('heading 1');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('bullet-list');
+            expect((s[0] as { children: { children: { name: string }[] }[] }).children[0].children[0].name).toBe('atx-heading');
+        });
+    });
+});

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -115,16 +115,17 @@ describe('updateParagraph same-block menu model', () => {
         expect(muya.editor.selection.focus?.offset).toBe(6);
     });
 
-    it('inserts a thematic break below a non-empty paragraph', async () => {
+    it('inserts a thematic break + trailing empty paragraph below a non-empty paragraph', async () => {
         const muya = bootMuya('hello\n');
         placeCursorOnFirstBlock(muya);
         muya.updateParagraph('hr');
         await vi.waitFor(() => {
             const s = muya.getState();
-            expect(s.length).toBe(2);
+            expect(s.length).toBe(3);
             expect(s[0].name).toBe('paragraph');
             expect((s[0] as { text: string }).text).toBe('hello');
             expect(s[1].name).toBe('thematic-break');
+            expect(s[2].name).toBe('paragraph');
         });
     });
 

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -25,6 +25,16 @@ function placeCursorOnFirstBlock(muya: Muya) {
     first.setCursor(0, 0, true);
     return first;
 }
+function placeCursorOnLastContent(muya: Muya) {
+    const last = muya.editor.scrollPage!.lastContentInDescendant()!;
+    muya.editor.activeContentBlock = last as never;
+    last.setCursor(0, 0, true);
+    return last;
+}
+// eslint-disable-next-line ts/no-explicit-any
+function hasName(state: any[], name: string): boolean {
+    return state.some(b => b.name === name || (Array.isArray(b.children) && hasName(b.children, name)));
+}
 
 describe('updateParagraph same-block menu model', () => {
     it('converts a non-empty paragraph to a heading in place (convertible)', async () => {
@@ -136,6 +146,67 @@ describe('updateParagraph same-block menu model', () => {
         await vi.waitFor(() => {
             const s = muya.getState();
             expect(s[0].name).toBe('atx-heading');
+        });
+    });
+});
+
+describe('updateParagraph toggle-off active types', () => {
+    it('unwraps the matching list kind, leaving other kinds (ul > task > ol, click ordered)', async () => {
+        const muya = bootMuya('- a\n    - [ ] b\n        1. c\n');
+        placeCursorOnLastContent(muya); // cursor in the ordered list item
+        muya.updateParagraph('ol-order');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(hasName(s, 'order-list')).toBe(false);
+            expect(hasName(s, 'bullet-list')).toBe(true);
+            expect(hasName(s, 'task-list')).toBe(true);
+        });
+    });
+
+    it('removes every nested level of the clicked kind (ul > ul, click unordered)', async () => {
+        const muya = bootMuya('- a\n\n  - b\n');
+        placeCursorOnLastContent(muya); // cursor in the inner bullet list
+        muya.updateParagraph('ul-bullet');
+        await vi.waitFor(() => {
+            expect(hasName(muya.getState(), 'bullet-list')).toBe(false);
+        });
+    });
+
+    it('converts the cursor list to a different kind when that kind is not active', async () => {
+        const muya = bootMuya('- a\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('ol-order');
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('order-list');
+        });
+    });
+
+    it('toggles a heading back to a paragraph when its current level is clicked', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('heading 1');
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('paragraph');
+        });
+    });
+
+    it('changes the heading level when a different level is clicked', async () => {
+        const muya = bootMuya('# Title\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('heading 2');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[0].name).toBe('atx-heading');
+            expect((s[0] as { meta: { level: number } }).meta.level).toBe(2);
+        });
+    });
+
+    it('toggles a thematic break back to a paragraph when clicked from within', async () => {
+        const muya = bootMuya('---\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('hr');
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('paragraph');
         });
     });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -72,4 +72,16 @@ describe('updateParagraph same-block menu model', () => {
             expect((s[0] as { children: { children: { name: string }[] }[] }).children[0].children[0].name).toBe('atx-heading');
         });
     });
+
+    it('toggles an enclosing code block back to a paragraph instead of nesting one', async () => {
+        const muya = bootMuya('```\ncode here\n```\n');
+        placeCursorOnFirstBlock(muya);
+        muya.updateParagraph('pre');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s.length).toBe(1);
+            expect(s[0].name).toBe('paragraph');
+            expect((s[0] as { text: string }).text).toContain('code here');
+        });
+    });
 });

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -201,7 +201,7 @@ describe('updateParagraph toggle-off active types', () => {
         });
     });
 
-    it('toggles a thematic break to an EMPTY paragraph (drops the --- markers)', async () => {
+    it('toggles a thematic break to an EMPTY paragraph (drops the --- markers) and focuses it', async () => {
         const muya = bootMuya('---\n');
         placeCursorOnFirstBlock(muya);
         muya.updateParagraph('hr');
@@ -210,6 +210,25 @@ describe('updateParagraph toggle-off active types', () => {
             expect(s[0].name).toBe('paragraph');
             expect((s[0] as { text: string }).text).toBe('');
         });
+        expect(muya.editor.selection.anchorBlock?.text).toBe('');
+    });
+
+    it('toggling one of several thematic breaks lands the caret in ITS empty paragraph, not another rule', async () => {
+        const muya = bootMuya('a\n\n---\n\nb\n\n---\n\nc\n'); // two hrs at index 1 and 3
+        // eslint-disable-next-line ts/no-explicit-any
+        const secondHr = (muya.editor.scrollPage!.firstChild as any).next.next.next;
+        const hrContent = secondHr.firstContentInDescendant();
+        muya.editor.activeContentBlock = hrContent;
+        hrContent.setCursor(0, 0, true);
+        muya.updateParagraph('hr');
+        await vi.waitFor(() => {
+            const s = muya.getState();
+            expect(s[1].name).toBe('thematic-break'); // first rule survives
+            expect(s[3].name).toBe('paragraph'); // toggled one
+            expect((s[3] as { text: string }).text).toBe('');
+        });
+        // caret is in the new empty paragraph, not the surviving rule's "---"
+        expect(muya.editor.selection.anchorBlock?.text).toBe('');
     });
 
     it('keeps the caret in the same text when toggling a nested list off', async () => {

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -209,4 +209,14 @@ describe('updateParagraph toggle-off active types', () => {
             expect(muya.getState()[0].name).toBe('paragraph');
         });
     });
+
+    it('keeps the caret in the same text when toggling a nested list off', async () => {
+        const muya = bootMuya('- a\n\n  - bravo\n');
+        const content = placeCursorOnLastContent(muya); // cursor in "bravo"
+        content.setCursor(3, 3, true);
+        muya.updateParagraph('ul-bullet'); // toggle every bullet list off
+        await vi.waitFor(() => expect(hasName(muya.getState(), 'bullet-list')).toBe(false));
+        expect(muya.editor.selection.anchorBlock?.text).toBe('bravo');
+        expect(muya.editor.selection.anchor?.offset).toBe(3);
+    });
 });

--- a/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
+++ b/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
@@ -103,3 +103,48 @@ describe('cross-block format', () => {
         });
     });
 });
+
+// happy-dom does not track range offsets, so getCursor must report whatever the
+// cached selection currently holds (the per-leaf range _formatLeafInRange sets).
+// eslint-disable-next-line ts/no-explicit-any
+function stubDynamicCursor(muya: Muya, leaf: any) {
+    leaf.getCursor = () => {
+        const s = muya.editor.selection;
+        const a = s.anchor?.offset ?? 0;
+        const f = s.focus?.offset ?? 0;
+        return {
+            start: { offset: Math.min(a, f) },
+            end: { offset: Math.max(a, f) },
+            anchor: { offset: a, block: leaf },
+            focus: { offset: f, block: leaf },
+            isCollapsed: a === f,
+            isSelectionInSameBlock: true,
+            direction: 'forward',
+            type: 'Range',
+        };
+    };
+}
+
+describe('inline format — selection range & heading markers', () => {
+    it('preserves the partial selection range in BOTH blocks after a cross-block bold', () => {
+        const muya = boot('alpha beta\n\ngamma delta\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const second = (sp.firstChild!.next as Parent).firstContentInDescendant()!;
+        stubDynamicCursor(muya, first);
+        stubDynamicCursor(muya, second);
+        muya.editor.activeContentBlock = second;
+        // select "ha beta" .. "gamma d": first@3 -> second@7
+        muya.editor.selection.setSelection(
+            { offset: 3, block: first, path: first.path },
+            { offset: 7, block: second, path: second.path },
+        );
+        muya.format('strong');
+        const sel = muya.editor.selection;
+        // The selected text stays selected INSIDE the new markers in both blocks.
+        expect(sel.anchorBlock!.text).toBe('alp**ha beta**');
+        expect(sel.anchor!.offset).toBe(5); // 3 + len("**")
+        expect(sel.focusBlock!.text).toBe('**gamma d**elta');
+        expect(sel.focus!.offset).toBe(9); // 7 + len("**")
+    });
+});

--- a/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
+++ b/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
@@ -60,6 +60,28 @@ describe('cross-block format', () => {
         });
     });
 
+    it('keeps the selection spanning both blocks after a cross-block format', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const second = (sp.firstChild!.next as Parent).firstContentInDescendant()!;
+        stubFullRange(first);
+        stubFullRange(second);
+        muya.editor.activeContentBlock = second;
+        muya.editor.selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: second.text.length, block: second, path: second.path },
+        );
+        muya.format('strong');
+        await vi.waitFor(() => expect(muya.getMarkdown()).toContain('**alpha**'));
+        // The span is restored across both blocks instead of collapsing onto the
+        // first block (the live DOM selection collapses for a cross-block range).
+        const sel = muya.editor.selection;
+        expect(sel.anchorBlock).not.toBe(sel.focusBlock);
+        expect(sel.anchorBlock!.text).toContain('alpha');
+        expect(sel.focusBlock!.text).toContain('bravo');
+    });
+
     it('skips a code block inside the range', async () => {
         const muya = boot('alpha\n\n```\ncode\n```\n\nbravo\n');
         const sp = muya.editor.scrollPage!;

--- a/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
+++ b/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
@@ -147,4 +147,46 @@ describe('inline format — selection range & heading markers', () => {
         expect(sel.focusBlock!.text).toBe('**gamma d**elta');
         expect(sel.focus!.offset).toBe(9); // 7 + len("**")
     });
+
+    it('skips the leading "# " marker when bolding a heading (same block)', async () => {
+        const muya = boot('# Title\n');
+        // eslint-disable-next-line ts/no-explicit-any
+        const c: any = muya.editor.scrollPage!.firstContentInDescendant()!; // "# Title"
+        muya.editor.activeContentBlock = c;
+        // muya.format() reads selection.getSelection(); happy-dom collapses the
+        // DOM selection, so stub it to the whole-heading range the user dragged.
+        muya.editor.selection.getSelection = () => ({
+            anchor: { offset: 0, block: c, path: c.path },
+            focus: { offset: 7, block: c, path: c.path },
+            start: { offset: 0, block: c },
+            end: { offset: 7, block: c },
+            isSelectionInSameBlock: true,
+            isCollapsed: false,
+            direction: 'forward',
+            type: 'Range',
+            // eslint-disable-next-line ts/no-explicit-any
+        }) as any;
+        stubDynamicCursor(muya, c); // Format.format reads getCursor after the clamp
+        muya.format('strong');
+        await vi.waitFor(() => expect(c.text).toBe('# **Title**')); // marker untouched
+    });
+
+    it('skips the heading marker for a heading inside a cross-block selection', async () => {
+        const muya = boot('# Heading\n\nbody text\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!; // "# Heading"
+        const second = (sp.firstChild!.next as Parent).firstContentInDescendant()!;
+        stubDynamicCursor(muya, first);
+        stubDynamicCursor(muya, second);
+        muya.editor.activeContentBlock = second;
+        muya.editor.selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: second.text.length, block: second, path: second.path },
+        );
+        muya.format('strong');
+        await vi.waitFor(() => {
+            expect(first.text).toBe('# **Heading**'); // "# " kept outside the bold
+            expect(second.text).toBe('**body text**');
+        });
+    });
 });

--- a/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
+++ b/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import type Parent from '../parent';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+const hosts: HTMLElement[] = [];
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+afterEach(() => {
+    while (hosts.length)
+        hosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+});
+
+function boot(md: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown: md } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    hosts.push(muya.domNode);
+    return muya;
+}
+
+// happy-dom collapses non-collapsed ranges to {0,0}, so stub getCursor on each
+// formattable leaf to report its full-text range when format() reads it (same
+// workaround formatToggle.spec uses).
+// eslint-disable-next-line ts/no-explicit-any
+function stubFullRange(leaf: any) {
+    leaf.getCursor = () => ({
+        start: { offset: 0 },
+        end: { offset: leaf.text.length },
+        anchor: { offset: 0, block: leaf },
+        focus: { offset: leaf.text.length, block: leaf },
+        isCollapsed: false,
+        isSelectionInSameBlock: true,
+        direction: 'forward',
+        type: 'Range',
+    });
+}
+
+describe('cross-block format', () => {
+    it('bolds every block in the selection', async () => {
+        const muya = boot('alpha\n\nbravo\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const second = (sp.firstChild!.next as Parent).firstContentInDescendant()!;
+        stubFullRange(first);
+        stubFullRange(second);
+        muya.editor.activeContentBlock = second;
+        muya.editor.selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: second.text.length, block: second, path: second.path },
+        );
+        muya.format('strong');
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('**alpha**');
+            expect(md).toContain('**bravo**');
+        });
+    });
+
+    it('skips a code block inside the range', async () => {
+        const muya = boot('alpha\n\n```\ncode\n```\n\nbravo\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const last = sp.lastContentInDescendant()!;
+        stubFullRange(first);
+        stubFullRange(last);
+        muya.editor.activeContentBlock = last;
+        muya.editor.selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: last.text.length, block: last, path: last.path },
+        );
+        muya.format('strong');
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('**alpha**');
+            expect(md).toContain('**bravo**');
+            expect(md).not.toContain('**code**');
+        });
+    });
+});

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1409,12 +1409,12 @@ export class Muya {
         if (!leaf || leaf.blockName === 'paragraph')
             return;
 
-        replaceBlockByLabel({
+        this._withPreservedOffset(() => replaceBlockByLabel({
             block: leaf,
             muya: this,
             label: 'paragraph',
             text: this._blockLeadingText(leaf),
-        });
+        }));
     }
 
     /**
@@ -1515,6 +1515,7 @@ export class Muya {
     private _snapshotSelection(): ISelectionSnapshot | null {
         const sel = this.editor.selection;
         const live = sel.getSelection();
+
         const anchor = live?.anchor ?? sel.anchor;
         const focus = live?.focus ?? sel.focus;
         const anchorPath = live?.anchor.path ?? sel.anchorPath;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1165,7 +1165,7 @@ export class Muya {
             return;
 
         if (type === 'upgrade heading' || type === 'degrade heading') {
-            this._changeHeadingLevel(block, type);
+            this._withPreservedOffset(() => this._changeHeadingLevel(block, type));
             return;
         }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1296,12 +1296,26 @@ export class Muya {
         fn();
 
         let target: Nullable<Content> = this.editor.activeContentBlock;
-        if (cursorText != null && target?.text !== cursorText)
-            target = this._findContentByText(cursorText) ?? target;
+        let delta = 0;
+        if (cursorText != null && target?.text !== cursorText) {
+            const sameText = this._findContentByText(cursorText);
+            if (sameText) {
+                // A structural unwrap cloned the cursor's block elsewhere; its
+                // text (and so the offsets) are unchanged.
+                target = sameText;
+            }
+            else if (target) {
+                // The text changed in place (e.g. a heading's leading `# `);
+                // shift offsets by the front length change so the caret tracks
+                // the same character.
+                delta = target.text.length - cursorText.length;
+            }
+        }
 
         if (target) {
             const len = target.text.length;
-            target.setCursor(Math.min(anchorOffset, len), Math.min(focusOffset, len), true);
+            const clamp = (n: number) => Math.max(0, Math.min(n, len));
+            target.setCursor(clamp(anchorOffset + delta), clamp(focusOffset + delta), true);
         }
     }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -29,7 +29,8 @@ import {
 } from './selection/offsetCursor';
 import { getTOC } from './state/getTOC';
 import { isAnyListState, isAtxHeadingState } from './state/types';
-import { insertFrontMatterAtStart, replaceBlockByLabel } from './ui/paragraphQuickInsertMenu/config';
+import { canTurnIntoMenu } from './ui/paragraphFrontMenu/config';
+import { insertBlockBelowByLabel, insertFrontMatterAtStart, replaceBlockByLabel } from './ui/paragraphQuickInsertMenu/config';
 import { Ui } from './ui/ui';
 import { deepClone } from './utils';
 import './assets/styles/blockSyntax.css';
@@ -564,6 +565,10 @@ export class Muya {
         return content?.parent ?? null;
     }
 
+    private _insertBlockBelow(block: Parent, label: string) {
+        insertBlockBelowByLabel({ block, muya: this, label });
+    }
+
     /**
      * Duplicate the block at the current cursor, placing the cursor in the
      * copy. No-op when there is no current block.
@@ -959,12 +964,28 @@ export class Muya {
             return;
         }
 
-        replaceBlockByLabel({
-            block,
-            muya: this,
-            label,
-            text: this._blockLeadingText(block),
-        });
+        // General conversion — the front menu's turn-into set is the single source
+        // of truth. Operate on the IMMEDIATE block (the paragraph/heading directly
+        // wrapping the cursor) so a heading inside a list item converts while the
+        // list stays intact.
+        const immediate = this._immediateBlockAtCursor();
+        if (!immediate)
+            return;
+
+        const leadingText = this._blockLeadingText(immediate);
+        const convertible = canTurnIntoMenu(immediate).some(item => item.label === label);
+
+        if (convertible) {
+            replaceBlockByLabel({ block: immediate, muya: this, label, text: leadingText });
+            return;
+        }
+
+        // Not a valid turn-into: empty block -> replace in place; non-empty -> insert
+        // a new block of `label` directly below and move focus into it.
+        if (leadingText.trim() === '')
+            replaceBlockByLabel({ block: immediate, muya: this, label, text: '' });
+        else
+            this._insertBlockBelow(immediate, label);
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1516,10 +1516,19 @@ export class Muya {
         const sel = this.editor.selection;
         const live = sel.getSelection();
 
-        const anchor = live?.anchor ?? sel.anchor;
-        const focus = live?.focus ?? sel.focus;
-        const anchorPath = live?.anchor.path ?? sel.anchorPath;
-        const focusPath = live?.focus.path ?? sel.focusPath;
+        // The live DOM selection carries a click-placed caret, so it is the
+        // source of truth for a single block. But it COLLAPSES to one block for
+        // a cross-block selection — so when the cached endpoints (committed on
+        // mouse-up, the same ones the menu/IPC round-trip relies on) span
+        // several blocks while live has collapsed, trust the cached endpoints so
+        // the whole span survives the rebuild.
+        const cachedCrossBlock = !!sel.anchorBlock && !!sel.focusBlock && sel.anchorBlock !== sel.focusBlock;
+        const useLive = !!live && !(cachedCrossBlock && live.isSelectionInSameBlock);
+
+        const anchor = useLive ? live!.anchor : sel.anchor;
+        const focus = useLive ? live!.focus : sel.focus;
+        const anchorPath = useLive ? live!.anchor.path : sel.anchorPath;
+        const focusPath = useLive ? live!.focus.path : sel.focusPath;
         if (!anchor || !focus || !anchorPath?.length || !focusPath?.length)
             return null;
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -452,11 +452,22 @@ export class Muya {
         if (!isSelectionInSameBlock || !(anchorBlock instanceof Format))
             return;
 
+        // A heading's text includes its leading `# ` marker; never format the
+        // marker itself, only the heading content. Clamp the start past it.
+        const markerLen = this._headingMarkerLen(anchorBlock);
+        let lo = Math.min(anchor.offset, focus.offset);
+        const hi = Math.max(anchor.offset, focus.offset);
+        if (markerLen > 0) {
+            lo = Math.max(lo, markerLen);
+            if (hi <= markerLen)
+                return; // the selection lies entirely within the marker
+        }
+
         // Restore the selection before applying the format — the menu/IPC
         // round-trip can drop the live DOM selection.
         selection.setSelection(
-            { offset: anchor.offset, block: anchorBlock, path: anchor.path },
-            { offset: focus.offset, block: focus.block, path: focus.path },
+            { offset: lo, block: anchorBlock, path: anchor.path },
+            { offset: hi, block: anchorBlock, path: focus.path },
         );
 
         anchorBlock.format(type);
@@ -541,12 +552,17 @@ export class Muya {
      * the leaf was skipped.
      */
     private _formatLeafInRange(type: string, leaf: Content, start: number, end: number): { start: number; end: number } | null {
-        if (!(leaf instanceof Format) || end <= start)
+        if (!(leaf instanceof Format))
+            return null;
+
+        // Never format a heading's leading `# ` marker, only its content.
+        const from = Math.max(start, this._headingMarkerLen(leaf));
+        if (end <= from)
             return null;
 
         const { selection } = this.editor;
         selection.setSelection(
-            { offset: start, block: leaf, path: leaf.path },
+            { offset: from, block: leaf, path: leaf.path },
             { offset: end, block: leaf, path: leaf.path },
         );
         leaf.format(type);
@@ -554,9 +570,17 @@ export class Muya {
         // leaf.format ends with setCursor(adjustedStart, adjustedEnd), which
         // updates the cached selection — read the adjusted range back from it.
         return {
-            start: selection.anchor?.offset ?? start,
+            start: selection.anchor?.offset ?? from,
             end: selection.focus?.offset ?? end,
         };
+    }
+
+    /** Length of a heading content's leading `#{1,6}` + space marker, else 0. */
+    private _headingMarkerLen(leaf: Content): number {
+        if (leaf.parent?.blockName !== 'atx-heading')
+            return 0;
+
+        return /^ {0,3}#{1,6}(?:\s+|$)/.exec(leaf.text)?.[0].length ?? 0;
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -477,19 +477,40 @@ export class Muya {
             return;
 
         const { first, last, firstOffset, lastOffset } = range;
-        const snapshot = this._snapshotSelection();
+
+        // Restore the span across the formatted leaves using each leaf's
+        // post-format offsets (adding a marker shifts them), so the SAME text
+        // stays selected in both endpoints rather than collapsing onto the
+        // pre-format offsets.
+        let anchorLeaf: Content | null = null;
+        let focusLeaf: Content | null = null;
+        let anchorOffset = 0;
+        let focusOffset = 0;
 
         let leaf: Content | null = first;
         while (leaf) {
             const start = leaf === first ? firstOffset : 0;
             const end = leaf === last ? lastOffset : leaf.text.length;
-            this._formatLeafInRange(type, leaf, start, end);
+            const adjusted = this._formatLeafInRange(type, leaf, start, end);
+            if (adjusted) {
+                if (!anchorLeaf) {
+                    anchorLeaf = leaf;
+                    anchorOffset = adjusted.start;
+                }
+                focusLeaf = leaf;
+                focusOffset = adjusted.end;
+            }
             if (leaf === last)
                 break;
             leaf = leaf.nextContentInContext() ?? null;
         }
 
-        this._restoreSelection(snapshot);
+        if (anchorLeaf && focusLeaf) {
+            this.editor.selection.setSelection(
+                { offset: anchorOffset, block: anchorLeaf, path: anchorLeaf.path },
+                { offset: focusOffset, block: focusLeaf, path: focusLeaf.path },
+            );
+        }
     }
 
     /** The selection's first/last content leaves and offsets, in document order. */
@@ -513,16 +534,29 @@ export class Muya {
         };
     }
 
-    /** Apply `type` to one leaf over [start, end], skipping non-formattable leaves. */
-    private _formatLeafInRange(type: string, leaf: Content, start: number, end: number) {
+    /**
+     * Apply `type` to one leaf over [start, end], skipping non-formattable
+     * leaves and a heading's leading `# ` marker. Returns the leaf's selection
+     * range AFTER formatting (offsets shift past inserted markers), or null when
+     * the leaf was skipped.
+     */
+    private _formatLeafInRange(type: string, leaf: Content, start: number, end: number): { start: number; end: number } | null {
         if (!(leaf instanceof Format) || end <= start)
-            return;
+            return null;
 
-        this.editor.selection.setSelection(
+        const { selection } = this.editor;
+        selection.setSelection(
             { offset: start, block: leaf, path: leaf.path },
             { offset: end, block: leaf, path: leaf.path },
         );
         leaf.format(type);
+
+        // leaf.format ends with setCursor(adjustedStart, adjustedEnd), which
+        // updates the cached selection — read the adjusted range back from it.
+        return {
+            start: selection.anchor?.offset ?? start,
+            end: selection.focus?.offset ?? end,
+        };
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -97,8 +97,8 @@ const PARAGRAPH_LABEL_MAP: Record<string, string> = {
 const CROSS_BLOCK_LIST_LABELS = new Set(['bullet-list', 'order-list', 'task-list']);
 
 function endpointPair(
-    anchor: Parent | null | undefined,
-    focus: Parent | null | undefined,
+    anchor: Nullable<Parent>,
+    focus: Nullable<Parent>,
 ): { anchor: Parent; focus: Parent } | null {
     return anchor && focus ? { anchor, focus } : null;
 }
@@ -422,6 +422,15 @@ export class Muya {
      */
     format(type: string) {
         const { selection } = this.editor;
+
+        // Cross-block selection: apply to each formattable leaf in range. The
+        // live DOM selection collapses across blocks, so detect via the cached
+        // endpoints (the same ones the menu/IPC round-trip relies on).
+        if (!this._selectionInSameBlock()) {
+            this._formatAcrossBlocks(type);
+            return;
+        }
+
         const sel = selection.getSelection();
         if (!sel)
             return;
@@ -440,6 +449,69 @@ export class Muya {
         );
 
         anchorBlock.format(type);
+    }
+
+    /**
+     * Apply an inline format to every formattable leaf in a cross-block
+     * selection, in document order. Non-formattable leaves (code/math/html/
+     * frontmatter/diagram) are skipped; link/image are no-ops across blocks
+     * (and the menu disables them). Ported from muyajs's multi-block format.
+     */
+    private _formatAcrossBlocks(type: string) {
+        if (type === 'link' || type === 'image')
+            return;
+
+        const range = this._orderedSelectionRange();
+        if (!range)
+            return;
+
+        const { first, last, firstOffset, lastOffset } = range;
+        const snapshot = this._snapshotSelection();
+
+        let leaf: Content | null = first;
+        while (leaf) {
+            const start = leaf === first ? firstOffset : 0;
+            const end = leaf === last ? lastOffset : leaf.text.length;
+            this._formatLeafInRange(type, leaf, start, end);
+            if (leaf === last)
+                break;
+            leaf = leaf.nextContentInContext() ?? null;
+        }
+
+        this._restoreSelection(snapshot);
+    }
+
+    /** The selection's first/last content leaves and offsets, in document order. */
+    private _orderedSelectionRange() {
+        const { selection } = this.editor;
+        const anchorLeaf = selection.anchorBlock;
+        const focusLeaf = selection.focusBlock;
+        if (!anchorLeaf || !focusLeaf)
+            return null;
+
+        const sp = this.editor.scrollPage!;
+        const anchorOut = anchorLeaf.outMostBlock;
+        const focusOut = focusLeaf.outMostBlock;
+        const forward = anchorOut && focusOut ? sp.offset(anchorOut) <= sp.offset(focusOut) : true;
+
+        return {
+            first: forward ? anchorLeaf : focusLeaf,
+            last: forward ? focusLeaf : anchorLeaf,
+            firstOffset: (forward ? selection.anchor?.offset : selection.focus?.offset) ?? 0,
+            lastOffset: (forward ? selection.focus?.offset : selection.anchor?.offset) ?? 0,
+        };
+    }
+
+    /** Apply `type` to one leaf over [start, end], skipping non-formattable leaves. */
+    private _formatLeafInRange(type: string, leaf: Content, start: number, end: number) {
+        if (!(leaf instanceof Format) || end <= start)
+            return;
+
+        this.editor.selection.setSelection(
+            { offset: start, block: leaf, path: leaf.path },
+            { offset: end, block: leaf, path: leaf.path },
+        );
+        leaf.format(type);
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -754,81 +754,67 @@ export class Muya {
     }
 
     /**
-     * Wrap each selected outmost block as one list item under a new list of
-     * `label`. Ported from muyajs handleListMenu's multi-block branch.
+     * Replace the selected outmost blocks with a single container built by
+     * `buildState`, then position the cursor/selection via `place`. Shared by the
+     * cross-block list / block-quote / code-block wraps (ported from muyajs's
+     * handleListMenu / handleQuoteMenu / handleCodeBlockMenu multi-block branches).
      */
+    private _wrapSelectedBlocks(
+        buildState: (blocks: Parent[]) => { name: string } & Record<string, unknown>,
+        place: (container: Parent) => void,
+    ) {
+        const blocks = this._selectedOutmostBlocks();
+        if (!blocks.length)
+            return;
+
+        const state = buildState(blocks);
+        const container = ScrollPage.loadBlock(state.name).create(this, state as never);
+        const parent = blocks[0].parent!;
+        parent.insertBefore(container, blocks[0]);
+        for (const b of blocks)
+            b.remove();
+
+        place(container);
+    }
+
+    /** Wrap the selected outmost blocks as items of a new list of `label`. */
     private _wrapSelectedBlocksInList(label: 'bullet-list' | 'order-list' | 'task-list') {
-        const blocks = this._selectedOutmostBlocks();
-        if (!blocks.length)
-            return;
-
         const { bulletListMarker, orderListDelimiter, preferLooseListItem } = this.options;
-        const isTask = label === 'task-list';
-        const itemName = isTask ? 'task-list-item' : 'list-item';
-        const children = blocks.map(b => isTask
-            ? { name: itemName, meta: { checked: false }, children: [b.getState()] }
-            : { name: itemName, children: [b.getState()] });
+        const itemName = label === 'task-list' ? 'task-list-item' : 'list-item';
+        const meta: Record<string, unknown> = label === 'order-list'
+            ? { loose: preferLooseListItem, delimiter: orderListDelimiter, start: 1 }
+            : { loose: preferLooseListItem, marker: bulletListMarker };
 
-        const meta: Record<string, unknown> = { loose: preferLooseListItem };
-        if (label === 'order-list') {
-            meta.delimiter = orderListDelimiter;
-            meta.start = 1;
-        }
-        else {
-            meta.marker = bulletListMarker;
-        }
-
-        const listState = { name: label, meta, children };
-        const listBlock = ScrollPage.loadBlock(label).create(this, listState as never);
-        const parent = blocks[0].parent!;
-        parent.insertBefore(listBlock, blocks[0]);
-        for (const b of blocks)
-            b.remove();
-
-        this._selectWrappedContent(listBlock);
+        this._wrapSelectedBlocks(
+            blocks => ({
+                name: label,
+                meta,
+                children: blocks.map(b => label === 'task-list'
+                    ? { name: itemName, meta: { checked: false }, children: [b.getState()] }
+                    : { name: itemName, children: [b.getState()] }),
+            }),
+            container => this._selectWrappedContent(container),
+        );
     }
 
-    /**
-     * Wrap each selected outmost block into a single new block-quote. Ported
-     * from muyajs handleQuoteMenu's multi-block branch.
-     */
+    /** Wrap the selected outmost blocks into a single block-quote. */
     private _wrapSelectedBlocksInQuote() {
-        const blocks = this._selectedOutmostBlocks();
-        if (!blocks.length)
-            return;
-
-        const quoteState = { name: 'block-quote', children: blocks.map(b => b.getState()) };
-        const quoteBlock = ScrollPage.loadBlock('block-quote').create(this, quoteState as never);
-        const parent = blocks[0].parent!;
-        parent.insertBefore(quoteBlock, blocks[0]);
-        for (const b of blocks)
-            b.remove();
-
-        this._selectWrappedContent(quoteBlock);
+        this._wrapSelectedBlocks(
+            blocks => ({ name: 'block-quote', children: blocks.map(b => b.getState()) }),
+            container => this._selectWrappedContent(container),
+        );
     }
 
-    /**
-     * Join each selected outmost block's leading text into a single fenced code
-     * block. Ported from muyajs handleCodeBlockMenu's multi-block branch.
-     */
+    /** Join the selected outmost blocks' text into a single fenced code block. */
     private _wrapSelectedBlocksInCodeBlock() {
-        const blocks = this._selectedOutmostBlocks();
-        if (!blocks.length)
-            return;
-
-        const code = blocks.map(b => this._blockLeadingText(b)).join('\n');
-        const codeState = { name: 'code-block', meta: { type: 'fenced', lang: '' }, text: code };
-        const codeBlock = ScrollPage.loadBlock('code-block').create(this, codeState as never);
-        const parent = blocks[0].parent!;
-        parent.insertBefore(codeBlock, blocks[0]);
-        for (const b of blocks)
-            b.remove();
-
-        codeBlock.firstContentInDescendant()?.setCursor(0, 0, true);
-    }
-
-    private _insertBlockBelow(block: Parent, label: string) {
-        insertBlockBelowByLabel({ block, muya: this, label });
+        this._wrapSelectedBlocks(
+            blocks => ({
+                name: 'code-block',
+                meta: { type: 'fenced', lang: '' },
+                text: blocks.map(b => this._blockLeadingText(b)).join('\n'),
+            }),
+            container => container.firstContentInDescendant()?.setCursor(0, 0, true),
+        );
     }
 
     /**
@@ -1280,7 +1266,7 @@ export class Muya {
         if (leadingText.trim() === '')
             replaceBlockByLabel({ block: immediate, muya: this, label, text: '' });
         else
-            this._insertBlockBelow(immediate, label);
+            insertBlockBelowByLabel({ block: immediate, muya: this, label });
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1236,16 +1236,19 @@ export class Muya {
     }
 
     /**
-     * Run an in-place conversion, then restore the caret to its prior text
-     * offset on the resulting content block (clamped to its length).
+     * Run an in-place conversion, then restore the prior selection (anchor AND
+     * focus, so a range stays selected — not just a collapsed caret) on the
+     * resulting content block, with offsets clamped to its length.
      */
     private _withPreservedOffset(fn: () => void) {
-        const offset = this.editor.selection.anchor?.offset ?? 0;
+        const { selection } = this.editor;
+        const anchorOffset = selection.anchor?.offset ?? 0;
+        const focusOffset = selection.focus?.offset ?? anchorOffset;
         fn();
         const content = this.editor.activeContentBlock;
         if (content) {
-            const next = Math.min(offset, content.text.length);
-            content.setCursor(next, next, true);
+            const len = content.text.length;
+            content.setCursor(Math.min(anchorOffset, len), Math.min(focusOffset, len), true);
         }
     }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1283,9 +1283,8 @@ export class Muya {
 
     /**
      * Run a conversion, then restore the prior selection (anchor AND focus, so a
-     * range stays selected) on the content that still holds the cursor's text.
-     * In-place conversions leave it as the active block; structural unwraps clone
-     * the cursor's block, so fall back to locating the block with the same text.
+     * range stays selected) on the active content block — every conversion ends
+     * with the caret's content active (unwraps restore it themselves).
      */
     private _withPreservedOffset(fn: () => void) {
         const { selection } = this.editor;
@@ -1295,35 +1294,32 @@ export class Muya {
 
         fn();
 
-        let target: Nullable<Content> = this.editor.activeContentBlock;
-        let delta = 0;
-        if (cursorText != null && target?.text !== cursorText) {
-            const sameText = this._findContentByText(cursorText);
-            if (sameText) {
-                // A structural unwrap cloned the cursor's block elsewhere; its
-                // text (and so the offsets) are unchanged.
-                target = sameText;
-            }
-            else if (target) {
-                // The text changed in place (e.g. a heading's leading `# `);
-                // shift offsets by the front length change so the caret tracks
-                // the same character.
-                delta = target.text.length - cursorText.length;
-            }
-        }
+        const target = this.editor.activeContentBlock;
+        if (!target)
+            return;
 
-        if (target) {
-            const len = target.text.length;
-            const clamp = (n: number) => Math.max(0, Math.min(n, len));
-            target.setCursor(clamp(anchorOffset + delta), clamp(focusOffset + delta), true);
-        }
+        // Conversions leave the caret's content as the active block (unwraps
+        // restore it themselves). The text can change in place (e.g. a heading's
+        // `# ` marker), so shift offsets by that front delta to track the same
+        // character.
+        const delta = cursorText != null && target.text !== cursorText
+            ? target.text.length - cursorText.length
+            : 0;
+        const len = target.text.length;
+        const clamp = (n: number) => Math.max(0, Math.min(n, len));
+        target.setCursor(clamp(anchorOffset + delta), clamp(focusOffset + delta), true);
     }
 
-    /** The first content leaf whose text equals `text`, in document order. */
+    /**
+     * The first FORMATTABLE content leaf whose text equals `text`, in document
+     * order. Restricting to Format leaves skips marker-only content (a thematic
+     * break's `---`, code/math/html), so toggling one never lands the caret on
+     * an unrelated block that happens to share that text.
+     */
     private _findContentByText(text: string): Content | null {
         let leaf: Nullable<Content> = this.editor.scrollPage?.firstContentInDescendant();
         while (leaf) {
-            if (leaf.text === text)
+            if (leaf instanceof Format && leaf.text === text)
                 return leaf;
             leaf = leaf.nextContentInContext();
         }
@@ -1418,6 +1414,7 @@ export class Muya {
         if (!inner.length)
             return;
 
+        const cursorText = (this.editor.activeContentBlock ?? this.editor.selection.anchorBlock)?.text;
         const parent = block.parent!;
         let ref: Parent = block;
         let firstNew: Parent | null = null;
@@ -1429,7 +1426,12 @@ export class Muya {
         }
 
         block.remove();
-        firstNew?.firstContentInDescendant()?.setCursor(0, 0, true);
+
+        // Keep the caret in the lifted block that still holds the cursor's text
+        // (its content was cloned), falling back to the first lifted block.
+        const restored = (cursorText != null ? this._findContentByText(cursorText) : null)
+            ?? firstNew?.firstContentInDescendant();
+        restored?.setCursor(0, 0, true);
     }
 
     /** Leading text of a block, with the atx hash run stripped for headings. */

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1372,12 +1372,15 @@ export class Muya {
         }
 
         const state = block.getState();
-        replaceBlockByLabel({
-            block,
-            muya: this,
-            label: 'paragraph',
-            text: isCodeBlockState(state) ? state.text : this._blockLeadingText(block),
-        });
+        let text = '';
+        if (isCodeBlockState(state))
+            text = state.text;
+        // A thematic break's text is all marker (`---` / `***` / …) with no
+        // content, so it resets to an empty paragraph.
+        else if (block.blockName !== 'thematic-break')
+            text = this._blockLeadingText(block);
+
+        replaceBlockByLabel({ block, muya: this, label: 'paragraph', text });
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -594,6 +594,10 @@ export class Muya {
             this._wrapSelectedBlocksInQuote();
             return true;
         }
+        if (label === 'code-block') {
+            this._wrapSelectedBlocksInCodeBlock();
+            return true;
+        }
 
         return false;
     }
@@ -712,6 +716,26 @@ export class Muya {
             b.remove();
 
         quoteBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Join each selected outmost block's leading text into a single fenced code
+     * block. Ported from muyajs handleCodeBlockMenu's multi-block branch.
+     */
+    private _wrapSelectedBlocksInCodeBlock() {
+        const blocks = this._selectedOutmostBlocks();
+        if (!blocks.length)
+            return;
+
+        const code = blocks.map(b => this._blockLeadingText(b)).join('\n');
+        const codeState = { name: 'code-block', meta: { type: 'fenced', lang: '' }, text: code };
+        const codeBlock = ScrollPage.loadBlock('code-block').create(this, codeState as never);
+        const parent = blocks[0].parent!;
+        parent.insertBefore(codeBlock, blocks[0]);
+        for (const b of blocks)
+            b.remove();
+
+        codeBlock.firstContentInDescendant()?.setCursor(0, 0, true);
     }
 
     private _insertBlockBelow(block: Parent, label: string) {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -963,8 +963,10 @@ export class Muya {
     /**
      * Insert a GFM table at the current cursor. An EMPTY cursor block is
      * replaced in place; a NON-empty block keeps its content and the table is
-     * inserted directly below it (matching the Paragraph menu's insert-below
-     * rule for non-convertible blocks). Pass `{ replace: true }` to always
+     * inserted directly AFTER it inside its own container (e.g. right after the
+     * paragraph in a list item, not after the whole list) — matching the
+     * Paragraph menu's insert-below rule for non-convertible blocks. Pass
+     * `{ replace: true }` to always
      * replace the cursor block — the in-editor grid picker uses this to consume
      * its trigger block (a `/table` quick-insert line or the empty paragraph the
      * front-menu offers). The table has `rows` rows × `columns` columns with the
@@ -976,7 +978,7 @@ export class Muya {
      * state.
      */
     createTable({ rows, columns }: { rows: number; columns: number }, { replace = false }: { replace?: boolean } = {}) {
-        const block = this._outmostBlockAtCursor();
+        const block = this._immediateBlockAtCursor();
         if (!block)
             return;
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -586,12 +586,16 @@ export class Muya {
             return false;
 
         const label = PARAGRAPH_LABEL_MAP[type];
-        if (!CROSS_BLOCK_LIST_LABELS.has(label))
-            return false;
+        if (CROSS_BLOCK_LIST_LABELS.has(label)) {
+            this._wrapSelectedBlocksInList(label as 'bullet-list' | 'order-list' | 'task-list');
+            return true;
+        }
+        if (label === 'block-quote') {
+            this._wrapSelectedBlocksInQuote();
+            return true;
+        }
 
-        this._wrapSelectedBlocksInList(label as 'bullet-list' | 'order-list' | 'task-list');
-
-        return true;
+        return false;
     }
 
     /**
@@ -689,6 +693,25 @@ export class Muya {
             b.remove();
 
         listBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+    }
+
+    /**
+     * Wrap each selected outmost block into a single new block-quote. Ported
+     * from muyajs handleQuoteMenu's multi-block branch.
+     */
+    private _wrapSelectedBlocksInQuote() {
+        const blocks = this._selectedOutmostBlocks();
+        if (!blocks.length)
+            return;
+
+        const quoteState = { name: 'block-quote', children: blocks.map(b => b.getState()) };
+        const quoteBlock = ScrollPage.loadBlock('block-quote').create(this, quoteState as never);
+        const parent = blocks[0].parent!;
+        parent.insertBefore(quoteBlock, blocks[0]);
+        for (const b of blocks)
+            b.remove();
+
+        quoteBlock.firstContentInDescendant()?.setCursor(0, 0, true);
     }
 
     private _insertBlockBelow(block: Parent, label: string) {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -665,6 +665,23 @@ export class Muya {
     }
 
     /**
+     * Select the full span of a freshly-wrapped container (first content leaf to
+     * last) so the selection keeps covering the wrapped content. Best-effort.
+     */
+    private _selectWrappedContent(container: Parent) {
+        const head = container.firstContentInDescendant();
+        const tail = container.lastContentInDescendant();
+        if (!head || !tail)
+            return;
+
+        this.editor.activeContentBlock = tail;
+        this.editor.selection.setSelection(
+            { offset: 0, block: head, path: head.path },
+            { offset: tail.text.length, block: tail, path: tail.path },
+        );
+    }
+
+    /**
      * Wrap each selected outmost block as one list item under a new list of
      * `label`. Ported from muyajs handleListMenu's multi-block branch.
      */
@@ -696,7 +713,7 @@ export class Muya {
         for (const b of blocks)
             b.remove();
 
-        listBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+        this._selectWrappedContent(listBlock);
     }
 
     /**
@@ -715,7 +732,7 @@ export class Muya {
         for (const b of blocks)
             b.remove();
 
-        quoteBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+        this._selectWrappedContent(quoteBlock);
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -903,16 +903,21 @@ export class Muya {
     }
 
     /**
-     * Insert a GFM table at the current cursor, replacing the block the cursor
-     * is in. The table has `rows`
-     * rows × `columns` columns with the first row as the header; every cell is
-     * empty with `align: 'none'`. The cursor lands in the first cell. No-op when
-     * there is no current block. `rows`/`columns` are coerced to integers and
-     * clamped to a valid GFM shape (`rows >= 2`, `columns >= 1`) so invalid
-     * input (e.g. `rows: 0`, non-finite, or fractional values) still yields a
-     * usable table instead of an invalid state.
+     * Insert a GFM table at the current cursor. An EMPTY cursor block is
+     * replaced in place; a NON-empty block keeps its content and the table is
+     * inserted directly below it (matching the Paragraph menu's insert-below
+     * rule for non-convertible blocks). Pass `{ replace: true }` to always
+     * replace the cursor block — the in-editor grid picker uses this to consume
+     * its trigger block (a `/table` quick-insert line or the empty paragraph the
+     * front-menu offers). The table has `rows` rows × `columns` columns with the
+     * first row as the header; every cell is empty with `align: 'none'`. The
+     * cursor lands in the first cell. No-op when there is no current block.
+     * `rows`/`columns` are coerced to integers and clamped to a valid GFM shape
+     * (`rows >= 2`, `columns >= 1`) so invalid input (e.g. `rows: 0`, non-finite,
+     * or fractional values) still yields a usable table instead of an invalid
+     * state.
      */
-    createTable({ rows, columns }: { rows: number; columns: number }) {
+    createTable({ rows, columns }: { rows: number; columns: number }, { replace = false }: { replace?: boolean } = {}) {
         const block = this._outmostBlockAtCursor();
         if (!block)
             return;
@@ -941,7 +946,15 @@ export class Muya {
         };
 
         const newTable = ScrollPage.loadBlock('table').create(this, state);
-        block.replaceWith(newTable);
+
+        // An empty block is disposable, so replace it in place; a block with
+        // real content is kept and the table goes directly below it. The picker
+        // passes `replace` to always consume its trigger block.
+        if (replace || this._blockLeadingText(block).trim() === '')
+            block.replaceWith(newTable);
+        else
+            block.parent!.insertAfter(newTable, block);
+
         newTable.firstContentInDescendant()?.setCursor(0, 0, true);
     }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -811,7 +811,9 @@ export class Muya {
             blocks => ({
                 name: 'code-block',
                 meta: { type: 'fenced', lang: '' },
-                text: blocks.map(b => this._blockLeadingText(b)).join('\n'),
+                text: this.editor.jsonState
+                    .getMarkdownFromState(blocks.map(b => b.getState()))
+                    .replace(/\n+$/, ''),
             }),
             container => container.firstContentInDescendant()?.setCursor(0, 0, true),
         );
@@ -1197,52 +1199,54 @@ export class Muya {
         if (label.endsWith('-list') && isAnyListState(block.getState())) {
             // Selecting the active list type toggles the list off (unwrap each
             // item back into paragraphs); a different type converts in place,
-            // preserving every item.
-            if (block.blockName === label)
-                this._unwrapToParagraphs(block);
-            else
-                this._convertListType(block, label);
+            // preserving every item. Keep the caret on the same text.
+            this._withPreservedOffset(() => {
+                if (block.blockName === label)
+                    this._unwrapToParagraphs(block);
+                else
+                    this._convertListType(block, label);
+            });
 
             return;
         }
 
-        // Invoking "Code Block" while the cursor is already inside a code block
-        // toggles it back to a paragraph (muyajs semantics) instead of nesting a
-        // fresh code block into the inner `code` wrapper.
-        if (label === 'code-block' && this._toggleEnclosingCodeBlock())
+        // Invoking "Code Block" / "Quote Block" while the cursor is already
+        // inside that container toggles it back to a paragraph (muyajs
+        // semantics) instead of nesting a fresh one below.
+        if ((label === 'code-block' || label === 'block-quote') && this._toggleEnclosingContainer(label))
             return;
-
-        // hr/table only replace an empty block so user content is never
-        // silently dropped.
-        if (
-            (label === 'thematic-break' || label === 'table')
-            && this._blockLeadingText(block).trim() !== ''
-        ) {
-            return;
-        }
 
         this._convertOrInsertBelow(label);
     }
 
     /**
-     * Toggle the code block enclosing the cursor back to a paragraph carrying
-     * its code text. Returns false when the cursor is not inside a code block.
+     * Toggle the container of `blockName` (code-block / block-quote) enclosing
+     * the cursor back to a paragraph. Returns false when the cursor is not
+     * inside such a container.
      */
-    private _toggleEnclosingCodeBlock(): boolean {
+    private _toggleEnclosingContainer(blockName: string): boolean {
         const content = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
-        const codeBlock = content?.closestBlock('code-block') as Parent | null;
-        if (!codeBlock)
+        const container = content?.closestBlock(blockName) as Parent | null;
+        if (!container)
             return false;
 
-        const state = codeBlock.getState();
-        replaceBlockByLabel({
-            block: codeBlock,
-            muya: this,
-            label: 'paragraph',
-            text: isCodeBlockState(state) ? state.text : '',
-        });
+        this._withPreservedOffset(() => this.resetToParagraph(container));
 
         return true;
+    }
+
+    /**
+     * Run an in-place conversion, then restore the caret to its prior text
+     * offset on the resulting content block (clamped to its length).
+     */
+    private _withPreservedOffset(fn: () => void) {
+        const offset = this.editor.selection.anchor?.offset ?? 0;
+        fn();
+        const content = this.editor.activeContentBlock;
+        if (content) {
+            const next = Math.min(offset, content.text.length);
+            content.setCursor(next, next, true);
+        }
     }
 
     /**
@@ -1259,7 +1263,7 @@ export class Muya {
 
         const leadingText = this._blockLeadingText(immediate);
         if (canTurnIntoMenu(immediate).some(item => item.label === label)) {
-            replaceBlockByLabel({ block: immediate, muya: this, label, text: leadingText });
+            this._withPreservedOffset(() => replaceBlockByLabel({ block: immediate, muya: this, label, text: leadingText }));
             return;
         }
 
@@ -1285,11 +1289,12 @@ export class Muya {
             return;
         }
 
+        const state = block.getState();
         replaceBlockByLabel({
             block,
             muya: this,
             label: 'paragraph',
-            text: this._blockLeadingText(block),
+            text: isCodeBlockState(state) ? state.text : this._blockLeadingText(block),
         });
     }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -28,7 +28,7 @@ import {
     resolveSentinelCursor,
 } from './selection/offsetCursor';
 import { getTOC } from './state/getTOC';
-import { isAnyListState, isAtxHeadingState } from './state/types';
+import { isAnyListState, isAtxHeadingState, isCodeBlockState } from './state/types';
 import { canTurnIntoMenu } from './ui/paragraphFrontMenu/config';
 import { insertBlockBelowByLabel, insertFrontMatterAtStart, replaceBlockByLabel } from './ui/paragraphQuickInsertMenu/config';
 import { Ui } from './ui/ui';
@@ -1220,6 +1220,12 @@ export class Muya {
             return;
         }
 
+        // Invoking "Code Block" while the cursor is already inside a code block
+        // toggles it back to a paragraph (muyajs semantics) instead of nesting a
+        // fresh code block into the inner `code` wrapper.
+        if (label === 'code-block' && this._toggleEnclosingCodeBlock())
+            return;
+
         // hr/table only replace an empty block so user content is never
         // silently dropped.
         if (
@@ -1229,24 +1235,48 @@ export class Muya {
             return;
         }
 
-        // General conversion — the front menu's turn-into set is the single source
-        // of truth. Operate on the IMMEDIATE block (the paragraph/heading directly
-        // wrapping the cursor) so a heading inside a list item converts while the
-        // list stays intact.
+        this._convertOrInsertBelow(label);
+    }
+
+    /**
+     * Toggle the code block enclosing the cursor back to a paragraph carrying
+     * its code text. Returns false when the cursor is not inside a code block.
+     */
+    private _toggleEnclosingCodeBlock(): boolean {
+        const content = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
+        const codeBlock = content?.closestBlock('code-block') as Parent | null;
+        if (!codeBlock)
+            return false;
+
+        const state = codeBlock.getState();
+        replaceBlockByLabel({
+            block: codeBlock,
+            muya: this,
+            label: 'paragraph',
+            text: isCodeBlockState(state) ? state.text : '',
+        });
+
+        return true;
+    }
+
+    /**
+     * General same-block conversion: the front menu's turn-into set is the
+     * single source of truth. Operate on the IMMEDIATE block so a heading inside
+     * a list item converts while the list stays intact; a target that is not a
+     * valid turn-into replaces an empty block in place, or is inserted as a new
+     * block directly below a non-empty one (focus moves into it).
+     */
+    private _convertOrInsertBelow(label: string) {
         const immediate = this._immediateBlockAtCursor();
         if (!immediate)
             return;
 
         const leadingText = this._blockLeadingText(immediate);
-        const convertible = canTurnIntoMenu(immediate).some(item => item.label === label);
-
-        if (convertible) {
+        if (canTurnIntoMenu(immediate).some(item => item.label === label)) {
             replaceBlockByLabel({ block: immediate, muya: this, label, text: leadingText });
             return;
         }
 
-        // Not a valid turn-into: empty block -> replace in place; non-empty -> insert
-        // a new block of `label` directly below and move focus into it.
         if (leadingText.trim() === '')
             replaceBlockByLabel({ block: immediate, muya: this, label, text: '' });
         else

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1282,20 +1282,39 @@ export class Muya {
     }
 
     /**
-     * Run an in-place conversion, then restore the prior selection (anchor AND
-     * focus, so a range stays selected — not just a collapsed caret) on the
-     * resulting content block, with offsets clamped to its length.
+     * Run a conversion, then restore the prior selection (anchor AND focus, so a
+     * range stays selected) on the content that still holds the cursor's text.
+     * In-place conversions leave it as the active block; structural unwraps clone
+     * the cursor's block, so fall back to locating the block with the same text.
      */
     private _withPreservedOffset(fn: () => void) {
         const { selection } = this.editor;
         const anchorOffset = selection.anchor?.offset ?? 0;
         const focusOffset = selection.focus?.offset ?? anchorOffset;
+        const cursorText = (this.editor.activeContentBlock ?? selection.anchorBlock)?.text;
+
         fn();
-        const content = this.editor.activeContentBlock;
-        if (content) {
-            const len = content.text.length;
-            content.setCursor(Math.min(anchorOffset, len), Math.min(focusOffset, len), true);
+
+        let target: Nullable<Content> = this.editor.activeContentBlock;
+        if (cursorText != null && target?.text !== cursorText)
+            target = this._findContentByText(cursorText) ?? target;
+
+        if (target) {
+            const len = target.text.length;
+            target.setCursor(Math.min(anchorOffset, len), Math.min(focusOffset, len), true);
         }
+    }
+
+    /** The first content leaf whose text equals `text`, in document order. */
+    private _findContentByText(text: string): Content | null {
+        let leaf: Nullable<Content> = this.editor.scrollPage?.firstContentInDescendant();
+        while (leaf) {
+            if (leaf.text === text)
+                return leaf;
+            leaf = leaf.nextContentInContext();
+        }
+
+        return null;
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -93,6 +93,16 @@ const PARAGRAPH_LABEL_MAP: Record<string, string> = {
     'sequence': 'diagram sequence',
 };
 
+// The outmost-block labels that wrap a cross-block selection into a list.
+const CROSS_BLOCK_LIST_LABELS = new Set(['bullet-list', 'order-list', 'task-list']);
+
+function endpointPair(
+    anchor: Parent | null | undefined,
+    focus: Parent | null | undefined,
+): { anchor: Parent; focus: Parent } | null {
+    return anchor && focus ? { anchor, focus } : null;
+}
+
 export class Muya {
     static plugins: IPlugin[] = [];
 
@@ -565,6 +575,122 @@ export class Muya {
         return content?.parent ?? null;
     }
 
+    /**
+     * Cross-block paragraph-menu handling: a selection that spans several
+     * outmost blocks wraps each block into one list item. Returns true when the
+     * operation was handled so the single-block path is skipped. Quote/code and
+     * other cross-block targets are gated by the menu layer and fall through.
+     */
+    private _handleCrossBlockParagraph(type: string): boolean {
+        if (this._selectionInSameBlock())
+            return false;
+
+        const label = PARAGRAPH_LABEL_MAP[type];
+        if (!CROSS_BLOCK_LIST_LABELS.has(label))
+            return false;
+
+        this._wrapSelectedBlocksInList(label as 'bullet-list' | 'order-list' | 'task-list');
+
+        return true;
+    }
+
+    /**
+     * The outmost-block endpoints of the current selection. Prefers the pair
+     * that spans two different outmost blocks: the live DOM selection is the
+     * truth in the browser, but the cached selection endpoints survive the
+     * menu/IPC round-trip (and the headless test environment, where
+     * `Selection.extend` collapses a cross-node range to one block).
+     */
+    private _selectionEndpoints(): { anchor: Parent; focus: Parent } | null {
+        const sel = this.editor.selection.getSelection();
+        const live = endpointPair(sel?.anchor.block?.outMostBlock, sel?.focus.block?.outMostBlock);
+        const cached = endpointPair(
+            this.editor.selection.anchorBlock?.outMostBlock,
+            this.editor.selection.focusBlock?.outMostBlock,
+        );
+
+        if (live && live.anchor !== live.focus)
+            return live;
+        if (cached && cached.anchor !== cached.focus)
+            return cached;
+
+        return live ?? cached;
+    }
+
+    /** Whether the current selection stays within a single outmost block. */
+    private _selectionInSameBlock(): boolean {
+        const endpoints = this._selectionEndpoints();
+        if (!endpoints)
+            return true;
+
+        return endpoints.anchor === endpoints.focus;
+    }
+
+    /**
+     * The contiguous run of OUTMOST (scrollPage-child) blocks the current
+     * selection spans, in document order. Mirrors clipboard's outmost walk.
+     */
+    private _selectedOutmostBlocks(): Parent[] {
+        const endpoints = this._selectionEndpoints();
+        if (!endpoints)
+            return [];
+
+        const a = endpoints.anchor;
+        const f = endpoints.focus;
+
+        if (a === f)
+            return [a];
+
+        const sp = this.editor.scrollPage!;
+        const start = sp.offset(a) <= sp.offset(f) ? a : f;
+        const end = start === a ? f : a;
+        const blocks: Parent[] = [];
+        let node: Parent | null = start;
+        while (node) {
+            blocks.push(node);
+            if (node === end)
+                break;
+            node = node.next as Parent | null;
+        }
+
+        return blocks;
+    }
+
+    /**
+     * Wrap each selected outmost block as one list item under a new list of
+     * `label`. Ported from muyajs handleListMenu's multi-block branch.
+     */
+    private _wrapSelectedBlocksInList(label: 'bullet-list' | 'order-list' | 'task-list') {
+        const blocks = this._selectedOutmostBlocks();
+        if (!blocks.length)
+            return;
+
+        const { bulletListMarker, orderListDelimiter, preferLooseListItem } = this.options;
+        const isTask = label === 'task-list';
+        const itemName = isTask ? 'task-list-item' : 'list-item';
+        const children = blocks.map(b => isTask
+            ? { name: itemName, meta: { checked: false }, children: [b.getState()] }
+            : { name: itemName, children: [b.getState()] });
+
+        const meta: Record<string, unknown> = { loose: preferLooseListItem };
+        if (label === 'order-list') {
+            meta.delimiter = orderListDelimiter;
+            meta.start = 1;
+        }
+        else {
+            meta.marker = bulletListMarker;
+        }
+
+        const listState = { name: label, meta, children };
+        const listBlock = ScrollPage.loadBlock(label).create(this, listState as never);
+        const parent = blocks[0].parent!;
+        parent.insertBefore(listBlock, blocks[0]);
+        for (const b of blocks)
+            b.remove();
+
+        listBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+    }
+
     private _insertBlockBelow(block: Parent, label: string) {
         insertBlockBelowByLabel({ block, muya: this, label });
     }
@@ -898,6 +1024,9 @@ export class Muya {
     updateParagraph(type: string) {
         const block = this._outmostBlockAtCursor();
         if (!block)
+            return;
+
+        if (this._handleCrossBlockParagraph(type))
             return;
 
         if (type === 'upgrade heading' || type === 'degrade heading') {

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -96,6 +96,17 @@ const PARAGRAPH_LABEL_MAP: Record<string, string> = {
 // The outmost-block labels that wrap a cross-block selection into a list.
 const CROSS_BLOCK_LIST_LABELS = new Set(['bullet-list', 'order-list', 'task-list']);
 
+// Paragraph-menu labels whose block toggles back to a paragraph when the cursor
+// is already inside one (the menu item is checked) — clicking unwraps/removes it.
+const TOGGLEABLE_BLOCK_LABELS = new Set([
+    'bullet-list',
+    'order-list',
+    'task-list',
+    'block-quote',
+    'code-block',
+    'thematic-break',
+]);
+
 function endpointPair(
     anchor: Nullable<Parent>,
     focus: Nullable<Parent>,
@@ -1196,43 +1207,78 @@ export class Muya {
         if (label === 'paragraph')
             return this._convertLeafToParagraph();
 
-        if (label.endsWith('-list') && isAnyListState(block.getState())) {
-            // Selecting the active list type toggles the list off (unwrap each
-            // item back into paragraphs); a different type converts in place,
-            // preserving every item. Keep the caret on the same text.
-            this._withPreservedOffset(() => {
-                if (block.blockName === label)
-                    this._unwrapToParagraphs(block);
-                else
-                    this._convertListType(block, label);
-            });
-
+        // Clicking an already-active type (its block is an ancestor of the
+        // cursor, i.e. the menu item is checked) toggles it off: unwrap every
+        // ancestor of that kind, or convert the matching leaf back to a paragraph.
+        if (this._toggleIfActive(label))
             return;
+
+        // A list kind clicked while inside a list of a DIFFERENT kind converts
+        // the cursor's (innermost) list to that kind.
+        if (label.endsWith('-list')) {
+            const list = this._closestListAtCursor();
+            if (list) {
+                this._withPreservedOffset(() => this._convertListType(list, label));
+                return;
+            }
         }
-
-        // Invoking "Code Block" / "Quote Block" while the cursor is already
-        // inside that container toggles it back to a paragraph (muyajs
-        // semantics) instead of nesting a fresh one below.
-        if ((label === 'code-block' || label === 'block-quote') && this._toggleEnclosingContainer(label))
-            return;
 
         this._convertOrInsertBelow(label);
     }
 
     /**
-     * Toggle the container of `blockName` (code-block / block-quote) enclosing
-     * the cursor back to a paragraph. Returns false when the cursor is not
-     * inside such a container.
+     * If the cursor is inside a block matching `label` (the menu item is
+     * checked), toggle it off and return true: unwrap EVERY ancestor of that
+     * kind (so nested same-kind lists collapse in one click and the item ends up
+     * un-checked), or convert a matching leaf (heading of that level / hr) back
+     * to a paragraph. Returns false when nothing matches.
      */
-    private _toggleEnclosingContainer(blockName: string): boolean {
-        const content = this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
-        const container = content?.closestBlock(blockName) as Parent | null;
-        if (!container)
+    private _toggleIfActive(label: string): boolean {
+        const cursorContent = () => this.editor.activeContentBlock ?? this.editor.selection.anchorBlock;
+        const content = cursorContent();
+        if (!content)
             return false;
 
-        this._withPreservedOffset(() => this.resetToParagraph(container));
+        // Headings match only when the cursor's heading is exactly that level.
+        if (label.startsWith('atx-heading ')) {
+            const heading = content.closestBlock('atx-heading') as Parent | null;
+            if (!heading)
+                return false;
+
+            const state = heading.getState();
+            const level = Number(label.slice('atx-heading '.length));
+            if (!isAtxHeadingState(state) || state.meta.level !== level)
+                return false;
+
+            this._withPreservedOffset(() => this.resetToParagraph(heading));
+            return true;
+        }
+
+        if (!TOGGLEABLE_BLOCK_LABELS.has(label) || !content.closestBlock(label))
+            return false;
+
+        this._withPreservedOffset(() => {
+            for (let guard = 0; guard < 20; guard++) {
+                const target = cursorContent()?.closestBlock(label) as Parent | null;
+                if (!target)
+                    break;
+                this.resetToParagraph(target);
+            }
+        });
 
         return true;
+    }
+
+    /** The nearest list ancestor of the cursor, of any kind. */
+    private _closestListAtCursor(): Parent | null {
+        let node: Nullable<Parent> = (this.editor.activeContentBlock ?? this.editor.selection.anchorBlock)?.parent;
+        while (node) {
+            if (node.blockName === 'bullet-list' || node.blockName === 'order-list' || node.blockName === 'task-list')
+                return node;
+            node = node.parent;
+        }
+
+        return null;
     }
 
     /**

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1398,16 +1398,23 @@ export class Muya {
             return;
         }
 
-        const state = block.getState();
-        let text = '';
-        if (isCodeBlockState(state))
-            text = state.text;
-        // A thematic break's text is all marker (`---` / `***` / …) with no
-        // content, so it resets to an empty paragraph.
-        else if (block.blockName !== 'thematic-break')
-            text = this._blockLeadingText(block);
+        replaceBlockByLabel({ block, muya: this, label: 'paragraph', text: this._paragraphTextFor(block) });
+    }
 
-        replaceBlockByLabel({ block, muya: this, label: 'paragraph', text });
+    /**
+     * The text a plain paragraph should carry when `block` is reset/converted to
+     * one: a code block keeps its raw code; a thematic break is all marker
+     * (`---` / `***` / …) with no content, so it yields an empty paragraph;
+     * everything else keeps its leading text (heading hashes stripped).
+     */
+    private _paragraphTextFor(block: Parent): string {
+        const state = block.getState();
+        if (isCodeBlockState(state))
+            return state.text;
+        if (block.blockName === 'thematic-break')
+            return '';
+
+        return this._blockLeadingText(block);
     }
 
     /**
@@ -1426,7 +1433,7 @@ export class Muya {
             block: leaf,
             muya: this,
             label: 'paragraph',
-            text: this._blockLeadingText(leaf),
+            text: this._paragraphTextFor(leaf),
         }));
     }
 

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1288,26 +1288,44 @@ export class Muya {
      */
     private _withPreservedOffset(fn: () => void) {
         const { selection } = this.editor;
+        const anchorBlock = selection.anchorBlock;
+        const focusBlock = selection.focusBlock;
         const anchorOffset = selection.anchor?.offset ?? 0;
         const focusOffset = selection.focus?.offset ?? anchorOffset;
-        const cursorText = (this.editor.activeContentBlock ?? selection.anchorBlock)?.text;
+        const anchorText = anchorBlock?.text;
+        const focusText = focusBlock?.text;
+        const multiBlock = !!anchorBlock && !!focusBlock && anchorBlock !== focusBlock;
 
         fn();
 
+        const clampTo = (n: number, len: number) => Math.max(0, Math.min(n, len));
+
+        // A selection spanning several blocks (e.g. across list items) — re-find
+        // both endpoints by their text so the whole span survives an unwrap.
+        if (multiBlock && anchorText != null && focusText != null) {
+            const a = this._findContentByText(anchorText);
+            const f = this._findContentByText(focusText);
+            if (a && f) {
+                this.editor.selection.setSelection(
+                    { offset: clampTo(anchorOffset, a.text.length), block: a, path: a.path },
+                    { offset: clampTo(focusOffset, f.text.length), block: f, path: f.path },
+                );
+                return;
+            }
+        }
+
+        // Single block: the caret's content is the active block (in-place result
+        // or unwrap-restored). The text can change in place (a heading's `# `
+        // marker), so shift offsets by that front delta to track the same char.
         const target = this.editor.activeContentBlock;
         if (!target)
             return;
 
-        // Conversions leave the caret's content as the active block (unwraps
-        // restore it themselves). The text can change in place (e.g. a heading's
-        // `# ` marker), so shift offsets by that front delta to track the same
-        // character.
-        const delta = cursorText != null && target.text !== cursorText
-            ? target.text.length - cursorText.length
+        const delta = anchorText != null && target.text !== anchorText
+            ? target.text.length - anchorText.length
             : 0;
         const len = target.text.length;
-        const clamp = (n: number) => Math.max(0, Math.min(n, len));
-        target.setCursor(clamp(anchorOffset + delta), clamp(focusOffset + delta), true);
+        target.setCursor(clampTo(anchorOffset + delta, len), clampTo(focusOffset + delta, len), true);
     }
 
     /**

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -375,7 +375,8 @@ describe('replaceBlockByLabel — in-editor "table" shows the grid picker (rever
         handler(2, 3);
 
         expect(createTable).toHaveBeenCalledTimes(1);
-        expect(createTable).toHaveBeenCalledWith({ rows: 3, columns: 4 });
+        // The picker always replaces its disposable trigger block.
+        expect(createTable).toHaveBeenCalledWith({ rows: 3, columns: 4 }, { replace: true });
     });
 
     it('falls back to the block DOM node as the reference when the cursor has no coords', () => {

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -437,7 +437,10 @@ export function showTablePicker(muya: Muya, block: Parent) {
         return;
 
     const handler = (row: number, column: number) => {
-        muya.createTable({ rows: row + 1, columns: column + 1 });
+        // The picker's trigger block (a `/table` quick-insert line or the empty
+        // paragraph the front-menu offers) is disposable, so always replace it
+        // rather than inserting the table below it.
+        muya.createTable({ rows: row + 1, columns: column + 1 }, { replace: true });
     };
 
     eventCenter.emit('muya-table-picker', { row: -1, column: -1 }, reference, handler);

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -602,11 +602,19 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
         cursorBlock.setCursor(0, 0, true);
     }
     else {
-        const cursorBlock = newBlock.firstContentInDescendant();
-        // Set the cursor between <div>\n\n</div> when create html-block
-        const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
-        cursorBlock.setCursor(offset, offset, true);
+        placeCaretInNewBlock(newBlock, label);
     }
+}
+
+// Move the caret into a freshly-built block: between <div>\n\n</div> for an
+// html-block, otherwise to the end of its text.
+function placeCaretInNewBlock(newBlock: Parent, label: string) {
+    const cursorBlock = newBlock.firstContentInDescendant();
+    if (!cursorBlock)
+        return;
+
+    const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
+    cursorBlock.setCursor(offset, offset, true);
 }
 
 // Build a fresh block of `label` and insert it directly AFTER `block`
@@ -622,9 +630,5 @@ export function insertBlockBelowByLabel({ block, muya, label }: {
     if (!newBlock)
         return;
     block.parent!.insertAfter(newBlock, block);
-    const cursorBlock = newBlock.firstContentInDescendant();
-    if (!cursorBlock)
-        return;
-    const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
-    cursorBlock.setCursor(offset, offset, true);
+    placeCaretInNewBlock(newBlock, label);
 }

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -517,7 +517,7 @@ function buildDiagramBlock(label: string, muya: Muya) {
     return ScrollPage.loadBlock(name).create(muya, diagramState);
 }
 
-function buildReplacementBlock(label: string, muya: Muya, text: string) {
+export function buildReplacementBlock(label: string, muya: Muya, text: string) {
     if (label.startsWith('atx-heading '))
         return buildHeadingBlock(label, muya, text);
     if (label.startsWith('diagram '))
@@ -607,4 +607,24 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
         const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
         cursorBlock.setCursor(offset, offset, true);
     }
+}
+
+// Build a fresh block of `label` and insert it directly AFTER `block`
+// (inside the same container), then move the caret into the new block.
+// Used by the Paragraph menu when the target type is not a valid front-menu
+// turn-into of a non-empty block.
+export function insertBlockBelowByLabel({ block, muya, label }: {
+    block: Parent;
+    muya: Muya;
+    label: string;
+}) {
+    const newBlock = buildReplacementBlock(label, muya, '');
+    if (!newBlock)
+        return;
+    block.parent!.insertAfter(newBlock, block);
+    const cursorBlock = newBlock.firstContentInDescendant();
+    if (!cursorBlock)
+        return;
+    const offset = label === 'html-block' ? 6 : cursorBlock.text.length;
+    cursorBlock.setCursor(offset, offset, true);
 }

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/config.ts
@@ -592,18 +592,25 @@ export function replaceBlockByLabel({ block, muya, label, text = '' }: {
     const newBlock = buildReplacementBlock(label, muya, text);
 
     block.replaceWith(newBlock);
+    finishInsertedBlock(newBlock, muya, label);
+}
+
+// Position the caret after a block was inserted or replaced. A thematic-break
+// is not editable, so append a trailing empty paragraph and put the caret there
+// (so the user can keep typing below the rule); otherwise move the caret into
+// the new block.
+function finishInsertedBlock(newBlock: Parent, muya: Muya, label: string) {
     if (label === 'thematic-break') {
         const nextParagraphBlock = ScrollPage.loadBlock('paragraph').create(
             muya,
             deepClone(emptyStates.paragraph),
         );
-        newBlock.parent.insertAfter(nextParagraphBlock, newBlock);
-        const cursorBlock = nextParagraphBlock.firstContentInDescendant();
-        cursorBlock.setCursor(0, 0, true);
+        newBlock.parent!.insertAfter(nextParagraphBlock, newBlock);
+        nextParagraphBlock.firstContentInDescendant()?.setCursor(0, 0, true);
+        return;
     }
-    else {
-        placeCaretInNewBlock(newBlock, label);
-    }
+
+    placeCaretInNewBlock(newBlock, label);
 }
 
 // Move the caret into a freshly-built block: between <div>\n\n</div> for an
@@ -630,5 +637,5 @@ export function insertBlockBelowByLabel({ block, muya, label }: {
     if (!newBlock)
         return;
     block.parent!.insertAfter(newBlock, block);
-    placeCaretInNewBlock(newBlock, label);
+    finishInsertedBlock(newBlock, muya, label);
 }


### PR DESCRIPTION
## Summary

Reworks the desktop **Paragraph** and **Format** menus on the `@muyajs/core` engine so their checked / disabled / click behavior matches the legacy `muyajs` engine, plus **3 deliberate upgrades**. This restores the cross-block capabilities that were dropped during the muya migration (the current engine's `updateParagraph` only acted on a single block and `format` no-op'd across blocks).

Design + implementation plan were brainstormed and written up beforehand (kept outside the repo per workflow); this PR implements that plan task-by-task with tests.

### Kept upgrades (vs muyajs)
1. **Front Matter "disable when present"** — the Front Matter item is disabled whenever the document already starts with a front-matter block.
2. **Cross-block "honest set"** — across a multi-block selection the Paragraph menu enables only the items with a defined cross-block action: code block, quote, ordered/bullet/task list (everything else, and link/image in Format, is disabled).
3. **Same-block conversion via the front menu's `canTurnIntoMenu` as the single source of truth** — convertible targets convert in place; a non-convertible target replaces an empty block, or inserts a new block directly below a non-empty one (focus moves into it).

Everything else mirrors muyajs (affiliation-chain checked state, "table keeps formatting", list/code toggle, cross-block per-block format).

## Changes

### Engine — `packages/muya`
- Same-block `updateParagraph` rebuilt around `canTurnIntoMenu` + insert-below, operating on the immediate block (so a heading inside a list item converts while the list stays intact).
- Cross-block selection wrapping into a **list / block-quote / single code block**.
- Cross-block inline **format** applied per formattable leaf (skips code/math/html/frontmatter/diagram; link/image disabled across blocks).
- Selection kept spanning the wrapped content after a wrap.
- Invoking **Code Block inside a code block** toggles it back to a paragraph (instead of nesting / corrupting the document).

### Desktop — `packages/desktop`
- `updateSelectionMenus`: cross-block honest set; Front Matter disabled when the doc has one; format disabled in every non-formattable code-fence block (code/math/html/frontmatter/diagram) while **table cells keep formatting**.
- `createApplicationMenuState` / `editor.vue`: detect diagrams as a non-formattable block and plumb the `hasFrontMatter` flag.

## Tests & gates
- `packages/muya`: **996** unit tests pass · `lint:types` clean · ESLint 0 errors · no circular deps.
- `packages/desktop`: **546** unit tests pass · `typecheck` clean · ESLint 0 errors.
- New specs: `updateParagraph.menu`, `crossBlockParagraph`, `crossBlockFormat` (muya); front-matter / honest-set / format-breadth additions + `application-menu-state` (desktop).

## Manual verification
Unit-tested throughout; recommend a manual pass in the running app over the design's acceptance scenarios (cross-block wraps, table formatting, front-matter disable, code-block toggle) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
