### PR TITLE
refactor(desktop): remove remaining no-explicit-any suppressions

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -114,6 +114,7 @@
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",
     "@playwright/test": "^1.60.0",
+    "@types/codemirror": "^5.60.15",
     "@types/deep-equal": "^1.0.4",
     "@types/dragula": "^3.7.5",
     "@types/element-resize-detector": "^1.1.6",

--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -15,6 +15,7 @@ import { selectTheme } from '../menu/actions/theme'
 import { dockMenu } from '../menu/templates'
 import registerSpellcheckerListeners from '../spellchecker'
 import { watchers } from '../utils/imagePathAutoComplement'
+import { onInternalChannel } from '../utils/internalIpc'
 import { WindowType } from '../windows/base'
 import EditorWindow from '../windows/editor'
 import SettingWindow from '../windows/setting'
@@ -283,53 +284,54 @@ class App {
       selectTheme(newTheme)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('broadcast-preferences-changed', (change: any) => {
-      const nextPreferences = {
-        ...preferences.getAll(),
-        ...change
-      }
-      nativeTheme.themeSource = getNativeThemeSource(nextPreferences)
+    onInternalChannel(
+      'broadcast-preferences-changed',
+      (change: Partial<ReturnType<typeof preferences.getAll>>) => {
+        const nextPreferences = {
+          ...preferences.getAll(),
+          ...change
+        }
+        nativeTheme.themeSource = getNativeThemeSource(nextPreferences)
 
       // When followSystemTheme is enabled, immediately switch to match system
-      if (change.followSystemTheme === true) {
-        const systemIsDark = nativeTheme.shouldUseDarkColors
-        const lightModeTheme = preferences.getItem<string>('lightModeTheme')
-        const darkModeTheme = preferences.getItem<string>('darkModeTheme')
-        const newTheme = systemIsDark ? darkModeTheme : lightModeTheme
+        if (change.followSystemTheme === true) {
+          const systemIsDark = nativeTheme.shouldUseDarkColors
+          const lightModeTheme = preferences.getItem<string>('lightModeTheme')
+          const darkModeTheme = preferences.getItem<string>('darkModeTheme')
+          const newTheme = systemIsDark ? darkModeTheme : lightModeTheme
 
-        log.info(
-          `followSystemTheme enabled, switching to: ${newTheme} (system ${systemIsDark ? 'dark' : 'light'})`
-        )
-        selectTheme(newTheme)
-        preferences.setItem('theme', newTheme)
-      }
+          log.info(
+            `followSystemTheme enabled, switching to: ${newTheme} (system ${systemIsDark ? 'dark' : 'light'})`
+          )
+          selectTheme(newTheme)
+          preferences.setItem('theme', newTheme)
+        }
       // When light/dark mode theme preferences change, apply immediately if following system
-      if (
-        preferences.getItem<boolean>('followSystemTheme') &&
+        if (
+          preferences.getItem<boolean>('followSystemTheme') &&
         (change.lightModeTheme || change.darkModeTheme)
-      ) {
-        const systemIsDark = nativeTheme.shouldUseDarkColors
+        ) {
+          const systemIsDark = nativeTheme.shouldUseDarkColors
 
         // Get current values, but prefer the NEW values from the change event
-        let lightModeTheme = preferences.getItem<string>('lightModeTheme')
-        let darkModeTheme = preferences.getItem<string>('darkModeTheme')
+          let lightModeTheme = preferences.getItem<string>('lightModeTheme')
+          let darkModeTheme = preferences.getItem<string>('darkModeTheme')
 
         // If these preferences were just changed, use the new values from the change object
-        if (change.lightModeTheme !== undefined) {
-          lightModeTheme = change.lightModeTheme
-        }
-        if (change.darkModeTheme !== undefined) {
-          darkModeTheme = change.darkModeTheme
-        }
+          if (change.lightModeTheme !== undefined) {
+            lightModeTheme = change.lightModeTheme
+          }
+          if (change.darkModeTheme !== undefined) {
+            darkModeTheme = change.darkModeTheme
+          }
 
-        const newTheme = systemIsDark ? darkModeTheme : lightModeTheme
+          const newTheme = systemIsDark ? darkModeTheme : lightModeTheme
 
-        log.info(`Theme preference changed, applying: ${newTheme}`)
-        selectTheme(newTheme)
-        preferences.setItem('theme', newTheme)
-      }
-    })
+          log.info(`Theme preference changed, applying: ${newTheme}`)
+          selectTheme(newTheme)
+          preferences.setItem('theme', newTheme)
+        }
+      })
 
     // Listen for system theme changes and auto-switch if enabled
     if (!this._themeListenerRegistered) {
@@ -666,8 +668,7 @@ class App {
       this._createEditorWindow()
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('screen-capture', async(win: any) => {
+    onInternalChannel('screen-capture', async(win: BrowserWindow) => {
       if (isOsx) {
         // Use macOs `screencapture` command line when in macOs system.
         const screenshotFileName = await this.getScreenshotFileName()
@@ -695,33 +696,30 @@ class App {
       }
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('app-create-settings-window', (category: any) => {
-      this._openSettingsWindow(category as string | undefined)
+    onInternalChannel('app-create-settings-window', (category?: string) => {
+      this._openSettingsWindow(category)
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('app-open-file-by-id', (windowId: any, filePath: any) => {
+    onInternalChannel('app-open-file-by-id', (windowId: number, filePath: string) => {
       const openFilesInNewWindow = this._accessor.preferences.getItem<boolean>('openFilesInNewWindow')
       if (openFilesInNewWindow) {
-        this._createEditorWindow(null, [filePath as string])
+        this._createEditorWindow(null, [filePath])
       } else {
-        const editor = this._windowManager.get(windowId as number) as EditorWindow | undefined
+        const editor = this._windowManager.get(windowId) as EditorWindow | undefined
         if (editor) {
           editor.openTab(filePath, {}, true)
         }
       }
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('app-open-files-by-id', (windowId: any, fileList: any) => {
+    onInternalChannel('app-open-files-by-id', (windowId: number, fileList: string[]) => {
       const openFilesInNewWindow = this._accessor.preferences.getItem<boolean>('openFilesInNewWindow')
       if (openFilesInNewWindow) {
-        this._createEditorWindow(null, fileList as string[])
+        this._createEditorWindow(null, fileList)
       } else {
-        const editor = this._windowManager.get(windowId as number) as EditorWindow | undefined
+        const editor = this._windowManager.get(windowId) as EditorWindow | undefined
         if (editor) {
           editor.openTabsFromPaths(
-            (fileList as string[])
+            fileList
               .map((p) => normalizeMarkdownPath(p))
               .filter((i): i is PathInfo => i !== null && !i.isDir)
               .map((i) => i.path)
@@ -730,32 +728,30 @@ class App {
       }
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('app-open-markdown-by-id', (windowId: any, data: any) => {
+    onInternalChannel('app-open-markdown-by-id', (windowId: number, data: string) => {
       const openFilesInNewWindow = this._accessor.preferences.getItem<boolean>('openFilesInNewWindow')
       if (openFilesInNewWindow) {
-        this._createEditorWindow(null, [], [data as string])
+        this._createEditorWindow(null, [], [data])
       } else {
-        const editor = this._windowManager.get(windowId as number) as EditorWindow | undefined
+        const editor = this._windowManager.get(windowId) as EditorWindow | undefined
         if (editor) {
-          editor.openUntitledTab(true, data as string)
+          editor.openUntitledTab(true, data)
         }
       }
     })
 
-    ipcMain.on(
+    onInternalChannel(
       'app-open-directory-by-id',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (windowId: any, pathname: any, openInSameWindow: any) => {
+      (windowId: number, pathname: string, openInSameWindow: boolean) => {
         const { openFolderInNewWindow } = this._accessor.preferences.getAll()
         if (openInSameWindow || !openFolderInNewWindow) {
-          const editor = this._windowManager.get(windowId as number) as EditorWindow | undefined
+          const editor = this._windowManager.get(windowId) as EditorWindow | undefined
           if (editor) {
-            editor.openFolder(pathname as string)
+            editor.openFolder(pathname)
             return
           }
         }
-        this._createEditorWindow(pathname as string)
+        this._createEditorWindow(pathname)
       }
     )
 

--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -6,6 +6,7 @@ import log from 'electron-log'
 import { app, BrowserWindow, clipboard, dialog, nativeTheme, shell, ipcMain } from 'electron'
 import type { BrowserWindowConstructorOptions } from 'electron'
 import { isChildOfDirectory } from 'common/filesystem/paths'
+import type { IUserPreferences } from '@shared/types/preferences'
 import { isLinux, isOsx, isWindows } from '../config'
 import parseArgs from '../cli/parser'
 import { normalizeAndResolvePath } from '../filesystem'
@@ -286,7 +287,7 @@ class App {
 
     onInternalChannel(
       'broadcast-preferences-changed',
-      (change: Partial<ReturnType<typeof preferences.getAll>>) => {
+      (change: Partial<IUserPreferences>) => {
         const nextPreferences = {
           ...preferences.getAll(),
           ...change

--- a/packages/desktop/src/main/app/nativeTheme.ts
+++ b/packages/desktop/src/main/app/nativeTheme.ts
@@ -10,8 +10,8 @@ export const getNativeThemeSource = ({
   followSystemTheme,
   theme
 }: {
-  followSystemTheme: boolean
-  theme: unknown
+  followSystemTheme?: boolean
+  theme?: unknown
 }): NativeThemeSource => {
   if (followSystemTheme) {
     return 'system'

--- a/packages/desktop/src/main/app/windowManager.ts
+++ b/packages/desktop/src/main/app/windowManager.ts
@@ -6,6 +6,7 @@ import Watcher, {
   WATCHER_STABILITY_THRESHOLD,
   WATCHER_STABILITY_POLL_INTERVAL
 } from '../filesystem/watcher'
+import { onInternalChannel } from '../utils/internalIpc'
 import type BaseWindow from '../windows/base'
 import type Preference from '../preferences'
 import { WindowType } from '../windows/base'
@@ -417,41 +418,34 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
 
     // --- local events ---------------
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('watcher-unwatch-all-by-id', (windowId: any) => {
-      this._watcher.unwatchByWindowId(windowId as number)
+    onInternalChannel('watcher-unwatch-all-by-id', (windowId: number) => {
+      this._watcher.unwatchByWindowId(windowId)
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('watcher-watch-file', (win: any, filePath: any) => {
+    onInternalChannel('watcher-watch-file', (win: IBrowserWindow, filePath: string) => {
       this._watcher.watch(win, filePath, 'file')
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('watcher-watch-directory', (win: any, pathname: any) => {
+    onInternalChannel('watcher-watch-directory', (win: IBrowserWindow, pathname: string) => {
       this._watcher.watch(win, pathname, 'dir')
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('watcher-unwatch-file', (win: any, filePath: any) => {
+    onInternalChannel('watcher-unwatch-file', (win: IBrowserWindow, filePath: string) => {
       this._watcher.unwatch(win, filePath, 'file')
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('watcher-unwatch-directory', (win: any, pathname: any) => {
+    onInternalChannel('watcher-unwatch-directory', (win: IBrowserWindow, pathname: string) => {
       this._watcher.unwatch(win, pathname, 'dir')
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('window-add-file-path', (windowId: any, filePath: any) => {
-      const editor = this.get(windowId as number) as EditorWindow | undefined
+    onInternalChannel('window-add-file-path', (windowId: number, filePath: string) => {
+      const editor = this.get(windowId) as EditorWindow | undefined
       if (!editor) {
         log.error(`Cannot find window id "${windowId}" to add opened file.`)
         return
       }
       editor.addToOpenedFiles(filePath)
     })
-    ipcMain.on(
+    onInternalChannel(
       'window-change-file-path',
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (windowId: any, pathname: any, oldPathname: any) => {
-        const editor = this.get(windowId as number) as EditorWindow | undefined
+      (windowId: number, pathname: string, oldPathname: string) => {
+        const editor = this.get(windowId) as EditorWindow | undefined
         if (!editor) {
           log.error(`Cannot find window id "${windowId}" to change file path.`)
           return
@@ -460,36 +454,28 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
       }
     )
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('window-file-saved', (windowId: any, pathname: any) => {
+    onInternalChannel('window-file-saved', (windowId: number, pathname: string) => {
       // A changed event is emitted earliest after the stability threshold.
       const duration = WATCHER_STABILITY_THRESHOLD + WATCHER_STABILITY_POLL_INTERVAL * 2
-      this._watcher.ignoreChangedEvent(windowId as number, pathname as string, duration)
+      this._watcher.ignoreChangedEvent(windowId, pathname, duration)
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('window-close-by-id', (id: any) => {
-      this.forceCloseById(id as number)
+    onInternalChannel('window-close-by-id', (id: number) => {
+      this.forceCloseById(id)
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('window-reload-by-id', (id: any) => {
-      const window = this.get(id as number)
+    onInternalChannel('window-reload-by-id', (id: number) => {
+      const window = this.get(id)
       if (window) {
         window.reload()
       }
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('window-toggle-always-on-top', (win: any) => {
+    onInternalChannel('window-toggle-always-on-top', (win: IBrowserWindow) => {
       const flag = !win.isAlwaysOnTop()
       win.setAlwaysOnTop(flag)
       this._appMenu.updateAlwaysOnTopMenu(win.id, flag)
     })
 
-    // Dispatched in-process via `ipcMain.emit(channel, payload)` — emit passes
-    // args directly to listeners (no synthetic IpcMainEvent). Single-arg
-    // signature here, unlike the renderer-IPC listeners below.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(ipcMain as any).on('broadcast-preferences-changed', (prefs: Record<string, unknown>) => {
+    onInternalChannel('broadcast-preferences-changed', (prefs: Record<string, unknown>) => {
       // We can not dynamic change the title bar style, so do not need to send it to renderer.
       if (typeof prefs.titleBarStyle !== 'undefined') {
         delete prefs.titleBarStyle
@@ -501,9 +487,7 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
       }
     })
 
-    // Dispatched in-process via `ipcMain.emit` — see comment above.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(ipcMain as any).on('broadcast-user-data-changed', (userData: Record<string, unknown>) => {
+    onInternalChannel('broadcast-user-data-changed', (userData: Record<string, unknown>) => {
       for (const { browserWindow } of this._windows.values()) {
         browserWindow?.webContents.send('mt::user-preference', userData)
       }

--- a/packages/desktop/src/main/commands/index.ts
+++ b/packages/desktop/src/main/commands/index.ts
@@ -7,7 +7,9 @@ export const COMMANDS = COMMAND_CONSTANTS
 // CommandCallback is intentionally loose: registered command handlers vary
 // widely in their signatures (some take a BrowserWindow, some take nothing,
 // some take a string id, etc.). Mirrors the JS reality where callsites
-// passed any function shape and the manager just invoked it.
+// passed any function shape and the manager just invoked it. A single non-`any`
+// type cannot both accept every typed handler (contravariant params) and stay
+// callable with real args, so this stays an explicit, documented escape hatch.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CommandCallback = (...args: any[]) => any
 

--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -235,8 +235,9 @@ class Watcher {
       },
 
       usePolling
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- chokidar's `ignored` callback signature varies between versions; this options bag works at runtime but defies the bundled type
-    } as any)
+      // chokidar's `ignored` callback signature varies between versions; this options
+      // bag works at runtime but defies the bundled type.
+    } as unknown as Parameters<typeof chokidar.watch>[1])
 
     let disposed = false
     let enospcReached = false

--- a/packages/desktop/src/main/keyboard/index.ts
+++ b/packages/desktop/src/main/keyboard/index.ts
@@ -50,8 +50,7 @@ class KeyboardLayoutMonitor extends EventEmitter {
   // we preserve the original JS behavior verbatim: the first positional argument is
   // always treated as the callback. Parameters are typed loosely to keep TS happy
   // with the override against the base signature.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override addListener(eventNameOrCallback: any, _listener?: any): this {
+  override addListener(eventNameOrCallback: unknown, _listener?: unknown): this {
     this._ensureNativeListener()
     this.on(KEYBOARD_LAYOUT_MONITOR_CHANNEL_ID, eventNameOrCallback as KeyboardInfoListener)
     return this
@@ -59,10 +58,8 @@ class KeyboardLayoutMonitor extends EventEmitter {
 
   // NOTE: Preserves the pre-existing single-argument override; the original JS
   // also delegated to `this.removeListener(channel, callback)` (recursive).
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  override removeListener(eventNameOrCallback: any, _listener?: any): this {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(this as any).removeListener(KEYBOARD_LAYOUT_MONITOR_CHANNEL_ID, eventNameOrCallback)
+  override removeListener(eventNameOrCallback: unknown, _listener?: unknown): this {
+    this.removeListener(KEYBOARD_LAYOUT_MONITOR_CHANNEL_ID, eventNameOrCallback as KeyboardInfoListener)
     return this
   }
 

--- a/packages/desktop/src/main/menu/actions/paragraph.ts
+++ b/packages/desktop/src/main/menu/actions/paragraph.ts
@@ -172,7 +172,7 @@ const setMultipleStatus = (
     .forEach((item: MenuItem) => (item.enabled = status))
 }
 
-interface SelectionState {
+export interface SelectionState {
   affiliation: Record<string, boolean>
   isTable?: boolean
   isLooseListItem?: boolean

--- a/packages/desktop/src/main/menu/index.ts
+++ b/packages/desktop/src/main/menu/index.ts
@@ -6,7 +6,8 @@ import { ensureDirSync, isDirectory2, isFile2 } from 'common/filesystem'
 import { isLinux, isOsx, isWindows } from '../config'
 import { updateSidebarMenu } from '../menu/actions/edit'
 import { updateFormatMenu } from '../menu/actions/format'
-import { updateSelectionMenus } from '../menu/actions/paragraph'
+import { updateSelectionMenus, type SelectionState } from '../menu/actions/paragraph'
+import { onInternalChannel } from '../utils/internalIpc'
 import { viewLayoutChanged } from '../menu/actions/view'
 import configureMenu, { configSettingMenu } from '../menu/templates'
 import { setLanguage } from '../i18n.js'
@@ -466,8 +467,7 @@ class AppMenu {
         viewLayoutChanged(this.getWindowMenuById(windowId), viewSettings)
       }
     )
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('mt::editor-selection-changed', (_e, windowId: number, changes: any) => {
+    ipcMain.on('mt::editor-selection-changed', (_e, windowId: number, changes: SelectionState) => {
       if (!this.has(windowId)) {
         log.error(`UpdateApplicationMenu: Cannot find window menu for window id ${windowId}.`)
         return
@@ -475,18 +475,14 @@ class AppMenu {
       updateSelectionMenus(this.getWindowMenuById(windowId), changes)
     })
 
-    // Note: these channels are dispatched via `ipcMain.emit(...)` from other modules
-    // (see actions/file.ts), so payload is a single positional argument.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('menu-add-recently-used', (pathname: any) => {
-      this.addRecentlyUsedDocument(pathname as string)
+    onInternalChannel('menu-add-recently-used', (pathname: string) => {
+      this.addRecentlyUsedDocument(pathname)
     })
     ipcMain.on('menu-clear-recently-used', () => {
       this.clearRecentlyUsedDocuments()
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('broadcast-preferences-changed', async(prefs: any) => {
+    onInternalChannel('broadcast-preferences-changed', async(prefs: Partial<IUserPreferences>) => {
       if (prefs.theme !== undefined || prefs.followSystemTheme !== undefined) {
         this.updateAppMenu()
       }

--- a/packages/desktop/src/main/preferences/index.ts
+++ b/packages/desktop/src/main/preferences/index.ts
@@ -1,10 +1,11 @@
 import fs from 'fs'
 import path from 'path'
-import Store from 'electron-store'
+import Store, { type Schema } from 'electron-store'
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import log from 'electron-log'
 import { isWindows } from '../config'
 import { hasSameKeys } from '../utils'
+import { onInternalChannel } from '../utils/internalIpc'
 import { getSupportedLanguages, isLanguageSupported } from 'common/i18n'
 import { TypedEmitter } from '@shared/types/typedEmitter'
 import type { IUserPreferences } from '@shared/types/preferences'
@@ -42,8 +43,7 @@ class Preference extends TypedEmitter<PreferenceEvents> {
       path.join(this.preferencesPath, `./${PREFERENCES_FILE_NAME}.json`)
     )
     this.store = new Store<IUserPreferences>({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      schema: schema as any,
+      schema: schema as unknown as Schema<IUserPreferences>,
       name: PREFERENCES_FILE_NAME,
       migrations: {
         '0.18.6': (store) => {
@@ -187,11 +187,8 @@ class Preference extends TypedEmitter<PreferenceEvents> {
       this.setItem('autoSave', !this.getItem('autoSave'))
     })
 
-    // Note: dispatched via `ipcMain.emit(...)`. The payload arrives as the
-    // first positional argument.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ipcMain.on('set-user-preference', (settings: any) => {
-      this.setItems(settings as Record<string, unknown>)
+    onInternalChannel('set-user-preference', (settings: Record<string, unknown>) => {
+      this.setItems(settings)
     })
   }
 

--- a/packages/desktop/src/main/utils/internalIpc.ts
+++ b/packages/desktop/src/main/utils/internalIpc.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron'
+import type { IpcMainEvent } from 'electron'
+
+// Subscribe to an in-process channel dispatched via `ipcMain.emit(channel, ...args)`,
+// which forwards the payload args to listeners verbatim — there is no synthetic
+// `IpcMainEvent` like the renderer->main path that `ipcMain.on` is typed for. The
+// signature adaptation is contained here so callers keep real payload types.
+export function onInternalChannel<TArgs extends unknown[]>(
+  channel: string,
+  listener: (...args: TArgs) => void
+): void {
+  ipcMain.on(channel, listener as unknown as (event: IpcMainEvent, ...args: unknown[]) => void)
+}

--- a/packages/desktop/src/main/windows/base.ts
+++ b/packages/desktop/src/main/windows/base.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import type { BrowserWindow } from 'electron'
 import { TypedEmitter } from '@shared/types/typedEmitter'
+import type Accessor from '../app/accessor'
 
 /**
  * A MarkText window.
@@ -40,30 +41,26 @@ export interface BaseWindowEvents {
   'window-closed': []
 }
 
-// Minimal shape for the accessor we keep a private reference to. The real
-// Accessor lives in src/main/app/accessor.ts and is not strongly typed here
-// because of the wide preferences/menu/keybinding surface it carries.
-type AccessorLike = unknown
-
-// Subset of preference accessor used while building the renderer URL.
-interface PreferenceLike {
+// Subset of preference accessor used while building the renderer URL. Fields are
+// optional to mirror `IUserPreferences` (the real `Preference.getAll()` return).
+export interface PreferenceLike {
   getAll(): {
-    codeFontFamily: string
-    codeFontSize: number
-    hideScrollbar: boolean
-    theme: string
-    titleBarStyle: string
+    codeFontFamily?: string
+    codeFontSize?: number
+    hideScrollbar?: boolean
+    theme?: string
+    titleBarStyle?: string
     [key: string]: unknown
   }
 }
 
-interface EnvLike {
+export interface EnvLike {
   debug: boolean
   paths: { userDataPath: string }
 }
 
 class BaseWindow extends TypedEmitter<BaseWindowEvents> {
-  protected _accessor: AccessorLike
+  protected _accessor: Accessor
   public id: number | null
   public browserWindow: BrowserWindow | null
   public lifecycle: WindowLifecycleValue
@@ -72,7 +69,7 @@ class BaseWindow extends TypedEmitter<BaseWindowEvents> {
   /**
    * @param accessor The application accessor for application instances.
    */
-  constructor(accessor: AccessorLike) {
+  constructor(accessor: Accessor) {
     super()
 
     this._accessor = accessor
@@ -132,11 +129,11 @@ class BaseWindow extends TypedEmitter<BaseWindowEvents> {
     url.searchParams.set('type', type)
 
     // Settings
-    url.searchParams.set('cff', codeFontFamily)
+    url.searchParams.set('cff', codeFontFamily ?? '')
     url.searchParams.set('cfs', String(codeFontSize))
     url.searchParams.set('hsb', hideScrollbar ? '1' : '0')
-    url.searchParams.set('theme', theme)
-    url.searchParams.set('tbs', titleBarStyle)
+    url.searchParams.set('theme', theme ?? '')
+    url.searchParams.set('tbs', titleBarStyle ?? '')
 
     return url
   }
@@ -151,7 +148,7 @@ class BaseWindow extends TypedEmitter<BaseWindowEvents> {
     return this._buildUrlWithSettings(windowId, env, userPreference).toString()
   }
 
-  protected _getPreferredBackgroundColor(theme: string): string {
+  protected _getPreferredBackgroundColor(theme: string | undefined): string {
     // Hardcode the theme background color and show the window direct for the fastet window ready time.
     // Later with custom themes we need the background color (e.g. from meta information) and wait
     // that the window is loaded and then pass theme data to the renderer.

--- a/packages/desktop/src/main/windows/editor.ts
+++ b/packages/desktop/src/main/windows/editor.ts
@@ -89,8 +89,7 @@ class EditorWindow extends BaseWindow {
     options: Partial<BrowserWindowConstructorOptions> = {},
     bufferStoreInfo: BufferStoreInfo | null = null
   ): BrowserWindow {
-    const accessor = this._accessor
-    const { menu: appMenu, env, preferences, editorBufferStore } = accessor
+    const { menu: appMenu, env, preferences, editorBufferStore } = this._accessor
     const addBlankTab =
       !bufferStoreInfo && !rootDirectory && fileList.length === 0 && markdownList.length === 0
 
@@ -391,8 +390,7 @@ class EditorWindow extends BaseWindow {
 
     if (this.lifecycle === WindowLifecycle.READY) {
       const { browserWindow } = this
-      const _accessor = this._accessor
-      const { menu: appMenu, preferences } = _accessor
+      const { menu: appMenu, preferences } = this._accessor
 
       if (this._openedRootDirectory) {
         ipcMain.emit('watcher-unwatch-directory', browserWindow, this._openedRootDirectory)

--- a/packages/desktop/src/main/windows/editor.ts
+++ b/packages/desktop/src/main/windows/editor.ts
@@ -5,6 +5,7 @@ import log from 'electron-log'
 import windowStateKeeper from 'electron-window-state'
 import { isChildOfDirectory, isSamePathSync } from 'common/filesystem/paths'
 import BaseWindow, { WindowLifecycle, WindowType } from './base'
+import type Accessor from '../app/accessor'
 import { ensureWindowPosition, zoomIn, zoomOut } from './utils'
 import { TITLE_BAR_HEIGHT, editorWinOptions, isLinux, isOsx } from '../config'
 import { showEditorContextMenu } from '../contextMenu/editor'
@@ -61,7 +62,7 @@ class EditorWindow extends BaseWindow {
   /**
    * @param accessor The application accessor for application instances.
    */
-  constructor(accessor: unknown) {
+  constructor(accessor: Accessor) {
     super(accessor)
     this.type = WindowType.EDITOR
 
@@ -88,8 +89,7 @@ class EditorWindow extends BaseWindow {
     options: Partial<BrowserWindowConstructorOptions> = {},
     bufferStoreInfo: BufferStoreInfo | null = null
   ): BrowserWindow {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const accessor = this._accessor as any
+    const accessor = this._accessor
     const { menu: appMenu, env, preferences, editorBufferStore } = accessor
     const addBlankTab =
       !bufferStoreInfo && !rootDirectory && fileList.length === 0 && markdownList.length === 0
@@ -149,14 +149,14 @@ class EditorWindow extends BaseWindow {
 
     if (spellcheckerEnabled && !isOsx) {
       try {
-        switchLanguage(win, spellcheckerLanguage)
+        switchLanguage(win, spellcheckerLanguage as string)
       } catch (error) {
         log.error('Unable to set spell checker language on startup:', error)
       }
     }
 
     // Create a menu for the current window
-    appMenu.addEditorMenu(win, { sourceCodeModeEnabled })
+    appMenu.addEditorMenu(win, { sourceCodeModeEnabled: sourceCodeModeEnabled as boolean })
 
     win.webContents.on('context-menu', (event, params) => {
       showEditorContextMenu(win!, event, params, preferences.getItem('spellcheckerEnabled'))
@@ -170,7 +170,7 @@ class EditorWindow extends BaseWindow {
       this.bringToFront()
 
       const lineEnding = preferences.getPreferredEol()
-      appMenu.updateLineEndingMenu(this.id, lineEnding)
+      appMenu.updateLineEndingMenu(this.id!, lineEnding)
 
       win!.webContents.send('mt::bootstrap-editor', {
         addBlankTab,
@@ -247,8 +247,7 @@ class EditorWindow extends BaseWindow {
       (channel) => {
         // Electron's BrowserWindow.on() is heavily overloaded — the union of
         // event names can't be satisfied by a single overload, so we widen.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(win as any)!.on(channel, () => {
+        ;(win! as { on(event: string, listener: () => void): void }).on(channel, () => {
           win!.webContents.send(`mt::window-${channel}`)
         })
       }
@@ -325,8 +324,7 @@ class EditorWindow extends BaseWindow {
     if (this.lifecycle === WindowLifecycle.QUITTED) return
 
     const { browserWindow } = this
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { preferences } = this._accessor as any
+    const { preferences } = this._accessor
     const eol = preferences.getPreferredEol()
     const { autoGuessEncoding, trimTrailingNewline, autoNormalizeLineEndings } =
       preferences.getAll()
@@ -393,8 +391,7 @@ class EditorWindow extends BaseWindow {
 
     if (this.lifecycle === WindowLifecycle.READY) {
       const { browserWindow } = this
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const _accessor = this._accessor as any
+      const _accessor = this._accessor
       const { menu: appMenu, preferences } = _accessor
 
       if (this._openedRootDirectory) {
@@ -488,8 +485,7 @@ class EditorWindow extends BaseWindow {
 
     browserWindow!.webContents.once('did-finish-load', () => {
       this.lifecycle = WindowLifecycle.READY
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { preferences } = this._accessor as any
+      const { preferences } = this._accessor
       const { sideBarVisibility, restoreLayoutState, tabBarVisibility, sourceCodeModeEnabled } =
         preferences.getAll()
       const resolvedSideBarVisibility = restoreLayoutState ? !!sideBarVisibility : false
@@ -535,8 +531,7 @@ class EditorWindow extends BaseWindow {
     selected: boolean
   ): void {
     const { _accessor, _openedFiles, browserWindow } = this
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { menu: appMenu } = _accessor as any
+    const { menu: appMenu } = _accessor
     const { pathname } = rawDocument
 
     // Listen for file changed.
@@ -568,8 +563,7 @@ class EditorWindow extends BaseWindow {
       throw new Error('Invalid state.')
     }
     const { browserWindow, bufferStoreInfo, _accessor } = this
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { menu: appMenu, preferences } = _accessor as any
+    const { menu: appMenu, preferences } = _accessor
 
     try {
       const bufferState = JSON.parse(

--- a/packages/desktop/src/main/windows/setting.ts
+++ b/packages/desktop/src/main/windows/setting.ts
@@ -23,8 +23,7 @@ class SettingWindow extends BaseWindow {
    * @param category The settings category tab name.
    */
   createWindow(category: string | null = null): BrowserWindow {
-    const accessor = this._accessor
-    const { menu: appMenu, env, keybindings, preferences } = accessor
+    const { menu: appMenu, env, keybindings, preferences } = this._accessor
     const winOptions: BrowserWindowConstructorOptions = Object.assign({}, preferencesWinOptions)
     centerWindowOptions(
       winOptions as BrowserWindowConstructorOptions & {

--- a/packages/desktop/src/main/windows/setting.ts
+++ b/packages/desktop/src/main/windows/setting.ts
@@ -2,7 +2,8 @@ import path from 'path'
 import { BrowserWindow, ipcMain } from 'electron'
 import type { BrowserWindowConstructorOptions } from 'electron'
 import { electronLocalshortcut } from '@hfelix/electron-localshortcut'
-import BaseWindow, { WindowLifecycle, WindowType } from './base'
+import BaseWindow, { WindowLifecycle, WindowType, type EnvLike, type PreferenceLike } from './base'
+import type Accessor from '../app/accessor'
 import { centerWindowOptions } from './utils'
 import { TITLE_BAR_HEIGHT, preferencesWinOptions, isLinux, isOsx } from '../config'
 import log from 'electron-log'
@@ -11,7 +12,7 @@ class SettingWindow extends BaseWindow {
   /**
    * @param accessor The application accessor for application instances.
    */
-  constructor(accessor: unknown) {
+  constructor(accessor: Accessor) {
     super(accessor)
     this.type = WindowType.SETTINGS
   }
@@ -22,8 +23,7 @@ class SettingWindow extends BaseWindow {
    * @param category The settings category tab name.
    */
   createWindow(category: string | null = null): BrowserWindow {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const accessor = this._accessor as any
+    const accessor = this._accessor
     const { menu: appMenu, env, keybindings, preferences } = accessor
     const winOptions: BrowserWindowConstructorOptions = Object.assign({}, preferencesWinOptions)
     centerWindowOptions(
@@ -115,10 +115,8 @@ class SettingWindow extends BaseWindow {
 
   protected override _buildUrlString(
     windowId: number | null,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    env: any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    userPreference: any,
+    env: EnvLike,
+    userPreference: PreferenceLike,
     category?: string | null
   ): string {
     const url = this._buildUrlWithSettings(windowId, env, userPreference)

--- a/packages/desktop/src/renderer/src/bootstrap.ts
+++ b/packages/desktop/src/renderer/src/bootstrap.ts
@@ -119,8 +119,8 @@ const bootstrapRenderer = (): void => {
     paths
   }
   // `global` is not available in a sandboxed renderer — attach to window.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(window as any).marktext = marktext
+  // RendererPaths has no string index signature, so widen through `unknown`.
+  window.marktext = marktext as unknown as Window['marktext']
 
   configureLogger()
 }

--- a/packages/desktop/src/renderer/src/codeMirror/index.ts
+++ b/packages/desktop/src/renderer/src/codeMirror/index.ts
@@ -4,6 +4,7 @@ import 'codemirror/addon/edit/closetag'
 import 'codemirror/addon/selection/active-line'
 import 'codemirror/mode/meta'
 import codeMirror from 'codemirror/lib/codemirror'
+import type CodeMirror from 'codemirror'
 
 import loadmode from './loadmode'
 import overlayMode from './overlayMode'
@@ -14,15 +15,14 @@ import 'codemirror/lib/codemirror.css'
 import './index.css'
 import 'codemirror/theme/railscasts.css'
 
-// CodeMirror 5 ships without TypeScript declarations. The bare `codemirror`
-// and `codemirror/lib/*` specifiers are declared as `any` shims in
-// src/types/shims.d.ts, so the surface is loose by design.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CodeMirrorLike = any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CodeMirrorInstance = any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CodeMirrorDoc = any
+// The runtime is imported from `codemirror/lib/codemirror` (a `any` shim), but
+// the public editor surface is typed via `@types/codemirror`.
+// Only the legacy `window.CodeMirror` exposure references this; never read typed.
+type CodeMirrorLike = unknown
+type CodeMirrorInstance = CodeMirror.Editor
+type CodeMirrorDoc = CodeMirror.Doc
+// `getCursor()` returns extra runtime flags not present on the typed `Position`.
+type CursorPosition = CodeMirror.Position & { outside?: boolean; hitSide?: boolean }
 
 interface ModeInfoEntry {
   name?: string
@@ -94,21 +94,21 @@ export const setCursorAtLastLine = (cm: CodeMirrorInstance): void => {
 
 // if cursor at firstLine return true
 export const isCursorAtFirstLine = (cm: CodeMirrorInstance): boolean => {
-  const cursor = cm.getCursor()
+  const cursor = cm.getCursor() as CursorPosition
   const { line, ch, outside } = cursor
 
-  return line === 0 && ch === 0 && outside
+  return line === 0 && ch === 0 && !!outside
 }
 
 export const isCursorAtLastLine = (cm: CodeMirrorInstance): boolean => {
   const lastLine = cm.lastLine()
-  const cursor = cm.getCursor()
+  const cursor = cm.getCursor() as CursorPosition
   const { line, outside, sticky } = cursor
   return line === lastLine && (outside || !sticky)
 }
 
 export const isCursorAtBegin = (cm: CodeMirrorInstance): boolean => {
-  const cursor = cm.getCursor()
+  const cursor = cm.getCursor() as CursorPosition
   const { line, ch, hitSide } = cursor
   return line === 0 && ch === 0 && !!hitSide
 }
@@ -120,7 +120,7 @@ export const onlyHaveOneLine = (cm: CodeMirrorInstance): boolean => {
 export const isCursorAtEnd = (cm: CodeMirrorInstance): boolean => {
   const lastLine = cm.lastLine()
   const lastLineHandle = cm.getLineHandle(lastLine)
-  const cursor = cm.getCursor()
+  const cursor = cm.getCursor() as CursorPosition
   const { line, ch, hitSide } = cursor
 
   return line === lastLine && ch === lastLineHandle.text.length && !!hitSide
@@ -167,7 +167,10 @@ export const setMode = (doc: CodeMirrorDoc, text: string): Promise<MatchedMode> 
   const { mode, mime } = m.mode as { mode: string; mime: string | string[] }
   return new Promise((resolve) => {
     codeMirror.requireMode(mode, () => {
-      doc.setOption('mode', mime || mode)
+      ;(doc as unknown as { setOption(option: string, value: unknown): void }).setOption(
+        'mode',
+        mime || mode
+      )
       codeMirror.autoLoadMode(doc, mode)
       resolve(m)
     })
@@ -175,7 +178,7 @@ export const setMode = (doc: CodeMirrorDoc, text: string): Promise<MatchedMode> 
 }
 
 export const setTextDirection = (cm: CodeMirrorInstance, textDirection: string): void => {
-  cm.setOption('direction', textDirection)
+  cm.setOption('direction', textDirection as 'ltr' | 'rtl')
 }
 
 export default codeMirror

--- a/packages/desktop/src/renderer/src/codeMirror/index.ts
+++ b/packages/desktop/src/renderer/src/codeMirror/index.ts
@@ -15,7 +15,7 @@ import 'codemirror/lib/codemirror.css'
 import './index.css'
 import 'codemirror/theme/railscasts.css'
 
-// The runtime is imported from `codemirror/lib/codemirror` (a `any` shim), but
+// The runtime is imported from `codemirror/lib/codemirror` (an `any` shim), but
 // the public editor surface is typed via `@types/codemirror`.
 // Only the legacy `window.CodeMirror` exposure references this; never read typed.
 type CodeMirrorLike = unknown

--- a/packages/desktop/src/renderer/src/commands/quickOpen.ts
+++ b/packages/desktop/src/renderer/src/commands/quickOpen.ts
@@ -13,8 +13,9 @@ interface QuickOpenSubcommand {
   title?: string
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type FolderState = any
+interface FolderState {
+  projectTree: { pathname: string } | null
+}
 type RootState = { editor: EditorState; project: FolderState; [key: string]: unknown }
 
 type CancelFn = (() => void) | null
@@ -29,8 +30,7 @@ class QuickOpenCommand {
   subcommandSelectedIndex: number
   private _editorState: EditorState
   private _folderState: FolderState
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _directorySearcher: any
+  private _directorySearcher: FileSearcher
   private _cancelFn: CancelFn
 
   constructor(rootState: RootState) {
@@ -118,7 +118,7 @@ class QuickOpenCommand {
     }
 
     const searchResult: string[] = []
-    const rootPath: string | null = isRootDirOpened ? _folderState.projectTree.pathname : null
+    const rootPath: string | null = isRootDirOpened ? _folderState.projectTree!.pathname : null
 
     // Add files that are not in the current root directory but opened.
     if (tabsAvailable) {
@@ -155,15 +155,15 @@ class QuickOpenCommand {
     // Search root directory on disk.
     return new Promise<QuickOpenSubcommand[]>((resolve, reject) => {
       let canceled = false
-      const promises = this._directorySearcher
-        .search([rootPath], '', {
-          didMatch: (result: string) => {
+      const promises: Promise<void> & { cancel?: () => void } = this._directorySearcher
+        .search([rootPath!], '', {
+          didMatch: (result: unknown) => {
             if (canceled) return
-            searchResult.push(result)
+            searchResult.push(result as string)
           },
-          didSearchPaths: (numPathsFound: number) => {
+          didSearchPaths: (numPathsFound: unknown) => {
             // Cancel when more than 30 files were found. User should specify the search query.
-            if (!canceled && numPathsFound > 30) {
+            if (!canceled && (numPathsFound as number) > 30) {
               canceled = true
               if (promises.cancel) {
                 promises.cancel()
@@ -213,7 +213,7 @@ class QuickOpenCommand {
   }
 
   _getPath = (pathname: string): { title?: string; description: string } => {
-    const rootPath: string = this._folderState.projectTree.pathname
+    const rootPath: string = this._folderState.projectTree!.pathname
     if (!window.fileUtils.isChildOfDirectory(rootPath, pathname)) {
       return { title: pathname, description: pathname }
     }

--- a/packages/desktop/src/renderer/src/i18n/index.ts
+++ b/packages/desktop/src/renderer/src/i18n/index.ts
@@ -50,8 +50,7 @@ export const t = (key: string, ...args: unknown[]): string => {
 
     // vue-i18n's `t` is heavily overloaded; the variadic call signature here
     // intentionally bypasses the strict overload set.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (i18n.global.t as any)(key, ...args)
+    return (i18n.global.t as (key: string, ...args: unknown[]) => string)(key, ...args)
   } catch (error) {
     console.error('❌ 翻译函数执行错误:', error)
     return key

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -435,13 +435,14 @@ export const useEditorStore = defineStore('editor', {
         })
         const id = getUniqueId()
         // Dynamic IPC channel — not part of the static IpcMainEventChannels contract.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(window.electron.ipcRenderer.once as any)(
-          `mt::response-of-image-path-${id}`,
-          (_: unknown, files: string[]) => {
-            rs(files)
-          }
-        )
+        ;(
+          window.electron.ipcRenderer.once as (
+            channel: string,
+            listener: (event: unknown, files: string[]) => void
+          ) => void
+        )(`mt::response-of-image-path-${id}`, (_: unknown, files: string[]) => {
+          rs(files)
+        })
         window.electron.ipcRenderer.send('mt::ask-for-image-auto-path', {
           pathname,
           src,

--- a/packages/desktop/src/renderer/src/store/project.ts
+++ b/packages/desktop/src/renderer/src/store/project.ts
@@ -11,10 +11,10 @@ import { useLayoutStore } from './layout'
 import { useEditorStore } from './editor'
 import { debouncedSendBufferedState } from './bufferedState'
 import type { TreeNode } from '../components/sideBar/types'
+import type { FileChangeDetail } from '@shared/types/files'
 
 type ProjectTree = TreeNode
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type TreeChange = any
+type TreeChange = FileChangeDetail
 
 const normalizeProjectRoot = (pathname: string | null | undefined): string => {
   return pathname ? window.path.normalize(pathname) : ''
@@ -73,6 +73,9 @@ interface PendingEvent {
 }
 
 export const useProjectStore = defineStore('project', () => {
+  // Heterogeneous UI state: assigned file nodes, folder nodes, and the empty
+  // "no selection" object/null across sidebar components; a single non-`any`
+  // union breaks both the assignments and the field reads, so it stays a hatch.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const activeItem = ref<any>({})
   const createCache = ref<CreateCacheEntry | Record<string, never>>({})
@@ -161,9 +164,9 @@ export const useProjectStore = defineStore('project', () => {
     switch (type) {
       case 'add': {
         const { pathname, data, isMarkdown } = change
-        addFile(projectTree.value!, change, String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
+        addFile(projectTree.value!, change as Parameters<typeof addFile>[1], String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
         if (isMarkdown && newFileNameCache.value && pathname === newFileNameCache.value) {
-          const fileState = getFileStateFromData(data)
+          const fileState = getFileStateFromData(data as Record<string, unknown>)
           editorStore.UPDATE_CURRENT_FILE(fileState)
           newFileNameCache.value = ''
         }
@@ -181,7 +184,7 @@ export const useProjectStore = defineStore('project', () => {
         break
       case 'change':
         if (change?.mtimeMs !== undefined) {
-          updateFileMtime(projectTree.value!, change, String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
+          updateFileMtime(projectTree.value!, change as Parameters<typeof updateFileMtime>[1], String(preferencesStore.fileSortBy), String(preferencesStore.fileSortOrder))
         }
         break
       default:

--- a/packages/desktop/src/types/shims.d.ts
+++ b/packages/desktop/src/types/shims.d.ts
@@ -22,7 +22,8 @@ declare module 'command-exists'
 declare module 'pako'
 declare module 'snabbdom-to-html'
 declare module 'prismjs/themes/*'
-declare module 'codemirror'
+// `codemirror` (the bare module) is typed by `@types/codemirror`; only the
+// submodules below ship no declarations and are shimmed as `any`.
 declare module 'codemirror/keymap/*'
 declare module 'codemirror/lib/*'
 declare module 'codemirror/mode/*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@types/codemirror':
+        specifier: ^5.60.15
+        version: 5.60.17
       '@types/deep-equal':
         specifier: ^1.0.4
         version: 1.0.4
@@ -3631,6 +3634,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/codemirror@5.60.17':
+    resolution: {integrity: sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -3824,6 +3830,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -12711,6 +12720,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/codemirror@5.60.17':
+    dependencies:
+      '@types/tern': 0.23.9
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -12931,6 +12944,10 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.19
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/trusted-types@2.0.7':
     optional: true


### PR DESCRIPTION
## Summary

Follow-up to #4527, which removed the bulk of `@typescript-eslint/no-explicit-any` suppressions but deliberately kept a set of documented escape hatches. This PR removes ~49 of those remaining hatches across the main and renderer processes, replacing `any` with real types (or `unknown` + a narrowing cast where the boundary is genuinely dynamic). Behavior is preserved throughout — the changes are type-only.

It also adds `@types/codemirror` (dev-only) so the CodeMirror editor wrapper can be typed against the public `Editor`/`Doc` API.

## What changed

- **Internal IPC channels** — a small typed `onInternalChannel` helper adapts `ipcMain.on`'s renderer-path signature for the in-process `ipcMain.emit` bus, so all watcher/window/app/broadcast listeners (`app/index.ts`, `windowManager.ts`, `menu/index.ts`, `preferences/index.ts`) carry real payload types.
- **Window accessor** — `BaseWindow._accessor` is typed `Accessor` (via `import type`, no runtime cycle); this surfaced and fixed a latent gap where `Preference.getAll()`'s optional fields were used as required.
- **Renderer** — real types/casts for the project-tree change payload (shared `FileChangeDetail`), the dynamic `ipcRenderer.once` channel, vue-i18n's `t()`, `window.marktext`, and the file searcher.
- **CodeMirror** — the `codemirror` shim that shadowed `@types/codemirror` is dropped, and the editor wrapper (`codeMirror/index.ts`) is typed against `Editor`/`Doc`/`Position`.

## Kept as documented hatches (with rationale comments)

A clean, non-`any` type isn't achievable without a redesign or churning vendored code for these:

- `CommandCallback` — a heterogeneous handler registry can't be both assignable-from-typed-handlers and callable with args.
- `project.ts` `activeItem` — heterogeneous UI state (file/folder nodes + empty/null).
- vue-i18n `createI18n` options — casting them collapses the `legacy: false` inference and breaks `locale.value`.
- The 4 vendored CodeMirror mode files (`loadmode`, `markdownMathMode`, `mltiplexMode`, `overlayMode`) — verbatim CodeMirror addon source that re-implements CM internals `@types/codemirror` doesn't model.
- `muya.d.ts` / `muya-core.d.ts` — deletion-conditioned bridges to the legacy/TS muya engines (tied to the muya migration).

## Verification

- `pnpm run typecheck` — 0 errors
- `pnpm run lint` — 0 errors (pre-existing `no-non-null-assertion` warnings only)
- `pnpm run test` — 540/540 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)