### PR TITLE
test(desktop): backfill renderer/main unit coverage for post-migration gaps

### DIFF
--- a/packages/desktop/test/unit/specs/ask-for-image-path.spec.ts
+++ b/packages/desktop/test/unit/specs/ask-for-image-path.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IMAGE_EXTENSIONS } from 'common/filesystem/paths'
+
+// `DataCenter` (main process) registers `mt::ask-for-image-path` via
+// `ipcMain.handle`. The handler opens a native file dialog and maps the
+// result to `filePaths[0]` or `''`. We mock the Electron surface, capture
+// the registered handler, and drive it directly — the dialog itself is
+// manual-only but the return-mapping + filter are a pure unit slice.
+
+const { handlers, showOpenDialog, fromWebContents } = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  showOpenDialog: vi.fn(),
+  fromWebContents: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, listener: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, listener)
+    },
+    on: () => {}
+  },
+  dialog: { showOpenDialog },
+  BrowserWindow: { fromWebContents }
+}))
+
+vi.mock('keytar', () => ({ default: { getPassword: vi.fn(), setPassword: vi.fn() } }))
+vi.mock('electron-log', () => ({ default: { error: vi.fn(), info: vi.fn() } }))
+vi.mock('common/filesystem', () => ({ ensureDirSync: vi.fn() }))
+
+vi.mock('electron-store', () => ({
+  default: class {
+    private data: Record<string, unknown> = {}
+    get(key: string) {
+      return this.data[key]
+    }
+
+    set(key: string | Record<string, unknown>, value?: unknown) {
+      if (typeof key === 'string') this.data[key] = value
+      else Object.assign(this.data, key)
+    }
+
+    get store() {
+      return this.data
+    }
+  }
+}))
+
+const { default: DataCenter } = await import('main_renderer/dataCenter')
+
+const FAKE_WIN = { id: 1 }
+const fakeEvent = { sender: {} } as never
+
+function getHandler() {
+  // Instantiating DataCenter registers the ipcMain handler (the side effect is the point).
+  // eslint-disable-next-line no-new
+  new DataCenter({ dataCenterPath: '/tmp/mt-dc', userDataPath: '/tmp/mt-ud' })
+  const handler = handlers.get('mt::ask-for-image-path')
+  if (!handler) throw new Error('mt::ask-for-image-path handler was not registered')
+  return handler
+}
+
+describe('mt::ask-for-image-path handler', () => {
+  beforeEach(() => {
+    handlers.clear()
+    showOpenDialog.mockReset()
+    fromWebContents.mockReset()
+    fromWebContents.mockReturnValue(FAKE_WIN)
+  })
+
+  it('returns filePaths[0] when the user picks a file', async() => {
+    const handler = getHandler()
+    showOpenDialog.mockResolvedValue({ filePaths: ['/abs/x.png'], canceled: false })
+
+    const result = await handler(fakeEvent)
+
+    expect(result).toBe('/abs/x.png')
+  })
+
+  it("returns '' when the dialog is canceled (empty filePaths)", async() => {
+    const handler = getHandler()
+    showOpenDialog.mockResolvedValue({ filePaths: [], canceled: true })
+
+    const result = await handler(fakeEvent)
+
+    expect(result).toBe('')
+  })
+
+  it("returns '' when there is no owning BrowserWindow", async() => {
+    const handler = getHandler()
+    fromWebContents.mockReturnValue(null)
+
+    const result = await handler(fakeEvent)
+
+    expect(result).toBe('')
+    expect(showOpenDialog).not.toHaveBeenCalled()
+  })
+
+  it('opens the dialog with an openFile property and the image-extension filter', async() => {
+    const handler = getHandler()
+    showOpenDialog.mockResolvedValue({ filePaths: ['/abs/y.jpg'], canceled: false })
+
+    await handler(fakeEvent)
+
+    expect(showOpenDialog).toHaveBeenCalledWith(
+      FAKE_WIN,
+      expect.objectContaining({
+        properties: ['openFile'],
+        filters: [{ name: 'Images', extensions: [...IMAGE_EXTENSIONS] }]
+      })
+    )
+  })
+})

--- a/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
@@ -126,3 +126,84 @@ describe('useEditorStore copyGithubSlug', () => {
     expect(notice.notify).not.toHaveBeenCalled()
   })
 })
+
+describe('useEditorStore EXPORT (title derivation from listToc)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  // currentFile is IFileState; EXPORT only reads { filename, pathname }.
+  const setCurrentFile = (store: ReturnType<typeof useEditorStore>) => {
+    store.currentFile = {
+      filename: 'notes.md',
+      pathname: '/x/notes.md'
+    } as unknown as typeof store.currentFile
+  }
+
+  it('picks the shallowest heading and breaks early when a lvl-1 is reached', () => {
+    const store = useEditorStore()
+    setCurrentFile(store)
+    store.listToc = [
+      { lvl: 2, content: 'Sub' },
+      { lvl: 1, content: 'Top' }
+    ]
+
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.EXPORT({ type: 'pdf', pageOptions: {} })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const [channel, payload] = sendSpy.mock.calls[0]
+    expect(channel).toBe('mt::response-export')
+    expect(payload).toMatchObject({
+      type: 'pdf',
+      title: 'Top',
+      content: '',
+      filename: 'notes.md',
+      pathname: '/x/notes.md',
+      pageOptions: {}
+    })
+  })
+
+  it('keeps the first lvl-1 heading and ignores later shallower entries (loop break)', () => {
+    const store = useEditorStore()
+    setCurrentFile(store)
+    // headerRef starts lvl-1 -> loop breaks on first iteration, later lvl-0 ignored.
+    store.listToc = [
+      { lvl: 1, content: 'First' },
+      { lvl: 0, content: 'Shallower-but-skipped' }
+    ]
+
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.EXPORT({ type: 'pdf', pageOptions: {} })
+
+    expect(sendSpy.mock.calls[0][1]).toMatchObject({ title: 'First' })
+  })
+
+  it('sends an empty title when listToc is empty', () => {
+    const store = useEditorStore()
+    setCurrentFile(store)
+    store.listToc = []
+
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.EXPORT({ type: 'pdf', pageOptions: {} })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][1]).toMatchObject({ title: '' })
+  })
+
+  it('sends no IPC when currentFile is null (guard)', () => {
+    const store = useEditorStore()
+    store.currentFile = null
+    store.listToc = [{ lvl: 1, content: 'Top' }]
+
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.EXPORT({ type: 'pdf', pageOptions: {} })
+
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// `theme.ts` transitively imports `@/config`, whose first line reads
+// `window.path.sep` at module-load time. Stub the preload `window.path` surface
+// before the hoisted import runs.
+vi.hoisted(() => {
+  const w = globalThis as unknown as { window?: { path?: { sep: string } } }
+  w.window ??= {}
+  w.window.path ??= { sep: '/' }
+})
+
+import { addCommonStyle, setWrapCodeBlocks, setEditorWidth } from '@/util/theme'
+import { COMMON_STYLE_ID, DEFAULT_CODE_FONT_FAMILY } from '@/config'
+
+const styleHtml = (id: string) =>
+  (document.querySelector(`#${id}`) as HTMLStyleElement | null)?.innerHTML ?? ''
+
+const styleCount = (id: string) => document.querySelectorAll(`#${id}`).length
+
+describe('theme.ts style injection helpers', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+    document.body.className = ''
+  })
+
+  // Items 196, 210 — addCommonStyle injects code font onto the engine .mu-code-block.
+  describe('addCommonStyle', () => {
+    it('injects code font-family/size onto the .mu-code-block selector list', () => {
+      addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 24 })
+
+      const css = styleHtml(COMMON_STYLE_ID)
+      // selector list targets the engine block class
+      expect(css).toContain('.mu-code-block')
+      // family is the requested font followed by the default fallback chain
+      expect(css).toContain(`font-family: Courier New, ${DEFAULT_CODE_FONT_FAMILY};`)
+      // size is the numeric value suffixed with px
+      expect(css).toContain('font-size: 24px;')
+    })
+
+    it('targets the engine .mu-code-block class (not a legacy ag-* class)', () => {
+      addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 14 })
+
+      const css = styleHtml(COMMON_STYLE_ID)
+      expect(css).toContain('.mu-code-block')
+      expect(css).not.toContain('.ag-code-block')
+    })
+
+    it('prepends the webkit scrollbar hide rule when hideScrollbar is true', () => {
+      addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 14, hideScrollbar: true })
+
+      expect(styleHtml(COMMON_STYLE_ID)).toContain('::-webkit-scrollbar {display: none;}')
+    })
+
+    it('omits the scrollbar rule when hideScrollbar is false', () => {
+      addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 14, hideScrollbar: false })
+
+      expect(styleHtml(COMMON_STYLE_ID)).not.toContain('::-webkit-scrollbar')
+    })
+
+    it('reuses a single style element across calls (replaces, never appends)', () => {
+      addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 14 })
+      addCommonStyle({ codeFontFamily: 'Fira Code', codeFontSize: 18 })
+
+      expect(styleCount(COMMON_STYLE_ID)).toBe(1)
+      const css = styleHtml(COMMON_STYLE_ID)
+      // only the latest call's values survive
+      expect(css).toContain(`font-family: Fira Code, ${DEFAULT_CODE_FONT_FAMILY};`)
+      expect(css).toContain('font-size: 18px;')
+      expect(css).not.toContain('Courier New')
+      expect(css).not.toContain('font-size: 14px;')
+    })
+  })
+
+  // Item 197 — setWrapCodeBlocks toggles pre-wrap vs pre on .mu-code-block .mu-code.
+  describe('setWrapCodeBlocks', () => {
+    const WRAP_STYLE_ID = 'ag-code-wrap'
+
+    it('uses white-space: pre-wrap and overflow: hidden when wrapping is enabled', () => {
+      setWrapCodeBlocks(true)
+
+      const css = styleHtml(WRAP_STYLE_ID)
+      expect(css).toContain('.mu-code-block .mu-code {')
+      expect(css).toContain('white-space: pre-wrap;')
+      expect(css).toContain('overflow: hidden;')
+    })
+
+    it('uses white-space: pre and overflow: auto when wrapping is disabled', () => {
+      setWrapCodeBlocks(false)
+
+      const css = styleHtml(WRAP_STYLE_ID)
+      expect(css).toContain('.mu-code-block .mu-code {')
+      expect(css).toContain('white-space: pre;')
+      expect(css).toContain('overflow: auto;')
+      // the disabled rule must not leak the wrapped values
+      expect(css).not.toContain('white-space: pre-wrap;')
+    })
+
+    it('replaces the rule in the same single style element when toggled true -> false', () => {
+      setWrapCodeBlocks(true)
+      setWrapCodeBlocks(false)
+
+      expect(styleCount(WRAP_STYLE_ID)).toBe(1)
+      const css = styleHtml(WRAP_STYLE_ID)
+      expect(css).toContain('white-space: pre;')
+      expect(css).not.toContain('white-space: pre-wrap;')
+    })
+  })
+
+  // Item 209 — setEditorWidth validates input and injects --editorAreaWidth override.
+  describe('setEditorWidth', () => {
+    const WIDTH_STYLE_ID = 'editor-width'
+
+    it.each(['60ch', '800px', '50%'])(
+      'writes a calc() override for the valid value %s',
+      (value) => {
+        setEditorWidth(value)
+
+        expect(styleHtml(WIDTH_STYLE_ID)).toBe(
+          `:root { --editorAreaWidth: calc(100px + ${value}); }`
+        )
+      }
+    )
+
+    it('clears the override (empty innerHTML) for an empty string', () => {
+      setEditorWidth('800px')
+      setEditorWidth('')
+
+      expect(styleHtml(WIDTH_STYLE_ID)).toBe('')
+    })
+
+    it.each(['abc', '10', '10em'])(
+      'rejects the invalid value %s and writes nothing',
+      (value) => {
+        setEditorWidth(value)
+
+        expect(styleHtml(WIDTH_STYLE_ID)).toBe('')
+      }
+    )
+
+    it('reuses a single style element across calls', () => {
+      setEditorWidth('60ch')
+      setEditorWidth('50%')
+      setEditorWidth('abc')
+
+      expect(styleCount(WIDTH_STYLE_ID)).toBe(1)
+      // the invalid final call cleared the previously valid override
+      expect(styleHtml(WIDTH_STYLE_ID)).toBe('')
+    })
+  })
+})

--- a/packages/desktop/test/unit/specs/format-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/format-menu-state.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { type Menu } from 'electron'
+import { type Menu, type MenuItemConstructorOptions } from 'electron'
 
 // `@/store/editor` transitively imports `@/config`, which reads
 // `window.path.sep` at module load (normally injected by the preload bridge).
@@ -10,6 +10,17 @@ vi.hoisted(() => {
   w.window.path ??= { sep: '/' }
 })
 
+// The menu templates pull in `../actions/*` (which register `ipcMain.on` at
+// module load), `electron-log`, and the i18n loader (reads locale JSON off
+// disk). None of that is exercised here — we only build the menu structure and
+// read accelerators — so stub the heavy surfaces to keep the slice hermetic.
+vi.mock('electron', () => ({
+  ipcMain: { on: () => {}, emit: () => {}, handle: () => {} },
+  BrowserWindow: { fromWebContents: () => undefined, getAllWindows: () => [] }
+}))
+vi.mock('electron-log', () => ({ default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }))
+vi.mock('main_renderer/i18n', () => ({ t: (key: string) => key }))
+
 import { createSelectionFormatState } from '@/store/editor'
 import { updateFormatMenu } from 'main_renderer/menu/actions/format'
 // The toolbar config is a deep subpath of @muyajs/core that vite resolves at
@@ -18,6 +29,11 @@ import { updateFormatMenu } from 'main_renderer/menu/actions/format'
 import inlineFormatIcons from '@muyajs/core/ui/inlineFormatToolbar/config'
 import keybindingsWindows from 'main_renderer/keyboard/keybindingsWindows'
 import keybindingsLinux from 'main_renderer/keyboard/keybindingsLinux'
+import keybindingsDarwin from 'main_renderer/keyboard/keybindingsDarwin'
+import { isEqualAccelerator } from 'common/keybinding'
+import paragraphTemplate from 'main_renderer/menu/templates/paragraph'
+import editTemplate from 'main_renderer/menu/templates/edit'
+import viewTemplate from 'main_renderer/menu/templates/view'
 
 interface IInlineFormatIcon { type: string, shortcut?: string }
 
@@ -189,5 +205,124 @@ describe('Format-menu accelerators vs muya inlineFormatToolbar shortcuts', () =>
       normalizeShortcut('Ctrl+Shift+M')
     )
     expect(normalizeShortcut(keybindingsWindows.get('format.inline-math'))).not.toBe(toolbar)
+  })
+})
+
+// The Format slice above pins one menu's accelerators. The Paragraph/Edit/View
+// templates source their accelerators the same way — `keybindings.getAccelerator(id)`
+// off the active platform map — so a hardcoded literal in a template would silently
+// diverge from the table. This walks each template with a fake keybindings backed by
+// every platform map and asserts the menu items pass the table value through verbatim.
+describe('menu template accelerators match the platform keybinding tables (Paragraph/Edit/View)', () => {
+  type Template = (kb: { getAccelerator(id: string): string | null }) => MenuItemConstructorOptions
+
+  // Sentinel-id keybindings: records the id of every accelerator the template
+  // pulls and returns the id itself so it can be recovered from the menu item.
+  const SENTINEL = ''
+  const makeIdProbe = () => ({
+    getAccelerator: (id: string) => `${SENTINEL}${id}`
+  })
+
+  // Mirrors the real `getAccelerator`: empty bindings collapse to null (which the
+  // templates turn into `accelerator: undefined`), non-empty bindings pass through.
+  const makeMapKeybindings = (map: Map<string, string>) => ({
+    getAccelerator: (id: string) => {
+      const name = map.get(id)
+      return name || null
+    }
+  })
+
+  // Map lookups are guaranteed present by the "exists in every platform table"
+  // tests, so resolve to '' rather than sprinkling non-null assertions.
+  const accel = (map: Map<string, string>, id: string): string => map.get(id) ?? ''
+
+  // Walk the submenu tree, collecting every defined `accelerator` in source order.
+  const collectAccelerators = (node: MenuItemConstructorOptions): (string | undefined)[] => {
+    const out: (string | undefined)[] = []
+    const submenu = node.submenu
+    if (!Array.isArray(submenu)) return out
+    for (const item of submenu) {
+      if ('accelerator' in item) out.push(item.accelerator)
+      if (item.submenu && Array.isArray(item.submenu)) {
+        out.push(...collectAccelerators(item as MenuItemConstructorOptions))
+      }
+    }
+    return out
+  }
+
+  // The ids the template actually referenced, in the order items appear.
+  const referencedIds = (template: Template): string[] =>
+    collectAccelerators(template(makeIdProbe()))
+      .filter((a): a is string => typeof a === 'string' && a.startsWith(SENTINEL))
+      .map((a) => a.slice(SENTINEL.length))
+
+  const PLATFORMS: ReadonlyArray<readonly [string, Map<string, string>]> = [
+    ['Windows', keybindingsWindows],
+    ['Linux', keybindingsLinux],
+    ['Darwin', keybindingsDarwin]
+  ]
+
+  const TEMPLATES: ReadonlyArray<readonly [string, Template]> = [
+    ['paragraph', paragraphTemplate as unknown as Template],
+    ['edit', editTemplate as unknown as Template],
+    ['view', viewTemplate as unknown as Template]
+  ]
+
+  for (const [tName, template] of TEMPLATES) {
+    it(`${tName} template only references ids that exist in every platform table`, () => {
+      const ids = referencedIds(template)
+      expect(ids.length).toBeGreaterThan(0)
+      for (const id of ids) {
+        for (const [pName, map] of PLATFORMS) {
+          expect(`${pName}:${id}=${map.has(id)}`).toBe(`${pName}:${id}=true`)
+        }
+      }
+    })
+
+    for (const [pName, map] of PLATFORMS) {
+      it(`${tName} template accelerators equal the ${pName} table values (no hardcoded literal)`, () => {
+        const ids = referencedIds(template)
+        // Build the same menu with real table values; items line up 1:1 with `ids`
+        // because the source order is deterministic.
+        const produced = collectAccelerators(template(makeMapKeybindings(map)))
+        expect(produced.length).toBe(ids.length)
+
+        produced.forEach((value, i) => {
+          const id = ids[i]
+          const expected = map.get(id) ?? ''
+          if (expected) {
+            // Non-empty binding: the item must carry exactly that accelerator.
+            expect(typeof value).toBe('string')
+            expect(isEqualAccelerator(value as string, expected)).toBe(true)
+          } else {
+            // Empty binding collapses to `accelerator: undefined`.
+            expect(value).toBeUndefined()
+          }
+        })
+      })
+    }
+  }
+
+  // Spot-check the specific ids the checklist calls out, against the real table
+  // values, so a wholesale table edit is caught even if the pass-through holds.
+  it('binds the checklist-named ids to their documented platform accelerators', () => {
+    expect(referencedIds(paragraphTemplate as unknown as Template)).toContain('paragraph.heading-1')
+    expect(referencedIds(paragraphTemplate as unknown as Template)).toContain('paragraph.front-matter')
+    expect(referencedIds(editTemplate as unknown as Template)).toContain('edit.duplicate')
+    expect(referencedIds(editTemplate as unknown as Template)).toContain('edit.find-next')
+    expect(referencedIds(editTemplate as unknown as Template)).toContain('edit.find-previous')
+    expect(referencedIds(viewTemplate as unknown as Template)).toContain('view.source-code-mode')
+    expect(referencedIds(viewTemplate as unknown as Template)).toContain('view.typewriter-mode')
+    expect(referencedIds(viewTemplate as unknown as Template)).toContain('view.focus-mode')
+
+    expect(isEqualAccelerator(accel(keybindingsDarwin, 'paragraph.heading-1'), 'Command+1')).toBe(true)
+    expect(keybindingsWindows.get('paragraph.heading-1')).toBe('')
+    expect(isEqualAccelerator(accel(keybindingsDarwin, 'edit.duplicate'), 'Command+Option+D')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsLinux, 'edit.duplicate'), 'Ctrl+Shift+E')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsLinux, 'edit.find-next'), 'F3')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsDarwin, 'edit.find-next'), 'Cmd+G')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsWindows, 'view.source-code-mode'), 'Ctrl+E')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsDarwin, 'view.source-code-mode'), 'Command+Option+S')).toBe(true)
+    expect(isEqualAccelerator(accel(keybindingsWindows, 'view.focus-mode'), 'Ctrl+Shift+J')).toBe(true)
   })
 })

--- a/packages/desktop/test/unit/specs/image-deletion-url.spec.ts
+++ b/packages/desktop/test/unit/specs/image-deletion-url.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `@/store/editor` transitively imports `@/config`, which reads
+// `window.path.sep` at module load (normally injected by the preload bridge).
+// It also reaches `window.electron.clipboard` at runtime. Stub the surfaces
+// before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: {
+        clipboard: { writeText: (s: string) => void }
+        ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void }
+      }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+// The notification service touches the DOM / template HTML; stub it so we can
+// observe `notify` without rendering a toast. SHOW_IMAGE_DELETION_URL chains a
+// `.then()` off `notify(...)`, so the stub must resolve a Promise.
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(() => Promise.resolve()), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+import notice from '@/services/notification'
+
+describe('useEditorStore SHOW_IMAGE_DELETION_URL', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    ;(notice.notify as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  })
+
+  it('notifies with a confirm toast pinned for 20s carrying the deletion URL', () => {
+    const store = useEditorStore()
+    const url = 'https://imgur.example/delete/abc123'
+
+    store.SHOW_IMAGE_DELETION_URL(url)
+
+    expect(notice.notify).toHaveBeenCalledTimes(1)
+    expect(notice.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ showConfirm: true, time: 20000 })
+    )
+    const opts = (notice.notify as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(typeof opts.title).toBe('string')
+    expect(opts.title.length).toBeGreaterThan(0)
+    expect(opts.message).toContain(url)
+  })
+
+  it('copies the deletion URL to the clipboard when the confirm resolves', async() => {
+    const store = useEditorStore()
+    const url = 'https://imgur.example/delete/xyz789'
+    const writeSpy = vi.spyOn(window.electron.clipboard, 'writeText')
+
+    store.SHOW_IMAGE_DELETION_URL(url)
+
+    // Clipboard write is chained off the notify Promise — flush microtasks.
+    expect(writeSpy).not.toHaveBeenCalled()
+    await Promise.resolve()
+    expect(writeSpy).toHaveBeenCalledWith(url)
+  })
+})

--- a/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
+++ b/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
@@ -78,4 +78,44 @@ describe('moveImageToFolder relative-directory persistence', () => {
     expect(path.isAbsolute(result)).toBe(false)
     expect(result.startsWith('assets/')).toBe(true)
   })
+
+  // Item 114: editor.vue imageInsertAction='path'. The string-path branch
+  // (typeof image==='string' → destImagePath = image, verbatim, no copy) lives
+  // in editor.vue:917-920 and is not importable. The automatable slice is its
+  // binary fallback (editor.vue:926-932): a saved-on-disk tab with
+  // preferRelative routes a File through moveImageToFolder(null, file, relDir,
+  // true, currentPathname). pathname is null there because a File needs no
+  // source dir — assert that path stays portable and never dereferences null.
+  it('routes a binary File through the relative branch with a null pathname (path-action fallback)', async() => {
+    const file = new File([new Uint8Array([4, 5, 6])], 'pasted.png', { type: 'image/png' })
+    const result = await moveImageToFolder(
+      null as unknown as string,
+      file,
+      assetsDir,
+      true,
+      docPath
+    )
+    // No copy for a binary File — it is written, not copied.
+    expect(copy).not.toHaveBeenCalled()
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    // The written destination is inside the assets dir...
+    expect((writeFile.mock.calls[0] as unknown[])[0] as string).toMatch(/pasted\.png$/)
+    expect(((writeFile.mock.calls[0] as unknown[])[0] as string).startsWith(assetsDir)).toBe(true)
+    // ...and the inserted reference is the portable relative path.
+    expect(path.isAbsolute(result)).toBe(false)
+    expect(result.startsWith('assets/')).toBe(true)
+    expect(result.endsWith('pasted.png')).toBe(true)
+  })
+
+  it('a string local path already inside outputDir is returned verbatim when isRelative is false (path-action string passthrough analog)', async() => {
+    // Mirrors the editor.vue 'path' string branch intent: an absolute local
+    // path that already lives in the output dir is neither copied nor uploaded;
+    // the absolute reference is preserved unchanged.
+    const local = path.join(assetsDir, 'pic.png')
+    const result = await moveImageToFolder(docPath, local, assetsDir, false, docPath)
+    expect(copy).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
+    expect(result).toBe(local)
+    expect(path.isAbsolute(result)).toBe(true)
+  })
 })

--- a/packages/desktop/test/unit/specs/printService-image.spec.ts
+++ b/packages/desktop/test/unit/specs/printService-image.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// `resolveLocalImageSrc` reads `window.DIRNAME` + `window.path.resolve` for the
+// relative-resolve branch. Stub those preload surfaces before the hoisted
+// import runs (copied from exportHtml.spec.ts). The function is otherwise a
+// pure string transform — no Muya/engine needed.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: {
+        sep: string
+        join?: (...parts: string[]) => string
+        resolve?: (...parts: string[]) => string
+      }
+      DIRNAME?: string
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= {
+    sep: '/',
+    join: (...parts: string[]) => parts.join('/'),
+    resolve: (...parts: string[]) =>
+      parts.join('/').replace(/\/\.\//g, '/').replace(/\/{2,}/g, '/')
+  }
+  w.window.DIRNAME = '/docs'
+})
+
+import { resolveLocalImageSrc } from '@/util/resolveImageSrc'
+
+// Branch coverage the exportHtml.spec.ts wrapper does NOT exercise (it only
+// covers the relative-resolve and http-untouched paths). Driving the exported
+// fn directly here pins the absolute / drive / UNC / data: / extensionless /
+// already-file:// / https branches (issue 230 / GH#678).
+describe('resolveLocalImageSrc — branch coverage', () => {
+  it('(a) POSIX absolute image path → file:// (no double slash)', () => {
+    expect(resolveLocalImageSrc('/tmp/b.png')).toBe('file:///tmp/b.png')
+  })
+
+  it('(b) Windows drive image path → file:// preserving backslashes', () => {
+    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:\\pics\\b.png')
+  })
+
+  it('(c) UNC image path → file:// preserving the \\\\host prefix', () => {
+    expect(resolveLocalImageSrc('\\\\host\\share\\c.png')).toBe(
+      'file://\\\\host\\share\\c.png'
+    )
+  })
+
+  it('(d) data: URI is left untouched (no file:// prefix)', () => {
+    const src = 'data:image/png;base64,iVBORw0KGgo='
+    expect(resolveLocalImageSrc(src)).toBe(src)
+  })
+
+  it('(e) extensionless absolute server path is NOT rewritten to file://', () => {
+    // No recognised image extension before `?`/end → IMAGE_EXT_REG gate fails,
+    // so `/api/image?id=1` must NOT become `file:///api/image…`.
+    expect(resolveLocalImageSrc('/api/image?id=1')).toBe('/api/image?id=1')
+  })
+
+  it('(f) already-file:// src is left untouched (no file://file://…)', () => {
+    expect(resolveLocalImageSrc('file:///docs/a.png')).toBe('file:///docs/a.png')
+  })
+
+  it('(g) https URL is left untouched', () => {
+    expect(resolveLocalImageSrc('https://example.com/a.png')).toBe(
+      'https://example.com/a.png'
+    )
+  })
+
+  it('absolute path with a query keeps its extension recognised (POSIX → file://)', () => {
+    // `.png` immediately followed by `?` still matches IMAGE_EXT_REG.
+    expect(resolveLocalImageSrc('/tmp/b.png?v=2')).toBe('file:///tmp/b.png?v=2')
+  })
+
+  it('empty / falsy src is returned as-is', () => {
+    expect(resolveLocalImageSrc('')).toBe('')
+  })
+})

--- a/packages/desktop/test/unit/specs/source-code-image-action.spec.ts
+++ b/packages/desktop/test/unit/specs/source-code-image-action.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { parse, compileScript } from 'vue/compiler-sfc'
+import ts from 'typescript'
+import { ref } from 'vue'
+
+// `handleImageAction` lives as a <script setup> closure in sourceCode.vue
+// (registered on the `image-action` bus during onMounted). The desktop unit
+// runner ships no @vitejs/plugin-vue and no @vue/test-utils, so the SFC cannot
+// be imported or mounted directly. Instead, compile the *real* source at
+// runtime, swap its imports for injected stubs, and run setup() to grab the
+// closure off the dev-mode `__returned__` bindings. This drives the actual
+// product algorithm and re-reads the file every run, so it cannot drift.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const vuePath = resolve(here, '../../../src/renderer/src/components/editorWithTabs/sourceCode.vue')
+
+interface CMCursor {
+  line: number
+  ch: number
+}
+
+interface SetupBindings {
+  editor: { value: unknown }
+  handleImageAction: (payload: unknown) => void
+}
+
+interface SetupModule {
+  default: { setup: (props: unknown, ctx: { expose: () => void }) => SetupBindings }
+}
+
+const loadComponent = (deps: Record<string, unknown>) => {
+  const src = readFileSync(vuePath, 'utf8')
+  const { descriptor } = parse(src)
+  const compiled = compileScript(descriptor, { id: 'test' })
+  // Drop every import; bindings come from the injected `__deps` object so the
+  // store/codeMirror/muya/config modules never load.
+  const noImports = compiled.content
+    .split('\n')
+    .filter((l) => !/^\s*import\s/.test(l))
+    .join('\n')
+  // esbuild's transformSync trips over jsdom's TextEncoder realm, so transpile
+  // the TS away with the (pure-JS) typescript compiler.
+  const js = ts.transpileModule(noImports, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+  }).outputText
+  // Running the compiled setup needs the Function constructor; there is no
+  // module loader to hand it the swapped-in dependency object otherwise.
+  // eslint-disable-next-line no-new-func
+  const factory = new Function(
+    '__deps',
+    'exports',
+    'module',
+    `const { _defineComponent, ref, watch, onMounted, onBeforeUnmount, nextTick,
+      useEditorStore, usePreferencesStore, storeToRefs, codeMirror,
+      setCursorAtFirstLine, setTextDirection, getWordCount, adjustCursor, bus,
+      oneDarkThemes, railscastsThemes } = __deps
+    ${js}
+    return module.exports`
+  ) as (deps: Record<string, unknown>, exports: object, module: object) => SetupModule
+  const m = { exports: {} as Record<string, unknown> }
+  const exported = factory(deps, m.exports, m)
+  return exported.default
+}
+
+const makeDeps = (over: Record<string, unknown> = {}) => ({
+  _defineComponent: (o: unknown) => o,
+  ref,
+  watch: () => {},
+  onMounted: () => {},
+  onBeforeUnmount: () => {},
+  nextTick: () => Promise.resolve(),
+  useEditorStore: () => ({ LISTEN_FOR_CONTENT_CHANGE: () => {} }),
+  usePreferencesStore: () => ({}),
+  storeToRefs: () => ({ theme: ref(''), sourceCode: ref(true), currentFile: ref(null) }),
+  codeMirror: () => ({}),
+  setCursorAtFirstLine: vi.fn(),
+  setTextDirection: () => {},
+  getWordCount: () => 0,
+  adjustCursor: (c: unknown) => c,
+  bus: { on: () => {}, off: () => {}, emit: () => {} },
+  oneDarkThemes: [],
+  railscastsThemes: [],
+  ...over
+})
+
+interface StubCM {
+  getValue: () => string
+  setValue: (v: string) => void
+  getCursor: (which: string) => CMCursor | null
+  setSelection: ReturnType<typeof vi.fn>
+}
+
+const makeCM = (value: string, focus: CMCursor | null, anchor: CMCursor | null): StubCM => {
+  let current = value
+  return {
+    getValue: () => current,
+    setValue: (v: string) => {
+      current = v
+    },
+    getCursor: (which: string) => (which === 'focus' ? focus : anchor),
+    setSelection: vi.fn()
+  }
+}
+
+const bootHandler = (cm: StubCM, deps: Record<string, unknown> = makeDeps()) => {
+  const comp = loadComponent(deps)
+  const ret = comp.setup(
+    { markdown: '', muyaIndexCursor: null, textDirection: 'ltr' },
+    { expose: () => {} }
+  )
+  ret.editor.value = cm
+  return ret.handleImageAction
+}
+
+describe('sourceCode handleImageAction', () => {
+  it('rewrites ![id](old) to ![alt](result) on the matched line', () => {
+    const cm = makeCM('![abc123](old.png) tail', { line: 0, ch: 0 }, { line: 0, ch: 0 })
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(cm.getValue()).toBe('![cat](new.png) tail')
+  })
+
+  it('rewrites only the line carrying the id, leaving siblings intact', () => {
+    const cm = makeCM(
+      'before\n![abc123](old.png)\nafter',
+      { line: 0, ch: 0 },
+      { line: 0, ch: 0 }
+    )
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(cm.getValue()).toBe('before\n![cat](new.png)\nafter')
+  })
+
+  it('shifts a cursor sitting after the image by the length delta', () => {
+    // ![abc123](old.png) is 18 chars; ![cat](new.png) is 15 -> delta -3.
+    const focus = { line: 0, ch: 20 }
+    const anchor = { line: 0, ch: 20 }
+    const cm = makeCM('![abc123](old.png) tail', focus, anchor)
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(focus.ch).toBe(17)
+    expect(anchor.ch).toBe(17)
+    expect(cm.setSelection).toHaveBeenCalledWith(anchor, focus, { scroll: true })
+  })
+
+  it('clamps a cursor inside the old image to the end of the new image text', () => {
+    // New image text length = alt(3) + result(7) + 5 = 15.
+    const focus = { line: 0, ch: 5 }
+    const anchor = { line: 0, ch: 5 }
+    const cm = makeCM('![abc123](old.png)', focus, anchor)
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(focus.ch).toBe(15)
+    expect(anchor.ch).toBe(15)
+  })
+
+  it('leaves a cursor at or before the image start untouched', () => {
+    const focus = { line: 0, ch: 0 }
+    const anchor = { line: 0, ch: 0 }
+    const cm = makeCM('![abc123](old.png) tail', focus, anchor)
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(focus.ch).toBe(0)
+    expect(anchor.ch).toBe(0)
+  })
+
+  it('only adjusts pointers that sit on the rewritten line', () => {
+    const focus = { line: 1, ch: 4 }
+    const anchor = { line: 1, ch: 4 }
+    const cm = makeCM('![abc123](old.png)\nplain text line', focus, anchor)
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    // Image is on line 0; line-1 pointers are off the edited line, so untouched.
+    expect(focus.ch).toBe(4)
+    expect(anchor.ch).toBe(4)
+  })
+
+  it('does nothing when the id is absent from every line', () => {
+    const deps = makeDeps()
+    const cm = makeCM('no images here', { line: 0, ch: 3 }, { line: 0, ch: 3 })
+    bootHandler(cm, deps)({ id: 'zzz', result: 'r.png', alt: 'x' })
+    expect(cm.getValue()).toBe('no images here')
+    expect(cm.setSelection).not.toHaveBeenCalled()
+    expect((deps.setCursorAtFirstLine as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled()
+  })
+
+  it('early-returns on the structure-deleted branch (id present, no image markup)', () => {
+    // The id still appears (indexOf > 0) but the ![..](..) was deleted, so the
+    // broad image regex finds no match -> early return, no selection change.
+    const deps = makeDeps()
+    const cm = makeCM('see abc123 ref', { line: 0, ch: 10 }, { line: 0, ch: 10 })
+    bootHandler(cm, deps)({ id: 'abc123', result: 'r.png', alt: 'x' })
+    expect(cm.getValue()).toBe('see abc123 ref')
+    expect(cm.setSelection).not.toHaveBeenCalled()
+    expect((deps.setCursorAtFirstLine as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled()
+  })
+
+  it('skips an image whose id starts at column 0 (indexOf > 0 quirk)', () => {
+    // findIndex uses `line.indexOf(id) > 0` (strict), so a line that begins
+    // with the id renders no rewrite. Pinning the off-by-one rather than fixing.
+    const cm = makeCM('abc123](old.png)', { line: 0, ch: 0 }, { line: 0, ch: 0 })
+    bootHandler(cm)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(cm.getValue()).toBe('abc123](old.png)')
+  })
+
+  it('falls back to setCursorAtFirstLine when a pointer is null after a rewrite', () => {
+    const deps = makeDeps()
+    const cm = makeCM('![abc123](old.png)', { line: 0, ch: 5 }, null)
+    bootHandler(cm, deps)({ id: 'abc123', result: 'new.png', alt: 'cat' })
+    expect(cm.getValue()).toBe('![cat](new.png)')
+    expect(cm.setSelection).not.toHaveBeenCalled()
+    expect((deps.setCursorAtFirstLine as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/desktop/test/unit/specs/spellchecker-language-command.spec.ts
+++ b/packages/desktop/test/unit/specs/spellchecker-language-command.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+
+// The notification service renders a DOM toast from a raw HTML template; stub
+// it so we can observe `notify` without touching the DOM.
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import SpellcheckerLanguageCommand from '@/commands/spellcheckerLanguage'
+import { SpellChecker } from '@/spellchecker'
+import bus from '@/bus'
+import notice from '@/services/notification'
+
+// Minimal stand-in for the renderer SpellChecker instance the command reads
+// (`lang` and `isEnabled` only).
+const makeChecker = (lang: string, isEnabled: boolean): SpellChecker =>
+  ({ lang, isEnabled }) as unknown as SpellChecker
+
+describe('SpellcheckerLanguageCommand', () => {
+  let emitSpy: Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    emitSpy = vi.spyOn(bus, 'emit') as unknown as Mock
+  })
+
+  describe('run() — building subcommands from available dictionaries', () => {
+    it('builds one subcommand per available dictionary and selects the current lang', async() => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue([
+        'en-US',
+        'de-DE',
+        'fr-FR'
+      ])
+      const command = new SpellcheckerLanguageCommand(makeChecker('de-DE', true))
+
+      await command.run()
+
+      expect(command.subcommands).toHaveLength(3)
+      expect(command.subcommands.map((c) => c.value)).toEqual(['en-US', 'de-DE', 'fr-FR'])
+      expect(command.subcommands[1].id).toBe('spellchecker.switch-language-id-de-DE')
+      // de-DE is index 1 in the dictionary list.
+      expect(command.subcommandSelectedIndex).toBe(1)
+    })
+
+    it('falls back to ["en-US"] when the dictionary list is empty', async() => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue([])
+      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', true))
+
+      await command.run()
+
+      expect(command.subcommands).toHaveLength(1)
+      expect(command.subcommands[0].value).toBe('en-US')
+      expect(command.subcommandSelectedIndex).toBe(0)
+    })
+
+    it('sets subcommandSelectedIndex to -1 when the current lang is not offered', async() => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'fr-FR'])
+      const command = new SpellcheckerLanguageCommand(makeChecker('de-DE', true))
+
+      await command.run()
+
+      expect(command.subcommandSelectedIndex).toBe(-1)
+    })
+  })
+
+  describe('executeSubcommand() — enabled vs disabled', () => {
+    it('emits switch-spellchecker-language with the picked value when enabled', async() => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'de-DE'])
+      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', true))
+      await command.run()
+
+      await command.executeSubcommand('spellchecker.switch-language-id-de-DE')
+
+      expect(emitSpy).toHaveBeenCalledWith('switch-spellchecker-language', 'de-DE')
+      expect(notice.notify).not.toHaveBeenCalled()
+    })
+
+    it('does NOT emit and notifies a warning when the spellchecker is disabled', async() => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'de-DE'])
+      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', false))
+      await command.run()
+
+      await command.executeSubcommand('spellchecker.switch-language-id-de-DE')
+
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        'switch-spellchecker-language',
+        expect.anything()
+      )
+      expect(notice.notify).toHaveBeenCalledTimes(1)
+      expect(notice.notify).toHaveBeenCalledWith({
+        title: 'Spelling',
+        type: 'warning',
+        message: 'Cannot change language because spellchecker is disabled.'
+      })
+    })
+  })
+})

--- a/packages/desktop/test/unit/specs/theme-emoji-patch.spec.ts
+++ b/packages/desktop/test/unit/specs/theme-emoji-patch.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// `theme.ts` transitively imports `@/config`, whose first line reads
+// `window.path.sep` at module-load time. Stub the preload `window.path` surface
+// before the dynamic import runs.
+vi.hoisted(() => {
+  const w = globalThis as unknown as { window?: { path?: { sep: string } } }
+  w.window ??= {}
+  w.window.path ??= { sep: '/' }
+})
+
+// `theme.ts` reads `isLinux` from `./util/index` (same module as `@/util`) at
+// the top level. The Linux-only emoji-picker font patch is composed into the
+// common <style> sheet (`#ag-common-style`) by `addCommonStyle`. We mock
+// `@/util` per test to flip the platform branch and re-import the module, then
+// assert the patched CSS still targets the engine `.mu-emoji-picker` selector so
+// a future mu-*/ag-* selector drift is caught (regression: muyajs -> @muyajs/core).
+const EMOJI_SELECTOR = '.mu-emoji-picker section .emoji-wrapper .item span'
+const EMOJI_FONT = 'Noto Color Emoji'
+
+const loadTheme = async(isLinux: boolean) => {
+  vi.resetModules()
+  vi.doMock('@/util', () => ({ isLinux, isOsx: false, isWindows: false }))
+  return await import('@/util/theme')
+}
+
+const commonStyleHtml = () =>
+  (document.querySelector('#ag-common-style') as HTMLStyleElement | null)?.innerHTML ?? ''
+
+const commonOptions = { codeFontFamily: 'Fira Code', codeFontSize: 14 }
+
+describe('theme.ts emoji-picker Linux font patch', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''
+    document.body.className = ''
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@/util')
+  })
+
+  it('injects the .mu-emoji-picker font fallback into the common sheet on Linux', async() => {
+    const { addCommonStyle } = await loadTheme(true)
+    addCommonStyle(commonOptions)
+
+    const css = commonStyleHtml()
+    expect(css).toContain(EMOJI_SELECTOR)
+    expect(css).toContain(EMOJI_FONT)
+    expect(css).toContain(`${EMOJI_SELECTOR} { font-family: sans-serif, "${EMOJI_FONT}"; }`)
+  })
+
+  it('omits the emoji patch entirely off Linux', async() => {
+    const { addCommonStyle } = await loadTheme(false)
+    addCommonStyle(commonOptions)
+
+    const css = commonStyleHtml()
+    expect(css).not.toContain('.mu-emoji-picker')
+    expect(css).not.toContain(EMOJI_FONT)
+  })
+
+  it('keeps targeting the engine .mu-emoji-picker selector (not a legacy ag-* class) on Linux', async() => {
+    const { addCommonStyle } = await loadTheme(true)
+    addCommonStyle(commonOptions)
+
+    const css = commonStyleHtml()
+    expect(css).toContain('.mu-emoji-picker')
+    expect(css).not.toContain('.ag-emoji-picker')
+  })
+
+  it('routes the patch through addStyles (theme + common) on Linux', async() => {
+    const { addStyles } = await loadTheme(true)
+    addStyles({ theme: 'light', ...commonOptions })
+
+    expect(commonStyleHtml()).toContain(EMOJI_SELECTOR)
+    // The theme sheet itself carries the theme CSS, not the emoji patch.
+    const themeHtml = (document.querySelector('#ag-theme') as HTMLStyleElement | null)?.innerHTML
+    expect(themeHtml).not.toContain('.mu-emoji-picker')
+  })
+
+  it('routes nothing emoji-related through addStyles off Linux', async() => {
+    const { addStyles } = await loadTheme(false)
+    addStyles({ theme: 'light', ...commonOptions })
+
+    expect(commonStyleHtml()).not.toContain('.mu-emoji-picker')
+  })
+})

--- a/packages/desktop/test/unit/specs/upload-image.spec.ts
+++ b/packages/desktop/test/unit/specs/upload-image.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { uploadImage } from '@/util/fileSystem'
+
+// uploadImage forwards to the preload contextBridge surface
+// (window.uploader.uploadImage). It must hand the IPC layer only a plain
+// serializable {currentUploader,cliScript} object — the full Pinia $state is a
+// Vue Proxy that Electron's structured-clone cannot serialize.
+const uploadImageFn = vi.fn((_payload?: unknown) => Promise.resolve('https://cdn/x.png'))
+
+const win = window as unknown as {
+  uploader: { uploadImage: typeof uploadImageFn }
+}
+
+beforeEach(() => {
+  uploadImageFn.mockClear()
+  win.uploader = { uploadImage: uploadImageFn }
+})
+
+describe('uploadImage IPC payload shape', () => {
+  const docPath = '/tmp/notes/a.md'
+
+  it('forwards a local path string with isPath:true and only the picked prefs', async() => {
+    const source = '/Users/someone/pictures/pic.png'
+    const result = await uploadImage(docPath, source, {
+      currentUploader: 'picgo',
+      cliScript: ''
+    })
+
+    expect(uploadImageFn).toHaveBeenCalledTimes(1)
+    const payload = uploadImageFn.mock.calls[0][0] as Record<string, unknown>
+    expect(payload.pathname).toBe(docPath)
+    expect(payload.image).toBe(source)
+    expect(payload.isPath).toBe(true)
+    expect(payload.preferences).toEqual({ currentUploader: 'picgo', cliScript: '' })
+    expect(result).toBe('https://cdn/x.png')
+  })
+
+  it('forwards a binary File with isPath:false and a Uint8Array + name', async() => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'pic.png', { type: 'image/png' })
+    await uploadImage(docPath, file, { currentUploader: 'picgo', cliScript: '' })
+
+    expect(uploadImageFn).toHaveBeenCalledTimes(1)
+    const payload = uploadImageFn.mock.calls[0][0] as {
+      pathname: string
+      image: { data: Uint8Array; name: string }
+      isPath: boolean
+      preferences: unknown
+    }
+    expect(payload.pathname).toBe(docPath)
+    expect(payload.isPath).toBe(false)
+    expect(payload.image.name).toBe('pic.png')
+    expect(payload.image.data).toBeInstanceOf(Uint8Array)
+    expect(Array.from(payload.image.data)).toEqual([1, 2, 3])
+    expect(payload.preferences).toEqual({ currentUploader: 'picgo', cliScript: '' })
+  })
+
+  it('drops extra prefs keys, keeping only currentUploader and cliScript', async() => {
+    // Simulates being handed the full preferences $state — only the two
+    // whitelisted keys may cross the IPC boundary (structured-clone safety).
+    const fatPrefs = {
+      currentUploader: 'picgo',
+      cliScript: '/usr/local/bin/upload.sh',
+      imageInsertAction: 'folder',
+      autoGuessEncoding: true,
+      nested: { foo: 'bar' }
+    } as unknown as { currentUploader: string; cliScript?: string }
+
+    await uploadImage(docPath, '/x/y.png', fatPrefs)
+
+    const payload = uploadImageFn.mock.calls[0][0] as { preferences: Record<string, unknown> }
+    expect(payload.preferences).toEqual({
+      currentUploader: 'picgo',
+      cliScript: '/usr/local/bin/upload.sh'
+    })
+    expect(Object.keys(payload.preferences).sort()).toEqual(['cliScript', 'currentUploader'])
+  })
+
+  it('defaults cliScript to an empty string when absent', async() => {
+    await uploadImage(docPath, '/x/y.png', { currentUploader: 'picgo' })
+
+    const payload = uploadImageFn.mock.calls[0][0] as { preferences: Record<string, unknown> }
+    expect(payload.preferences).toEqual({ currentUploader: 'picgo', cliScript: '' })
+  })
+
+  it('returns the uploader-provided URL', async() => {
+    uploadImageFn.mockResolvedValueOnce('https://cdn/custom.png')
+    const result = await uploadImage(docPath, '/x/y.png', { currentUploader: 'github' })
+    expect(result).toBe('https://cdn/custom.png')
+  })
+})


### PR DESCRIPTION
## Summary
Backfills desktop **renderer/main unit** coverage for behaviors left unprotected after the muyajs → @muyajs/core migration (test-only; no product source changes). Disjoint from #4586 (clipboard cross-block copy) — no overlapping files or cases.

11 specs (8 new, 3 extended):
- `move-image-to-folder` — imageInsertAction `path`/`folder` resolution slices
- `upload-image` — `uploadImage` IPC payload `{currentUploader, cliScript}` + fallback
- `ask-for-image-path` — `mt::ask-for-image-path` main handler returns `filePaths[0]` or `''`
- `source-code-image-action` — source-mode image-action patches the CodeMirror text
- `image-deletion-url` — `image-uploaded` bus event → deletion-URL notification + clipboard
- `format-menu-state` — Paragraph/Edit/View menu accelerators match the platform keybinding tables
- `editor-theme-style` — `addCommonStyle` code font, `setWrapCodeBlocks`, `setEditorWidth` injection
- `printService-image` — `resolveLocalImageSrc` POSIX/drive/UNC/data/extensionless branches
- `editor-store-anchor` — EXPORT title derived from `listToc` top heading

## Verification
Full desktop unit suite: **642 passed (25 files)**; ESLint + vue-tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)