### PR TITLE
fix(clipboard): copy only the selected part of cross-block selections

### DIFF
--- a/packages/muya/src/clipboard/__tests__/copyCrossBlockLeaf.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyCrossBlockLeaf.spec.ts
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// Cross-block copy with a leaf-block endpoint (heading / code-block):
+//  - an atx heading's `# ` marker rides along in the selected text and is
+//    dropped only when the selection starts past it (paragraph either way);
+//  - a code-block endpoint keeps its fence + language and truncates its body
+//    to the caret instead of dumping the whole block.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function stub(muya: Muya, ab: Content, ao: number, fb: Content, fo: number) {
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: ao, block: ab, path: ab.path },
+        focus: { offset: fo, block: fb, path: fb.path },
+        isCollapsed: false,
+        isSelectionInSameBlock: false,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+describe('cross-block copy with an atx-heading endpoint', () => {
+    it('keeps the whole heading (with marker) when selected from its start', () => {
+        const muya = bootMuya('# Heading\n\npara\n');
+        const sp = muya.editor.scrollPage!;
+        const heading = sp.firstContentInDescendant()!;
+        const para = sp.lastContentInDescendant()!;
+        // from offset 0 of "# Heading" through "pa"
+        stub(muya, heading, 0, para, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        // marker rides in the text; re-parses to a heading on paste
+        expect(text).toBe('# Heading\n\npa\n');
+    });
+
+    it('drops the marker when the selection starts after it', () => {
+        const muya = bootMuya('# Heading\n\npara\n');
+        const sp = muya.editor.scrollPage!;
+        const heading = sp.firstContentInDescendant()!;
+        const para = sp.lastContentInDescendant()!;
+        // from offset 2 ("# |Heading") through "pa"
+        stub(muya, heading, 2, para, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        expect(text).toBe('Heading\n\npa\n');
+    });
+});
+
+describe('cross-block copy with a setext-heading endpoint', () => {
+    it('keeps the whole setext heading when selected from its start', () => {
+        const muya = bootMuya('Heading\n===\n\npara\n');
+        const sp = muya.editor.scrollPage!;
+        const heading = sp.firstContentInDescendant()!;
+        const para = sp.lastContentInDescendant()!;
+        stub(muya, heading, 0, para, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        expect(text).toBe('Heading\n===\n\npa\n');
+    });
+
+    it('keeps the heading (underline from meta) on a partial selection', () => {
+        const muya = bootMuya('Heading\n===\n\npara\n');
+        const sp = muya.editor.scrollPage!;
+        const heading = sp.firstContentInDescendant()!;
+        const para = sp.lastContentInDescendant()!;
+        // from offset 2 ("He|ading") through "pa"
+        stub(muya, heading, 2, para, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        expect(text).toBe('ading\n===\n\npa\n');
+    });
+});
+
+describe('cross-block copy with a code-block endpoint', () => {
+    it('truncates the code body to the caret and keeps the fence + language', () => {
+        const muya = bootMuya('para\n\n```js\nconst a = 1\n```\n');
+        const sp = muya.editor.scrollPage!;
+        const para = sp.firstContentInDescendant()!;
+        const codeBody = sp.lastContentInDescendant()!;
+        // from "pa" of para to after "co" in the code body
+        stub(muya, para, 2, codeBody, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        expect(text).toBe('ra\n\n```js\nco\n```\n');
+    });
+
+    it('keeps the whole code block when its body is fully selected', () => {
+        const muya = bootMuya('para\n\n```js\nconst a = 1\n```\n');
+        const sp = muya.editor.scrollPage!;
+        const para = sp.firstContentInDescendant()!;
+        const codeBody = sp.lastContentInDescendant()!;
+        stub(muya, para, 2, codeBody, codeBody.text.length);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+        expect(text).toBe('ra\n\n```js\nconst a = 1\n```\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/copyCrossBlockList.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyCrossBlockList.spec.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// A cross-block copy/cut whose endpoint lands partway inside a list item must
+// carry only the selected portion of that item, not the whole item. Regression:
+// the list branch of `appendPartialState` sliced list items by index but never
+// truncated the boundary item's text — so selecting up to "ba|" in `- bar`
+// copied the whole `- bar`.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function stubCrossSelection(
+    muya: Muya,
+    anchorBlock: Content,
+    anchorOffset: number,
+    focusBlock: Content,
+    focusOffset: number,
+) {
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: anchorOffset, block: anchorBlock, path: anchorBlock.path },
+        focus: { offset: focusOffset, block: focusBlock, path: focusBlock.path },
+        isCollapsed: false,
+        isSelectionInSameBlock: false,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+describe('cross-block copy into a trailing list', () => {
+    it('copies only the selected head of the last list item, not the whole item', () => {
+        const muya = bootMuya('foo\n\n- bar\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const fooContent = scrollPage.firstContentInDescendant()!;
+        const barContent = scrollPage.lastContentInDescendant()!;
+
+        // anchor after "f" in foo, focus after "ba" inside the list item
+        stubCrossSelection(muya, fooContent, 1, barContent, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('oo\n\n- ba\n');
+    });
+
+    it('preserves earlier fully-selected items and truncates only the boundary item', () => {
+        const muya = bootMuya('foo\n\n- one\n- two\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const fooContent = scrollPage.firstContentInDescendant()!;
+        const twoContent = scrollPage.lastContentInDescendant()!;
+
+        // anchor after "f" in foo, focus after "t" inside the second item
+        stubCrossSelection(muya, fooContent, 1, twoContent, 1);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('oo\n\n- one\n- t\n');
+    });
+});
+
+describe('cross-block copy out of a leading list', () => {
+    it('copies the selected tail of the first list item', () => {
+        const muya = bootMuya('- bar\n\nfoo\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const barContent = scrollPage.firstContentInDescendant()!;
+        const fooContent = scrollPage.lastContentInDescendant()!;
+
+        // anchor after "ba" inside the list item, focus after "f" in foo
+        stubCrossSelection(muya, barContent, 2, fooContent, 1);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('- r\n\nf\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/copyCrossBlockQuote.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyCrossBlockQuote.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// A cross-block copy/cut whose endpoint lands partway inside a trailing
+// block-quote must carry only the selected head of the quote, not the whole
+// quote. Regression: `appendPartialState` pushed the entire block-quote state
+// for any block-quote endpoint, ignoring the caret offset — so selecting up to
+// "gam|" inside `> gamma` copied the whole `> gamma`.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function stubCrossSelection(
+    muya: Muya,
+    anchorBlock: Content,
+    anchorOffset: number,
+    focusBlock: Content,
+    focusOffset: number,
+) {
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: anchorOffset, block: anchorBlock, path: anchorBlock.path },
+        focus: { offset: focusOffset, block: focusBlock, path: focusBlock.path },
+        isCollapsed: false,
+        isSelectionInSameBlock: false,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+describe('cross-block copy into a trailing block-quote', () => {
+    it('copies only the selected head of the quote, not the whole quote', () => {
+        const muya = bootMuya('alpha\n\n- one\n- two\n\n> gamma\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const alphaContent = scrollPage.firstContentInDescendant()!;
+        const gammaContent = scrollPage.lastContentInDescendant()!;
+
+        // anchor after "al" in alpha, focus after "gam" inside the quote
+        stubCrossSelection(muya, alphaContent, 2, gammaContent, 3);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('pha\n\n- one\n- two\n\n> gam\n');
+    });
+
+    it('copies the selected tail of a leading block-quote, not the whole quote', () => {
+        const muya = bootMuya('> alpha\n\n- one\n- two\n\ngamma\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const alphaContent = scrollPage.firstContentInDescendant()!;
+        const gammaContent = scrollPage.lastContentInDescendant()!;
+
+        // anchor after "al" inside the leading quote, focus after "gam" in gamma
+        stubCrossSelection(muya, alphaContent, 2, gammaContent, 3);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('> pha\n\n- one\n- two\n\ngam\n');
+    });
+});

--- a/packages/muya/src/clipboard/__tests__/copyWithinContainer.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/copyWithinContainer.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../block/base/content';
+import type { Muya } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../muya';
+import { SelectionCaretType, SelectionDirection } from '../../selection/types';
+
+// Copying a multi-leaf selection that stays inside a single list or block-quote
+// must truncate both boundary items to the caret, not carry whole items / the
+// whole quote. Regression: `collectSameOutMostBlockState` pushed the whole
+// block-quote and sliced list items by index without truncating their text.
+
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function stubCrossSelection(
+    muya: Muya,
+    anchorBlock: Content,
+    anchorOffset: number,
+    focusBlock: Content,
+    focusOffset: number,
+) {
+    muya.editor.selection.getSelection = () => ({
+        anchor: { offset: anchorOffset, block: anchorBlock, path: anchorBlock.path },
+        focus: { offset: focusOffset, block: focusBlock, path: focusBlock.path },
+        isCollapsed: false,
+        isSelectionInSameBlock: false,
+        direction: SelectionDirection.FORWARD,
+        type: SelectionCaretType.RANGE,
+    });
+}
+
+describe('copy within a single list', () => {
+    it('truncates both boundary items and keeps fully-selected middle items', () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const oneContent = scrollPage.firstContentInDescendant()!;
+        const threeContent = scrollPage.lastContentInDescendant()!;
+
+        // after "o" in "one" to after "th" in "three"
+        stubCrossSelection(muya, oneContent, 1, threeContent, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('- ne\n- two\n- th\n');
+    });
+});
+
+describe('copy within a single block-quote', () => {
+    it('truncates both boundary paragraphs, not the whole quote', () => {
+        const muya = bootMuya('> alpha\n>\n> beta\n');
+        const scrollPage = muya.editor.scrollPage!;
+
+        const alphaContent = scrollPage.firstContentInDescendant()!;
+        const betaContent = scrollPage.lastContentInDescendant()!;
+
+        // after "al" in "alpha" to after "be" in "beta"
+        stubCrossSelection(muya, alphaContent, 2, betaContent, 2);
+
+        const { text } = muya.editor.clipboard.getClipboardData();
+
+        expect(text).toBe('> pha\n>\n> be\n');
+    });
+});

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -245,25 +245,39 @@ function appendPartialState(
         return;
     }
 
-    // Atomic blocks (code-block, html-block, table, math-block, frontmatter,
-    // diagram) are copied whole.
+    const truncated
+        = position === 'start'
+            ? block.text.substring(offset)
+            : block.text.substring(0, offset);
+
+    // Blocks whose marker lives in meta, not in the text: setext heading (its
+    // `===`/`---` underline) and the code-family (code-block, html-block,
+    // math-block, frontmatter, diagram fences/wrappers). Keep the block's own
+    // type + meta and truncate only its text — the serializer rebuilds the
+    // marker from meta. A fully-selected endpoint keeps the whole block. A code
+    // fence's language line has no place in the body text, so copy it whole.
     if (
-        /code-block|html-block|table|math-block|frontmatter|diagram/.test(
-            outBlock!.blockName,
-        )
+        /setext-heading|code-block|html-block|math-block|frontmatter|diagram/.test(outBlock!.blockName)
+        && block.blockName !== 'language-input'
     ) {
+        if (truncated.length === 0)
+            return;
+        copyState.push({ ...(outBlock as Parent).getState(), text: truncated } as TState);
+
+        return;
+    }
+
+    // A table, or a code fence's language line, is copied whole.
+    if (outBlock!.blockName === 'table' || block.blockName === 'language-input') {
         copyState.push((outBlock as Parent).getState());
 
         return;
     }
 
-    // Paragraph, headings and thematic-break: emit the selected substring as a
+    // Paragraph, atx/setext heading and thematic-break: emit the substring as a
     // paragraph. An atx heading's `# ` marker lives in the text, so it rides
-    // along when selected (and re-parses to a heading on paste).
-    const truncated
-        = position === 'start'
-            ? block.text.substring(offset)
-            : block.text.substring(0, offset);
+    // along when selected (and re-parses to a heading on paste) and is dropped
+    // when the selection starts after it — matching the in-place cut.
     if (truncated.length === 0)
         return;
 

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -3,16 +3,10 @@ import type Parent from '../block/base/parent';
 import type TreeNode from '../block/base/treeNode';
 import type { Muya } from '../muya';
 import type { ISelection } from '../selection/types';
-import type {
-    IBulletListState,
-    IOrderListState,
-    ITaskListState,
-    TState,
-} from '../state/types';
+import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import type Clipboard from './index';
 import StateToMarkdown from '../state/stateToMarkdown';
-import { isAnyListState } from '../state/types';
 import { getClipBoardHtml, getSanitizeClipboardHtml } from '../utils/marked';
 import { CopyType } from './types';
 
@@ -47,35 +41,6 @@ function buildHtmlOptions(options: Muya['options']) {
     } = options;
 
     return { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript };
-}
-
-// Collapse the three list flavours (task/order/bullet) into one slice
-// operation. `keep` decides which list items survive by index; the discriminated
-// union is rebuilt per-branch so each `children` array keeps its concrete type.
-function sliceListState(
-    listState: IOrderListState | IBulletListState | ITaskListState,
-    keep: (index: number) => boolean,
-): IOrderListState | IBulletListState | ITaskListState {
-    switch (listState.name) {
-        case 'task-list':
-            return {
-                name: 'task-list',
-                meta: listState.meta,
-                children: listState.children.filter((_, index) => keep(index)),
-            };
-        case 'order-list':
-            return {
-                name: 'order-list',
-                meta: listState.meta,
-                children: listState.children.filter((_, index) => keep(index)),
-            };
-        default:
-            return {
-                name: 'bullet-list',
-                meta: listState.meta,
-                children: listState.children.filter((_, index) => keep(index)),
-            };
-    }
 }
 
 /**
@@ -134,6 +99,129 @@ function resolveSelectionOrder(
     };
 }
 
+// Truncate a leaf block's state (paragraph, heading, …) to the selected side
+// of `offset`. Keeps the head (`0..offset`) for an end edge, the tail
+// (`offset..`) for a start edge.
+function truncateLeafState(
+    leafState: TState,
+    leaf: Content,
+    offset: number,
+    position: 'start' | 'end',
+): TState {
+    const text
+        = position === 'start'
+            ? leaf.text.substring(offset)
+            : leaf.text.substring(0, offset);
+
+    return { ...leafState, text } as TState;
+}
+
+// Build the partial state of a container (block-quote and any nested
+// containers) for whichever edge `position` names: keep the sibling blocks on
+// the selected side of the boundary leaf, recurse into the boundary child, and
+// truncate the boundary leaf's own text. Mirrors the legacy DOM-selection
+// serialization, which carried only the selected portion of a quote.
+function buildPartialContainerState(
+    container: Parent,
+    leaf: Content,
+    offset: number,
+    position: 'start' | 'end',
+): TState {
+    const fullState = container.getState() as TState & { children?: TState[] };
+    const childStates = fullState.children;
+    if (childStates == null)
+        return truncateLeafState(fullState, leaf, offset, position);
+
+    const childBlocks = container.children.map(child => child);
+    const idx = childBlocks.findIndex(
+        child => child === leaf || leaf.isInBlock(child as Parent),
+    );
+    if (idx < 0)
+        return fullState;
+
+    const boundaryChild = childBlocks[idx];
+    const boundaryFullState = childStates[idx] as TState & { children?: TState[] };
+    const boundaryState
+        = boundaryFullState.children != null
+            ? buildPartialContainerState(boundaryChild as Parent, leaf, offset, position)
+            : truncateLeafState(boundaryFullState, leaf, offset, position);
+
+    const keptChildren
+        = position === 'start'
+            ? [boundaryState, ...childStates.slice(idx + 1)]
+            : [...childStates.slice(0, idx), boundaryState];
+
+    return { ...fullState, children: keptChildren } as TState;
+}
+
+// Build the partial state of a container when BOTH selection boundaries stay
+// inside it (e.g. selecting across items of one list, or paragraphs of one
+// block-quote): keep the children between the two boundary leaves, truncate
+// both boundary leaves to the caret, and recurse into nested containers.
+function buildRangeContainerState(
+    container: Parent,
+    startLeaf: Content,
+    startOffset: number,
+    endLeaf: Content,
+    endOffset: number,
+): TState {
+    const fullState = container.getState() as TState & { children?: TState[] };
+    const childStates = fullState.children;
+    if (childStates == null) {
+        // A leaf-text block with both boundaries in the same content leaf:
+        // truncate to the selected span. When the boundaries are in different
+        // leaves of the same block (e.g. a code fence's language line and its
+        // body), there is no single text to slice — copy the whole block.
+        if (startLeaf !== endLeaf)
+            return fullState;
+
+        return {
+            ...fullState,
+            text: startLeaf.text.substring(startOffset, endOffset),
+        } as TState;
+    }
+
+    const childBlocks = container.children.map(child => child);
+    const startIdx = childBlocks.findIndex(
+        child => child === startLeaf || startLeaf.isInBlock(child as Parent),
+    );
+    const endIdx = childBlocks.findIndex(
+        child => child === endLeaf || endLeaf.isInBlock(child as Parent),
+    );
+    if (startIdx < 0 || endIdx < 0)
+        return fullState;
+
+    // Both boundaries share a child: recurse into it (or truncate it if it is a
+    // leaf block holding text directly).
+    if (startIdx === endIdx) {
+        const child = childBlocks[startIdx];
+        const childFull = childStates[startIdx] as TState & { children?: TState[] };
+        const childState
+            = childFull.children != null
+                ? buildRangeContainerState(child as Parent, startLeaf, startOffset, endLeaf, endOffset)
+                : { ...childFull, text: startLeaf.text.substring(startOffset, endOffset) } as TState;
+
+        return { ...fullState, children: [childState] } as TState;
+    }
+
+    const startChildFull = childStates[startIdx] as TState & { children?: TState[] };
+    const startState
+        = startChildFull.children != null
+            ? buildPartialContainerState(childBlocks[startIdx] as Parent, startLeaf, startOffset, 'start')
+            : truncateLeafState(startChildFull, startLeaf, startOffset, 'start');
+
+    const endChildFull = childStates[endIdx] as TState & { children?: TState[] };
+    const endState
+        = endChildFull.children != null
+            ? buildPartialContainerState(childBlocks[endIdx] as Parent, endLeaf, endOffset, 'end')
+            : truncateLeafState(endChildFull, endLeaf, endOffset, 'end');
+
+    return {
+        ...fullState,
+        children: [startState, ...childStates.slice(startIdx + 1, endIdx), endState],
+    } as TState;
+}
+
 // Handle the start / end outmost block of a cross-block selection, pushing the
 // partial state for whichever edge `position` names.
 function appendPartialState(
@@ -144,81 +232,67 @@ function appendPartialState(
     const { startOutBlock, endOutBlock, startBlock, endBlock, startOffset, endOffset } = order;
     const outBlock = position === 'start' ? startOutBlock : endOutBlock;
     const block = position === 'start' ? startBlock : endBlock;
-    // Handle anchor and focus in different blocks
+    const offset = position === 'start' ? startOffset : endOffset;
+
+    // A block-quote or list endpoint is partially selected: carry only the
+    // selected side of the container, with the boundary item's own text
+    // truncated to the caret, rather than the whole container/item.
+    if (/block-quote|bullet-list|order-list|task-list/.test(outBlock!.blockName)) {
+        copyState.push(
+            buildPartialContainerState(outBlock as Parent, block, offset, position),
+        );
+
+        return;
+    }
+
+    // Atomic blocks (code-block, html-block, table, math-block, frontmatter,
+    // diagram) are copied whole.
     if (
-        /block-quote|code-block|html-block|table|math-block|frontmatter|diagram/.test(
+        /code-block|html-block|table|math-block|frontmatter|diagram/.test(
             outBlock!.blockName,
         )
     ) {
         copyState.push((outBlock as Parent).getState());
+
+        return;
     }
-    else if (/bullet-list|order-list|task-list/.test(outBlock!.blockName)) {
-        const listItemBlockName
-            = outBlock!.blockName === 'task-list' ? 'task-list-item' : 'list-item';
-        const listItem = block.farthestBlock(listItemBlockName);
-        const offset = (outBlock as Parent).offset(listItem!);
-        // outBlock is a list parent at runtime; getState() returns a
-        // bullet/order/task-list state whose `children` is an
-        // IListItemState/ITaskListItemState array. Narrow via the
-        // discriminated-union guard before slicing.
-        const listState = (outBlock as Parent).getState();
-        if (isAnyListState(listState)) {
-            copyState.push(
-                sliceListState(listState, index =>
-                    position === 'start' ? index >= offset : index <= offset),
-            );
-        }
-    }
-    else {
-        if (position === 'start' && startOffset < startBlock.text.length) {
-            copyState.push({
-                name: 'paragraph',
-                text: startBlock.text.substring(startOffset),
-            });
-        }
-        else if (position === 'end' && endOffset > 0) {
-            copyState.push({
-                name: 'paragraph',
-                text: endBlock.text.substring(0, endOffset),
-            });
-        }
-    }
+
+    // Paragraph, headings and thematic-break: emit the selected substring as a
+    // paragraph. An atx heading's `# ` marker lives in the text, so it rides
+    // along when selected (and re-parses to a heading on paste).
+    const truncated
+        = position === 'start'
+            ? block.text.substring(offset)
+            : block.text.substring(0, offset);
+    if (truncated.length === 0)
+        return;
+
+    copyState.push({ name: 'paragraph', text: truncated });
 }
 
 function collectSameOutMostBlockState(order: ICopyOrder): TState[] {
-    const { anchorOutMostBlock, anchorBlock, focusBlock } = order;
+    const { anchorOutMostBlock, startBlock, endBlock, startOffset, endOffset } = order;
     const copyState: TState[] = [];
 
-    // Handle anchor and focus in same list\quote block
-    if (/block-quote|table/.test(anchorOutMostBlock!.blockName)) {
+    // A table is copied whole (its own cross-cell selection path handles
+    // partial rectangles elsewhere).
+    if (anchorOutMostBlock!.blockName === 'table') {
         copyState.push((anchorOutMostBlock as Parent).getState());
 
         return copyState;
     }
 
-    const listItemBlockName
-        = anchorOutMostBlock!.blockName === 'task-list'
-            ? 'task-list-item'
-            : 'list-item';
-    const anchorFarthestListItem = anchorBlock.farthestBlock(listItemBlockName);
-    const focusFarthestListItem = focusBlock.farthestBlock(listItemBlockName);
-    const anchorOffset = (anchorOutMostBlock as Parent).offset(
-        anchorFarthestListItem!,
+    // List or block-quote: keep only the selected range, with both boundary
+    // items/paragraphs truncated to the caret.
+    copyState.push(
+        buildRangeContainerState(
+            anchorOutMostBlock as Parent,
+            startBlock,
+            startOffset,
+            endBlock,
+            endOffset,
+        ),
     );
-    const focusOffset = (anchorOutMostBlock as Parent).offset(
-        focusFarthestListItem!,
-    );
-    const minOffset = Math.min(anchorOffset, focusOffset);
-    const maxOffset = Math.max(anchorOffset, focusOffset);
-    const listState = (anchorOutMostBlock as Parent).getState();
-    if (isAnyListState(listState)) {
-        copyState.push(
-            sliceListState(
-                listState,
-                index => index >= minOffset && index <= maxOffset,
-            ),
-        );
-    }
 
     return copyState;
 }


### PR DESCRIPTION
## Problem

Cutting or copying a selection that **spans multiple blocks** put too much on the clipboard whenever an endpoint landed *partway inside* a non-paragraph block. The document side of the cut was correct, but the clipboard (what you paste) carried whole blocks/items instead of the selected portion.

Reported cases:
- Select from `alpha` into a list down to `> gam|ma` (block-quote) → clipboard contained the whole `> gamma`.
- `foo` + `- bar`, select `oo\n\n- ba` → clipboard contained `oo\n\n- bar` (whole list item).

Root cause: `@muyajs/core` rebuilds the clipboard markdown from the block **state tree** by offset (the legacy engine serialized the live DOM selection, which was partial by construction). `appendPartialState` only truncated paragraphs — block-quotes/lists were dumped whole or sliced by item index without truncating the boundary item, and the atomic branch dumped code/etc. whole. `collectSameOutMostBlockState` had the same flaw for selections that stay inside one container.

## Fix

Reconstruct the partial state faithfully, per block type:

| Block | Partial-endpoint behaviour |
|---|---|
| paragraph | substring (unchanged) |
| atx-heading | substring as paragraph — `# ` marker rides in the text and re-parses on paste |
| setext-heading | keep heading, truncate text (underline rebuilt from meta) |
| block-quote, bullet/order/task-list | recurse + truncate the boundary item; preserve meta (e.g. task `checked`) |
| code-block, html-block, math-block, frontmatter, diagram | keep type + meta, truncate body; whole when fully selected; a code fence's language line copies whole |
| table | whole (its dedicated cross-cell path handles partial rectangles) |

Two helpers do the work: `buildPartialContainerState` (one boundary, for cross-block start/end) and `buildRangeContainerState` (both boundaries inside one container).

## Tests

New unit specs (happy-dom, real booted editor): `copyCrossBlockQuote`, `copyCrossBlockList`, `copyWithinContainer`, `copyCrossBlockLeaf`. Full muya suite green (1120 tests); typecheck + lint clean. The reported list/quote scenarios and the heading/code/setext endpoints were also verified end-to-end in real Chromium.

## Commits

1. `fix(clipboard): copy only the selected part of block-quotes and lists`
2. `fix(clipboard): truncate code/setext-heading endpoints instead of dumping whole`

🤖 Generated with [Claude Code](https://claude.com/claude-code)