### PR TITLE
fix(editor): align code block line numbers vertically

### DIFF
--- a/packages/muya/src/utils/__tests__/codeBlockLineNumbers.spec.ts
+++ b/packages/muya/src/utils/__tests__/codeBlockLineNumbers.spec.ts
@@ -112,4 +112,37 @@ describe('repositionLineNumberSpans', () => {
 
         expect((wrapper.children[0] as HTMLElement).style.top).toBe('0px');
     });
+
+    it('anchors line numbers to the first line so the line-box leading cancels', () => {
+        const wrapper = document.createElement('span');
+        syncLineNumbersSpans(wrapper, 3);
+        const codeEl = document.createElement('code');
+        codeEl.appendChild(document.createTextNode('a\nb\nc'));
+
+        // happy-dom performs no layout. Emulate three stacked lines whose
+        // measured tops carry a constant line-box leading offset (110, 140,
+        // 170). The gutter must use the first line as its origin — not the
+        // wrapper rect — so that leading cancels and line 1 sits at 0px.
+        const tops = [110, 140, 170];
+        let call = 0;
+        const rangeProto = Range.prototype as unknown as {
+            getBoundingClientRect: () => { top: number };
+        };
+        const origRangeRect = rangeProto.getBoundingClientRect;
+        rangeProto.getBoundingClientRect = () => ({ top: tops[call++] });
+        // The wrapper's own rect must no longer influence the result.
+        (wrapper as unknown as { getBoundingClientRect: () => { top: number } })
+            .getBoundingClientRect = () => ({ top: 999 });
+
+        try {
+            repositionLineNumberSpans(wrapper, codeEl);
+        }
+        finally {
+            rangeProto.getBoundingClientRect = origRangeRect;
+        }
+
+        expect((wrapper.children[0] as HTMLElement).style.top).toBe('0px');
+        expect((wrapper.children[1] as HTMLElement).style.top).toBe('30px');
+        expect((wrapper.children[2] as HTMLElement).style.top).toBe('60px');
+    });
 });

--- a/packages/muya/src/utils/__tests__/codeBlockLineNumbers.spec.ts
+++ b/packages/muya/src/utils/__tests__/codeBlockLineNumbers.spec.ts
@@ -4,6 +4,7 @@ import {
     computeLineCount,
     LINE_NUMBERS_ROWS_CLASS,
     lineNumbersWrapperHTML,
+    repositionLineNumberSpans,
     syncLineNumbersSpans,
 } from '../codeBlockLineNumbers';
 
@@ -97,5 +98,18 @@ describe('syncLineNumbersSpans', () => {
         syncLineNumbersSpans(wrapper, 4);
         syncLineNumbersSpans(wrapper, 0);
         expect(wrapper.childElementCount).toBe(0);
+    });
+});
+
+describe('repositionLineNumberSpans', () => {
+    it('keeps the only line of an empty code block flush with the top', () => {
+        const wrapper = document.createElement('span');
+        syncLineNumbersSpans(wrapper, 1);
+        // An empty code element has no text nodes to measure from.
+        const codeEl = document.createElement('code');
+
+        repositionLineNumberSpans(wrapper, codeEl);
+
+        expect((wrapper.children[0] as HTMLElement).style.top).toBe('0px');
     });
 });

--- a/packages/muya/src/utils/codeBlockLineNumbers.ts
+++ b/packages/muya/src/utils/codeBlockLineNumbers.ts
@@ -90,13 +90,15 @@ export function repositionLineNumberSpans(
         node = walker.nextNode() as Text | null;
     }
 
-    // Trailing empty line after a final "\n": no text node to measure from.
-    // Place it one line-height below the previous span.
+    // Lines with no text node to measure from: the trailing empty line after a
+    // final "\n", or the single line of a wholly empty code block. The first
+    // line is always flush with the top; later ones stack one line-height below
+    // their predecessor.
     if (lineIdx < spans.length) {
-        const prevTop = lineIdx > 0 ? Number.parseFloat(spans[lineIdx - 1].style.top || '0') : 0;
         const lineH = Number.parseFloat(getComputedStyle(wrapper).lineHeight) || 24;
         for (let i = lineIdx; i < spans.length; i++) {
-            spans[i].style.top = `${prevTop + lineH}px`;
+            const prevTop = i > 0 ? Number.parseFloat(spans[i - 1].style.top || '0') : 0;
+            spans[i].style.top = i > 0 ? `${prevTop + lineH}px` : '0px';
         }
     }
 }

--- a/packages/muya/src/utils/codeBlockLineNumbers.ts
+++ b/packages/muya/src/utils/codeBlockLineNumbers.ts
@@ -53,7 +53,6 @@ export function repositionLineNumberSpans(
         return;
 
     const text = codeEl.textContent ?? '';
-    const wrapperTop = wrapper.getBoundingClientRect().top;
 
     // Global character offsets where each logical line begins.
     const lineStarts: number[] = [0];
@@ -68,6 +67,13 @@ export function repositionLineNumberSpans(
 
     let nodeStart = 0;
     let lineIdx = 0;
+    // Origin = the measured top of the first logical line. A collapsed range's
+    // rect top sits at the text/caret box (below the line-box leading), so
+    // subtracting the wrapper top would offset every number down by that
+    // constant leading. Anchoring to the first line cancels it and keeps line 1
+    // flush with the gutter top, while preserving correct per-line deltas for
+    // wrap mode.
+    let baseTop: number | null = null;
     let node = walker.nextNode() as Text | null;
 
     while (node !== null && lineIdx < lineStarts.length) {
@@ -80,9 +86,11 @@ export function repositionLineNumberSpans(
             const offsetInNode = lineStarts[lineIdx] - nodeStart;
             range.setStart(node, offsetInNode);
             range.collapse(true);
-            const top = range.getBoundingClientRect().top - wrapperTop;
+            const measured = range.getBoundingClientRect().top;
+            if (baseTop === null)
+                baseTop = measured;
             if (lineIdx < spans.length)
-                spans[lineIdx].style.top = `${top}px`;
+                spans[lineIdx].style.top = `${measured - baseTop}px`;
             lineIdx++;
         }
 


### PR DESCRIPTION
## Summary

Fixes two vertical-alignment bugs in the code-block line-number gutter (`@muyajs/core`), both rooted in `repositionLineNumberSpans`:

1. **Empty code block** — when a code block is just created (no text node to measure), the TreeWalker finds nothing and `lineIdx` stays `0`. The trailing-empty-line fallback then placed the only line number one full line-height below a non-existent predecessor, so the "1" rendered a row too low. Fixed by treating the first line as flush with the gutter top (`0px`); only later trailing lines stack a line-height below their predecessor.

2. **Non-empty code block** — a collapsed range's `getBoundingClientRect().top` sits at the text/caret box, which is below the line-box top by the line-box leading (~0.3em). Positioning each span as `range.top - wrapperTop` pushed every number down by that constant leading, so numbers didn't line up with their code rows. Fixed by anchoring every span to the **first measured line's top** instead of the wrapper top — the constant leading cancels, line 1 stays flush (matching the empty case), and per-line deltas are preserved so wrap mode still aligns.

This mirrors the legacy `muyajs` gutter, which anchored line numbers to the code's first line rather than an outer wrapper.

## Before / After

- Before: line "1" in an empty block, and every line number once code is typed, render ~one row / ~0.3em too low.
- After: line numbers align with their corresponding code rows (and the empty first line).

## Testing

- Added two unit tests in `codeBlockLineNumbers.spec.ts` (written TDD, fail before the fix):
  - empty block → first line number at `0px`
  - leading cancellation → spans anchored to the first line (`0 / 30 / 60px`), wrapper rect ignored
- `pnpm -C packages/muya test` (codeBlockLineNumbers + lineNumbersGutter specs), `lint`, and `lint:types` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)