### PR TITLE
fix(muya): round-2 paste/clipboard parity fixes from a full muyajs re-audit

### DIFF
--- a/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
@@ -140,4 +140,14 @@ describe('paste — multi-line paragraph into a heading keeps only the first lin
         const block = contentBlocks(muya)[0];
         expect(await paste(muya, block, 8, 8, 'A')).toBe('# hello Aworld\n');
     });
+
+    it('a multi-line paragraph pasted into a SETEXT heading stays one block (only atx splits)', async () => {
+        const muya = bootMuya('Title\n===\n');
+        const block = contentBlocks(muya)[0]; // setext-heading content 'Title'
+        const md = await paste(muya, block, block.text.length, block.text.length, 'aaa\nbbb');
+        // muyajs keeps the whole paragraph inside the setext heading — one block.
+        expect(muya.editor.scrollPage!.length()).toBe(1);
+        expect(md).toContain('Titleaaa');
+        expect(md).toContain('bbb');
+    });
 });

--- a/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
@@ -151,3 +151,15 @@ describe('paste — multi-line paragraph into a heading keeps only the first lin
         expect(md).toContain('bbb');
     });
 });
+
+describe('paste — NEWLINE into an emptied non-paragraph wrapper (muyajs removeBlock parity)', () => {
+    it('removes the emptied heading wrapper instead of leaving a stray empty block', async () => {
+        const muya = bootMuya('# heading\n');
+        const block = contentBlocks(muya)[0];
+        // cursor before the heading text (offset 0); paste a non-mergeable block.
+        await paste(muya, block, 0, 0, '---');
+        // muyajs's NEWLINE branch removes the now-empty wrapper unconditionally;
+        // the heading must not linger as a stray empty block.
+        expect(muya.editor.scrollPage!.length()).toBe(1);
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pasteCellLiteral.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteCellLiteral.spec.ts
@@ -88,6 +88,13 @@ async function pasteInto(muya: Muya, block: Content, start: number, end: number,
 }
 
 describe('paste — table cell takes text literally (muyajs parity)', () => {
+    it('trims surrounding whitespace from a normal cell paste', async () => {
+        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+        const cell = firstCellContent(muya); // header cell 'a1'
+        await pasteInto(muya, cell, 0, cell.text.length, '  hi  ');
+        expect(cell.text).toBe('hi');
+    });
+
     it('normalizes CRLF to LF so no stray carriage return survives', async () => {
         const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
         const cell = firstCellContent(muya);

--- a/packages/muya/src/clipboard/__tests__/pasteCellLiteral.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteCellLiteral.spec.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// muyajs trims pasted table-cell text and normalizes CRLF to LF before folding
+// newlines into `<br/>`. A table cell takes the paste literally, so a stray
+// `\r` would otherwise survive verbatim — the ideal place to pin both fixes.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+vi.mock('../../utils/paste', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../utils/paste')>();
+    return { ...actual, normalizePastedHTML: async (html: string) => html };
+});
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstCellContent(muya: Muya): Content {
+    // The first content leaf of a table-first document is the first header cell.
+    return muya.editor.scrollPage!.firstContentInDescendant()!;
+}
+
+function stubSelection(muya: Muya, block: Content, start: number, end: number) {
+    const path = block.path;
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: start, block, path },
+        focus: { offset: end, block, path },
+        isCollapsed: start === end,
+        isSelectionInSameBlock: true,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+function pasteEvent(text: string) {
+    return {
+        preventDefault() {},
+        stopPropagation() {},
+        clipboardData: {
+            getData: (t: string) => (t === 'text/plain' ? text : ''),
+            files: [],
+            items: [],
+        },
+    } as unknown as ClipboardEvent;
+}
+
+async function pasteInto(muya: Muya, block: Content, start: number, end: number, text: string) {
+    stubSelection(muya, block, start, end);
+    await muya.editor.clipboard.pasteHandler(pasteEvent(text), text, '');
+    await new Promise(r => setTimeout(r, 40));
+}
+
+describe('paste — table cell takes text literally (muyajs parity)', () => {
+    it('normalizes CRLF to LF so no stray carriage return survives', async () => {
+        const muya = bootMuya('| a1 | b1 |\n| --- | --- |\n| a2 | b2 |\n');
+        const cell = firstCellContent(muya);
+        await pasteInto(muya, cell, 0, cell.text.length, 'x\r\ny');
+        // newlines fold to <br/>; the carriage return must be gone, not kept.
+        expect(cell.text).toBe('x<br/>y');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
@@ -92,6 +92,15 @@ describe('paste — same-type list merges into the enclosing list (A5, muyajs pa
         expect(await paste(muya, block, 1, 1, '- x\n- y')).toBe('- ax\n- y\n');
     });
 
+    it('does NOT fold the first item for a task list — appends all (muyajs parity)', async () => {
+        const muya = bootMuya('- [ ] a\n');
+        const block = contentBlocks(muya)[0]; // task-list-item content 'a'
+        // muyajs never inline-folds a task item; 'a' stays, x and y are new items.
+        expect(await paste(muya, block, 1, 1, '- [ ] x\n- [ ] y')).toBe(
+            '- [ ] a\n- [ ] x\n- [ ] y\n',
+        );
+    });
+
     it('reconciles tight + loose into a loose list', async () => {
         const muya = bootMuya('- a\n');
         const block = contentBlocks(muya)[0];

--- a/packages/muya/src/clipboard/__tests__/pastePlainTextHtml.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pastePlainTextHtml.spec.ts
@@ -80,7 +80,7 @@ describe('paste as plain text — block-level HTML is literal (A8, muyajs parity
         expect(muya.editor.scrollPage!.length()).toBe(1);
     });
 
-    it('splits multi-line block HTML into per-line paragraphs (no raw newline in a block)', async () => {
+    it('folds the first line into the anchor and makes the rest one html-block (muyajs parity)', async () => {
         const html = '<ul>\n<li>a</li>\n</ul>';
         const muya = bootMuya('foo\n', { clipboardText: () => html });
         const block = firstContent(muya);
@@ -97,10 +97,10 @@ describe('paste as plain text — block-level HTML is literal (A8, muyajs parity
         await muya.editor.clipboard.pasteAsPlainText();
         await new Promise(r => setTimeout(r, 40));
 
-        // First line folds into 'foo'; the remaining two lines become their own
-        // paragraphs, so the markdown round-trips stably.
+        // muyajs: line 0 folds into 'foo' as literal text, the remaining lines
+        // become a single live html-block — two blocks, not three paragraphs.
         const md = muya.getMarkdown();
-        expect(md).toBe('foo<ul>\n\n<li>a</li>\n\n</ul>\n');
-        expect(muya.editor.scrollPage!.length()).toBe(3);
+        expect(md).toBe('foo<ul>\n\n<li>a</li>\n</ul>\n');
+        expect(muya.editor.scrollPage!.length()).toBe(2);
     });
 });

--- a/packages/muya/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/muya/src/clipboard/mergePasteIntoHeading.ts
@@ -27,29 +27,35 @@ export function mergePasteIntoHeading(
     if (states.length === 0)
         return states;
 
-    const isHeading
-        = wrapperBlock?.blockName === 'atx-heading'
-            || wrapperBlock?.blockName === 'setext-heading';
-    if (!isHeading)
+    const isAtx = wrapperBlock?.blockName === 'atx-heading';
+    const isSetext = wrapperBlock?.blockName === 'setext-heading';
+    if (!isAtx && !isSetext)
         return states;
 
     const first = states[0];
     if (first.name !== 'paragraph')
         return states;
 
-    // A heading is a single line: only the first soft-line of the pasted
-    // paragraph stays in the heading; any following lines become a paragraph
-    // block below it. The anchor's tail is NOT kept here — the caller sews it
-    // onto the last pasted block instead.
-    const [firstLine, ...restLines] = first.text.split('\n');
-
     const original = anchorBlock.text;
-    anchorBlock.text = original.substring(0, cursor.startOffset) + firstLine;
-    anchorBlock.update();
-
+    const head = original.substring(0, cursor.startOffset);
     const remaining = states.slice(1);
-    if (restLines.length > 0)
-        remaining.unshift({ name: 'paragraph', text: restLines.join('\n') });
+
+    // The anchor's tail is NOT kept here — the caller sews it onto the last
+    // pasted block instead.
+    if (isSetext) {
+        // A setext heading line can hold soft breaks, so the whole first
+        // paragraph stays in it (muyajs only splits atx).
+        anchorBlock.text = head + first.text;
+    }
+    else {
+        // An atx heading is a single line: only the first soft-line stays; the
+        // following lines become a paragraph block below it.
+        const [firstLine, ...restLines] = first.text.split('\n');
+        anchorBlock.text = head + firstLine;
+        if (restLines.length > 0)
+            remaining.unshift({ name: 'paragraph', text: restLines.join('\n') });
+    }
+    anchorBlock.update();
 
     return remaining;
 }

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -258,9 +258,14 @@ function tryMergeListPaste(
     const pastedItems = firstState.children;
     const pastedFirst = pastedItems[0].children[0];
 
+    // A task list never folds its first item: muyajs prepends an `input` child
+    // so its `liChildren[0].type === 'p'` check is false and it appends every
+    // pasted item. Bullet/order lists fold the first item's paragraph inline.
+    const canFold = firstState.name !== 'task-list' && isParagraphState(pastedFirst);
+
     const mergedChildren = [...listState.children];
     let foldedOnly = false;
-    if (isParagraphState(pastedFirst)) {
+    if (canFold) {
         anchorPara.text = head + pastedFirst.text;
         currentItem.children = [...currentItem.children, ...pastedItems[0].children.slice(1)];
         mergedChildren.push(...pastedItems.slice(1));

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -527,8 +527,11 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
     if (!anchorBlock)
         return;
 
-    const { text, imageFile, pasteType } = data;
+    const { imageFile, pasteType } = data;
     let { html } = data;
+    // Normalize Windows CRLF / lone CR to LF so every downstream `split('\n')`
+    // and offset calculation sees one newline convention (muyajs strips \r).
+    const text = data.text.replace(/\r\n?/g, '\n');
 
     if (!isSelectionInSameBlock) {
         clipboard.cutHandler();

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -443,33 +443,28 @@ function applyLiteralPaste(
     }
 }
 
-// A8: under Paste as Plain Text, block-level HTML is inserted as literal text
-// (muyajs `pasteAsPlainText` copyAsHtml branch) rather than a live html-block —
-// the markup stays visible as source. The first line folds into the anchor; any
-// remaining lines become their own paragraphs, so no block keeps a raw newline.
+// A8: under Paste as Plain Text, block-level HTML follows muyajs's
+// `pasteAsPlainText` copyAsHtml branch — its first line folds into the anchor as
+// literal text (the open tag stays visible at the seam), and any remaining lines
+// become a single live html-block below, matching muyajs's
+// `createBlockP(lines.slice(1).join('\n')) + insertHtmlBlock`.
 function applyPlainTextBlockHtml(clipboard: Clipboard, ctx: IPasteContext, text: string): void {
     const { anchorBlock, start, end, content } = ctx;
     const head = content.substring(0, start.offset);
     const tail = content.substring(end.offset);
     const lines = text.trim().split('\n');
 
-    if (lines.length === 1) {
-        anchorBlock.text = head + lines[0] + tail;
-        anchorBlock.update();
-        const offset = head.length + lines[0].length;
-        anchorBlock.setCursor(offset, offset, true);
-
-        return;
-    }
-
-    anchorBlock.text = head + lines[0];
+    anchorBlock.text = head + lines[0] + tail;
     anchorBlock.update();
+    const offset = head.length + lines[0].length;
+    anchorBlock.setCursor(offset, offset, true);
 
-    const rest = lines.slice(1).map(line => ({ name: 'paragraph' as const, text: line }));
-    const lastLine = rest[rest.length - 1];
-    lastLine.text += tail;
-    const last = insertStatesAfter(clipboard.muya, ctx.wrapperBlock, rest);
-    seatCursorAtSeam(last, lastLine.text.length - tail.length);
+    if (lines.length === 1)
+        return;
+
+    const htmlState = { name: 'html-block', text: lines.slice(1).join('\n') };
+    const newBlock = ScrollPage.loadBlock(htmlState.name).create(clipboard.muya, htmlState);
+    ctx.wrapperBlock?.parent?.insertAfter(newBlock, ctx.wrapperBlock);
 }
 
 // Block-level HTML (`<ul>`/`<ol>`/`<pre>`/`<blockquote>` … — tags in

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -415,8 +415,10 @@ function applyLiteralPaste(
         return;
     }
 
+    // A table cell holds a single visual line: trim and fold newlines to
+    // `<br/>` (muyajs trims pasted cell text on both the framed and normal path).
     if (anchorBlock.blockName === 'table.cell.content')
-        markdown = markdown.replace(/\n/g, '<br/>');
+        markdown = markdown.trim().replace(/\n/g, '<br/>');
 
     anchorBlock.text
         = content.substring(0, start.offset)

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -82,13 +82,22 @@ function insertStatesAfter(
     return wb;
 }
 
-function removeEmptyOriginParagraph(originWrapperBlock: Nullable<Parent>): void {
-    if (originWrapperBlock?.blockName !== 'paragraph')
+// Drop the anchor's wrapper when the paste emptied it. muyajs removes any
+// emptied wrapper (removeBlock), so a heading whose text was consumed is
+// cleaned up too — not just a paragraph.
+function removeEmptyOriginWrapper(originWrapperBlock: Nullable<Parent>): void {
+    const blockName = originWrapperBlock?.blockName;
+    if (
+        blockName !== 'paragraph'
+        && blockName !== 'atx-heading'
+        && blockName !== 'setext-heading'
+    ) {
         return;
+    }
 
-    const originState = originWrapperBlock.getState();
-    if (isParagraphState(originState) && originState.text === '')
-        originWrapperBlock.remove();
+    const originState = originWrapperBlock!.getState() as { text?: string };
+    if (originState.text === '')
+        originWrapperBlock!.remove();
 }
 
 function seatCursorAtSeam(last: Nullable<Parent>, offset: number): void {
@@ -183,7 +192,7 @@ function pasteNewline(
     const offset = sewTail(states, tail);
     const last = insertStatesAfter(muya, ctx.wrapperBlock, states);
     if (head.length === 0)
-        removeEmptyOriginParagraph(ctx.originWrapperBlock);
+        removeEmptyOriginWrapper(ctx.originWrapperBlock);
 
     seatCursorAtSeam(last, offset);
 }
@@ -475,12 +484,8 @@ function applyHtmlBlockPaste(
     const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
     wrapperBlock?.parent?.insertAfter(newBlock, wrapperBlock);
 
-    // Drop the empty paragraph the html-block replaced.
-    if (originWrapperBlock?.blockName === 'paragraph') {
-        const originState = originWrapperBlock.getState();
-        if (isParagraphState(originState) && originState.text === '')
-            originWrapperBlock.remove();
-    }
+    // Drop the empty wrapper the html-block replaced.
+    removeEmptyOriginWrapper(originWrapperBlock);
 
     const offset = state.text.length;
     newBlock.lastContentInDescendant().setCursor(offset, offset, true);


### PR DESCRIPTION
Stacked on #4546. A second pass comparing `@muyajs/core`'s clipboard paste
pipeline against legacy muyajs surfaced six more behavioural divergences. Each
is fixed as its own atomic commit with a regression test (RED→GREEN verified).

| Area | Before | After (muyajs parity) |
|---|---|---|
| Setext heading paste | a multi-line paragraph got split | the whole paragraph stays in the setext heading; only **atx** splits |
| Emptied paste wrapper | only emptied `paragraph` wrappers were removed | any emptied wrapper (atx/setext heading too) is removed, matching muyajs `removeBlock` |
| Task-list paste | the first pasted item folded inline | a task list never inline-folds its first item (muyajs prepends an `input` child) — append all |
| Paste-as-plain-text block HTML | split into one paragraph per line | line 0 folds into the anchor, the rest becomes **one** live html-block |
| Paste entry newlines | Windows `\r\n` / lone `\r` could survive | normalized to `\n` once at entry |
| Table-cell normal paste | not trimmed | trimmed (the framed-cell path already trimmed) |

### Tests
- 94/94 clipboard specs green; full muya typecheck clean.
- New/updated specs: `pasteBlockMerge` (setext + emptied-wrapper), `pasteListMerge`
  (task list), `pastePlainTextHtml` (one html-block), `pasteCellLiteral`
  (trim + CRLF).

### Notes
- Kept as-is after review: caret-in-trailing-paragraph (muyajs latent bug),
  ranged-selection replace (muya correct), `copyBlock` API (backlog), inline-math
  `$` delimiters (muya correct).
- Rebase heads-up: develop #4538 made `LangInputContent.updateLanguage` private
  (`_updateLanguage`). This stack is based on the pre-#4538 develop and compiles;
  the A7 language-input paste call will need reconciling when the stack rebases
  onto current develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)