### PR TITLE
fix(search): scroll editor to match when opening a folder-search result

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -119,6 +119,7 @@ import {
   type ILocale
 } from '@muyajs/core'
 import { exportStyledHTML, type HeaderFooterPart } from '@/util/exportHtml'
+import { applyCursor, isIndexCursor } from '@/util/cursor'
 import EditorSearch from '../search/index.vue'
 import bus from '@/bus'
 import { DEFAULT_EDITOR_FONT_FAMILY } from '@/config'
@@ -1414,7 +1415,12 @@ const setMarkdownToEditor = (payload: unknown) => {
       resetSyntheticHistory(id, editor.value.getMarkdown())
     }
     if (newCursor) {
-      editor.value.setCursor(newCursor)
+      applyCursor(editor.value, newCursor)
+      // A folder-search jump carries an index cursor; a freshly opened file
+      // starts scrolled to the top, so reveal the resolved caret.
+      if (isIndexCursor(newCursor)) {
+        scrollToCursor()
+      }
     }
     // `setContent` rebuilds the block tree synchronously but fires no
     // `json-change`, so seed the TOC explicitly (otherwise it stays empty until
@@ -1432,22 +1438,6 @@ interface FileChangePayload {
   scrollTop?: number
   muyaIndexCursor?: unknown
   blocks?: unknown
-}
-
-// A source-mode (CodeMirror) index cursor: `{ anchor, focus }` in `{ line, ch }`
-// coordinates. Produced by sourceCode.vue and carried on `file-changed` as
-// `muyaIndexCursor` when handing a tab back to WYSIWYG. Both `line` AND `ch`
-// must be present numbers — otherwise the engine would clamp a missing `ch` to
-// 0 and silently restore the caret to the wrong column.
-const isIndexPosition = (pos: unknown): pos is { line: number; ch: number } => {
-  const p = pos as { line?: unknown; ch?: unknown } | null
-  return !!p && typeof p.line === 'number' && typeof p.ch === 'number'
-}
-const isIndexCursor = (
-  cursor: unknown
-): cursor is { anchor: { line: number; ch: number }; focus: { line: number; ch: number } } => {
-  const c = cursor as { anchor?: unknown; focus?: unknown } | null
-  return !!c && isIndexPosition(c.anchor) && isIndexPosition(c.focus)
 }
 
 // listen for markdown change form source mode or change tabs etc
@@ -1507,7 +1497,7 @@ const handleFileChange = (payload: unknown) => {
       // TOC (otherwise returning to an open tab keeps the other tab's TOC).
       editorStore.UPDATE_TOC(editor.value.getTOC())
       if (newCursor) {
-        editor.value.setCursor(newCursor)
+        applyCursor(editor.value, newCursor)
       } else if (isIndexCursor(muyaIndexCursor)) {
         // Source-mode handoff for a tab the engine has no history for (e.g.
         // first interaction after load): fall back to a caret-only remap. The
@@ -1528,7 +1518,7 @@ const handleFileChange = (payload: unknown) => {
       }
     }
   } else if (newCursor) {
-    editor.value.setCursor(newCursor)
+    applyCursor(editor.value, newCursor)
   }
 
   if (typeof scrollTop === 'number') {

--- a/packages/desktop/src/renderer/src/util/cursor.ts
+++ b/packages/desktop/src/renderer/src/util/cursor.ts
@@ -1,0 +1,41 @@
+// A source-mode (CodeMirror) index cursor: `{ anchor, focus }` in `{ line, ch }`
+// coordinates. Carried by folder-search jumps and the source -> WYSIWYG handoff.
+// Both `line` AND `ch` must be present numbers — otherwise the engine clamps a
+// missing `ch` to 0 and restores the caret to the wrong column.
+interface IndexPosition {
+  line: number
+  ch: number
+}
+
+export interface IndexCursor {
+  anchor: IndexPosition
+  focus: IndexPosition
+}
+
+const isIndexPosition = (pos: unknown): pos is IndexPosition => {
+  const p = pos as { line?: unknown; ch?: unknown } | null
+  return !!p && typeof p.line === 'number' && typeof p.ch === 'number'
+}
+
+export const isIndexCursor = (cursor: unknown): cursor is IndexCursor => {
+  const c = cursor as { anchor?: unknown; focus?: unknown } | null
+  return !!c && isIndexPosition(c.anchor) && isIndexPosition(c.focus)
+}
+
+interface CursorEditor {
+  setCursor: (cursor: unknown) => void
+  setCursorByOffset: (cursor: IndexCursor) => boolean
+}
+
+// Restore a persisted caret onto the live editor, picking the right engine API
+// for the cursor's shape. An index cursor (`{ line, ch }`) must go through
+// `setCursorByOffset`, which resolves the offsets against the block tree;
+// `setCursor` only understands block-key cursors (`{ offset, anchorPath }`) and
+// silently no-ops on a `{ line, ch }` cursor.
+export const applyCursor = (editor: CursorEditor, cursor: unknown): void => {
+  if (isIndexCursor(cursor)) {
+    editor.setCursorByOffset(cursor)
+  } else if (cursor) {
+    editor.setCursor(cursor)
+  }
+}

--- a/packages/desktop/test/unit/specs/cursor-apply.spec.ts
+++ b/packages/desktop/test/unit/specs/cursor-apply.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { applyCursor, isIndexCursor } from '@/util/cursor'
+
+describe('applyCursor', () => {
+  const makeEditor = () => ({
+    setCursor: vi.fn(),
+    setCursorByOffset: vi.fn(() => true)
+  })
+
+  it('routes a source-code index cursor to setCursorByOffset', () => {
+    const editor = makeEditor()
+    const cursor = { anchor: { line: 3, ch: 2 }, focus: { line: 3, ch: 5 } }
+
+    applyCursor(editor, cursor)
+
+    expect(editor.setCursorByOffset).toHaveBeenCalledWith(cursor)
+    expect(editor.setCursor).not.toHaveBeenCalled()
+  })
+
+  it('routes a block-key cursor to setCursor', () => {
+    const editor = makeEditor()
+    const cursor = {
+      anchor: { offset: 1 },
+      focus: { offset: 4 },
+      anchorPath: ['p', 0],
+      focusPath: ['p', 0]
+    }
+
+    applyCursor(editor, cursor)
+
+    expect(editor.setCursor).toHaveBeenCalledWith(cursor)
+    expect(editor.setCursorByOffset).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for a null cursor', () => {
+    const editor = makeEditor()
+
+    applyCursor(editor, null)
+
+    expect(editor.setCursor).not.toHaveBeenCalled()
+    expect(editor.setCursorByOffset).not.toHaveBeenCalled()
+  })
+})
+
+describe('isIndexCursor', () => {
+  it('is true only when both ends carry numeric line and ch', () => {
+    expect(isIndexCursor({ anchor: { line: 0, ch: 0 }, focus: { line: 1, ch: 2 } })).toBe(true)
+    expect(isIndexCursor({ anchor: { offset: 0 }, focus: { offset: 1 } })).toBe(false)
+    expect(isIndexCursor({ anchor: { line: 0 }, focus: { line: 1, ch: 2 } })).toBe(false)
+    expect(isIndexCursor(null)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Running a folder-wide search and clicking a match opens the file in a tab, but the editor does **not** scroll to / reveal the matched line. The tab opens, the caret just never moves.

## Root cause

`searchResultItem.vue` builds a **source-code index cursor** — `{ anchor: { line, ch }, focus: { line, ch } }` — and passes it through as a plain `cursor`. The editor then fed every `cursor` to the engine's `setCursor`, which only understands **block-key cursors** (`{ offset, anchorPath }`). On a `{ line, ch }` cursor it resolves no block and silently returns (`muya.ts` `setCursor`), so the caret never moves and nothing scrolls.

The engine already has the right API for this shape — `setCursorByOffset(indexCursor)` — but it was only wired into the source-mode → WYSIWYG handoff, not the search-jump path. The new-file open path (`setMarkdownToEditor`) also never called `scrollToCursor` at all.

## Fix

1. New `util/cursor.ts` — a pure, tested helper (`isIndexCursor` + `applyCursor`) that routes index cursors to `setCursorByOffset` and block-key cursors to `setCursor`. The two shapes are unambiguous (`line/ch` vs `offset`), so the normal session-restore cursor is unaffected.
2. `editor.vue` — route all three cursor-application sites through `applyCursor`, drop the inline `isIndexCursor` duplicate, and scroll to the resolved caret on the new-file open path.

## Tests

- New `cursor-apply.spec.ts` covers the routing decision (index → `setCursorByOffset`, block-key → `setCursor`, null → no-op).
- Full unit suite passes (565/565); `typecheck` clean; `lint` 0 errors.
- Visual scroll position confirmed manually in `pnpm run dev` (headless layout has no real geometry to assert in unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)