### PR TITLE
fix(editor): restore undo after an external file reload

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1438,6 +1438,7 @@ interface FileChangePayload {
   scrollTop?: number
   muyaIndexCursor?: unknown
   blocks?: unknown
+  isReload?: boolean
 }
 
 // listen for markdown change form source mode or change tabs etc
@@ -1448,7 +1449,8 @@ const handleFileChange = (payload: unknown) => {
     cursor: newCursor,
     muyaIndexCursor,
     history: payloadHistory,
-    scrollTop
+    scrollTop,
+    isReload
   } = (payload ?? {}) as FileChangePayload
   if (!editor.value) return
   const container = getScrollContainer()
@@ -1486,6 +1488,28 @@ const handleFileChange = (payload: unknown) => {
       // Map the CodeMirror `{ line, ch }` cursor onto a block-key cursor so the
       // WYSIWYG caret lands where the source-mode cursor was (PG2).
       editor.value.setCursorByOffset(muyaIndexCursor)
+    } else if (isReload) {
+      // External disk reload (`loadChange`): the tab is already the live engine
+      // document, so record the new on-disk content as a SINGLE invertible undo
+      // boundary via `replaceContent` (legacy muyajs full-state-snapshot parity)
+      // — the first undo after the reload restores the pre-reload document in one
+      // step. `setContent` would clear the engine history and lose that boundary;
+      // restoring the per-tab engine history (the tab-switch path) would clobber
+      // it too. `replaceContent` preserves the existing undo stack and pushes the
+      // boundary on top.
+      //
+      // The new content is this tab's clean baseline (the store seeds
+      // `lastSavedHistoryId: 0`), so re-seed the save-tracking allocator BEFORE
+      // applying: `replaceContent` fires a SYNCHRONOUS `json-change` that would
+      // otherwise mark the tab dirty against the stale (pre-reload) baseline.
+      if (id) {
+        resetSyntheticHistory(id, newMarkdown)
+      }
+      editor.value.replaceContent(newMarkdown)
+      editorStore.UPDATE_TOC(editor.value.getTOC())
+      if (newCursor) {
+        applyCursor(editor.value, newCursor)
+      }
     } else {
       // Tab switch / programmatic content swap: `setContent` replaces the
       // document and clears history, so restore the real engine history (kept

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -391,7 +391,11 @@ export const useEditorStore = defineStore('editor', {
           cursor,
           renderCursor: true,
           history,
-          scrollTop
+          scrollTop,
+          // External disk reload: the engine handler records the new content as a
+          // single invertible undo boundary (replaceContent) instead of clearing
+          // history (setContent), so the first undo restores the pre-reload doc.
+          isReload: true
         })
       }
       debouncedSendBufferedState()

--- a/packages/desktop/test/e2e/external-reload-undo.spec.ts
+++ b/packages/desktop/test/e2e/external-reload-undo.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test'
+import {
+  launchWithMarkdown,
+  waitForMenuReady,
+  getMarkdownContent,
+  sendIpcToRenderer
+} from './helpers'
+
+// Trigger an editor undo through the same IPC channel the Edit › Undo menu item
+// uses (`mt::editor-edit-action` → bus `undo` → editor.undo()).
+const undo = async(app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> => {
+  await sendIpcToRenderer(app, 'mt::editor-edit-action', 'undo')
+}
+
+// Reproduce the watcher's external-change report: the same `mt::update-file`
+// payload shape the main-process watcher sends (a `loadMarkdownFile` result in
+// `change.data`). Drives the real renderer reload path
+// LISTEN_FOR_FILE_CHANGE → loadChange → bus `file-changed` → handleFileChange.
+const reportExternalChange = async(
+  app: Parameters<typeof sendIpcToRenderer>[0],
+  pathname: string,
+  markdown: string
+): Promise<void> => {
+  await sendIpcToRenderer(app, 'mt::update-file', {
+    type: 'change',
+    change: {
+      pathname,
+      mtimeMs: 1,
+      data: {
+        markdown,
+        filename: 'note.md',
+        pathname,
+        encoding: { encoding: 'utf8', hasBOM: false },
+        lineEnding: 'lf',
+        adjustLineEndingOnSave: false,
+        trimTrailingNewline: 1,
+        isMixedLineEndings: false
+      }
+    }
+  })
+}
+
+test.describe('External disk reload — undo restores the pre-change document', () => {
+  // Legacy muyajs kept a full-state snapshot of the pre-reload document so the
+  // first Ctrl+Z after an external reload restored it. The @muyajs/core reload
+  // path must record the same single invertible undo boundary (via
+  // `Muya.replaceContent`) instead of `setContent` (which clears history).
+  test('first undo after an external reload restores the old content', async() => {
+    const { app, page, filePath } = await launchWithMarkdown('old content here\n')
+    await waitForMenuReady(app)
+
+    // Auto-reload only applies silently when autoSave is on AND the tab is
+    // unmodified (a freshly-loaded tab is saved). Enable autoSave so the change
+    // applies without the manual "Reload" confirmation prompt.
+    await sendIpcToRenderer(app, 'mt::user-preference', { autoSave: true })
+    await page.waitForTimeout(100)
+
+    await reportExternalChange(app, filePath, 'new content here\n')
+    await page.waitForTimeout(600)
+
+    // The tab now reflects the new on-disk content...
+    expect((await getMarkdownContent(page, app)).trim()).toBe('new content here')
+    // ...and stays clean: the reloaded content matches the file on disk, so the
+    // tab must NOT be flagged unsaved (replaceContent fires a json-change that
+    // would otherwise mark it dirty against the stale baseline).
+    expect(await page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved'))).toBe(
+      false
+    )
+
+    // The first undo reverts the external change in one step, back to the
+    // document as it was before the reload.
+    await undo(app)
+    await page.waitForTimeout(600)
+    expect((await getMarkdownContent(page, app)).trim()).toBe('old content here')
+    // The undone document now diverges from on-disk content, so the tab is dirty.
+    await expect
+      .poll(() => page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved')))
+      .toBe(true)
+    await app.close()
+  })
+})


### PR DESCRIPTION
## Problem

When a file open in a tab is modified on disk by another program and reloaded, the first <kbd>Ctrl</kbd>+<kbd>Z</kbd> could no longer revert to the pre-reload document. This is a regression from the legacy `muyajs` engine, whose full-state-snapshot history let undo restore the previous content after an external reload.

### Root cause

The desktop store (`store/editor.ts` → `loadChange`) still builds a single-entry "undo → previous document" history and emits it on `file-changed`, but the `@muyajs/core` engine handler (`editorWithTabs/editor.vue` → `handleFileChange`) routed the external reload through the **tab-switch** branch, applying the new content via `setContent`. `setContent` clears the engine undo history, so the external change was never recorded as an undoable boundary. (The source-mode handoff path already used `replaceContent` for exactly this reason — the external-reload path just didn't.)

## Fix

- Tag the external-reload `file-changed` emit with `isReload` (`store/editor.ts`).
- Handle `isReload` separately in `handleFileChange` (`editor.vue`): apply the new content via `Muya.replaceContent`, which records the change as a **single invertible undo boundary** on top of the preserved per-tab history. The first undo now reverts the reload in one step.
- `replaceContent` fires a **synchronous** `json-change`, so re-seed the save-tracking allocator to the new content beforehand (the reloaded content is the tab's clean baseline, matching the store's `lastSavedHistoryId: 0`); otherwise the reloaded tab would be flagged unsaved against the stale baseline. Trailing-newline normalization is already stripped from the content signature, so engine newline normalization does not affect the clean baseline.

## Tests

New e2e `test/e2e/external-reload-undo.spec.ts` drives the real reload path (`mt::update-file` → `loadChange` → bus `file-changed` → `handleFileChange`) with the watcher's payload shape and asserts:

- after reload the tab shows the new on-disk content and stays **clean**;
- the first undo restores the **pre-reload** content in one step;
- after that undo the tab is **dirty** (the document now diverges from disk).

Written test-first (failed RED with `setContent`, passes GREEN with `replaceContent`).

### Verification

- `pnpm run test:e2e` — 112 passed / 0 failed (incl. PG14/PG15 undo + saved-indicator parity, no regression).
- `pnpm run test:unit` — 567 passed.
- `pnpm run typecheck` — clean.
- ESLint on changed files — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)