### PR TITLE
fix(muya): restore the focused frontmatter delimiter markers

### DIFF
--- a/packages/muya/src/__tests__/frontMatter.spec.ts
+++ b/packages/muya/src/__tests__/frontMatter.spec.ts
@@ -2,8 +2,10 @@
 
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
+import type { ILocale } from '../i18n/types';
 import type { IFrontmatterState } from '../state/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { zhCN } from '../locales';
 import { Muya } from '../muya';
 import { replaceBlockByLabel } from '../ui/paragraphQuickInsertMenu/config';
 
@@ -40,12 +42,14 @@ afterEach(() => {
         delete (window as Partial<Window>).MUYA_VERSION;
 });
 
-function bootMuya(markdown: string, frontmatterType?: string): Muya {
+function bootMuya(markdown: string, frontmatterType?: string, locale?: ILocale): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const options = { markdown } as ConstructorParameters<typeof Muya>[1] & { frontmatterType?: string };
     if (frontmatterType !== undefined)
         options.frontmatterType = frontmatterType;
+    if (locale !== undefined)
+        options.locale = locale;
     const muya = new Muya(host, options);
     muya.init();
     bootedHosts.push(muya.domNode);
@@ -221,5 +225,37 @@ describe('quick-insert front matter (replaceBlockByLabel)', () => {
 
         expect((muya.getState()[0] as IFrontmatterState).meta.lang).toBe('toml');
         expect(muya.getMarkdown().startsWith('+++\n')).toBe(true);
+    });
+});
+
+// The focused front-matter block renders before/after delimiter markers via the
+// CSS rule `pre.mu-active.mu-frontmatter::before/::after` (blockSyntax.css). Two
+// regressions are guarded:
+//   - The block's class must be `mu-frontmatter`; the CSS once targeted the
+//     non-existent `mu-front-matter`, so the markers never showed (muyajs parity).
+//   - The marker text is driven by the i18n `frontMatterDelimiter` attribute on
+//     the <pre> (CSS `content: attr(frontMatterDelimiter)`), not a hardcoded
+//     `---`, so it localizes with the editor locale.
+describe('front matter delimiter marker', () => {
+    function frontmatterPre(muya: Muya): HTMLElement {
+        const block = muya.editor.scrollPage!.find(0) as unknown as Parent;
+        return block.domNode!;
+    }
+
+    it('tags the front-matter <pre> with the class the marker CSS targets', () => {
+        const muya = bootMuya('---\ntitle: hi\n---\n\nbody\n');
+        const pre = frontmatterPre(muya);
+        expect(pre.tagName).toBe('PRE');
+        expect(pre.classList.contains('mu-frontmatter')).toBe(true);
+    });
+
+    it('exposes the localized marker text as the frontMatterDelimiter attribute (default en)', () => {
+        const muya = bootMuya('---\ntitle: hi\n---\n\nbody\n');
+        expect(frontmatterPre(muya).getAttribute('frontMatterDelimiter')).toBe('Front Matter');
+    });
+
+    it('localizes the marker text with the editor locale', () => {
+        const muya = bootMuya('---\ntitle: hi\n---\n\nbody\n', undefined, zhCN);
+        expect(frontmatterPre(muya).getAttribute('frontMatterDelimiter')).toBe('顶部信息块');
     });
 });

--- a/packages/muya/src/__tests__/frontMatter.spec.ts
+++ b/packages/muya/src/__tests__/frontMatter.spec.ts
@@ -2,10 +2,8 @@
 
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
-import type { ILocale } from '../i18n/types';
 import type { IFrontmatterState } from '../state/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { zhCN } from '../locales';
 import { Muya } from '../muya';
 import { replaceBlockByLabel } from '../ui/paragraphQuickInsertMenu/config';
 
@@ -42,14 +40,12 @@ afterEach(() => {
         delete (window as Partial<Window>).MUYA_VERSION;
 });
 
-function bootMuya(markdown: string, frontmatterType?: string, locale?: ILocale): Muya {
+function bootMuya(markdown: string, frontmatterType?: string): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const options = { markdown } as ConstructorParameters<typeof Muya>[1] & { frontmatterType?: string };
     if (frontmatterType !== undefined)
         options.frontmatterType = frontmatterType;
-    if (locale !== undefined)
-        options.locale = locale;
     const muya = new Muya(host, options);
     muya.init();
     bootedHosts.push(muya.domNode);
@@ -229,17 +225,28 @@ describe('quick-insert front matter (replaceBlockByLabel)', () => {
 });
 
 // The focused front-matter block renders before/after delimiter markers via the
-// CSS rule `pre.mu-active.mu-frontmatter::before/::after` (blockSyntax.css). Two
+// CSS rules `pre.mu-active.mu-frontmatter::before/::after` (blockSyntax.css). Two
 // regressions are guarded:
 //   - The block's class must be `mu-frontmatter`; the CSS once targeted the
 //     non-existent `mu-front-matter`, so the markers never showed (muyajs parity).
-//   - The marker text is driven by the i18n `frontMatterDelimiter` attribute on
-//     the <pre> (CSS `content: attr(frontMatterDelimiter)`), not a hardcoded
-//     `---`, so it localizes with the editor locale.
+//   - The marker text is driven by the `frontMatterStart` / `frontMatterEnd`
+//     attributes on the <pre>, which mirror the real delimiters `stateToMarkdown`
+//     emits per type (yaml `---`, toml `+++`, json `;;;`, json-braces `{` / `}`),
+//     not a hardcoded `---`.
 describe('front matter delimiter marker', () => {
     function frontmatterPre(muya: Muya): HTMLElement {
         const block = muya.editor.scrollPage!.find(0) as unknown as Parent;
         return block.domNode!;
+    }
+
+    async function insertFrontMatter(frontmatterType?: string): Promise<HTMLElement> {
+        const muya = bootMuya('body\n', frontmatterType);
+        placeCursorOn(muya, 0);
+        muya.updateParagraph('front-matter');
+        await vi.waitFor(() => {
+            expect(muya.getState()[0].name).toBe('frontmatter');
+        });
+        return frontmatterPre(muya);
     }
 
     it('tags the front-matter <pre> with the class the marker CSS targets', () => {
@@ -249,13 +256,27 @@ describe('front matter delimiter marker', () => {
         expect(pre.classList.contains('mu-frontmatter')).toBe(true);
     });
 
-    it('exposes the localized marker text as the frontMatterDelimiter attribute (default en)', () => {
-        const muya = bootMuya('---\ntitle: hi\n---\n\nbody\n');
-        expect(frontmatterPre(muya).getAttribute('frontMatterDelimiter')).toBe('Front Matter');
+    it('yaml (default \'-\') shows --- before and after', async () => {
+        const pre = await insertFrontMatter();
+        expect(pre.getAttribute('frontMatterStart')).toBe('---');
+        expect(pre.getAttribute('frontMatterEnd')).toBe('---');
     });
 
-    it('localizes the marker text with the editor locale', () => {
-        const muya = bootMuya('---\ntitle: hi\n---\n\nbody\n', undefined, zhCN);
-        expect(frontmatterPre(muya).getAttribute('frontMatterDelimiter')).toBe('顶部信息块');
+    it('toml (\'+\') shows +++ before and after', async () => {
+        const pre = await insertFrontMatter('+');
+        expect(pre.getAttribute('frontMatterStart')).toBe('+++');
+        expect(pre.getAttribute('frontMatterEnd')).toBe('+++');
+    });
+
+    it('json (\';\') shows ;;; before and after', async () => {
+        const pre = await insertFrontMatter(';');
+        expect(pre.getAttribute('frontMatterStart')).toBe(';;;');
+        expect(pre.getAttribute('frontMatterEnd')).toBe(';;;');
+    });
+
+    it('json braces (\'{\') shows { before and } after', async () => {
+        const pre = await insertFrontMatter('{');
+        expect(pre.getAttribute('frontMatterStart')).toBe('{');
+        expect(pre.getAttribute('frontMatterEnd')).toBe('}');
     });
 });

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -787,9 +787,12 @@ pre.mu-frontmatter span.mu-codeblock-content:first-of-type:empty::after {
 }
 
 /* code html math ...code block style */
-pre.mu-active.mu-front-matter::before,
-pre.mu-active.mu-front-matter::after {
-    content: '---';
+pre.mu-active.mu-frontmatter::before {
+    content: attr(frontMatterStart);
+}
+
+pre.mu-active.mu-frontmatter::after {
+    content: attr(frontMatterEnd);
 }
 
 pre.mu-active.mu-math-container::before,
@@ -812,8 +815,8 @@ pre.mu-active[data-role='vega-lite']::after {
     content: '```';
 }
 
-pre.mu-active.mu-front-matter::before,
-pre.mu-active.mu-front-matter::after,
+pre.mu-active.mu-frontmatter::before,
+pre.mu-active.mu-frontmatter::after,
 pre.mu-active[data-role='mermaid']::before,
 pre.mu-active[data-role='mermaid']::after,
 pre.mu-active[data-role='vega-lite']::before,
@@ -829,7 +832,7 @@ pre.mu-active.mu-math-container::after {
     font-weight: 100;
 }
 
-pre.mu-active.mu-front-matter::before,
+pre.mu-active.mu-frontmatter::before,
 pre.mu-active[data-role='mermaid']::before,
 pre.mu-active[data-role='vega-lite']::before,
 pre.mu-active.mu-math-container::before,
@@ -837,7 +840,7 @@ pre.mu-active.mu-fenced-code::before {
     top: -20px;
 }
 
-pre.mu-active.mu-front-matter::after,
+pre.mu-active.mu-frontmatter::after,
 pre.mu-active[data-role='mermaid']::after,
 pre.mu-active[data-role='vega-lite']::after,
 pre.mu-active.mu-math-container::after,

--- a/packages/muya/src/block/extra/frontmatter/index.ts
+++ b/packages/muya/src/block/extra/frontmatter/index.ts
@@ -11,6 +11,20 @@ import { ScrollPage } from '../../scrollPage';
 
 const debug = logger('frontmatter:');
 
+// The before/after focus markers mirror the delimiters `stateToMarkdown`
+// serializes for each front-matter type, so they reflect the real fences:
+// yaml `---`, toml `+++`, json `;;;`, or the json-braces variant (`{` / `}`).
+function delimiters(meta: IFrontmatterMeta): [string, string] {
+    switch (meta.lang) {
+        case 'toml':
+            return ['+++', '+++'];
+        case 'json':
+            return meta.style === ';' ? [';;;', ';;;'] : ['{', '}'];
+        default:
+            return ['---', '---'];
+    }
+}
+
 class Frontmatter extends Parent {
     public meta: IFrontmatterMeta;
 
@@ -67,6 +81,9 @@ class Frontmatter extends Parent {
         this.tagName = 'pre';
         this.meta = meta;
         this.classList = ['mu-frontmatter'];
+        const [start, end] = delimiters(meta);
+        this.attributes.frontMatterStart = start;
+        this.attributes.frontMatterEnd = end;
         this.createDomNode();
     }
 


### PR DESCRIPTION
## Summary

When a frontmatter block gains focus, the editor should render the delimiter markers above and below the block (parity with the legacy muyajs engine). In the current `@muyajs/core` engine these markers never appeared.

**Root cause:** a class-name mismatch. The CSS rules target `pre.mu-active.mu-front-matter` (hyphenated `front-matter`), but the block is actually tagged `mu-frontmatter` (no hyphen, set in `block/extra/frontmatter/index.ts`). The selector never matched, so the `::before` / `::after` markers were never shown. Code blocks (```` ``` ````), math (`$$`), and diagram blocks use the correct class, so only frontmatter was affected.

## Changes

- **`assets/styles/blockSyntax.css`** — fix the 6 `mu-front-matter` selectors to `mu-frontmatter` so the focused before/after marker rules apply.
- **Real type-based delimiters** — the marker text was hardcoded `content: '---'`, which is wrong for non-YAML front matter. It now reads `content: attr(frontMatterStart)` / `attr(frontMatterEnd)`, driven by attributes on the `<pre>`. `frontmatter/index.ts` computes them from the block's `meta`, mirroring exactly what `stateToMarkdown` serializes per type:
  - yaml → `---` / `---`
  - toml → `+++` / `+++`
  - json (`;` style) → `;;;` / `;;;`
  - json (braces style) → `{` / `}`
- **Tests** — `frontMatter.spec.ts` gains coverage asserting the `mu-frontmatter` class and the correct start/end delimiters for each of the four front-matter types.

## Verification

- `pnpm -C packages/muya lint:types` — clean
- `pnpm -C packages/muya lint:css` — only pre-existing warnings (confirmed identical via `git stash`; none introduced here)
- ESLint on changed files — clean
- `pnpm -C packages/muya exec vitest run src/__tests__/frontMatter.spec.ts` — 14 passed

The change only touches a CSS class and DOM attributes; frontmatter parsing/serialization is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)