### PR TITLE
fix(muya): restore editor cursor when closing the search bar (selectHighlight)

### DIFF
--- a/packages/muya/src/search/__tests__/search.spec.ts
+++ b/packages/muya/src/search/__tests__/search.spec.ts
@@ -93,6 +93,31 @@ describe('search.search()', () => {
     });
 });
 
+describe('search.search() — selectHighlight restores the editor cursor', () => {
+    it('places the cursor on the last active match when closing the search bar (empty value + selectHighlight)', () => {
+        const muya = bootMuya('apple banana apple cherry\n');
+        const block = placeCursorOnFirstBlock(muya);
+
+        const search = muya.editor.searchModule;
+        search.search('apple');
+        // Move the active match to the second "apple" (offset 13-18).
+        search.find('next');
+        expect(search.index).toBe(1);
+
+        // Closing the search bar empties the search with selectHighlight, which
+        // must drop the editor cursor back onto the last active match so the
+        // user can keep typing where the highlight was.
+        search.search('', { selectHighlight: true });
+
+        expect(highlightCount(muya)).toBe(0);
+        expect(muya.editor.activeContentBlock).toBe(block);
+        expect(muya.editor.selection.anchorBlock).toBe(block);
+        expect(muya.editor.selection.focusBlock).toBe(block);
+        expect(muya.editor.selection.anchor!.offset).toBe(13);
+        expect(muya.editor.selection.focus!.offset).toBe(18);
+    });
+});
+
 describe('search.find() — cursor navigation across matches', () => {
     it('wraps forward 0 -> 1 -> 2 -> 0 and backward 0 -> 2, moving the active mu-highlight', () => {
         const muya = bootMuya('x and x and x\n');

--- a/packages/muya/src/search/index.ts
+++ b/packages/muya/src/search/index.ts
@@ -143,8 +143,13 @@ export class Search {
     search(value: string, opts = {}) {
         const matches: IMatch[] = [];
         const options = Object.assign({}, DEFAULT_SEARCH_OPTIONS, opts);
-        const { highlightIndex } = options;
+        const { highlightIndex, selectHighlight } = options;
         let index = -1;
+
+        // The currently active match, captured before it is cleared below, so a
+        // `selectHighlight` request can drop the cursor back onto it when the
+        // new search has no match of its own (e.g. closing the search bar).
+        const prevActiveMatch = this.matches[this.index];
 
         // Empty last search.
         this._updateMatches(true);
@@ -184,6 +189,18 @@ export class Search {
         Object.assign(this, { _value: value, matches, index });
 
         this._updateMatches();
+
+        // Restore the editor cursor onto the active match. Mirrors muyajs's
+        // `render(selectHighlight)` -> `setCursor()` path: closing the search
+        // bar empties the search with `selectHighlight`, which must place the
+        // cursor where the highlight was so the user can keep typing there.
+        if (selectHighlight) {
+            const activeMatch = matches[index] ?? prevActiveMatch;
+            if (activeMatch) {
+                const { block, start, end } = activeMatch;
+                block.setCursor(start, end, true);
+            }
+        }
 
         return this;
     }


### PR DESCRIPTION
## Summary

Pressing **Escape** (or clicking outside / blurring) to close the find bar hid the bar and cleared the match highlights, but **did not restore the editor cursor** to the last active match — so the user could not keep typing where the highlight was. This is a muyajs → @muyajs/core migration parity gap.

### Root cause

`packages/muya/src/search/index.ts` declared a `selectHighlight` option in `ISearchOption` but `search()` never read it — it only consumed `highlightIndex`. The desktop renderer closes the bar via `editor.search('', { selectHighlight: true })` (`packages/desktop/src/renderer/src/components/search/index.vue` → `emptySearch(true)`), expecting the engine to drop the cursor onto the active match. The legacy engine did exactly that through `render(selectHighlight)` → `setCursor()`; muya had no equivalent, so the cursor stayed put.

### Fix

`search()` now honors `selectHighlight`: it captures the active match before clearing highlights, then places the cursor on the active match via `block.setCursor(start, end, true)`. On an empty search (closing the bar) it falls back to the previously active match — matching muyajs behavior, which selects the match range so typing continues there.

## Testing

- Added a characterizing unit test in `search.spec.ts` (search → `find('next')` → close with `selectHighlight` → cursor lands on the last active match's block/offsets). Confirmed it fails before the fix (cursor stuck at offset 0) and passes after.
- `pnpm -C packages/muya test` — 1066/1066 unit tests pass.
- `pnpm -C packages/muya lint:types` and `lint` clean for the search module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)