### PR TITLE
fix(muya): handle escaped dollar in inline math

### DIFF
--- a/packages/muya/src/block/base/__tests__/autoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/autoPair.spec.ts
@@ -169,6 +169,36 @@ describe('autoPair — 4278362f no markdown-syntax pairing inside inline math', 
         expect(text).toBe('$*x$');
         expect(needRender).toBe(false);
     });
+
+    it('does not treat an escaped dollar as skipping the closing math marker', () => {
+        const fakeThis = makeFakeThis(String.raw`$y=\$`, 4);
+        const event = makeInputEvent('insertText', '$');
+        const { text, needRender } = invokeAutoPair(
+            fakeThis,
+            event,
+            String.raw`$y=\$$`,
+            5,
+            { isInInlineMath: true },
+        );
+
+        expect(text).toBe(String.raw`$y=\$$`);
+        expect(needRender).toBe(false);
+    });
+
+    it('still skips the closing math marker after an even number of backslashes', () => {
+        const fakeThis = makeFakeThis(String.raw`$y=\\$`, 5);
+        const event = makeInputEvent('insertText', '$');
+        const { text, needRender } = invokeAutoPair(
+            fakeThis,
+            event,
+            String.raw`$y=\\$$`,
+            6,
+            { isInInlineMath: true },
+        );
+
+        expect(text).toBe(String.raw`$y=\\$`);
+        expect(needRender).toBe(true);
+    });
 });
 
 // ── marktext 701fb9ae "Append soft-lines on text removal" (#2853) ────────

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -93,10 +93,11 @@ function extractWord(
     };
 }
 
-function hasOddBackslashesBefore(text: string, charIndex: number) {
+function hasOddBackslashesBefore(text: string, charIndex: number): boolean {
     let count = 0;
-    for (let i = charIndex - 1; i >= 0 && text[i] === '\\'; i--)
+    for (let i = charIndex - 1; i >= 0 && text[i] === '\\'; i--) {
         count++;
+    }
 
     return count % 2 === 1;
 }

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -93,9 +93,9 @@ function extractWord(
     };
 }
 
-function hasOddBackslashesBefore(text: string, offset: number) {
+function hasOddBackslashesBefore(text: string, charIndex: number) {
     let count = 0;
-    for (let i = offset - 2; i >= 0 && text[i] === '\\'; i--)
+    for (let i = charIndex - 1; i >= 0 && text[i] === '\\'; i--)
         count++;
 
     return count % 2 === 1;
@@ -234,7 +234,8 @@ function collapsedInputAutoPair(
     if (event.inputType.startsWith('delete'))
         return deleteAutoPair(event, text, start, end, offset, inputChar, postInputChar, blockText);
 
-    const isEscapedDollar = inputChar === '$' && hasOddBackslashesBefore(text, offset);
+    const inputCharIndex = offset - 1;
+    const isEscapedDollar = inputChar === '$' && hasOddBackslashesBefore(text, inputCharIndex);
     if (
         !event.inputType.includes('delete')
         && inputChar === postInputChar

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -93,6 +93,14 @@ function extractWord(
     };
 }
 
+function hasOddBackslashesBefore(text: string, offset: number) {
+    let count = 0;
+    for (let i = offset - 2; i >= 0 && text[i] === '\\'; i--)
+        count++;
+
+    return count % 2 === 1;
+}
+
 function shouldRemoveClosingChar(
     inputChar: string,
     prePreInputChar: string,
@@ -226,9 +234,11 @@ function collapsedInputAutoPair(
     if (event.inputType.startsWith('delete'))
         return deleteAutoPair(event, text, start, end, offset, inputChar, postInputChar, blockText);
 
+    const isEscapedDollar = inputChar === '$' && hasOddBackslashesBefore(text, offset);
     if (
         !event.inputType.includes('delete')
         && inputChar === postInputChar
+        && !isEscapedDollar
         && shouldRemoveClosingChar(inputChar, prePreInputChar, options)
     ) {
         needRender = true;

--- a/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { ImageToken, LinkToken, StrongEmToken, SuperSubScriptToken, Token } from '../types';
+import type { CodeEmojiMathToken, ImageToken, LinkToken, StrongEmToken, SuperSubScriptToken, Token } from '../types';
 import { describe, expect, it } from 'vitest';
 import { tokenizer } from '../lexer';
 
@@ -96,6 +96,17 @@ describe('inline lexer — reference link (marktext d9f64bab)', () => {
         const tokens = tokenizer('[text][ref]', { labels });
         const types = tokens.map(t => t.type);
         expect(types, `tokens: ${JSON.stringify(types)}`).toContain('reference_link');
+    });
+});
+
+// Regression for issue #4555: escaped dollar signs inside inline math should
+// stay inside the math token instead of terminating the formula early.
+describe('inline lexer — inline math', () => {
+    it('parses escaped dollar signs inside inline math', () => {
+        const tokens = tokenizer(String.raw`$y = \$10000$`);
+        const math = tokens.find((t): t is CodeEmojiMathToken => t.type === 'inline_math');
+        expect(math, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
+        expect(math?.content).toBe(String.raw`y = \$10000`);
     });
 });
 

--- a/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -108,6 +108,13 @@ describe('inline lexer — inline math', () => {
         expect(math, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(math?.content).toBe(String.raw`y = \$10000`);
     });
+
+    it('parses inline math that ends with an escaped dollar sign', () => {
+        const tokens = tokenizer(String.raw`$x=\$$`);
+        const math = tokens.find((t): t is CodeEmojiMathToken => t.type === 'inline_math');
+        expect(math, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
+        expect(math?.content).toBe(String.raw`x=\$`);
+    });
 });
 
 // Defensive regression for marktext commit 8e32838b (PR #1531) — sup/sub

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -63,7 +63,7 @@ export type GfmRules = typeof gfmRules;
 
 // Markdown extensions (not belongs to GFM and Commonmark)
 export const inlineExtensionRules = {
-    inline_math: /^(\$)([^$]*?[^$\\])(\\*)\1(?!\1)/,
+    inline_math: /^(\$)((?:\\.|[^\\$])*[^\\$])(\\*)\1(?!\1)/,
     // This is not the best regexp, because it not support `2^2\\^`.
     superscript: /^(\^)((?:[^^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,
     subscript: /^(~)((?:[^~\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -63,7 +63,7 @@ export type GfmRules = typeof gfmRules;
 
 // Markdown extensions (not belongs to GFM and Commonmark)
 export const inlineExtensionRules = {
-    inline_math: /^(\$)((?:\\.|[^\\$])*[^\\$])(\\*)\1(?!\1)/,
+    inline_math: /^(\$)((?:\\.|[^\\$])+)(\\*)\1(?!\1)/,
     // This is not the best regexp, because it not support `2^2\\^`.
     superscript: /^(\^)((?:[^^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,
     subscript: /^(~)((?:[^~\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,


### PR DESCRIPTION
Closes #4555

## Summary

- Allow escaped dollar signs inside WYSIWYG inline math tokens, so `$y = \$10000$` renders as inline math instead of plain text.
- Prevent auto-pair from treating an escaped `$` as a request to skip the closing math marker.
- Add regression coverage for inline math tokenization and auto-pair input behavior.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on: Windows

Automated checks run:

- `pnpm -C packages/muya exec vitest run src/block/base/__tests__/autoPair.spec.ts src/inlineRenderer/__tests__/commonmarkExamples.spec.ts src/state/__tests__/renderToStaticHTML.spec.ts`
- `pnpm -C packages/muya lint:types`
- `pnpm -C packages/muya check-circular`
- `pnpm -C packages/muya test:spec:commonmark`
- `pnpm -C packages/muya test:spec:gfm`
- `pnpm --filter marktext build`
- `pnpm -C packages/desktop exec playwright test test/e2e/source-math.spec.ts test/e2e/fixture-render.spec.ts`

Additional validation:

- Verified that `$x$ and $y$` still parses as two separate inline math tokens.
- Verified that incomplete inline math such as `$y = \$` remains plain text until the closing marker is present.
- Verified that `$$` / math block behavior is unchanged.

## Notes for reviewers

This fixes the WYSIWYG inline-renderer path. The static Markdown-to-HTML path already handled escaped dollar signs correctly via the marked math extension.

The fix has two parts:

- Update the inline math tokenizer so escaped characters such as `\$` can remain inside the inline math token.
- Update auto-pair handling so typing an escaped dollar inside an auto-paired inline math expression does not remove the existing closing `$`.

Full `pnpm -C packages/muya test` was also attempted. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.