### PR TITLE
fix(muya): correct setext heading level when typing the underline

### DIFF
--- a/packages/muya/src/block/base/__tests__/setextHeadingLevel.spec.ts
+++ b/packages/muya/src/block/base/__tests__/setextHeadingLevel.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../../muya';
+import type SetextHeading from '../../commonMark/setextHeading';
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../../muya';
+
+// Typing a setext underline must produce the CommonMark level: `===` → level 1
+// (h1), `---` → level 2 (h2). Regression: `_convertToSetextHeading` inverted
+// the test (`/=/ ? 2 : 1`), so `===` rendered as an h2 until a source-mode
+// round-trip re-parsed it.
+
+vi.mock('../../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function convertViaUnderline(underline: string): SetextHeading {
+    const muya = bootMuya('hello world\n');
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+    content.text = `hello world\n${underline}`;
+    content.checkInlineUpdate();
+
+    return muya.editor.scrollPage!.firstChild as unknown as SetextHeading;
+}
+
+describe('setext heading conversion uses the CommonMark level', () => {
+    it('`===` underline creates a level-1 heading (h1)', () => {
+        const heading = convertViaUnderline('===');
+
+        expect(heading.blockName).toBe('setext-heading');
+        expect(heading.meta.level).toBe(1);
+        expect(heading.tagName).toBe('h1');
+    });
+
+    it('`---` underline creates a level-2 heading (h2)', () => {
+        const heading = convertViaUnderline('---');
+
+        expect(heading.blockName).toBe('setext-heading');
+        expect(heading.meta.level).toBe(2);
+        expect(heading.tagName).toBe('h2');
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1062,7 +1062,7 @@ class Format extends Content {
 
     // Setext Heading
     private _convertToSetextHeading(setextHeading: string) {
-        const level = /=/.test(setextHeading) ? 2 : 1;
+        const level = /=/.test(setextHeading) ? 1 : 2;
         if (
             this.parent?.blockName === 'setext-heading'
             && (this.parent as SetextHeading).meta.level === level


### PR DESCRIPTION
## Problem

Creating a setext heading by typing its underline produced the **wrong level**: typing `===` rendered an **H2** and `---` rendered an **H1** — the opposite of the CommonMark rule (`=` → h1, `-` → h2). Switching to source mode and back fixed it, because re-parsing derives the level from the parser's depth.

## Root cause

`Format._convertToSetextHeading` (`packages/muya/src/block/base/format.ts`):

```ts
const level = /=/.test(setextHeading) ? 2 : 1; // inverted
```

The `underline` stored in meta was correct (`===`), so `stateToMarkdown` emitted valid markdown and a source round-trip re-parsed the right level — which is why the bug only showed in the live WYSIWYG render.

## Fix

```ts
const level = /=/.test(setextHeading) ? 1 : 2;
```

## Tests

New spec `setextHeadingLevel.spec.ts` drives the live conversion (`content.checkInlineUpdate()`) and asserts `===` → level 1 / `<h1>` and `---` → level 2 / `<h2>`. Full muya suite green (1116); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)