### PR TITLE
fix(desktop): auto-focus the editor when creating or opening a tab

### DIFF
--- a/packages/desktop/src/renderer/src/commands/index.ts
+++ b/packages/desktop/src/renderer/src/commands/index.ts
@@ -65,7 +65,7 @@ const commands: CommandDescriptor[] = [
   {
     id: 'file.new-tab',
     execute: async() => {
-      bus.emit('mt::new-untitled-tab', { selected: '', markdown: '' })
+      bus.emit('mt::new-untitled-tab', { selected: true, markdown: '' })
     }
   },
   {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1426,6 +1426,8 @@ const setMarkdownToEditor = (payload: unknown) => {
     // `json-change`, so seed the TOC explicitly (otherwise it stays empty until
     // the first edit, and a file switch keeps the previous file's TOC).
     editorStore.UPDATE_TOC(editor.value.getTOC())
+    // A freshly created/opened tab should be ready to type into.
+    focusFreshEditor()
   }
 }
 
@@ -1542,6 +1544,23 @@ const blurEditor = () => {
 
 const focusEditor = () => {
   editor.value?.focus()
+}
+
+// Focus a freshly opened/created tab's editor. The sibling `file-changed`
+// handler (emitted first, while the store commits the tab switch) hides the
+// editor and queues a `requestAnimationFrame` via `scrollToCords` to restore
+// it, and focus() is a no-op while the container is `visibility:hidden`. Our
+// rAF is registered after that restore rAF, so it runs once the editor is
+// visible; then take DOM focus (the engine's `focus()` only sets the selection
+// range — the contenteditable also needs focus or no caret blinks) and place
+// the caret at the document start.
+const focusFreshEditor = () => {
+  requestAnimationFrame(() => {
+    const ed = editor.value
+    if (!ed) return
+    ed.domNode.focus()
+    ed.focus()
+  })
 }
 
 // When a focus-trapping modal (the command palette) opens, release the editor's

--- a/packages/desktop/test/e2e/tabs.spec.ts
+++ b/packages/desktop/test/e2e/tabs.spec.ts
@@ -38,4 +38,40 @@ test.describe('Tab management', () => {
     const after = await page.locator(tabSelector).count()
     expect(after).toBeGreaterThan(before)
   })
+
+  test('Creating a new untitled tab auto-focuses the editor', async() => {
+    // Drop focus first so the assertion proves the NEW tab grabbed focus rather
+    // than inheriting a stale one from the previously active editor.
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+
+    const before = await page.locator(tabSelector).count()
+    await sendIpcToRenderer(app, 'mt::new-untitled-tab', true, '')
+    await page.waitForFunction(
+      ({ selector, prev }) => document.querySelectorAll(selector).length > prev,
+      { selector: tabSelector, prev: before },
+      { timeout: 5000 }
+    )
+
+    // A freshly created untitled tab auto-focuses the WYSIWYG editor: the
+    // contenteditable (`.editor-component`) becomes `document.activeElement`,
+    // AND a collapsed caret lands inside it — together that's the blinking
+    // cursor the user expects without having to click into the editor first.
+    const isFocusedWithCaret = () => {
+      const root = document.querySelector('.editor-component')
+      const active = document.activeElement
+      const sel = window.getSelection()
+      return (
+        !!root &&
+        !!active &&
+        (root === active || root.contains(active)) &&
+        !!sel &&
+        sel.rangeCount > 0 &&
+        sel.isCollapsed &&
+        !!sel.anchorNode &&
+        root.contains(sel.anchorNode)
+      )
+    }
+    await page.waitForFunction(isFocusedWithCaret, null, { timeout: 5000 })
+    expect(await page.evaluate(isFocusedWithCaret)).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

A newly created untitled tab showed no caret — you had to click into the editor before typing. This restores the pre-muya-migration behavior where a new tab is focused and ready to type.

### Root cause
`setMarkdownToEditor` (renderer `editor.vue`) sets the document content on `file-loaded` but never focused the editor. Two things made a naive `focus()` fail:

1. The engine's `focus()` only sets the selection **range**; the contenteditable container also needs explicit **DOM focus** or no caret blinks.
2. The sibling `file-changed` handler (emitted **first**, while the store commits the tab switch) hides the editor (`visibility:hidden`) and queues a `requestAnimationFrame` via `scrollToCords` to restore it. A `focus()` in the `file-loaded` handler runs while the element is still hidden, and `focus()` on a `visibility:hidden` element is silently dropped.

While tracing this, a separate latent bug surfaced: the command-palette / shortcut **New Tab** (`commands/index.ts`) emitted `selected: ''`. The empty string is falsy yet not `null`, so it slipped past the `selected == null` guard in `NEW_UNTITLED_TAB` and the tab was added **without being selected**.

### Changes
1. **`editor.vue`** — add `focusFreshEditor`, which defers focus to a single `requestAnimationFrame`. Because `file-changed` is emitted before `file-loaded`, that handler's visibility-restore rAF is registered first and runs first within the same frame, so our rAF fires once the editor is visible; it then takes DOM focus and places the caret at the document start. Called from `setMarkdownToEditor`.
2. **`commands/index.ts`** — `selected: '' → true` so the command-palette / shortcut New Tab selects the new tab like the toolbar `+` button.

## Testing
- New e2e test in `tabs.spec.ts` asserts that after creating an untitled tab the editor is `document.activeElement` **and** holds a collapsed caret — i.e. the blinking cursor the user expects without clicking first. Verified it **fails without** the fix and **passes with** it; ran `--repeat-each=5` to confirm the single-rAF timing is not flaky.
- `tabs` + `editor-input` + `launch` + `command-palette` + `view-modes` e2e: green.
- `pnpm typecheck` clean; lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)