### PR TITLE
fix(muya): align normalizePastedHTML link unlinking with muyajs

### DIFF
--- a/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
+++ b/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { normalizePastedHTML } from '../paste';
+
+// muyajs `pasteCtrl.normalizePastedHTML` only "unlinks" an <a> whose visible
+// text equals its href AND whose href is an actual URL (`URL_REG.test(href) &&
+// href === text`). muya was missing the URL_REG guard, so any link whose text
+// happened to equal its href — even a non-URL like `<a href="foo">foo</a>` —
+// was stripped to a bare span. Restore the guard and sanitize the fallback span.
+
+function setOnline(value: boolean) {
+    Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+afterEach(() => {
+    setOnline(true);
+});
+
+describe('normalizePastedHTML — link unlinking matches muyajs', () => {
+    it('keeps a link whose href is not a URL even when text === href', async () => {
+        const out = await normalizePastedHTML('<a href="foo">foo</a>');
+        // Non-URL href: the link must survive, not collapse into a bare span.
+        expect(out).toContain('href="foo"');
+    });
+
+    it('keeps a link whose text differs from its href', async () => {
+        const out = await normalizePastedHTML('<a href="http://example.com/">click</a>');
+        expect(out).toContain('href="http://example.com/"');
+    });
+
+    it('unlinks a bare URL link (text === href) when no page title resolves', async () => {
+        // Offline → getPageTitle returns '' immediately → fallback span path.
+        // URL_REG needs a path segment after the host, so use `/page`.
+        setOnline(false);
+        const out = await normalizePastedHTML(
+            '<a href="http://example.com/page">http://example.com/page</a>',
+        );
+        expect(out).not.toContain('<a ');
+        expect(out).toContain('http://example.com/page');
+    });
+});

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -1,5 +1,5 @@
 import { PasteType } from '../clipboard/types';
-import { IMAGE_EXT_REG, PARAGRAPH_TYPES, PREVIEW_DOMPURIFY_CONFIG } from '../config';
+import { IMAGE_EXT_REG, PARAGRAPH_TYPES, PREVIEW_DOMPURIFY_CONFIG, URL_REG } from '../config';
 import { sanitize } from '../utils';
 
 const TIMEOUT = 1500;
@@ -90,7 +90,10 @@ export async function normalizePastedHTML(html: string) {
         const href = link.getAttribute('href');
         const text = link.textContent;
 
-        if (href === text && typeof href === 'string') {
+        // Only unlink a bare URL (text === href). muyajs guards with
+        // `URL_REG.test(href)` so a non-URL link whose text happens to equal its
+        // href (e.g. `<a href="foo">foo</a>`) survives instead of collapsing.
+        if (typeof href === 'string' && URL_REG.test(href) && href === text) {
             // Resolve empty string when `TIMEOUT` passed.
             const timer = new Promise((resolve) => {
                 setTimeout(() => {
@@ -103,8 +106,11 @@ export async function normalizePastedHTML(html: string) {
                 link.textContent = title as string;
             }
             else {
+                // Escape + sanitize the fallback text (muyajs uses
+                // `sanitize(text, PREVIEW_DOMPURIFY_CONFIG, true)`) so a stray
+                // angle bracket can't re-enter as live markup.
                 const span = document.createElement('span');
-                span.innerHTML = text as string;
+                span.innerHTML = sanitize(text as string, PREVIEW_DOMPURIFY_CONFIG, true) as string;
                 link.replaceWith(span);
             }
         }


### PR DESCRIPTION
Two divergences in the `<a>`-unlinking pass of `normalizePastedHTML`
(`packages/muya/src/utils/paste.ts`) versus legacy muyajs
(`pasteCtrl.normalizePastedHTML`):

1. **Missing `URL_REG` guard.** muyajs unlinks a bare URL only when
   `URL_REG.test(href) && href === text`. muya checked just `href === text`, so
   any link whose visible text happened to equal its href — even a non-URL like
   `<a href="foo">foo</a>` — was stripped to a bare span. Restore the URL guard
   so only real bare-URL links are unlinked.
2. **Unescaped fallback span.** When no page title resolves, the fallback set
   `span.innerHTML = text` raw; muyajs escapes + sanitizes via
   `sanitize(text, PREVIEW_DOMPURIFY_CONFIG, true)`. Match it so a stray angle
   bracket in the link text can't re-enter as live markup.

### Tests
New `src/utils/__tests__/normalizePastedHtml.spec.ts` (RED→GREEN verified):
non-URL link preserved, differing-text link preserved, bare-URL link unlinked to
an escaped span when offline. 141/141 utils specs green; typecheck clean.

Independent of the clipboard paste stack (touches only `utils/paste.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)