### PR TITLE
fix(muya): restore find-bar prefill from editor selection

### DIFF
--- a/packages/desktop/test/e2e/search-prefill-from-selection.spec.ts
+++ b/packages/desktop/test/e2e/search-prefill-from-selection.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, sendIpcToRenderer, focusEditor } from './helpers'
+
+// Regression: selecting a word and opening the find bar (Cmd+F) must prefill
+// the find input with the selection and run the search. The migration to
+// @muyajs/core made the engine emit a collapsed `selection-change` when the
+// find bar steals editor focus; the store used to clobber `searchMatches` on
+// that empty selection, wiping the just-prefilled value and the match list.
+test.describe('Find bar prefill from selection', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown(
+      '# Find test\n\nThe quick brown fox jumps over the lazy dog.\n'
+    )
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('double-click word prefills the find input and counts matches', async() => {
+    const point = await page.evaluate(() => {
+      const paras = Array.from(document.querySelectorAll('.mu-paragraph'))
+      for (const para of paras) {
+        const walker = document.createTreeWalker(para, NodeFilter.SHOW_TEXT)
+        while (walker.nextNode()) {
+          const t = walker.currentNode as Text
+          if (t.textContent && t.textContent.includes('fox')) {
+            const idx = t.textContent.indexOf('fox')
+            const range = document.createRange()
+            range.setStart(t, idx)
+            range.setEnd(t, idx + 3)
+            const rect = range.getBoundingClientRect()
+            return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+          }
+        }
+      }
+      return null
+    })
+    if (!point) throw new Error('could not locate the word "fox" in the editor')
+
+    await page.mouse.dblclick(point.x, point.y)
+    await expect.poll(() => page.evaluate(() => window.getSelection()?.toString())).toBe('fox')
+
+    await sendIpcToRenderer(app, 'mt::editor-edit-action', 'find')
+    const searchBar = page.locator('.search-bar')
+    await expect(searchBar).toBeVisible({ timeout: 5000 })
+
+    const input = page.locator('.search-bar input').first()
+    await expect(input).toHaveValue('fox')
+
+    // The selection seeds a real search: the result counter reports the match.
+    const result = page.locator('.search-bar .search-result')
+    await expect(result).toContainText('1 /')
+    await expect(result).not.toContainText('/ 0')
+  })
+})

--- a/packages/muya/src/search/index.ts
+++ b/packages/muya/src/search/index.ts
@@ -11,6 +11,10 @@ export class Search {
     public matches: IMatch[] = [];
     public index: number = -1;
 
+    get value() {
+        return this._value;
+    }
+
     private get _scrollPage() {
         return this._muya.editor.scrollPage;
     }


### PR DESCRIPTION
## Problem

Selecting a word in the editor and pressing **Cmd+F** should prefill the find input with the selection and run the search live. After the migration to `@muyajs/core`, the find input opened **empty** even though the word was correctly selected.

## Root cause

Not the engine's selection events — those are correct (a double-click emits a ranged `selection-change`, and the store seeds `searchMatches.value` with the selected word).

The regression is in the engine's `Search` result contract. Legacy muyajs exposed the active query publicly as `value` on the search result. The TS rewrite stores it in a **private `_value`** with no public accessor. The desktop find bar reads `result.value` (via `toSearchMatches`), so every `search()`/`find()`/`replace()` round-trip resolved the query to `''`. That empty value overwrote `searchMatches.value`, and the search component's watcher mirrored it into the input — wiping the just-prefilled text the moment the search ran.

## Fix

Expose a public `value` getter on `Search` (`packages/muya/src/search/index.ts`), restoring muyajs parity. One change fixes the prefill **and** the latent find-next/prev + replace paths that also read `.value`.

## Verification

- New desktop e2e `search-prefill-from-selection.spec.ts`: double-click a word, open the find bar, assert the input is seeded with the selection **and** the match counter reports the hit. Fails before the fix, passes after.
- Existing `find-replace.spec.ts` (3), muya search unit tests (4), muya `lint:types`, and eslint all pass.

Root cause was confirmed empirically with real-browser/Electron reproductions, not by inspection alone.