### PR TITLE
fix(muya): re-parse on parse-affecting option changes so ```math toggles live

### DIFF
--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -107,6 +107,19 @@ const TOGGLEABLE_BLOCK_LABELS = new Set([
     'thematic-break',
 ]);
 
+// Options consumed by the markdown→state lexer (markdownToState / lexBlock).
+// Changing any of these re-classifies block structure (e.g. ```math ⇄ code
+// block under GitLab compatibility, front matter, footnote definitions), which
+// a render-only rebuild from the already-parsed state cannot reflect — the
+// document must be re-parsed from markdown. See setOptions below.
+const PARSE_AFFECTING_OPTIONS = new Set<keyof IMuyaOptions>([
+    'isGitlabCompatibilityEnabled',
+    'math',
+    'footnote',
+    'frontMatter',
+    'trimUnnecessaryCodeBlockEmptyLines',
+]);
+
 function endpointPair(
     anchor: Nullable<Parent>,
     focus: Nullable<Parent>,
@@ -336,9 +349,11 @@ export class Muya {
      * Update editor options at runtime: merges `options` into `muya.options`,
      * reflects the container-level ones
      * (spellcheck, quick-insert hint), and — when `forceRender` is set — fully
-     * re-renders the document from its current state so render-affecting
-     * options (superSubScript, footnote, disableHtml, frontmatterType,
-     * codeBlockLineNumbers, GitLab compatibility, …) take effect. Unlike
+     * re-renders the document so render-affecting options (superSubScript,
+     * disableHtml, frontmatterType, codeBlockLineNumbers, …) take effect. When a
+     * PARSE-affecting option changes (GitLab compatibility, math, footnote,
+     * frontMatter, …) the document is first re-parsed from markdown, since those
+     * options decide block structure the cached state cannot reflect. Unlike
      * `setContent`, the undo history is preserved; the cursor is restored by path.
      */
     setOptions(options: Partial<IMuyaOptions>, forceRender = false) {
@@ -356,6 +371,15 @@ export class Muya {
 
         if (!forceRender)
             return;
+
+        // A parse-affecting option re-classifies block structure, so re-parse the
+        // current markdown into a fresh state before the render rebuild. This
+        // updates `jsonState` in place without clearing history (only `setContent`
+        // clears it), keeping setOptions' history-preserving contract.
+        if (Object.keys(options).some(key => PARSE_AFFECTING_OPTIONS.has(key as keyof IMuyaOptions))) {
+            const { jsonState } = this.editor;
+            jsonState.setContent(jsonState.markdownToState(this.getMarkdown()));
+        }
 
         this._forceRender();
     }

--- a/packages/muya/src/state/__tests__/gitlabMath.spec.ts
+++ b/packages/muya/src/state/__tests__/gitlabMath.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
+import ExportMarkdown from '../stateToMarkdown';
+
+// GitLab-flavoured Markdown lets a fenced code block tagged ```math render as
+// block math (display mode), serializing back as ```math instead of $$. In the
+// new engine the promotion is split across two seams:
+//   * parse:     utils/marked/walkTokens.ts rewrites a `code`/lang=math token
+//                into a `multiplemath` token with mathStyle='gitlab', but ONLY
+//                when BOTH `math` AND `isGitlabCompatibilityEnabled` are true.
+//   * serialize: state/stateToMarkdown.ts::_serializeMathBlock picks the fence
+//                purely from meta.mathStyle ('' → $$, 'gitlab' → ```math) — it
+//                does NOT re-read the option, so a block keeps its origin style.
+// The legacy engine (packages/muyajs) detected the same syntax with a dedicated
+// regex (`multiplemathGitlab` in parser/marked/blockRules.js). These specs lock
+// the state round-trip the renderer test (renderToStaticHTML.spec.ts) does not
+// cover, and pin where the two engines agree vs diverge.
+
+interface IMathLike {
+    name: string;
+    text?: string;
+    meta?: { mathStyle?: string; lang?: string; type?: string };
+}
+
+function parse(
+    markdown: string,
+    options: Partial<{ math: boolean; isGitlabCompatibilityEnabled: boolean }> = {},
+): IMathLike[] {
+    return new MarkdownToState({
+        footnote: false,
+        math: true,
+        isGitlabCompatibilityEnabled: true,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+        ...options,
+    } as never).generate(markdown) as unknown as IMathLike[];
+}
+
+function serialize(states: IMathLike[]): string {
+    return new ExportMarkdown({ listIndentation: 1 } as never).generate(
+        states as never,
+    );
+}
+
+describe('gitlab math — parse promotion (walkTokens)', () => {
+    it('promotes ```math to a gitlab-styled math block when math + gitlab are on', () => {
+        const [block] = parse('```math\nx^2\n```\n');
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('gitlab');
+        expect(block.text).toBe('x^2');
+    });
+
+    it('leaves ```math as a plain code block when gitlab compatibility is off', () => {
+        const [block] = parse('```math\nx^2\n```\n', { isGitlabCompatibilityEnabled: false });
+        expect(block.name).toBe('code-block');
+        expect(block.meta?.lang).toBe('math');
+        expect(block.meta?.mathStyle).toBeUndefined();
+    });
+
+    it('leaves ```math as a plain code block when math is off (both flags required)', () => {
+        const [block] = parse('```math\nx^2\n```\n', { math: false });
+        expect(block.name).toBe('code-block');
+        expect(block.meta?.lang).toBe('math');
+    });
+
+    it('always parses $$ as a non-gitlab math block, independent of the flag', () => {
+        for (const gitlab of [true, false]) {
+            const [block] = parse('$$\nx^2\n$$\n', { isGitlabCompatibilityEnabled: gitlab });
+            expect(block.name).toBe('math-block');
+            expect(block.meta?.mathStyle).toBe('');
+        }
+    });
+});
+
+describe('gitlab math — serialization (stateToMarkdown)', () => {
+    it('serializes a gitlab-styled math block back to ```math', () => {
+        const states = parse('```math\nx^2\n```\n');
+        expect(serialize(states)).toBe('```math\nx^2\n```\n');
+    });
+
+    it('serializes a $$ math block back to $$', () => {
+        const states = parse('$$\nx^2\n$$\n');
+        expect(serialize(states)).toBe('$$\nx^2\n$$\n');
+    });
+
+    it('keys the fence purely on meta.mathStyle, not on the option (mixed mode)', () => {
+        // A block authored in gitlab mode keeps the ```math fence even if the
+        // serializer is given a state that originated from $$ — proving the
+        // fence choice rides on the stored style, never the runtime flag.
+        const states = parse('$$\nx^2\n$$\n');
+        states[0].meta!.mathStyle = 'gitlab';
+        expect(serialize(states)).toBe('```math\nx^2\n```\n');
+    });
+
+    it('preserves indentation when a gitlab math block is nested in a list', () => {
+        const md = '- item\n\n  ```math\n  x^2\n  ```\n';
+        expect(serialize(parse(md))).toBe(md);
+    });
+});
+
+describe('gitlab math — round-trip stability', () => {
+    it('round-trips ```math unchanged with gitlab compatibility on', () => {
+        const md = '```math\nx^2\n```\n';
+        expect(serialize(parse(md))).toBe(md);
+    });
+
+    it('round-trips $$ unchanged regardless of the flag', () => {
+        const md = '$$\nx^2\n$$\n';
+        expect(serialize(parse(md, { isGitlabCompatibilityEnabled: false }))).toBe(md);
+    });
+});
+
+// Characterization of where the new engine (@muyajs/core) agrees with and
+// diverges from the legacy engine (packages/muyajs) for the SAME input under
+// gitlab compatibility. muyajs gated promotion on the regex
+//   /^ {0,3}(`{3,})math\n.../
+// — backtick-only, `math` immediately before the newline, ≤3 leading spaces.
+// muya instead promotes any marked `code` token whose lang === 'math', so its
+// acceptance set is "whatever marked treats as a fenced code block labelled
+// math". Most cases coincide; the tilde-fence case is the one real divergence.
+describe('gitlab math — consistency with legacy muyajs', () => {
+    it('agree — a 3-space indented ```math is still promoted (both engines)', () => {
+        const [block] = parse('   ```math\nx^2\n```\n');
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('gitlab');
+    });
+
+    it('agree — a 4-space indented fence is an indented code block, not math (both engines)', () => {
+        const [block] = parse('    ```math\nx^2\n```\n');
+        expect(block.name).toBe('code-block');
+        expect(block.meta?.type).toBe('indented');
+    });
+
+    it('agree — a 4+ backtick ```math fence is promoted (both engines)', () => {
+        const [block] = parse('````math\nx^2\n````\n');
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('gitlab');
+    });
+
+    it('agree — an info string after math (```math foo) is NOT promoted (both engines)', () => {
+        const [block] = parse('```math foo\nx^2\n```\n');
+        expect(block.name).toBe('code-block');
+    });
+
+    it('agree — the math language tag is case-sensitive — ```MATH is NOT promoted (both engines)', () => {
+        const [block] = parse('```MATH\nx^2\n```\n');
+        expect(block.name).toBe('code-block');
+        expect(block.meta?.lang).toBe('MATH');
+    });
+
+    it('diverge — a tilde ~~~math fence IS promoted by muya, but muyajs (backtick-only regex) left it a code block', () => {
+        const [block] = parse('~~~math\nx^2\n~~~\n');
+        // muya keys on marked\'s generic fenced-code parser, which accepts both
+        // ``` and ~~~ fences, so the math language tag promotes either way and
+        // the block re-serializes with a backtick fence. The legacy regex never
+        // matched ~~~, so the same source stayed a plain code block there.
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('gitlab');
+        expect(serialize(parse('~~~math\nx^2\n~~~\n'))).toBe('```math\nx^2\n```\n');
+    });
+});

--- a/packages/muya/src/state/__tests__/gitlabMathToggle.spec.ts
+++ b/packages/muya/src/state/__tests__/gitlabMathToggle.spec.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// Regression coverage for the live `isGitlabCompatibilityEnabled` toggle.
+// Toggling the preference drives `editor.setOptions({ isGitlabCompatibilityEnabled }, true)`
+// in the desktop renderer. Because GitLab compatibility is a PARSE-time option
+// (markdownToState / walkTokens decide whether ```math becomes a math block),
+// a render-only rebuild from the already-parsed state cannot reclassify an
+// existing ```math fence. These specs pin that the toggle re-parses so a
+// ```math block switches between code-block and math-block in both directions.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string, options: Partial<ConstructorParameters<typeof Muya>[1]> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// eslint-disable-next-line ts/no-explicit-any
+function firstBlock(muya: Muya): any {
+    return muya.getState()[0];
+}
+
+const MATH_FENCE = '```math\nx^2\n```\n';
+
+describe('isGitlabCompatibilityEnabled — live toggle re-parses ```math', () => {
+    it('starts as a code block when gitlab compatibility is off', () => {
+        const muya = bootMuya(MATH_FENCE, { math: true, isGitlabCompatibilityEnabled: false });
+        expect(firstBlock(muya).name).toBe('code-block');
+    });
+
+    it('promotes an existing ```math code block to a math block when toggled ON', () => {
+        const muya = bootMuya(MATH_FENCE, { math: true, isGitlabCompatibilityEnabled: false });
+        expect(firstBlock(muya).name).toBe('code-block');
+
+        muya.setOptions({ isGitlabCompatibilityEnabled: true }, true);
+
+        expect(firstBlock(muya).name).toBe('math-block');
+        expect(firstBlock(muya).meta.mathStyle).toBe('gitlab');
+    });
+
+    it('demotes an existing ```math math block back to a code block when toggled OFF', () => {
+        const muya = bootMuya(MATH_FENCE, { math: true, isGitlabCompatibilityEnabled: true });
+        expect(firstBlock(muya).name).toBe('math-block');
+
+        muya.setOptions({ isGitlabCompatibilityEnabled: false }, true);
+
+        expect(firstBlock(muya).name).toBe('code-block');
+        expect(firstBlock(muya).meta.lang).toBe('math');
+    });
+
+    it('leaves $$ math blocks untouched across a toggle', () => {
+        const muya = bootMuya('$$\nx^2\n$$\n', { math: true, isGitlabCompatibilityEnabled: false });
+        expect(firstBlock(muya).name).toBe('math-block');
+
+        muya.setOptions({ isGitlabCompatibilityEnabled: true }, true);
+
+        expect(firstBlock(muya).name).toBe('math-block');
+        expect(firstBlock(muya).meta.mathStyle).toBe('');
+    });
+});


### PR DESCRIPTION
## Problem

Toggling **Preferences → Markdown → Compatibility → Enable GitLab compatibility** did not switch an existing ` ```math ` block between a code block and a math block live. The same latent bug affected the other parse-time options (`math`, `footnote`, `frontMatter`, `trimUnnecessaryCodeBlockEmptyLines`).

## Root cause

The desktop renderer drives the toggle via `editor.setOptions({ isGitlabCompatibilityEnabled }, true)`. `setOptions(..., true)` → `_forceRender()` rebuilds the DOM from the **cached, already-parsed** state — `getState()` returns `deepClone(this._state)` — and never re-runs the markdown parser.

That is correct for **render-time** options (`superSubScript`, `codeBlockLineNumbers`, …) which only change how a given state node renders. But `isGitlabCompatibilityEnabled` is a **parse-time** option: `markdownToState` / `walkTokens` decide whether a ` ```math ` fence becomes a `math-block` or a plain `code-block`. Once a fence is classified, a render-only rebuild can never reclassify it.

## Fix

In `setOptions`, when a parse-affecting option changes, re-parse the current markdown into a fresh state (via `jsonState.markdownToState`, which reads the live options) **before** the render rebuild. This updates `jsonState` in place **without clearing undo history** (only `setContent(string)` clears it), preserving `setOptions`' history-preserving, cursor-restoring contract.

## Tests

- `gitlabMathToggle.spec.ts` — boots a real `Muya` instance and exercises the exact desktop `setOptions(..., true)` path; asserts a ` ```math ` block promotes/demotes in both directions and `$$` is left untouched. Fails before the fix, passes after.
- `gitlabMath.spec.ts` — characterizes the state-level parse/serialization round-trip the renderer test did not cover (the `math` + `gitlab` AND gate, `$$` ⇄ ` ```math ` fence selection by `meta.mathStyle`, list indentation, round-trip stability) and pins where the new engine agrees with vs. diverges from the legacy `muyajs` regex (the one divergence: muya promotes a `~~~math` tilde fence, muyajs did not).

Full muya suite: 1096/1096 passing. `lint:types` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)