### PR TITLE
fix(export): make "Overwrite theme font" actually override the selected theme

### DIFF
--- a/packages/desktop/src/renderer/src/util/pdf.ts
+++ b/packages/desktop/src/renderer/src/util/pdf.ts
@@ -50,20 +50,6 @@ export const getCssForOptions = async(options: PdfCssOptions): Promise<string> =
       margin: ${pageMarginTop}mm ${pageMarginRight}mm ${pageMarginBottom}mm ${pageMarginLeft}mm;}`
   }
 
-  // Font options
-  output += '.markdown-body{'
-  if (fontFamily) {
-    output += `font-family:"${fontFamily}",${FALLBACK_FONT_FAMILIES};`
-    output = `.hf-container{font-family:"${fontFamily}",${FALLBACK_FONT_FAMILIES};}${output}`
-  }
-  if (fontSize) {
-    output += `font-size:${fontSize}px;`
-  }
-  if (lineHeight) {
-    output += `line-height:${lineHeight};`
-  }
-  output += '}'
-
   // Auto numbering headings via CSS
   if (autoNumberingHeadings) {
     output += autoNumberingHeadingsCss
@@ -95,6 +81,23 @@ export const getCssForOptions = async(options: PdfCssOptions): Promise<string> =
       }
     }
   }
+
+  // Font options. Emitted AFTER the theme CSS so the "Overwrite theme font"
+  // settings win the cascade: a selected export theme also sets `.markdown-body`
+  // font-size/line-height/font-family, and at equal specificity the later rule
+  // wins — so the user's override must come last to actually override the theme.
+  output += '.markdown-body{'
+  if (fontFamily) {
+    output += `font-family:"${fontFamily}",${FALLBACK_FONT_FAMILIES};`
+    output = `.hf-container{font-family:"${fontFamily}",${FALLBACK_FONT_FAMILIES};}${output}`
+  }
+  if (fontSize) {
+    output += `font-size:${fontSize}px;`
+  }
+  if (lineHeight) {
+    output += `line-height:${lineHeight};`
+  }
+  output += '}'
 
   if (headerFooterFontSize) {
     output += `.page-header .hf-container,

--- a/packages/desktop/test/unit/specs/pdf.spec.ts
+++ b/packages/desktop/test/unit/specs/pdf.spec.ts
@@ -121,6 +121,36 @@ describe('getCssForOptions', () => {
     expect(css).toContain('.hf-container{font-family:"Foo"')
   })
 
+  it('emits the font override AFTER theme CSS so "overwrite theme font" wins', async() => {
+    // A selected export theme sets its own `.markdown-body { font-size/line-height/
+    // font-family }`. The whole point of the "Overwrite theme font" toggle is that
+    // the user's font wins over the theme — so the override rule must be emitted
+    // AFTER the theme block (same specificity → later wins), otherwise the theme
+    // silently clobbers the user's font size / line height / family.
+    const w = globalThis as unknown as {
+      window: { fileUtils: { isFile: () => Promise<boolean>, readFile: () => Promise<string> } }
+    }
+    w.window.fileUtils = {
+      isFile: async() => true,
+      readFile: async() => '.markdown-body{font-size:99px;line-height:9;font-family:"Theme";}'
+    }
+
+    const { getCssForOptions } = await loadPdf()
+    const css = await getCssForOptions({
+      theme: 'mytheme',
+      fontFamily: 'Foo',
+      fontSize: 14,
+      lineHeight: 1.6
+    })
+
+    const themeAt = css.indexOf('font-size:99px')
+    const overrideAt = css.indexOf('font-size:14px;')
+    expect(themeAt).toBeGreaterThanOrEqual(0)
+    expect(overrideAt).toBeGreaterThanOrEqual(0)
+    // The user's override must come after the theme rule to win the cascade.
+    expect(overrideAt).toBeGreaterThan(themeAt)
+  })
+
   it('adds heading auto-numbering CSS when autoNumberingHeadings is set', async() => {
     const { getCssForOptions } = await loadPdf()
     const css = await getCssForOptions({ autoNumberingHeadings: true })


### PR DESCRIPTION
## Problem

When an export theme (academic / liber / a custom disk theme) is selected, enabling **Style ▸ Overwrite theme font** and setting Font Family / Size / Line height has **no effect** — the exported PDF/HTML keeps the theme's font instead of the user's. The whole point of that toggle is to override the theme, so this defeats the feature.

## Root cause

`getCssForOptions` (`packages/desktop/src/renderer/src/util/pdf.ts`) emitted the user's `.markdown-body { font-family / font-size / line-height }` override **before** the theme CSS. Export themes also set `.markdown-body` font rules, so at equal specificity the theme — appended later — wins the cascade and silently clobbers the override. All three properties live in the same `.markdown-body {}` block, so font size, line height, and family all break together.

Without a theme selected the output was already correct, which is why the bug only shows up with a non-default theme.

## Fix

Move the font-override block so it is emitted **after** the theme CSS. At equal specificity the later rule wins, so the user's font now overrides the theme. The `@media print` wrapping, the `.hf-container` font-family mirror, and the empty-block behaviour are unchanged; the no-theme output is byte-identical aside from ordering.

## Verification

- Reproduced across all export paths with a real browser (styled HTML, PDF print-media, and the real `printService` innerHTML-injection path): font override worked **without** a theme, broke **with** a theme (got `16px / 1.3` instead of the set `20px / 2.0`); after the fix the user's values win even with the academic theme.
- Added a regression test asserting the override appears after the theme's `.markdown-body` rule in the generated CSS.
- `pnpm -C packages/desktop exec vitest run test/unit/specs/pdf.spec.ts` — 16 passed
- `pnpm run lint` — 0 errors
- `pnpm run typecheck` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)