### PR TITLE
fix(export): repair five styled-HTML export regressions (math, vega, footnotes, TOC, images)

### DIFF
--- a/packages/desktop/src/renderer/src/services/printService.ts
+++ b/packages/desktop/src/renderer/src/services/printService.ts
@@ -1,25 +1,4 @@
-// Resolve an <img>'s src for static (PDF) print (GH#678): a relative local
-// path is resolved to an absolute `file://` URL against the current document
-// directory; URLs, `data:` URIs, and already-absolute / `file://` srcs are
-// left untouched. Ported from the legacy muyajs `getImageInfo(src)` so the
-// desktop no longer depends on the muyajs engine (@muyajs/core's `getImageInfo`
-// takes a DOM element, and its `getImageSrc` would double-prefix `file://`).
-const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
-
-function resolveImageSrcForStaticPrint(src: string): string {
-  if (!src) return src
-  // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
-  if (/^(?:https?:|file:|data:)/i.test(src)) return src
-  // Only rewrite recognised local image paths (mirrors muyajs's IMAGE_EXT_REG
-  // gate) — leave anything else untouched, e.g. an extensionless absolute
-  // server path `/api/image?id=…` must not become `file:///api/image…`.
-  if (!IMAGE_EXT_REG.test(src)) return src
-  // Absolute local image path (POSIX / UNC / Windows drive) → file://.
-  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
-  // Relative local image path — resolve against the document directory.
-  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
-  return src
-}
+import { resolveLocalImageSrc } from '../util/resolveImageSrc'
 
 class MarkdownPrint {
   private container: HTMLElement | null = null
@@ -44,7 +23,7 @@ class MarkdownPrint {
       const images = printContainer.getElementsByTagName('img')
       for (const image of Array.from(images)) {
         const rawSrc = image.getAttribute('src') ?? ''
-        image.src = resolveImageSrcForStaticPrint(rawSrc)
+        image.src = resolveLocalImageSrc(rawSrc)
       }
     }
 

--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -12,6 +12,7 @@
 import type { Muya } from '@muyajs/core'
 import { MarkdownToHtml } from '@muyajs/core'
 import { sanitize, EXPORT_DOMPURIFY_CONFIG } from './dompurify'
+import { resolveLocalImageSrc } from './resolveImageSrc'
 
 export interface HeaderFooterPart {
   type?: number
@@ -111,6 +112,26 @@ const createTableBody = (article: string): string =>
 // Match a standalone `[TOC]` line (mirrors legacy marked TOC block token).
 const TOC_REG = /^ {0,3}\[TOC\] *$/im
 
+// Match the `src="…"` of an <img> tag in the (already sanitized, double-quoted)
+// engine output, so relative image paths can be rewritten to absolute `file://`
+// URLs. A string rewrite avoids re-serializing the whole article DOM (which
+// holds rendered KaTeX / diagram SVG).
+const IMG_SRC_REG = /(<img\b[^>]*?\ssrc=")([^"]*)(")/gi
+
+/**
+ * Rewrite relative / absolute-local `<img src>` to absolute `file://` URLs so a
+ * saved styled-HTML document still resolves its images after it is moved out of
+ * the source folder (legacy muyajs `correctImageSrc` parity, issue 230). Remote
+ * URLs and `data:` URIs are left untouched. Idempotent: a `file://` src is left
+ * as-is, so the PDF / print path (which rewrites again via printService) is a
+ * no-op the second time.
+ */
+const rewriteImageSrcs = (html: string): string =>
+  html.replace(IMG_SRC_REG, (match, pre: string, src: string, post: string) => {
+    const resolved = resolveLocalImageSrc(src)
+    return resolved === src ? match : `${pre}${resolved}${post}`
+  })
+
 /**
  * Build a styled, standalone HTML document equivalent to legacy muyajs
  * `exportStyledHTML`. Renders markdown through the new engine, injects the TOC
@@ -140,6 +161,10 @@ export const exportStyledHTML = async(
   // Pull out the rendered <article class="markdown-body">…</article> body.
   const articleMatch = /<article class="markdown-body">([\s\S]*)<\/article>/.exec(fullDoc)
   let article = articleMatch ? articleMatch[1] : fullDoc
+
+  // Resolve relative image paths to absolute file:// URLs so the saved document
+  // still shows its images when opened from a different folder (issue 230).
+  article = rewriteImageSrcs(article)
 
   // Inject the TOC at the `[TOC]` marker (legacy behaviour: only appears when
   // the document explicitly contains `[TOC]`). The marker is rendered as a

--- a/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
+++ b/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
@@ -1,0 +1,22 @@
+// Resolve an <img>'s src for export / static print (GH#678): a relative local
+// path is resolved to an absolute `file://` URL against the current document
+// directory; URLs, `data:` URIs, and already-absolute / `file://` srcs are left
+// untouched. Ported from the legacy muyajs `getImageInfo(src)` so a saved
+// styled-HTML / PDF document keeps rendering its images after it is moved out of
+// the source folder.
+const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
+
+export function resolveLocalImageSrc(src: string): string {
+  if (!src) return src
+  // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
+  if (/^(?:https?:|file:|data:)/i.test(src)) return src
+  // Only rewrite recognised local image paths (mirrors muyajs's IMAGE_EXT_REG
+  // gate) — leave anything else untouched, e.g. an extensionless absolute
+  // server path `/api/image?id=…` must not become `file:///api/image…`.
+  if (!IMAGE_EXT_REG.test(src)) return src
+  // Absolute local image path (POSIX / UNC / Windows drive) → file://.
+  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
+  // Relative local image path — resolve against the document directory.
+  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  return src
+}

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -6,13 +6,28 @@ import { describe, it, expect, vi } from 'vitest'
 vi.hoisted(() => {
   const w = globalThis as unknown as {
     window?: {
-      path?: { sep: string; join?: (...parts: string[]) => string }
+      path?: {
+        sep: string
+        join?: (...parts: string[]) => string
+        resolve?: (...parts: string[]) => string
+      }
       fileUtils?: unknown
       marktext?: unknown
+      DIRNAME?: string
     }
   }
   w.window ??= {}
-  w.window.path ??= { sep: '/', join: (...parts: string[]) => parts.join('/') }
+  w.window.path ??= {
+    sep: '/',
+    join: (...parts: string[]) => parts.join('/'),
+    // Minimal POSIX-ish resolve good enough for relative image rewriting:
+    // `resolve('/docs', './a.png')` → `/docs/a.png`.
+    resolve: (...parts: string[]) =>
+      parts.join('/').replace(/\/\.\//g, '/').replace(/\/{2,}/g, '/')
+  }
+  // The document directory the export wrapper resolves relative <img> src
+  // against (see resolveLocalImageSrc / window.DIRNAME).
+  w.window.DIRNAME = '/docs'
 })
 
 import { exportStyledHTML } from '@/util/exportHtml'
@@ -201,10 +216,19 @@ describe('exportStyledHTML — header/footer assembly', () => {
 })
 
 describe('exportStyledHTML — relative image paths', () => {
-  it('preserves a relative img src (not stripped by sanitize)', async() => {
+  it('rewrites a relative img src to an absolute file:// URL (issue 230)', async() => {
+    // window.DIRNAME is stubbed to '/docs', so `./a.png` resolves against it.
     const out = await exportStyledHTML(NO_MUYA, '![alt](./a.png)', {})
 
-    expect(out).toMatch(/<img[^>]+src="\.\/a\.png"/)
+    expect(out).toMatch(/<img[^>]+src="file:\/\/\/docs\/a\.png"/)
+    expect(out).not.toContain('src="./a.png"')
     expect(out).toContain('alt="alt"')
+  })
+
+  it('leaves a remote http(s) img src untouched', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '![alt](https://example.com/a.png)', {})
+
+    expect(out).toMatch(/<img[^>]+src="https:\/\/example\.com\/a\.png"/)
+    expect(out).not.toContain('file://')
   })
 })

--- a/packages/muya/src/assets/styles/exportStyle.css
+++ b/packages/muya/src/assets/styles/exportStyle.css
@@ -20,6 +20,71 @@
     }
 }
 
+/* Table of contents injected at a `[TOC]` marker by the desktop export
+   wrapper (getHtmlToc). Ported from legacy muyajs exportStyle.css so the
+   exported TOC keeps the same look: body-colour links (not link-blue) and a
+   dotted leader line after each entry. */
+.toc-container {
+    width: 100%;
+}
+
+.toc-container .toc-title {
+    margin-bottom: 0;
+
+    font-weight: 700;
+    font-size: 1.2em;
+}
+
+.toc-container li,
+.toc-container ul,
+.toc-container ul li {
+    list-style: none !important;
+}
+
+.toc-container > ul {
+    padding-left: 0;
+}
+
+.toc-container ul li span {
+    display: flex;
+}
+
+.toc-container ul li span a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.toc-container ul li span span.dots {
+    flex: 1;
+    height: 0.65em;
+    margin: 0 10px;
+
+    border-bottom: 2px dotted black;
+}
+
+.markdown-body sup.footnote-ref a {
+    text-decoration: none;
+}
+
+.markdown-body .footnotes {
+    font-size: 0.85em;
+
+    opacity: 0.8;
+}
+
+.markdown-body .footnotes .footnote-backref {
+    font-family: initial;
+    text-decoration: none;
+}
+
+/* Keep TOC links body-coloured / underline-free on hover too, overriding
+   github-markdown-css's `a:hover`. Separated from the base `a` rule and placed
+   here so source order stays specificity-ascending. */
+.toc-container ul li span a:hover {
+    color: inherit;
+    text-decoration: none;
+}
+
 .markdown-body pre {
     white-space: pre-wrap;
 }
@@ -56,20 +121,6 @@
 .markdown-body ul ol ol,
 .markdown-body ul ul ol {
     list-style-type: decimal;
-}
-
-.markdown-body sup.footnote-ref a {
-    text-decoration: none;
-}
-
-.markdown-body .footnotes {
-    font-size: 0.85em;
-    opacity: 0.8;
-}
-
-.markdown-body .footnotes .footnote-backref {
-    font-family: initial;
-    text-decoration: none;
 }
 
 .markdown-body div.plantuml,

--- a/packages/muya/src/assets/styles/exportStyle.css
+++ b/packages/muya/src/assets/styles/exportStyle.css
@@ -58,6 +58,20 @@
     list-style-type: decimal;
 }
 
+.markdown-body sup.footnote-ref a {
+    text-decoration: none;
+}
+
+.markdown-body .footnotes {
+    font-size: 0.85em;
+    opacity: 0.8;
+}
+
+.markdown-body .footnotes .footnote-backref {
+    font-family: initial;
+    text-decoration: none;
+}
+
 .markdown-body div.plantuml,
 .markdown-body div.mermaid,
 .markdown-body div.vega-lite,

--- a/packages/muya/src/state/__tests__/footnoteExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/footnoteExportHtml.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownToHtml } from '../markdownToHtml';
+
+// The styled-HTML / PDF export path goes through `MarkdownToHtml.renderHtml`,
+// which (unlike the spec-conformance `renderToStaticHTML`) historically never
+// ran the footnote post-processing. So an exported document left inline `[^id]`
+// refs as literal text and footnote definitions as raw
+// `<div class="footnote-block">` blocks (the `data-identifier` already stripped
+// by DOMPurify) — the bottom footnotes section never appeared. These assert the
+// export path now produces the standard GFM / pandoc footnote shape.
+
+const MUYA_FOOTNOTES_ON = {
+    options: { math: true, footnote: true },
+} as unknown as ConstructorParameters<typeof MarkdownToHtml>[1];
+
+async function renderExport(markdown: string): Promise<string> {
+    return new MarkdownToHtml(markdown, MUYA_FOOTNOTES_ON).renderHtml();
+}
+
+describe('footnote post-processing in MarkdownToHtml export', () => {
+    const MD = [
+        'Here is a ref[^1] and another[^2].',
+        '',
+        '[^1]: First note.',
+        '',
+        '[^2]: Second note.',
+        '',
+    ].join('\n');
+
+    it('numbers inline references as <sup class="footnote-ref">', async () => {
+        const out = await renderExport(MD);
+
+        expect(out).toMatch(
+            /<sup class="footnote-ref"><a href="#fn-1" id="fnref-1">1<\/a><\/sup>/,
+        );
+        expect(out).toMatch(
+            /<sup class="footnote-ref"><a href="#fn-2" id="fnref-2">2<\/a><\/sup>/,
+        );
+        // The literal `[^1]` / `[^2]` markers are gone from the prose.
+        expect(out).not.toMatch(/ref\[\^1\]/);
+        expect(out).not.toMatch(/another\[\^2\]/);
+    });
+
+    it('emits a bottom <section class="footnotes"> with backrefs', async () => {
+        const out = await renderExport(MD);
+
+        expect(out).toContain('<section class="footnotes">');
+        expect(out).toMatch(/<li id="fn-1">[\s\S]*First note\./);
+        expect(out).toMatch(/<li id="fn-2">[\s\S]*Second note\./);
+        expect(out).toMatch(/<a href="#fnref-1" class="footnote-backref">↩<\/a>/);
+        // The raw footnote-block wrapper must not leak into the output.
+        expect(out).not.toContain('footnote-block');
+    });
+});

--- a/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/parityExportHtml.spec.ts
@@ -54,6 +54,22 @@ describe('parity PG7: export inlines base stylesheets (offline-safe)', () => {
     );
 });
 
+describe('export ships the table-of-contents stylesheet', () => {
+    // The desktop wrapper injects the `[TOC]` list with `toc-container` /
+    // `toc-hN` / `dots` markup but no styles of its own — the styling rides
+    // along in the engine's inlined export stylesheet. Without it the exported
+    // TOC renders as plain link-blue bullets with no dotted leader (issue 229).
+    it('inlines the .toc-container rules (body-colour links + dotted leader)', async () => {
+        const out = await generateExport(SAMPLE);
+
+        expect(out).toContain('.toc-container');
+        // Links inherit the body colour rather than the default link blue.
+        expect(out).toMatch(/\.toc-container ul li span a\s*\{[^}]*color:\s*inherit/);
+        // The `.dots` leader line after each entry.
+        expect(out).toMatch(/span\.dots\s*\{[^}]*border-bottom:\s*2px dotted/);
+    });
+});
+
 describe('parity PG8: exported headings carry slug ids (live TOC anchors)', () => {
     it(
         'PG8: exported <h1>..<hN> carry an id attribute',

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -11,13 +11,12 @@ import { getHighlightHtml } from '../utils/marked';
 import { generateGithubSlug } from '../utils/slug';
 import { transformFootnotes } from './transformFootnotes';
 
-// Core stylesheets inlined into the exported document so the output is fully
-// self-contained and renders offline / behind CSP / air-gapped. Linking these
-// from a
-// CDN left a saved `.html` file unstyled with no network access, a regression
-// for an offline desktop editor. Callers that explicitly want the lighter
-// CDN-linked shell can opt in via `generate({ inlineStyles: false })`.
-const BASE_STYLESHEETS = [githubMarkdownCss, katexCss, prismCss];
+// The core stylesheets (github-markdown-css, katex, prism) are inlined into the
+// exported document so the output is fully self-contained and renders offline /
+// behind CSP / air-gapped — see `generate`. Linking them from a CDN left a
+// saved `.html` file unstyled with no network access, a regression for an
+// offline desktop editor. Callers that explicitly want the lighter CDN-linked
+// shell can opt in via `generate({ inlineStyles: false })`.
 
 // CDN `<link>` tags used when `inlineStyles` is disabled. Kept verbatim from
 // the previous default so the opt-out path is byte-identical to the old output.
@@ -241,9 +240,19 @@ export class MarkdownToHtml {
         // `extraCSS` may changed in the mean time.
         const { title = '', extraCSS = '', inlineStyles = true } = options;
 
-        const baseStyles = inlineStyles
-            ? BASE_STYLESHEETS.map(css => `  <style>${css}</style>`).join('\n')
-            : CDN_STYLESHEET_LINKS;
+        let baseStyles: string;
+        if (inlineStyles) {
+            // Embed the KaTeX fonts as data URIs so math renders offline. The
+            // font data (~300KB base64) is dynamically imported here so it only
+            // loads on export, never in the editor bundle.
+            const { embedKatexFonts } = await import('../utils/embedKatexFonts');
+            baseStyles = [githubMarkdownCss, embedKatexFonts(katexCss), prismCss]
+                .map(css => `  <style>${css}</style>`)
+                .join('\n');
+        }
+        else {
+            baseStyles = CDN_STYLESHEET_LINKS;
+        }
 
         return `<!DOCTYPE html>
 <html lang="en">

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -9,6 +9,7 @@ import loadRenderer from '../utils/diagram';
 
 import { getHighlightHtml } from '../utils/marked';
 import { generateGithubSlug } from '../utils/slug';
+import { transformFootnotes } from './transformFootnotes';
 
 // Core stylesheets inlined into the exported document so the output is fully
 // self-contained and renders offline / behind CSP / air-gapped. Linking these
@@ -162,13 +163,21 @@ export class MarkdownToHtml {
 
     // render pure html by marked
     async renderHtml() {
+        const footnote = this._muya?.options?.footnote ?? false;
         let html = getHighlightHtml(this.markdown, {
             superSubScript: this._muya?.options?.superSubScript ?? true,
-            footnote: this._muya?.options?.footnote ?? false,
+            footnote,
             isGitlabCompatibilityEnabled:
         this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
             math: this._muya?.options?.math ?? true,
         });
+
+        // Post-process footnotes into the standard GFM / pandoc shape (inline
+        // numbered <sup> refs + bottom <section class="footnotes"> with
+        // backrefs). Must run before DOMPurify strips the `data-identifier`
+        // marker the marked footnote extension emits.
+        if (footnote)
+            html = transformFootnotes(html);
 
         html = sanitize(html, EXPORT_DOMPURIFY_CONFIG, false) as string;
 

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -99,6 +99,12 @@ export class MarkdownToHtml {
                     tooltip: false,
                     renderer: 'svg',
                     theme: 'latimes', // only render light theme
+                    // Parse the spec to an AST and evaluate expressions with the
+                    // interpreter instead of compiling them via `new Function`,
+                    // which the sandboxed renderer's CSP blocks (`unsafe-eval`
+                    // is not granted) — without this the embed throws and the
+                    // chart renders as `< Invalid Diagram >`.
+                    ast: true,
                 });
             }
             else if (functionType === 'sequence') {

--- a/packages/muya/src/state/renderToStaticHTML.ts
+++ b/packages/muya/src/state/renderToStaticHTML.ts
@@ -1,6 +1,7 @@
 import { EXPORT_DOMPURIFY_CONFIG } from '../config';
 import { sanitize } from '../utils';
 import { getHighlightHtml } from '../utils/marked';
+import { transformFootnotes } from './transformFootnotes';
 
 export interface IRenderToStaticHTMLOptions {
     footnote?: boolean;
@@ -68,96 +69,4 @@ export function renderToStaticHTML(
         return html;
 
     return sanitize(html, EXPORT_DOMPURIFY_CONFIG, false) as string;
-}
-
-const FOOTNOTE_DEF_RE = /<div class="footnote-block" data-identifier="([^"]*)">([\s\S]*?)<\/div>\s*/g;
-
-// Inline `[^id]` syntax. Identifier matches the marked footnote extension's
-// block rule (utils/marked/extensions/footnote.ts: `[^^[\]\s]+`) so any id
-// the block accepts as a definition can also be picked up as a reference.
-const FOOTNOTE_REF_RE = /\[\^([^[\]\s]+)\]/g;
-
-// Pre/code blocks need to opt out: `[^id]` inside `<code>` or `<pre>` is
-// content, not a reference. We blank them out before scanning for refs and
-// restore them afterwards. The non-greedy match is enough since neither
-// element supports nesting itself in valid HTML.
-const CODE_GUARD_RE = /<(code|pre)\b[^>]*>[\s\S]*?<\/\1>/g;
-
-// Placeholder used to mask code spans / blocks while we scan for inline
-// `[^id]` references. The mid-string `_MUYA_FN_GUARD_` token can't appear in
-// marked's HTML output (no rule emits it), so the restore step is unambiguous.
-const CODE_PLACEHOLDER_PREFIX = '_MUYA_FN_GUARD_';
-const CODE_PLACEHOLDER_RESTORE_RE = /_MUYA_FN_GUARD_(\d+)_/g;
-
-function transformFootnotes(html: string): string {
-    // 1. Lift every footnote-block out of the body, remembering the rendered
-    //    definition html keyed by identifier. The body of the def is the inner
-    //    html marked already produced — paragraphs, lists, code, etc.
-    const definitions = new Map<string, string>();
-    let body = html.replace(FOOTNOTE_DEF_RE, (_, id: string, inner: string) => {
-        // First definition wins for duplicate identifiers — matches the way
-        // pandoc / GFM linkrefs treat repeated labels and what the plan asks
-        // for (Section 10, risk #2).
-        if (!definitions.has(id))
-            definitions.set(id, inner);
-        return '';
-    });
-
-    if (definitions.size === 0)
-        return html;
-
-    // 2. Stash code spans / blocks so step 3 only scans live prose.
-    const codeSlots: string[] = [];
-    body = body.replace(CODE_GUARD_RE, (m) => {
-        codeSlots.push(m);
-        return `${CODE_PLACEHOLDER_PREFIX}${codeSlots.length - 1}_`;
-    });
-
-    // 3. Find inline `[^id]` references in source order. Numbering follows
-    //    inline order (pandoc / GFM convention), not the order definitions
-    //    appear in source. Orphan refs (no matching def) stay as plain text;
-    //    repeats reuse the first-seen number.
-    const refNumber = new Map<string, number>();
-    let nextN = 1;
-    body = body.replace(FOOTNOTE_REF_RE, (match, id: string) => {
-        if (!definitions.has(id))
-            return match;
-        if (!refNumber.has(id))
-            refNumber.set(id, nextN++);
-        const n = refNumber.get(id)!;
-        return `<sup class="footnote-ref"><a href="#fn-${n}" id="fnref-${n}">${n}</a></sup>`;
-    });
-
-    // 4. Restore the protected code regions.
-    body = body.replace(CODE_PLACEHOLDER_RESTORE_RE, (_, i) => codeSlots[Number(i)]);
-
-    if (refNumber.size === 0)
-        return body;
-
-    // 5. Build the footnotes section in numeric order. Orphan definitions
-    //    (defined but never referenced inline) are dropped — same as the
-    //    parser-extension behaviour marktext shipped.
-    const orderedRefs = Array.from(refNumber.entries()).sort(
-        (a, b) => a[1] - b[1],
-    );
-    const items: string[] = [];
-    for (const [id, n] of orderedRefs) {
-        const inner = definitions.get(id) ?? '';
-        items.push(`<li id="fn-${n}">${appendBackref(inner, n)}</li>`);
-    }
-
-    const section = `\n<section class="footnotes">\n<ol>\n${items.join('\n')}\n</ol>\n</section>\n`;
-    return `${body.replace(/\s+$/, '')}\n${section}`;
-}
-
-function appendBackref(definitionHtml: string, n: number): string {
-    const backref = ` <a href="#fnref-${n}" class="footnote-backref">↩</a>`;
-    // Inject the backref inside the trailing `</p>` so the arrow sits next to
-    // the last word of the last paragraph (pandoc style). If the definition
-    // doesn't end with a paragraph (rare — e.g. ends in a list), tack the
-    // backref on after the block.
-    const lastClose = definitionHtml.lastIndexOf('</p>');
-    if (lastClose >= 0)
-        return `${definitionHtml.slice(0, lastClose)}${backref}${definitionHtml.slice(lastClose)}`;
-    return `${definitionHtml}${backref}`;
 }

--- a/packages/muya/src/state/transformFootnotes.ts
+++ b/packages/muya/src/state/transformFootnotes.ts
@@ -1,0 +1,100 @@
+// Post-process the marked footnote extension's raw output into the standard
+// GFM / pandoc shape: inline numbered `<sup class="footnote-ref">` markers plus
+// a bottom `<section class="footnotes">` list with backrefs.
+//
+// Shared by both export paths — the async `MarkdownToHtml` (styled HTML / PDF /
+// print) and the synchronous `renderToStaticHTML` (spec conformance). Must run
+// on the raw marked output BEFORE DOMPurify, because the `data-identifier`
+// marker the footnote extension emits is stripped by the default export config.
+
+const FOOTNOTE_DEF_RE = /<div class="footnote-block" data-identifier="([^"]*)">([\s\S]*?)<\/div>\s*/g;
+
+// Inline `[^id]` syntax. Identifier matches the marked footnote extension's
+// block rule (utils/marked/extensions/footnote.ts: `[^^[\]\s]+`) so any id
+// the block accepts as a definition can also be picked up as a reference.
+const FOOTNOTE_REF_RE = /\[\^([^[\]\s]+)\]/g;
+
+// Pre/code blocks need to opt out: `[^id]` inside `<code>` or `<pre>` is
+// content, not a reference. We blank them out before scanning for refs and
+// restore them afterwards. The non-greedy match is enough since neither
+// element supports nesting itself in valid HTML.
+const CODE_GUARD_RE = /<(code|pre)\b[^>]*>[\s\S]*?<\/\1>/g;
+
+// Placeholder used to mask code spans / blocks while we scan for inline
+// `[^id]` references. The mid-string `_MUYA_FN_GUARD_` token can't appear in
+// marked's HTML output (no rule emits it), so the restore step is unambiguous.
+const CODE_PLACEHOLDER_PREFIX = '_MUYA_FN_GUARD_';
+const CODE_PLACEHOLDER_RESTORE_RE = /_MUYA_FN_GUARD_(\d+)_/g;
+
+export function transformFootnotes(html: string): string {
+    // 1. Lift every footnote-block out of the body, remembering the rendered
+    //    definition html keyed by identifier. The body of the def is the inner
+    //    html marked already produced — paragraphs, lists, code, etc.
+    const definitions = new Map<string, string>();
+    let body = html.replace(FOOTNOTE_DEF_RE, (_, id: string, inner: string) => {
+        // First definition wins for duplicate identifiers — matches the way
+        // pandoc / GFM linkrefs treat repeated labels and what the plan asks
+        // for (Section 10, risk #2).
+        if (!definitions.has(id))
+            definitions.set(id, inner);
+        return '';
+    });
+
+    if (definitions.size === 0)
+        return html;
+
+    // 2. Stash code spans / blocks so step 3 only scans live prose.
+    const codeSlots: string[] = [];
+    body = body.replace(CODE_GUARD_RE, (m) => {
+        codeSlots.push(m);
+        return `${CODE_PLACEHOLDER_PREFIX}${codeSlots.length - 1}_`;
+    });
+
+    // 3. Find inline `[^id]` references in source order. Numbering follows
+    //    inline order (pandoc / GFM convention), not the order definitions
+    //    appear in source. Orphan refs (no matching def) stay as plain text;
+    //    repeats reuse the first-seen number.
+    const refNumber = new Map<string, number>();
+    let nextN = 1;
+    body = body.replace(FOOTNOTE_REF_RE, (match, id: string) => {
+        if (!definitions.has(id))
+            return match;
+        if (!refNumber.has(id))
+            refNumber.set(id, nextN++);
+        const n = refNumber.get(id)!;
+        return `<sup class="footnote-ref"><a href="#fn-${n}" id="fnref-${n}">${n}</a></sup>`;
+    });
+
+    // 4. Restore the protected code regions.
+    body = body.replace(CODE_PLACEHOLDER_RESTORE_RE, (_, i) => codeSlots[Number(i)]);
+
+    if (refNumber.size === 0)
+        return body;
+
+    // 5. Build the footnotes section in numeric order. Orphan definitions
+    //    (defined but never referenced inline) are dropped — same as the
+    //    parser-extension behaviour marktext shipped.
+    const orderedRefs = Array.from(refNumber.entries()).sort(
+        (a, b) => a[1] - b[1],
+    );
+    const items: string[] = [];
+    for (const [id, n] of orderedRefs) {
+        const inner = definitions.get(id) ?? '';
+        items.push(`<li id="fn-${n}">${appendBackref(inner, n)}</li>`);
+    }
+
+    const section = `\n<section class="footnotes">\n<ol>\n${items.join('\n')}\n</ol>\n</section>\n`;
+    return `${body.replace(/\s+$/, '')}\n${section}`;
+}
+
+function appendBackref(definitionHtml: string, n: number): string {
+    const backref = ` <a href="#fnref-${n}" class="footnote-backref">↩</a>`;
+    // Inject the backref inside the trailing `</p>` so the arrow sits next to
+    // the last word of the last paragraph (pandoc style). If the definition
+    // doesn't end with a paragraph (rare — e.g. ends in a list), tack the
+    // backref on after the block.
+    const lastClose = definitionHtml.lastIndexOf('</p>');
+    if (lastClose >= 0)
+        return `${definitionHtml.slice(0, lastClose)}${backref}${definitionHtml.slice(lastClose)}`;
+    return `${definitionHtml}${backref}`;
+}

--- a/packages/muya/src/types/index.d.ts
+++ b/packages/muya/src/types/index.d.ts
@@ -9,6 +9,10 @@ declare module '*.css';
 declare module '*.css?inline';
 declare module '*.woff';
 declare module '*.woff2';
+declare module '*.woff2?inline' {
+    const dataUri: string;
+    export default dataUri;
+}
 declare module 'joplin-turndown-plugin-gfm';
 declare module 'prismjs/plugins/keep-markup/prism-keep-markup';
 declare module 'prismjs/dependencies';

--- a/packages/muya/src/utils/__tests__/embedKatexFonts.spec.ts
+++ b/packages/muya/src/utils/__tests__/embedKatexFonts.spec.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import katexCss from 'katex/dist/katex.css?inline';
+import { describe, expect, it } from 'vitest';
+import { embedKatexFonts } from '../embedKatexFonts';
+
+describe('embedKatexFonts', () => {
+    it('rewrites every @font-face src to an embedded woff2 data URI', () => {
+        const out = embedKatexFonts(katexCss);
+
+        const faces = out.match(/@font-face\s*\{[^}]*\}/g) ?? [];
+        expect(faces.length).toBe(20);
+        for (const face of faces) {
+            expect(face).toMatch(/src:\s*url\(data:font\/woff2;base64,[^)]+\)\s*format\("woff2"\);/);
+        }
+    });
+
+    it('drops the now-broken relative font references and woff/ttf fallbacks', () => {
+        const out = embedKatexFonts(katexCss);
+
+        // No `url(fonts/…)` left, and no woff/ttf alternatives in any src.
+        expect(out).not.toMatch(/url\(\s*fonts\//);
+        expect(out).not.toContain('format("woff")');
+        expect(out).not.toContain('format("truetype")');
+    });
+
+    it('leaves non @font-face css untouched', () => {
+        const out = embedKatexFonts('.katex { font-size: 1.21em; }');
+        expect(out).toBe('.katex { font-size: 1.21em; }');
+    });
+});

--- a/packages/muya/src/utils/embedKatexFonts.ts
+++ b/packages/muya/src/utils/embedKatexFonts.ts
@@ -1,0 +1,92 @@
+// Embed the KaTeX woff2 fonts as base64 data URIs into the inlined katex
+// stylesheet so a saved standalone export renders math correctly offline.
+//
+// `katex/dist/katex.css` references its fonts with relative `url(fonts/…)`
+// paths. Inlined into an exported `.html` (and rewritten to hashed bundler
+// asset paths in a production build), those references resolve to nothing when
+// the file is opened from an arbitrary location with no network — KaTeX then
+// falls back to system fonts and every formula renders with the wrong glyphs /
+// metrics. Replacing each `@font-face` src with the embedded woff2 keeps the
+// export self-contained.
+//
+// Faces are matched by their `font-family` + `font-weight` + `font-style`
+// descriptors, NOT by the `url(…)` file name: a production build appends a
+// content hash to the asset file name, so the name is unreliable while the
+// descriptors are stable. Only woff2 is embedded (every browser MarkText
+// targets supports it); the `woff` / `ttf` fallbacks are dropped.
+
+import KaTeX_AMS_Regular from 'katex/dist/fonts/KaTeX_AMS-Regular.woff2?inline';
+import KaTeX_Caligraphic_Bold from 'katex/dist/fonts/KaTeX_Caligraphic-Bold.woff2?inline';
+import KaTeX_Caligraphic_Regular from 'katex/dist/fonts/KaTeX_Caligraphic-Regular.woff2?inline';
+import KaTeX_Fraktur_Bold from 'katex/dist/fonts/KaTeX_Fraktur-Bold.woff2?inline';
+import KaTeX_Fraktur_Regular from 'katex/dist/fonts/KaTeX_Fraktur-Regular.woff2?inline';
+import KaTeX_Main_Bold from 'katex/dist/fonts/KaTeX_Main-Bold.woff2?inline';
+import KaTeX_Main_BoldItalic from 'katex/dist/fonts/KaTeX_Main-BoldItalic.woff2?inline';
+import KaTeX_Main_Italic from 'katex/dist/fonts/KaTeX_Main-Italic.woff2?inline';
+import KaTeX_Main_Regular from 'katex/dist/fonts/KaTeX_Main-Regular.woff2?inline';
+import KaTeX_Math_BoldItalic from 'katex/dist/fonts/KaTeX_Math-BoldItalic.woff2?inline';
+import KaTeX_Math_Italic from 'katex/dist/fonts/KaTeX_Math-Italic.woff2?inline';
+import KaTeX_SansSerif_Bold from 'katex/dist/fonts/KaTeX_SansSerif-Bold.woff2?inline';
+import KaTeX_SansSerif_Italic from 'katex/dist/fonts/KaTeX_SansSerif-Italic.woff2?inline';
+import KaTeX_SansSerif_Regular from 'katex/dist/fonts/KaTeX_SansSerif-Regular.woff2?inline';
+import KaTeX_Script_Regular from 'katex/dist/fonts/KaTeX_Script-Regular.woff2?inline';
+import KaTeX_Size1_Regular from 'katex/dist/fonts/KaTeX_Size1-Regular.woff2?inline';
+import KaTeX_Size2_Regular from 'katex/dist/fonts/KaTeX_Size2-Regular.woff2?inline';
+import KaTeX_Size3_Regular from 'katex/dist/fonts/KaTeX_Size3-Regular.woff2?inline';
+import KaTeX_Size4_Regular from 'katex/dist/fonts/KaTeX_Size4-Regular.woff2?inline';
+import KaTeX_Typewriter_Regular from 'katex/dist/fonts/KaTeX_Typewriter-Regular.woff2?inline';
+
+// Keyed by `${font-family}|${font-weight}|${font-style}` (family unquoted,
+// weight/style lower-cased). Mirrors the @font-face table in katex.css.
+const FACE_TO_DATA_URI: Record<string, string> = {
+    'KaTeX_AMS|normal|normal': KaTeX_AMS_Regular,
+    'KaTeX_Caligraphic|bold|normal': KaTeX_Caligraphic_Bold,
+    'KaTeX_Caligraphic|normal|normal': KaTeX_Caligraphic_Regular,
+    'KaTeX_Fraktur|bold|normal': KaTeX_Fraktur_Bold,
+    'KaTeX_Fraktur|normal|normal': KaTeX_Fraktur_Regular,
+    'KaTeX_Main|bold|normal': KaTeX_Main_Bold,
+    'KaTeX_Main|bold|italic': KaTeX_Main_BoldItalic,
+    'KaTeX_Main|normal|italic': KaTeX_Main_Italic,
+    'KaTeX_Main|normal|normal': KaTeX_Main_Regular,
+    'KaTeX_Math|bold|italic': KaTeX_Math_BoldItalic,
+    'KaTeX_Math|normal|italic': KaTeX_Math_Italic,
+    'KaTeX_SansSerif|bold|normal': KaTeX_SansSerif_Bold,
+    'KaTeX_SansSerif|normal|italic': KaTeX_SansSerif_Italic,
+    'KaTeX_SansSerif|normal|normal': KaTeX_SansSerif_Regular,
+    'KaTeX_Script|normal|normal': KaTeX_Script_Regular,
+    'KaTeX_Size1|normal|normal': KaTeX_Size1_Regular,
+    'KaTeX_Size2|normal|normal': KaTeX_Size2_Regular,
+    'KaTeX_Size3|normal|normal': KaTeX_Size3_Regular,
+    'KaTeX_Size4|normal|normal': KaTeX_Size4_Regular,
+    'KaTeX_Typewriter|normal|normal': KaTeX_Typewriter_Regular,
+};
+
+const FONT_FACE_BLOCK_RE = /@font-face\s*\{[^}]*\}/g;
+// Each descriptor value runs up to the next `;`. Written as `:([^;]+);` (no
+// leading `\s*`, no lazy quantifier) so it is linear — the value is trimmed and
+// de-quoted in JS instead.
+const FAMILY_RE = /font-family:([^;]+);/;
+const WEIGHT_RE = /font-weight:([^;]+);/;
+const STYLE_RE = /font-style:([^;]+);/;
+const SRC_RE = /src:[^;]*;/;
+const QUOTE_RE = /^["']|["']$/g;
+
+function descriptor(block: string, re: RegExp, fallback: string): string {
+    return (block.match(re)?.[1]?.trim().replace(QUOTE_RE, '') ?? fallback);
+}
+
+export function embedKatexFonts(css: string): string {
+    return css.replace(FONT_FACE_BLOCK_RE, (block) => {
+        const family = descriptor(block, FAMILY_RE, '');
+        if (!family)
+            return block;
+        const weight = descriptor(block, WEIGHT_RE, 'normal').toLowerCase();
+        const style = descriptor(block, STYLE_RE, 'normal').toLowerCase();
+
+        const dataUri = FACE_TO_DATA_URI[`${family}|${weight}|${style}`];
+        if (!dataUri)
+            return block;
+
+        return block.replace(SRC_RE, `src: url(${dataUri}) format("woff2");`);
+    });
+}


### PR DESCRIPTION
## Summary

Repairs five regressions in the styled-HTML / PDF export path after the muyajs → @muyajs/core engine migration. Each is an independent, single-responsibility commit.

| Issue | Symptom | Root cause | Fix |
|---|---|---|---|
| Footnotes | `[^1]` left as literal text; definitions rendered as raw `<div class="footnote-block">`; no bottom section | `MarkdownToHtml.renderHtml` (the export path) never ran footnote post-processing — only the spec-conformance `renderToStaticHTML` did | Extract `transformFootnotes` into a shared module and call it from the export path before sanitization; add matching export CSS |
| Vega-Lite | Charts render as `< Invalid Diagram >` | vega-embed compiled spec expressions with `new Function`, which the sandboxed renderer's CSP (`unsafe-eval` not granted) blocks | Pass `ast: true` so vega-embed parses to an AST and evaluates with `vega.expressionInterpreter` |
| Inline math | Formulas render with the wrong glyphs/metrics offline | The inlined `katex.css` references `url(fonts/…)` that resolve to nothing in a saved standalone `.html` (and to hashed asset paths in a build) | Embed the woff2 faces as base64 data URIs, matched by `@font-face` family/weight/style; dynamically imported in `generate()` so the ~300KB stays out of the editor bundle |
| TOC | Exported `[TOC]` rendered as plain link-blue bullets with no dotted leader | `.toc-container` / `.dots` styling lived only in legacy muyajs | Port the legacy TOC rules into the engine export stylesheet |
| Images | Relative `![](./img/pic.png)` broke once the saved `.html` was moved out of the source folder | Styled-HTML export skips `printService`, so only the PDF/print path rewrote image paths | Share the resolver as `resolveLocalImageSrc` and apply it in `exportStyledHTML` (relative/absolute-local → `file://`, idempotent vs the PDF path) |

## Testing

- muya: 1085 unit tests pass, ESLint clean, `tsc --noEmit` clean. New specs: footnote export post-processing, KaTeX font embedding, TOC-stylesheet-shipped.
- desktop: 566 unit tests pass, `vue-tsc` clean. Updated the image-export spec to assert `file://` rewriting.

> Note: the math-font and vega-CSP fixes are verified at the HTML/options level by unit tests; the offline glyph rendering and CSP behavior are best eyeballed from a dev-build export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)