### PR TITLE
fix(muya): show code-block line numbers on first render for language-less blocks

### DIFF
--- a/packages/muya/src/block/commonMark/codeBlock/__tests__/lineNumbersGutter.spec.ts
+++ b/packages/muya/src/block/commonMark/codeBlock/__tests__/lineNumbersGutter.spec.ts
@@ -84,6 +84,35 @@ describe('code-block line-numbers gutter', () => {
             await nextFrame();
             expect(wrapper.childElementCount).toBe(1);
         });
+
+        // The lazy fill only runs from CodeBlockContent.update(). During the
+        // initial tree build that fires once per code-block via the
+        // language-load callback — but a fenced block with no info string, an
+        // unknown language, or an indented block never loads a language, so the
+        // gutter must be seeded on first render independent of the language.
+        it('fills spans on first render for a fenced block with no language', async () => {
+            const muya = bootMuya('```\nconst a = 1\nconst b = 2\nconst c = 3\n```\n', { codeBlockLineNumbers: true });
+            const wrapper = muya.domNode.querySelector<HTMLElement>('.mu-line-numbers-rows')!;
+            await nextFrame();
+            await nextFrame();
+            expect(wrapper.childElementCount).toBe(3);
+        });
+
+        it('fills spans on first render for an unknown language', async () => {
+            const muya = bootMuya('```not-a-real-language\none\ntwo\n```\n', { codeBlockLineNumbers: true });
+            const wrapper = muya.domNode.querySelector<HTMLElement>('.mu-line-numbers-rows')!;
+            await nextFrame();
+            await nextFrame();
+            expect(wrapper.childElementCount).toBe(2);
+        });
+
+        it('fills spans on first render for an indented code block', async () => {
+            const muya = bootMuya('    const a = 1\n    const b = 2\n', { codeBlockLineNumbers: true });
+            const wrapper = muya.domNode.querySelector<HTMLElement>('.mu-line-numbers-rows')!;
+            await nextFrame();
+            await nextFrame();
+            expect(wrapper.childElementCount).toBe(2);
+        });
     });
 
     describe('when codeBlockLineNumbers is false', () => {

--- a/packages/muya/src/block/commonMark/codeBlock/index.ts
+++ b/packages/muya/src/block/commonMark/codeBlock/index.ts
@@ -34,6 +34,13 @@ class CodeBlock extends Parent {
         const lnWrapper = (code as { lineNumbersWrapper?: HTMLElement | null }).lineNumbersWrapper;
         if (lnWrapper) {
             codeBlock.domNode!.appendChild(lnWrapper);
+            // The gutter fills from CodeBlockContent.update(), a no-op until the
+            // tree is wired. The language-load callback below re-runs it, but
+            // language-less / unknown-language / indented blocks never load one —
+            // seed them here so first render fills the gutter regardless of language.
+            requestAnimationFrame(() => {
+                codeBlock.lastContentInDescendant()?.update();
+            });
         }
 
         if (lang) {


### PR DESCRIPTION
## Problem

With **Settings → show code-block line numbers** enabled, the line-number gutter does not appear on a document's **first render** for code blocks that have no language. The gutter stays empty until the block is edited.

## Root cause

The gutter is filled lazily from `CodeBlockContent.update()` → `_updateLineNumbers()`. That call is a no-op during block construction because the tree isn't wired up yet (the parent's `lineNumbersWrapper` is unreachable, so it returns early).

After assembly, the **only** thing that re-runs `update()` is the async language-load callback in `CodeBlock.create`'s `if (lang)` branch:

```ts
if (lang) {
  requestAnimationFrame(() => { codeBlock.lang = lang }) // → loadLanguage().then(... update())
}
```

So:
- **Language-tagged** blocks (` ```js `) fill correctly — the highlight callback re-runs `update()`.
- **Language-less** (` ``` `), **unknown-language**, and **indented** code blocks never load a language → no callback → spans never fill on first render.

## Fix

Seed the gutter from `CodeBlock.create` once the tree is assembled, independent of the language. Language-tagged blocks still re-render via the highlight callback; the extra `update()` is cheap (guarded by `_lastLineCount`).

## Tests

The existing `lineNumbersGutter.spec.ts` only exercised language-tagged blocks, which masked the bug. Added coverage for the three previously-broken cases (no language, unknown language, indented).

- `lineNumbersGutter.spec.ts`: 13/13 pass
- full muya unit suite: 1079/1079 pass
- `lint:types` + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)