### PR TITLE
fix(muya): guard checkNeedRender against a null cursor (image-preview reclick crash)

### DIFF
--- a/packages/muya/src/block/base/__tests__/blurHandlerNullCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/blurHandlerNullCursor.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+// Regression: Format.checkNeedRender / blurHandler must not crash when the
+// block is active but its selection has no anchor/focus. This happens after
+// the image-preview path (select image -> Space opens SimpleImageViewer ->
+// Esc): ImageSelection never seats a text caret, so the image's paragraph
+// stays the active content block with a null selection. The next click fires
+// blurHandler() on that paragraph; checkNeedRender() then dereferenced
+// `anchor!.offset` / `focus!.offset` on an undefined cursor and threw
+// "Cannot read properties of undefined (reading 'offset')".
+
+interface IFormatBlock {
+    checkNeedRender: () => boolean;
+    blurHandler: () => void;
+    setCursor: (start: number, end: number, needUpdate?: boolean) => void;
+}
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstFormat(muya: Muya): IFormatBlock {
+    return muya.editor.scrollPage!.firstContentInDescendant()! as unknown as IFormatBlock;
+}
+
+// Force the "active block, no selection" state the image-preview path leaves
+// behind: `block.selection` is `muya.editor.selection`, so stubbing its
+// anchor/focus getters is exactly what `checkNeedRender`'s default cursor reads.
+function nullifySelection(muya: Muya): void {
+    vi.spyOn(muya.editor.selection, 'anchor', 'get').mockReturnValue(null);
+    vi.spyOn(muya.editor.selection, 'focus', 'get').mockReturnValue(null);
+}
+
+describe('format.checkNeedRender / blurHandler with a null selection', () => {
+    it('blurHandler() does not throw when the active block has no selection', () => {
+        const muya = bootMuya('a paragraph with **bold** text\n');
+        const block = firstFormat(muya);
+        nullifySelection(muya);
+
+        expect(() => block.blurHandler()).not.toThrow();
+    });
+
+    it('checkNeedRender() returns false instead of dereferencing a null cursor', () => {
+        const muya = bootMuya('hello **world**\n');
+        const block = firstFormat(muya);
+        nullifySelection(muya);
+
+        expect(() => block.checkNeedRender()).not.toThrow();
+        expect(block.checkNeedRender()).toBe(false);
+    });
+
+    it('still evaluates tokens when a real cursor sits inside inline markup', () => {
+        const muya = bootMuya('**bold**\n');
+        const block = firstFormat(muya);
+        // Caret inside the strong run (adjacent to the leading `**`): the cursor
+        // is next to the strong token, so a re-render is needed.
+        block.setCursor(2, 2, true);
+
+        expect(block.checkNeedRender()).toBe(true);
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -293,8 +293,10 @@ class Format extends Content {
         const { labels } = this.inlineRenderer;
         const { text } = this;
         const { start: cStart, end: cEnd, anchor, focus } = cursor;
-        const anchorOffset = cStart ? cStart.offset : anchor!.offset;
-        const focusOffset = cEnd ? cEnd.offset : focus!.offset;
+        const anchorOffset = cStart ? cStart.offset : anchor?.offset;
+        const focusOffset = cEnd ? cEnd.offset : focus?.offset;
+        if (anchorOffset == null || focusOffset == null)
+            return false;
         const NO_NEED_TOKEN_REG = /text|hard_line_break|soft_line_break/;
 
         for (const token of tokenizer(text, {


### PR DESCRIPTION
## Summary
Fixes a renderer crash when clicking an inline image again after closing its full-screen preview.

**Repro:** select an inline image → press Space (opens `SimpleImageViewer`) → press Esc → click the same image again → `TypeError: Cannot read properties of undefined (reading 'offset')`.

**Root cause:** `Format.checkNeedRender` (`packages/muya/src/block/base/format.ts`) resolved its anchor/focus offsets with non-null assertions (`anchor!.offset` / `focus!.offset`). `blurHandler()` invokes it with the default cursor derived from `this.selection.anchor/focus`. The image-preview path leaves the image's paragraph as the active content block with a **null selection** (no text caret is seated, and Esc doesn't restore one), so the next click's `blurHandler()` dereferenced `undefined.offset`.

**Fix:** when no cursor offset is resolvable there is nothing for the cursor-proximity check to compare against, so return `false` (no re-render needed) instead of dereferencing.

## Test
Adds `packages/muya/src/block/base/__tests__/blurHandlerNullCursor.spec.ts` (TDD — written failing first): `blurHandler()` / `checkNeedRender()` no longer throw with a null selection and return `false`, while a real cursor inside inline markup still triggers a re-render.

## Verification
- New spec: 3/3 pass
- Full muya unit suite: 1158 passed (148 files)
- CommonMark + GFM conformance: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)