### PR TITLE
fix(muya): serialize lists with the configured listIndentation

### DIFF
--- a/packages/muya/src/__tests__/setOptions.spec.ts
+++ b/packages/muya/src/__tests__/setOptions.spec.ts
@@ -99,6 +99,24 @@ describe('muya runtime options', () => {
         expect(muya.options.listIndentation).toBe(2);
         expect(muya.getMarkdown()).toBe(before);
     });
+
+    // Regression: getMarkdown() must serialize nested lists using the live
+    // `listIndentation` option. The legacy muyajs engine threaded it
+    // (muyajs/lib/index.js getMarkdown -> new ExportMarkdown(blocks,
+    // listIndentation, ...)), but the migrated JSONState.getMarkdownFromState
+    // constructed `new StateToMarkdown()` with no options, so it always fell
+    // back to the 1-space default and the desktop Preferences toggle had zero
+    // effect on source mode / saved files. A flat list (the test above) can't
+    // catch this — only a nested list exposes the indentation width.
+    it('setListIndentation drives the serialized nested-list indentation', () => {
+        const muya = bootMuya('- a\n  - b\n');
+        // Default listIndentation = 1 -> nested bullet at marker width (2).
+        expect(muya.getMarkdown()).toBe('- a\n  - b\n');
+
+        // listIndentation = 4 -> marker width (2) + (4 - 1) = 5 spaces.
+        muya.setListIndentation(4);
+        expect(muya.getMarkdown()).toBe('- a\n     - b\n');
+    });
 });
 
 // Render-affecting options: the inline renderer (`InlineRenderer.tokenizer`)

--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -267,6 +267,54 @@ sep
 `;
         expect(roundTrip(md, 'dfm')).toBe(md);
     });
+
+    // Characterization test, NOT a spec for desired behavior.
+    //
+    // The desktop preferences UI offers a `'tab'` option for list indentation
+    // (prefComponents/markdown/config.ts), but neither this engine nor the
+    // legacy muyajs engine ever implemented it. stateToMarkdown's constructor
+    // only branches on `'dfm'` and `typeof === 'number'`; any other value
+    // (including `'tab'`) falls through to the `else` and yields a 1-space
+    // indent (_listIndentationCount = 1). The TODO in stateToMarkdown.ts
+    // (mirrored verbatim from muyajs/lib/utils/exportMarkdown.js) records why:
+    // the serializer builds every indent out of spaces, and the author left
+    // mixing real tabs with those space-based indents (blockquote prefixes,
+    // subsequent-paragraph alignment) as "work for another day".
+    //
+    // This test pins that degraded-to-1-space behavior so it can't change
+    // silently. If `'tab'` ever gets a real implementation, this assertion
+    // SHOULD fail — replace it with the proper tab-indent fixture then.
+    it('treats the unimplemented \'tab\' option as a 1-space indent', () => {
+        const md = `start
+
+- foo
+- foo
+  - foo
+  - foo
+    - foo
+    - foo
+      - foo
+  - foo
+- foo
+
+sep
+
+1. foo
+2. foo
+   1. foo
+   2. foo
+      1. foo
+   3. foo
+3. foo
+   20. foo
+       141. foo
+            1. foo
+`;
+        // Identical to the 1-space fixture above, and identical to what
+        // listIndentation = 1 produces — confirming 'tab' is silently coerced.
+        expect(roundTrip(md, 'tab')).toBe(md);
+        expect(roundTrip(md, 'tab')).toBe(roundTrip(md, 1));
+    });
 });
 
 // stateToMarkdown reads `loose` straight off the list meta. In a real boot

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -216,7 +216,9 @@ class JSONState {
     // `getMarkdown` uses. Used by `Muya.getCursorOffset` to serialize a
     // sentinel-bearing state clone WITHOUT mutating the live `_state`.
     getMarkdownFromState(state: TState[]): string {
-        const mdGenerator = new StateToMarkdown();
+        const mdGenerator = new StateToMarkdown({
+            listIndentation: this._muya.options.listIndentation,
+        });
 
         return mdGenerator.generate(state);
     }

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -533,7 +533,18 @@ export default class ExportMarkdown {
         // Subsequent paragraph indentation
         const newIndent = indent + ' '.repeat(itemMarker.length);
 
-        // New list indentation. We already added one space to the indentation
+        // Extra indentation for a NESTED list, added on top of the parent
+        // item's content column — `newIndent` above already advanced by the
+        // marker width, i.e. the CommonMark-minimal nest (a child list must
+        // sit at least past the parent marker to parse as nested). The nested
+        // marker therefore lands at: itemMarker.length + (listIndentationCount - 1).
+        //
+        // So a numeric "N spaces" is an indentation LEVEL relative to the
+        // content column, NOT an absolute column count: for a `- ` marker
+        // (width 2), N=1 -> 2 cols (tightest), N=4 -> 5 cols. Only `dfm` pins a
+        // hard 4-column nest regardless of marker width (4 - itemMarker.length).
+        // This matches the legacy muyajs serializer byte-for-byte
+        // (muyajs/lib/utils/exportMarkdown.js `normalizeListItem`).
         let listIndent = '';
         const { _listIndentation: listIndentation } = this;
         if (listIndentation === 'dfm')


### PR DESCRIPTION
## Summary

The `listIndentation` preference (Preferences → Markdown → Lists: `dfm` / `tab` / 1–4 spaces) had **zero effect** in the current engine — setting it to e.g. "4 spaces" and switching to source mode (or saving) still produced 1-space nested-list indentation.

### Root cause (migration regression)

`JSONState.getMarkdownFromState` built the serializer with no options:

```ts
const mdGenerator = new StateToMarkdown()   // always defaults to listIndentation: 1
```

`getMarkdown()` is the only path the desktop renderer uses for **source-code mode and file saving**, so the option never reached the serializer. Legacy `muyajs` threaded it correctly (`new ExportMarkdown(blocks, listIndentation, ...)`); the `muyajs → @muyajs/core` migration dropped the wiring. `JSONState` already holds `this._muya.options`, so the fix is to pass the live value through.

### What changed

- **`state/index.ts`** — pass `listIndentation: this._muya.options.listIndentation` into `StateToMarkdown`.
- **`__tests__/setOptions.spec.ts`** — regression test asserting `getMarkdown()` reflects `setListIndentation()` on a **nested** list. The pre-existing test used a flat list, which can't expose the indentation width and so masked the bug.
- **`state/__tests__/listSerialization.spec.ts`** — characterization test pinning the unimplemented `'tab'` option as a 1-space indent (with a comment pointing at the long-standing TODO explaining why tab indentation was deferred).

### Behavior after fix

`listIndentation = N` means nested indent = marker width + (N − 1), matching marktext's longstanding serializer:

| setting | bullet `- ` nested | ordered `1. ` nested |
|---|---|---|
| 1 | 2 | 3 |
| 4 | 5 | 6 |
| dfm | 4 | 4 |
| tab | 2 (unimplemented, == 1) | 3 |

### Testing

- `pnpm -C packages/muya test` → 1071 passed
- `pnpm -C packages/muya lint:types` → clean
- eslint on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)