### PR TITLE
fix(muya): sync inline format toolbar highlight via selection-change

### DIFF
--- a/packages/muya/src/ui/inlineFormatToolbar/__tests__/selectionSync.spec.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/__tests__/selectionSync.spec.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+import { InlineFormatToolbar } from '../index';
+
+// The toolbar must perceive inline-format changes itself and update its
+// active-state highlight, rather than the engine telling it to. Any format
+// change — including ones applied OUTSIDE the toolbar (the desktop Format menu,
+// a command, a keyboard shortcut) — ends in a selection update that
+// re-broadcasts the selection's current formats via `selection-change`. While
+// the toolbar is open it listens for that and re-renders, so e.g. bolding the
+// selection from the menu lights up the bold button.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+    // baseFloat observes its container with a ResizeObserver; happy-dom doesn't
+    // ship one, so stand in a no-op.
+    if (typeof globalThis.ResizeObserver === 'undefined') {
+        globalThis.ResizeObserver = class {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as never;
+    }
+});
+
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function emitSelectionChange(
+    muya: Muya,
+    formats: Array<{ type: string }>,
+    extra: { isCollapsed?: boolean; isSelectionInSameBlock?: boolean } = {},
+): void {
+    muya.eventCenter.emit('selection-change', {
+        formats,
+        isCollapsed: extra.isCollapsed ?? false,
+        isSelectionInSameBlock: extra.isSelectionInSameBlock ?? true,
+    });
+}
+
+describe('inlineFormatToolbar self-syncs its highlight on selection-change', () => {
+    it('lights up bold when a selection-change reports strong while the toolbar is open', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = new InlineFormatToolbar(muya);
+        toolbar.status = true; // the toolbar is open over a selection
+
+        emitSelectionChange(muya, [{ type: 'strong' }]);
+
+        const boldItem = toolbar.container!.querySelector('li.item.strong');
+        expect(boldItem).toBeTruthy();
+        expect(boldItem!.classList.contains('active')).toBe(true);
+    });
+
+    it('drops the highlight when a later selection-change no longer reports the format', () => {
+        const muya = bootMuya('**bold** plain\n');
+        const toolbar = new InlineFormatToolbar(muya);
+        toolbar.status = true;
+
+        emitSelectionChange(muya, [{ type: 'strong' }]);
+        expect(toolbar.container!.querySelector('li.item.strong')!.classList.contains('active')).toBe(true);
+
+        emitSelectionChange(muya, []); // selection moved to unformatted text
+        expect(toolbar.container!.querySelector('li.item.strong')!.classList.contains('active')).toBe(false);
+    });
+
+    it('ignores selection-change while the toolbar is hidden', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = new InlineFormatToolbar(muya);
+        toolbar.status = false; // closed
+
+        emitSelectionChange(muya, [{ type: 'strong' }]);
+
+        // The handler bails before the first render, so nothing is drawn.
+        expect(toolbar.container!.querySelector('li.item.strong')).toBeNull();
+    });
+
+    it('ignores collapsed / cross-block selections (single-block tool)', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = new InlineFormatToolbar(muya);
+        toolbar.status = true;
+
+        emitSelectionChange(muya, [{ type: 'strong' }], { isCollapsed: true });
+        expect(toolbar.container!.querySelector('li.item.strong')).toBeNull();
+
+        emitSelectionChange(muya, [{ type: 'strong' }], { isSelectionInSameBlock: false });
+        expect(toolbar.container!.querySelector('li.item.strong')).toBeNull();
+    });
+});

--- a/packages/muya/src/ui/inlineFormatToolbar/index.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/index.ts
@@ -111,6 +111,18 @@ export class InlineFormatToolbar extends BaseFloat {
             }
         });
 
+        // While open, re-sync the highlight from the selection's current
+        // formats — this is how formats applied outside the toolbar (menu /
+        // command / shortcut) light up their buttons. Single-block tool, so
+        // ignore collapsed / cross-block selections.
+        eventCenter.subscribe('selection-change', ({ formats, isCollapsed, isSelectionInSameBlock }) => {
+            if (!this.status || isCollapsed || !isSelectionInSameBlock)
+                return;
+
+            this._formats = formats;
+            this._render();
+        });
+
         eventCenter.attachDOMEvent(domNode, 'keydown', (event) => {
             this._handleKeydown(event, editor);
         });


### PR DESCRIPTION
## Problem

Select some text and apply **Bold** from the application **Format** menu: the text becomes bold, but the inline format toolbar's **Bold** button does **not** light up (stays un-highlighted).

## Root cause

`InlineFormatToolbar` refreshes its active-state highlight only from the block's `keyup` / `click` handlers (interactive selection) and from its own button clicks. A format applied **outside** the toolbar — the Format menu, a command, or a keyboard shortcut — flows through `Muya.format()` and never touches those handlers, so the toolbar's cached `formats` go stale. (`Cmd+B` happens to work only because the trailing `keyup` re-broadcasts.)

## Fix

Let the toolbar perceive the change itself rather than coupling the engine to it. The engine already emits a general `selection-change` event that carries the selection's current `formats`, and it fires after any edit (`block.format()` ends in `setCursor → setSelection → selection-change`). The toolbar now subscribes to it and re-renders its highlight while it is open; collapsed / cross-block selections are ignored (it is a single-block tool).

`muya.ts` (the engine) is untouched — it stays unaware of the toolbar. This mirrors how the desktop already consumes `selection-change` to update its native Format menu.

Net change: `packages/muya/src/ui/inlineFormatToolbar/index.ts` (+12).

## Tests

- New `inlineFormatToolbar/__tests__/selectionSync.spec.ts` (4 cases): lights up on `strong`; drops the highlight when the format is gone; ignores a hidden toolbar; ignores collapsed / cross-block selections. Verified red before the fix.
- Full muya unit suite green (1029), `lint:types`, ESLint, and madge circular-dep check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
