### PR TITLE
fix(editor): keep spelling suggestions when "no underline" is enabled

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -765,8 +765,9 @@ watch(spellcheckerEnabled, (value, oldValue) => {
 
 watch(spellcheckerNoUnderline, (value, oldValue) => {
   if (value !== oldValue) {
-    // Set Muya's spellcheck container attribute.
-    editor.value.setOptions({ spellcheckEnabled: !value })
+    // Hide only the spelling squiggle; the native checker (and its right-click
+    // suggestions) stays controlled by `spellcheckerEnabled`.
+    editor.value.setOptions({ spellcheckHideMarks: value })
   }
 })
 
@@ -1691,6 +1692,7 @@ onMounted(() => {
     sequenceTheme: sequenceTheme.value,
     plantumlServer: preferencesStore.plantumlServer,
     spellcheckEnabled: spellcheckerEnabled.value,
+    spellcheckHideMarks: spellcheckerNoUnderline.value,
     // Resolve the OS clipboard to a local file path on paste (image-from-file).
     clipboardFilePath: guessClipboardFilePath,
     // Read the OS clipboard's plain text for "Paste as Plain Text" (execCommand('paste') no longer fires).

--- a/packages/muya/src/__tests__/spellcheckOptions.spec.ts
+++ b/packages/muya/src/__tests__/spellcheckOptions.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../config';
+import { Muya } from '../muya';
+
+// `spellcheckEnabled` (native check + right-click suggestions) and
+// `spellcheckHideMarks` (hide the squiggle only) must be INDEPENDENT engine
+// options. Historically the desktop "no underline" preference reused
+// `spellcheckEnabled`, so hiding the underline also disabled the native
+// checker and killed context-menu suggestions. These assertions pin the
+// decoupled behaviour: one toggles the container `spellcheck` attribute, the
+// other toggles a container class, and neither touches the other.
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('spellcheck options decoupling', () => {
+    it('spellcheckEnabled only toggles the container spellcheck attribute', () => {
+        const muya = bootMuya('helllo wrold\n');
+        const node = muya.domNode;
+
+        muya.setOptions({ spellcheckEnabled: true });
+        expect(node.getAttribute('spellcheck')).toBe('true');
+        expect(node.classList.contains(CLASS_NAMES.MU_HIDE_SPELLING_MARKS)).toBe(false);
+
+        muya.setOptions({ spellcheckEnabled: false });
+        expect(node.getAttribute('spellcheck')).toBe('false');
+        expect(node.classList.contains(CLASS_NAMES.MU_HIDE_SPELLING_MARKS)).toBe(false);
+    });
+
+    it('spellcheckHideMarks only toggles the hide-marks class, never the spellcheck attribute', () => {
+        const muya = bootMuya('helllo wrold\n');
+        const node = muya.domNode;
+
+        // Enable native checking first; hiding marks must not disturb it.
+        muya.setOptions({ spellcheckEnabled: true });
+        expect(node.getAttribute('spellcheck')).toBe('true');
+
+        muya.setOptions({ spellcheckHideMarks: true });
+        expect(node.classList.contains(CLASS_NAMES.MU_HIDE_SPELLING_MARKS)).toBe(true);
+        // Native checker stays on => right-click suggestions still work.
+        expect(node.getAttribute('spellcheck')).toBe('true');
+
+        muya.setOptions({ spellcheckHideMarks: false });
+        expect(node.classList.contains(CLASS_NAMES.MU_HIDE_SPELLING_MARKS)).toBe(false);
+        expect(node.getAttribute('spellcheck')).toBe('true');
+    });
+
+    it('the two options compose for the "check but no underline" state', () => {
+        const muya = bootMuya('helllo wrold\n');
+        const node = muya.domNode;
+
+        muya.setOptions({ spellcheckEnabled: true, spellcheckHideMarks: true });
+        expect(node.getAttribute('spellcheck')).toBe('true');
+        expect(node.classList.contains(CLASS_NAMES.MU_HIDE_SPELLING_MARKS)).toBe(true);
+    });
+});

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -2,6 +2,13 @@
     outline: none;
 }
 
+/* Hide the native spelling squiggle while keeping `spellcheck="true"`, so the
+   native checker and its right-click suggestions stay active. Toggled by the
+   `spellcheckHideMarks` option. */
+.mu-hide-spelling-marks ::spelling-error {
+    text-decoration: none !important;
+}
+
 .mu-container {
     box-sizing: border-box;
     max-width: var(--editor-area-width, 800px);

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -121,6 +121,7 @@ export const CLASS_NAMES = genUpper2LowerKeyHash([
     'MU_LINE_END',
     'MU_HEADER_TIGHT_SPACE',
     'MU_HIDE',
+    'MU_HIDE_SPELLING_MARKS',
     'MU_HIGHLIGHT',
     'MU_HTML_BLOCK',
     'MU_HTML_ESCAPE',
@@ -332,6 +333,10 @@ export const MUYA_DEFAULT_OPTIONS = {
     // NOTE: The browser is not able to correct misspelled words words without a custom
     // implementation like in MarkText.
     spellcheckEnabled: false,
+    // Hide the native spelling squiggle via CSS while keeping `spellcheckEnabled`
+    // (and thus the native checker + right-click suggestions) active. Independent
+    // of `spellcheckEnabled`.
+    spellcheckHideMarks: false,
     // Markdown extensions
     frontMatter: true, // Whether to support frontmatter.
     superSubScript: true,

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -362,6 +362,13 @@ export class Muya {
         if ('spellcheckEnabled' in options)
             this.domNode.setAttribute('spellcheck', options.spellcheckEnabled ? 'true' : 'false');
 
+        if ('spellcheckHideMarks' in options) {
+            this.domNode.classList.toggle(
+                CLASS_NAMES.MU_HIDE_SPELLING_MARKS,
+                !!options.spellcheckHideMarks,
+            );
+        }
+
         if ('hideQuickInsertHint' in options) {
             this.domNode.classList.toggle(
                 CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT,
@@ -1740,7 +1747,7 @@ export class Muya {
  * [ensureContainerDiv ensure container element is div]
  */
 function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
-    const { spellcheckEnabled, hideQuickInsertHint, focusMode } = options;
+    const { spellcheckEnabled, spellcheckHideMarks, hideQuickInsertHint, focusMode } = options;
     const newContainer = document.createElement('div');
     const attrs = originContainer.attributes;
     // Copy attrs from origin container to new container
@@ -1750,6 +1757,9 @@ function getContainer(originContainer: HTMLElement, options: IMuyaOptions) {
 
     if (!hideQuickInsertHint)
         newContainer.classList.add(CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT);
+
+    if (spellcheckHideMarks)
+        newContainer.classList.add(CLASS_NAMES.MU_HIDE_SPELLING_MARKS);
 
     // Apply focus mode at construction when initially enabled; `setFocusMode`
     // toggles it thereafter.

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -24,6 +24,7 @@ export interface IMuyaOptions {
     hideLinkPopup: boolean;
     autoCheck: boolean;
     spellcheckEnabled: boolean;
+    spellcheckHideMarks: boolean;
     superSubScript: boolean;
     footnote: boolean;
     math: boolean;


### PR DESCRIPTION
## Problem

Enabling **Preferences → Spelling → "Hide marks for spelling errors"** (`spellcheckerNoUnderline`) also removed the **right-click spelling suggestions**, not just the squiggle.

### Root cause

Both the `spellcheckerEnabled` and `spellcheckerNoUnderline` watchers wrote the **same** engine option `spellcheckEnabled`, which maps to the editor container's `spellcheck` DOM attribute:

```js
// no-underline watcher (before)
editor.setOptions({ spellcheckEnabled: !value })
```

So turning "no underline" on set `spellcheck="false"`, which disables Chromium's native checker — the sole source of `params.misspelledWord` / `dictionarySuggestions` that populate the context menu. Underline and suggestions were coupled to one attribute.

This is **not** a regression from the muyajs → `@muyajs/core` engine swap (both engines map `spellcheckEnabled` to the attribute identically). It dates back to **#2895 (2021)**, when the custom node-spellchecker (which drew its own underlines and kept a "passive mode") was replaced by Electron's builtin checker.

## Fix

Decouple the two concerns into **independent** options:

- **muya:** new `spellcheckHideMarks` option toggles a `mu-hide-spelling-marks` class on the container. A CSS rule clears the native squiggle via the highlight pseudo-element while keeping `spellcheck="true"`:
  ```css
  .mu-hide-spelling-marks ::spelling-error { text-decoration: none !important; }
  ```
- **desktop:** the `spellcheckerNoUnderline` preference now drives `spellcheckHideMarks` (seeded at editor construction too), so the two spelling preferences no longer fight over `spellcheckEnabled`.

Resulting semantics:

| enabled | no-underline | behavior |
|---|---|---|
| false | * | no check, no underline, no suggestions |
| true | false | check + underline + suggestions |
| true | true | check + **no underline** + suggestions ✅ |

## Verification

- New muya unit tests assert the two options are independent: `spellcheckEnabled` only toggles the `spellcheck` attribute, `spellcheckHideMarks` only toggles the class and never touches the attribute.
- Mechanism verified in **Electron 42's Chromium** via a throwaway harness: `::spelling-error` applies to native-spellcheck-flagged words, `text-decoration: none` removes the squiggle, and the `spellcheck` attribute stays `true` so context-menu suggestions remain.
- Manual QA confirmed: with both options on, no squiggle but right-click suggestions still appear.
- `pnpm -C packages/muya test` (1110 passing), muya typecheck/eslint, and desktop typecheck/eslint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)