### PR TITLE
test(muya-e2e): backfill real-DOM e2e coverage for post-migration gaps

### DIFF
--- a/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
@@ -1,6 +1,7 @@
 import type { TState } from '@muyajs/core';
 import { expect, test } from '../fixtures/muya';
-import { editor } from '../helpers/selectors';
+import { slowType } from '../helpers/keyboard';
+import { editor, floats, quickInsertItem } from '../helpers/selectors';
 
 /**
  * Mermaid diagram rendering. Unlike PlantUML (which round-trips through the
@@ -119,5 +120,130 @@ test.describe('mermaid diagram', () => {
         const md = await page.evaluate(() => window.muya!.getMarkdown());
         expect(md).toContain('```mermaid');
         expect(md).toContain('graph TD');
+    });
+});
+
+/**
+ * Quick-insert (slash menu) path for diagram blocks. The other tests in this
+ * file (and the sibling diagram specs) drive `setContent` directly; the
+ * narrowly-missing coverage is the QUICK-INSERT menu route a real user takes:
+ * type `/`, filter, click the menu entry, then author the diagram body.
+ *
+ * The menu is the `paragraphQuickInsertMenu` plugin (registered by the host).
+ * It shows when the focused `paragraph.content` text matches `/^[/、]\S*$/`
+ * (config.ts `checkQuickInsert`), filters the entries with Fuse, and clicking
+ * an item dispatches `replaceBlockByLabel(label)` — for `diagram mermaid` /
+ * `diagram vega-lite` that swaps the paragraph for an empty diagram block of
+ * the right `meta.type`/`meta.lang` and drops the caret into its code editor.
+ *
+ * The diagram code editor (`codeBlockContent`) auto-pairs brackets/quotes
+ * (default `autoPairBracket`/`autoPairQuote`), so a vega-lite JSON body typed
+ * key-by-key would double its `{`/`"`. We therefore type only the
+ * bracket/quote-free mermaid body through real keystrokes, and author the
+ * vega-lite body via the freshly-inserted active code block's text setter
+ * (still exercising the quick-insert insertion + live preview render).
+ *
+ * Floats never set `display:none` — `hide()` only zeroes the inline opacity
+ * and parks the box off-screen (baseFloat.ts), and Playwright's `toBeHidden`
+ * ignores opacity. So the reliable "the menu acted" signal is that the
+ * diagram block was inserted, mirroring ui/slash-menu.spec.ts which asserts on
+ * the inserted block rather than the float's visibility.
+ */
+test.describe('diagram via quick-insert menu', () => {
+    // A bracket/quote-free mermaid body types cleanly through real keystrokes
+    // without tripping the code editor's auto-pair.
+    const MERMAID_BODY = 'graph TD\nA-->B';
+
+    // Reset to a single empty paragraph, focus it, then trigger the slash menu
+    // narrowed by `filter` so the target diagram entry is unambiguous.
+    async function openQuickInsert(page: import('@playwright/test').Page, filter: string) {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.type('/');
+        await expect(page.locator(floats.quickInsert)).toBeVisible();
+        await slowType(page, filter);
+    }
+
+    test('inserting a mermaid diagram from the slash menu renders an <svg>', async ({ page }) => {
+        await openQuickInsert(page, 'mermaid');
+
+        // Click the diagram entry — `data-label="diagram mermaid"`.
+        const item = page.locator(quickInsertItem('diagram mermaid'));
+        await expect(item).toBeVisible();
+        await item.click();
+
+        // The paragraph is now an empty diagram block; the caret sits in its
+        // code editor. Type the body via real keystrokes.
+        await expect(page.locator(editor.diagramBlock)).toHaveCount(1);
+        await slowType(page, MERMAID_BODY);
+
+        // The preview updates live on input; allow generous time for the async
+        // mermaid render (dynamic import + parse + run).
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+
+        // The fence language round-trips back to ```mermaid carrying the body.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```mermaid');
+        expect(md).toContain('graph TD');
+        expect(md).toContain('A-->B');
+    });
+
+    test('inserting a vega-lite diagram from the slash menu renders an <svg>', async ({ page }) => {
+        await openQuickInsert(page, 'vega');
+
+        // Click the diagram entry — `data-label="diagram vega-lite"`.
+        const item = page.locator(quickInsertItem('diagram vega-lite'));
+        await expect(item).toBeVisible();
+        await item.click();
+
+        await expect(page.locator(editor.diagramBlock)).toHaveCount(1);
+
+        // The empty quick-inserted diagram serializes as a vega-lite fence with
+        // `meta.lang: 'json'` (buildDiagramBlock) before any body is authored.
+        // The in-place replace settles a tick after the DOM node mounts, so
+        // poll the serialized markdown rather than reading it once.
+        await expect
+            .poll(() => page.evaluate(() => window.muya!.getMarkdown()))
+            .toContain('```vega-lite');
+
+        // Author the JSON body on the freshly-inserted code block — typing it
+        // key-by-key would trip the editor's `{`/`"` auto-pair. The caret was
+        // placed in the diagram's code editor on insert, so its `outContainer`
+        // is the diagram block and `attachments.head` is the live preview;
+        // writing the text then calling `preview.update(text)` is exactly the
+        // path the engine's own `_updatePreviewIfHave` runs on every keystroke.
+        const spec = JSON.stringify({
+            $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+            data: { values: [{ a: 'A', b: 28 }, { a: 'B', b: 55 }, { a: 'C', b: 43 }] },
+            mark: 'bar',
+            encoding: {
+                x: { field: 'a', type: 'nominal' },
+                y: { field: 'b', type: 'quantitative' },
+            },
+        });
+        await page.evaluate((text) => {
+            const block = window.muya!.editor.activeContentBlock as unknown as {
+                text: string;
+                outContainer?: { attachments?: { head?: { update: (code: string) => void } } };
+            } | null;
+            block!.text = text;
+            block!.outContainer?.attachments?.head?.update(text);
+        }, spec);
+
+        // Vega-Lite renders asynchronously to an `<svg>` with mark elements.
+        const svg = page.locator(`${editor.diagramPreview} svg`).first();
+        await expect(svg).toBeVisible({ timeout: 15_000 });
+        const markCount = await page.evaluate(() => {
+            const root = document.querySelector('.mu-diagram-preview svg');
+            return root ? root.querySelectorAll('path, rect').length : 0;
+        });
+        expect(markCount).toBeGreaterThan(0);
+
+        // The fence language round-trips back to ```vega-lite carrying the body.
+        const md = await page.evaluate(() => window.muya!.getMarkdown());
+        expect(md).toContain('```vega-lite');
+        expect(md).toContain('"mark":"bar"');
+        expect(md.trim().endsWith('```')).toBe(true);
     });
 });

--- a/packages/muya/e2e/tests/drag/table-column-toolbar.spec.ts
+++ b/packages/muya/e2e/tests/drag/table-column-toolbar.spec.ts
@@ -1,0 +1,225 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { editor, floats } from '../helpers/selectors';
+
+/**
+ * TableColumnToolbar (the `.mu-table-column-tools` per-column alignment +
+ * insert/remove popup) end-to-end coverage.
+ *
+ * Trigger contract (source of truth:
+ * `packages/muya/src/ui/tableColumnToolbar/index.ts`):
+ *   - A throttled (300ms) `mousemove` handler shows the toolbar when the
+ *     cursor sits OUTSIDE every cell but `elementsFromPoint(x, y + 27)`
+ *     lands inside a `table.cell` — i.e. hovering just ABOVE a column.
+ *     `_block` becomes that cell; `show(cell)` reveals the float.
+ *   - The toolbar renders six icons (config.ts order): align left / center
+ *     / right, insert column left / right, remove column.
+ *   - Clicking an align icon calls `table.alignColumn(offset, type)`, which
+ *     toggles every cell in that column between the requested alignment and
+ *     'none' (writing `data-align` + `meta.align` + an OT op).
+ *   - Item 92: the handler bails to `this.hide()` when the inline format
+ *     toolbar (`mu-format-picker`) is currently shown, so the column tools
+ *     never sit on top of the format picker.
+ *
+ * The engine `alignColumn` toggle is unit-tested in
+ * `src/block/gfm/table/__tests__/alignColumn.spec.ts`; THIS spec pins the
+ * hover-reveal + icon-click wiring + format-picker suppression that no test
+ * exercised.
+ */
+
+const THREE_COLUMN_TABLE = '| head one | head two | head three |\n| --- | --- | --- |\n| alpha | bravo | charlie |\n';
+
+async function makeThreeColumnTable(page: Page) {
+    await page.evaluate((md) => {
+        window.muya!.setContent(md);
+    }, THREE_COLUMN_TABLE);
+    const table = page.locator(editor.table).first();
+    await expect(table).toBeVisible();
+    // Header row + one body row.
+    await expect(table.locator('tr')).toHaveCount(2);
+    return table;
+}
+
+/** Read a parked baseFloat wrapper's opacity (>0 === shown). */
+async function wrapperOpacity(page: Page, selector: string): Promise<number> {
+    return page.locator(selector).first().evaluate((el) => {
+        const wrapper = el.closest('.mu-float-wrapper') as HTMLElement | null;
+        if (!wrapper)
+            return 0;
+        return Number.parseFloat(wrapper.style.opacity || '0');
+    });
+}
+
+async function expectShown(page: Page, selector: string) {
+    await expect.poll(async () => wrapperOpacity(page, selector), {
+        timeout: 5_000,
+        intervals: [50, 100, 250, 500],
+    }).toBeGreaterThan(0);
+}
+
+/**
+ * Hover just ABOVE the header cell at `column` so the column toolbar's
+ * handler picks it up: the cursor is in no cell, but `(x, y + 27)` lands
+ * inside the header cell. Probe ~10px above the cell's top edge.
+ */
+async function revealColumnToolbar(
+    page: Page,
+    table: ReturnType<Page['locator']>,
+    column: number,
+) {
+    const headerCell = table.locator('tr').first().locator('th, td').nth(column);
+    const box = await headerCell.boundingBox();
+    if (!box)
+        throw new Error('header cell has no bounding box');
+
+    const probeX = box.x + box.width / 2;
+    const probeY = box.y - 10;
+    await page.mouse.move(probeX, probeY);
+    await page.waitForTimeout(80);
+    await page.mouse.move(probeX, probeY + 1);
+
+    await expectShown(page, floats.tableColumnTools);
+    return page.locator(floats.tableColumnTools).first();
+}
+
+/** Every `data-align` value down the given column (header + body cells). */
+async function columnAligns(
+    table: ReturnType<Page['locator']>,
+    column: number,
+): Promise<string[]> {
+    return table.locator('tr').evaluateAll((rows, col) => {
+        return rows.map((row) => {
+            const cell = row.querySelectorAll('th, td')[col] as HTMLElement | undefined;
+            return cell?.dataset.align ?? '';
+        });
+    }, column);
+}
+
+test.describe('TableColumnToolbar (per-column alignment popup)', () => {
+    test('the toolbar appears when hovering just above a column', async ({ page }) => {
+        const table = await makeThreeColumnTable(page);
+        // Parked before the hover.
+        expect(await wrapperOpacity(page, floats.tableColumnTools)).toBe(0);
+
+        await revealColumnToolbar(page, table, 0);
+    });
+
+    test('the toolbar renders six column-operation icons', async ({ page }) => {
+        const table = await makeThreeColumnTable(page);
+        const toolbar = await revealColumnToolbar(page, table, 0);
+
+        // config.ts order: left / center / right align + insert-left /
+        // insert-right + remove. The align items render as `item left` etc.
+        // while the insert items share the `left` / `right` tokens
+        // (`item insert left`), so scope the align assertions with
+        // `:not(.insert)` to disambiguate.
+        const items = toolbar.locator('li.item');
+        await expect(items).toHaveCount(6);
+        await expect(toolbar.locator('li.item.left:not(.insert)')).toHaveCount(1);
+        await expect(toolbar.locator('li.item.center')).toHaveCount(1);
+        await expect(toolbar.locator('li.item.right:not(.insert)')).toHaveCount(1);
+        await expect(toolbar.locator('li.item.insert.left')).toHaveCount(1);
+        await expect(toolbar.locator('li.item.insert.right')).toHaveCount(1);
+        await expect(toolbar.locator('li.item.remove')).toHaveCount(1);
+    });
+
+    test('clicking center-align aligns the whole column and writes :---: in markdown', async ({ page }) => {
+        const table = await makeThreeColumnTable(page);
+        const toolbar = await revealColumnToolbar(page, table, 0);
+
+        // Plain table parses every column as 'none'.
+        expect(await columnAligns(table, 0)).toEqual(['none', 'none']);
+
+        await toolbar.locator('li.item.center').click();
+
+        // Every cell in column 0 (header + body) flips to center.
+        await expect
+            .poll(async () => columnAligns(table, 0))
+            .toEqual(['center', 'center']);
+        // The serialized delimiter row carries the center marker (`:---:`,
+        // dash count padded to the column width).
+        await expect.poll(async () => getMarkdown(page)).toMatch(/:-+:/);
+
+        // Sibling columns are untouched.
+        expect(await columnAligns(table, 1)).toEqual(['none', 'none']);
+    });
+
+    test('clicking center-align again toggles the column back to none', async ({ page }) => {
+        const table = await makeThreeColumnTable(page);
+        let toolbar = await revealColumnToolbar(page, table, 0);
+
+        // First click: center.
+        await toolbar.locator('li.item.center').click();
+        await expect
+            .poll(async () => columnAligns(table, 0))
+            .toEqual(['center', 'center']);
+        await expect.poll(async () => getMarkdown(page)).toMatch(/:-+:/);
+
+        // selectItem re-renders the same toolbar in place; move away then
+        // re-hover so the throttled handler re-targets the column cleanly.
+        await page.mouse.move(5, 5);
+        await page.waitForTimeout(80);
+        toolbar = await revealColumnToolbar(page, table, 0);
+
+        // Second click with the same alignment toggles back to none.
+        await toolbar.locator('li.item.center').click();
+        await expect
+            .poll(async () => columnAligns(table, 0))
+            .toEqual(['none', 'none']);
+        // The center marker is gone; a bare dashes delimiter remains.
+        await expect.poll(async () => getMarkdown(page)).not.toMatch(/:-+:/);
+        expect(await getMarkdown(page)).toMatch(/-{3,}/);
+    });
+
+    test('the toolbar hides when the inline format picker is opened over a cell', async ({ page }) => {
+        const table = await makeThreeColumnTable(page);
+        const toolbar = await revealColumnToolbar(page, table, 0);
+        await expect(toolbar).toBeVisible();
+
+        // Drag-select the body-cell text to open the inline format toolbar
+        // (`muya-format-picker` fires on a non-collapsed selection in a
+        // Format leaf — see block/base/format.ts; the table cell content is a
+        // Format leaf). A dblclick re-anchors the caret to a collapsed
+        // selection in this engine, so drive a real mouse drag instead.
+        const cellContent = table
+            .locator('tr')
+            .last()
+            .locator('td, th')
+            .first()
+            .locator('.mu-table-cell-content')
+            .first();
+        const contentBox = await cellContent.boundingBox();
+        if (!contentBox)
+            throw new Error('cell content has no bounding box');
+        await page.mouse.move(contentBox.x + 2, contentBox.y + contentBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(
+            contentBox.x + contentBox.width - 2,
+            contentBox.y + contentBox.height / 2,
+            { steps: 6 },
+        );
+        await page.mouse.up();
+        await expectShown(page, floats.inlineFormatToolbar);
+
+        // The column toolbar's handler bails to hide() while the format
+        // picker is shown — nudge the mouse back into the hover region so
+        // the throttled handler re-evaluates and suppresses the toolbar.
+        const headerCell = table.locator('tr').first().locator('th, td').first();
+        const box = await headerCell.boundingBox();
+        if (!box)
+            throw new Error('header cell has no bounding box');
+        const probeX = box.x + box.width / 2;
+        const probeY = box.y - 10;
+        await page.mouse.move(probeX, probeY);
+        await page.waitForTimeout(80);
+        await page.mouse.move(probeX, probeY + 1);
+
+        await expect
+            .poll(async () => wrapperOpacity(page, floats.tableColumnTools), {
+                timeout: 5_000,
+                intervals: [50, 100, 250, 500],
+            })
+            .toBe(0);
+    });
+});

--- a/packages/muya/e2e/tests/export/markdown-to-html.spec.ts
+++ b/packages/muya/e2e/tests/export/markdown-to-html.spec.ts
@@ -72,6 +72,53 @@ test.describe('export / MarkdownToHtml', () => {
         expect(html).toMatch(/class="mermaid"|<svg/);
     });
 
+    test('plantuml diagram input renders a .plantuml container with a plantuml.com img (not a bare code fence)', async ({ page }) => {
+        // A fenced `plantuml` block flows through the same renderHtml /
+        // _renderDiagram path as mermaid. The plantuml renderer encodes the
+        // source and replaces the <pre><code> with a `<div class="plantuml">`
+        // holding an `<img src="…plantuml.com/plantuml/svg/…">` (see
+        // utils/diagram/plantuml/index.ts::insertImgElement). We assert the
+        // diagram container shape, NOT the raw `@startuml` code fence.
+        const plantumlMd = '```plantuml\n@startuml\nA -> B\n@enduml\n```\n';
+        const html = await page.evaluate(async (md) => {
+            const instance = new window.MarkdownToHtml!(md);
+            return instance.generate();
+        }, plantumlMd);
+
+        // Diagram container class survives the pipeline.
+        expect(html).toContain('class="plantuml"');
+        // Encoded image points at the default plantuml server svg endpoint.
+        expect(html).toMatch(/<img\s+src="https:\/\/www\.plantuml\.com\/plantuml\/svg\/[^"]+"/);
+        // The literal source must NOT remain wrapped in a <code> fence — the
+        // diagram replaced the original <pre><code class="language-plantuml">.
+        expect(html).not.toMatch(/<code[^>]*>[\s\S]*@startuml/);
+    });
+
+    test('vega-lite diagram input renders a .vega-lite container', async ({ page }) => {
+        // vega-lite shares the _renderDiagram path. The container `<div
+        // class="vega-lite">` is created and inserted before the (async,
+        // CSP/headless-sensitive) embed runs, so the class survives whether
+        // the chart rasterises or falls back to `< Invalid Diagram >`.
+        const vegaMd = '```vega-lite\n'
+            + '{"$schema":"https://vega.github.io/schema/vega-lite/v5.json",'
+            + '"data":{"values":[{"a":"A","b":28},{"a":"B","b":55}]},'
+            + '"mark":"bar","encoding":{"x":{"field":"a","type":"nominal"},'
+            + '"y":{"field":"b","type":"quantitative"}}}\n'
+            + '```\n';
+        const html = await page.evaluate(async (md) => {
+            const instance = new window.MarkdownToHtml!(md);
+            return instance.generate();
+        }, vegaMd);
+
+        // Diagram container class survives the pipeline. vega-embed appends
+        // its own `vega-embed` class, so the container reads
+        // `class="vega-lite vega-embed"` — match the `vega-lite` token within
+        // the class attribute rather than the exact literal.
+        expect(html).toMatch(/<div\s+class="vega-lite(\s|")/);
+        // The raw spec must NOT remain wrapped in a <code> fence.
+        expect(html).not.toMatch(/<code[^>]*>[\s\S]*\$schema/);
+    });
+
     test('script injection: <script> tag is sanitised away and does not execute', async ({ page }) => {
         // Crucial XSS guarantee. The markdown payload below would, if
         // unsanitised, cause `window.__exported = true` on the host

--- a/packages/muya/e2e/tests/typing/code-block.spec.ts
+++ b/packages/muya/e2e/tests/typing/code-block.spec.ts
@@ -1,6 +1,21 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
-import { getMarkdown } from '../helpers/api';
+import { getMarkdown, getState } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
 import { editor } from '../helpers/selectors';
+
+/** A muya state node as returned by `muya.getState()`. */
+interface IStateNode {
+    name: string;
+    text?: string;
+    meta?: { type?: string; lang?: string };
+    children?: IStateNode[];
+}
+
+/** Read the top-level document state as a typed array of blocks. */
+async function getBlocks(page: Page): Promise<IStateNode[]> {
+    return (await getState(page)) as IStateNode[];
+}
 
 test.describe('code block', () => {
     test('typing ``` + Enter converts paragraph to a fenced code block', async ({ page }) => {
@@ -65,5 +80,67 @@ test.describe('code block', () => {
         const md = await getMarkdown(page);
         expect(md).toContain('```js');
         expect(md).toContain('const x = 1;');
+    });
+
+    // Item 97 — lazily-loaded (non-preloaded) language highlights after async load.
+    test('rust code block highlights after the lazy prism-rust import resolves', async ({ page }) => {
+        // `rust` is NOT in the preloaded set
+        // (markup/css/clike/javascript — packages/muya/src/utils/prism/loadLanguage.ts),
+        // so the first render emits plain text and `CodeBlock.set lang` kicks off a
+        // dynamic `import('prism-rust')`; on resolve it re-renders with Prism tokens.
+        await page.evaluate(() => {
+            window.muya!.setContent('```rust\nfn main() { let x = 1; }\n```\n');
+        });
+        await expect(page.locator(editor.codeBlock).first()).toBeVisible();
+
+        // The async import + re-highlight can take a moment, so poll for the first
+        // `.token` span instead of asserting synchronously.
+        const tokens = page.locator(`${editor.codeContent} .token`);
+        await expect(tokens.first()).toBeVisible({ timeout: 15_000 });
+        expect(await tokens.count()).toBeGreaterThan(0);
+
+        // `fn` is a rust keyword — its presence proves the rust grammar (not a
+        // fallback) drove the highlight.
+        await expect(
+            page.locator(`${editor.codeContent} .token.keyword`).first(),
+        ).toHaveText('fn');
+
+        // Round-trip survives serialization.
+        const md = await getMarkdown(page);
+        expect(md).toContain('```rust');
+        expect(md).toContain('fn main() { let x = 1; }');
+    });
+
+    // Item 45 — typing 4 leading spaces + text produces an INDENTED code block.
+    test('typing 4 leading spaces + text converts a paragraph to an indented code block', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        // `_convertToIndentedCodeBlock` (block/base/format.ts) fires from the
+        // inline-update pipeline once the text matches `^( {4,})` — four spaces
+        // then any text.
+        await slowType(page, '    code');
+
+        const codeBlock = page.locator(editor.codeBlock).first();
+        await expect(codeBlock).toBeVisible();
+
+        // Indented blocks carry `mu-indented-code`, never the fenced wrapper class.
+        // (Every code block — including indented — still renders a language-input
+        // row; for an indented block it stays empty, so we assert the wrapper
+        // class rather than the input's presence.)
+        await expect(codeBlock).toHaveClass(/mu-indented-code/);
+        await expect(codeBlock).not.toHaveClass(/mu-fenced-code/);
+        await expect(page.locator(editor.languageInput).first()).toHaveText('');
+
+        // State shape: a single code-block whose meta.type is 'indented'.
+        const blocks = await getBlocks(page);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('code-block');
+        expect(blocks[0].meta?.type).toBe('indented');
+
+        // Round-trip: serializes back to a 4-space-prefixed line, no ``` fence.
+        const md = await getMarkdown(page);
+        expect(md).toContain('    code');
+        expect(md).not.toContain('```');
     });
 });

--- a/packages/muya/e2e/tests/typing/table.spec.ts
+++ b/packages/muya/e2e/tests/typing/table.spec.ts
@@ -147,6 +147,52 @@ test.describe('table', () => {
         expect(md).toContain('|');
     });
 
+    test('typing an inline `code` span in a cell renders a live <code> and round-trips backticks', async ({ page }) => {
+        const table = await makeTwoByTwoTable(page);
+
+        // Same cell-editing path as the `**b**` test: the cell content leaf is
+        // a `Format` block, so the inline backtick-code tokenizer applies.
+        const bodyCell = table.locator('tr').nth(1).locator('td').first();
+        const cellContent = bodyCell.locator('.mu-table-cell-content');
+        await cellContent.click();
+        await slowType(page, '`c`');
+
+        // The code span renders as a live `<code.mu-inline-rule>` element inside
+        // the cell (see inlineRenderer/renderer/inlineCode.ts — it emits
+        // `h('code.mu-inline-rule', ...)`).
+        const code = bodyCell.locator('code');
+        await expect(code).toHaveCount(1);
+        await expect(code).toContainText('c');
+
+        // getMarkdown serialises the code span back into the body cell with its
+        // backtick markers. Same marker-absorption quirk as `**b**` shows up
+        // here, so assert the backtick opener rather than an exact `` `c` ``.
+        await expect.poll(() => getMarkdown(page)).toContain('`c');
+    });
+
+    test('typing an inline link `[x](http://y)` in a cell renders a live link with href and round-trips', async ({ page }) => {
+        const table = await makeTwoByTwoTable(page);
+
+        // Same cell-editing path as the `**b**` test; the inline link tokenizer
+        // applies inside the Format cell content leaf.
+        const bodyCell = table.locator('tr').nth(1).locator('td').first();
+        const cellContent = bodyCell.locator('.mu-table-cell-content');
+        await cellContent.click();
+        await slowType(page, '[x](http://y)');
+
+        // A link WITH anchor text renders via the "has children" branch of
+        // inlineRenderer/renderer/link.ts as `span.mu-inline-rule.mu-link`
+        // (NOT an `<a>` — only the no-text-link branch emits `a.mu-no-text-link`).
+        // The `href` rides on the span's props and is reflected as an attribute.
+        const linkSpan = bodyCell.locator('span.mu-link');
+        await expect(linkSpan).toHaveCount(1);
+        await expect(linkSpan).toHaveAttribute('href', 'http://y');
+        await expect(linkSpan).toContainText('x');
+
+        // getMarkdown serialises the link back into the body cell.
+        await expect.poll(() => getMarkdown(page)).toContain('[x](http://y)');
+    });
+
     test('clicking the table figure dead-zone places the caret in the last cell', async ({ page }) => {
         const table = await makeTwoByTwoTable(page);
 

--- a/packages/muya/e2e/tests/ui/code-block-language-selector.spec.ts
+++ b/packages/muya/e2e/tests/ui/code-block-language-selector.spec.ts
@@ -1,0 +1,138 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
+import { editor, floats } from '../helpers/selectors';
+
+// CodeBlockLanguageSelector (plugin name 'codePicker', float root
+// `.mu-list-picker`) is registered in the host (host/main.ts Muya.use).
+// It listens for `content-change` on `language-input` / `paragraph.content`
+// blocks, runs a fuse.js search over the prism language list (keys
+// name/title/alias) and renders the top-5 matches as `li.item[data-label]`
+// rows. Clicking a row applies that language to the code block.
+//
+// The matches below were confirmed against the live fuse index:
+//   'pyth' -> python, py, rpy, renpy, uscript   (top: python)
+// Source of truth: src/ui/codeBlockLanguageSelector/index.ts +
+// src/utils/prism/index.ts (search()).
+
+// A code block renders a `.mu-language-input` row nested inside its `<pre>`;
+// the `<pre>` intercepts pointer events at the input's center, so a plain
+// Playwright click is unreliable. Focus the language-input the way the engine
+// does — by placing the caret in its content block via setCursor — then real
+// keystrokes land in the input and drive the `content-change` pipeline.
+// (muya keeps a single contenteditable root, so DOM focus stays on
+// `.mu-editor`; the editor's `activeContentBlock` is the real focus target.)
+async function focusFirstLanguageInput(page: Page): Promise<void> {
+    await page.evaluate(() => {
+        const codeBlock = window.muya!.editor.scrollPage.firstChild;
+        codeBlock.firstContentInDescendant().setCursor(0, 0, true);
+    });
+    await expect
+        .poll(() => page.evaluate(() => window.muya!.editor.activeContentBlock?.blockName))
+        .toBe('language-input');
+}
+
+test.describe('code-block language selector', () => {
+    test('typing a fuzzy query in the language input opens the picker', async ({ page }) => {
+        // A fenced code block renders a `.mu-language-input` row; focusing it
+        // and typing emits `content-change` for the language-input block.
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        await expect(page.locator(floats.codeBlockLanguageSelector)).toBeVisible();
+    });
+
+    test('the picker lists fuzzy-matching language items', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        const picker = page.locator(floats.codeBlockLanguageSelector);
+        await expect(picker).toBeVisible();
+        // fuse returns up to 5 matches; each is an `li.item` carrying the
+        // language name as both `data-label` and `.language` text.
+        const items = picker.locator('li.item');
+        await expect(items.first()).toBeVisible();
+        const count = await items.count();
+        expect(count).toBeGreaterThan(0);
+        expect(count).toBeLessThanOrEqual(5);
+        // 'python' is among the matches for the 'pyth' query.
+        await expect(picker.locator('li.item[data-label="python"]')).toHaveCount(1);
+    });
+
+    test('each item carries its language label as data-label and text', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        const python = page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="python"]`);
+        await expect(python).toBeVisible();
+        // The visible row text comes from the `div.language` child.
+        await expect(python.locator('.language')).toHaveText('python');
+    });
+
+    test('clicking a language item applies it to the language input', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        await page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="python"]`).click();
+        // selectItem sets `block.text = name`, so the language input now reads
+        // 'python'.
+        await expect(page.locator(editor.languageInput).first()).toHaveText('python');
+    });
+
+    test('clicking a language item updates the serialized markdown fence', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        await page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="python"]`).click();
+        // The fenced block serializes with the chosen language tag. Markdown
+        // serialization is async after the in-place update — poll it.
+        await expect.poll(() => getMarkdown(page)).toContain('```python');
+    });
+
+    test('the picker hides when the query no longer matches any language', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusFirstLanguageInput(page);
+        await slowType(page, 'pyth');
+        await expect(page.locator(floats.codeBlockLanguageSelector)).toBeVisible();
+        // Clearing the input emits a `content-change` with an empty lang;
+        // `search('')` returns no modes so the selector calls `hide()`.
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        await page.keyboard.press('Backspace');
+        // baseFloat.hide() parks the wrapper off-screen (top:-9999px, opacity:0)
+        // rather than toggling display/visibility, so `toBeVisible()` still
+        // reports true — assert the off-screen park instead.
+        const wrapper = page
+            .locator(floats.codeBlockLanguageSelector)
+            .locator('xpath=ancestor::*[contains(@class,"mu-float-wrapper")]');
+        await expect
+            .poll(() => wrapper.evaluate(el => (el as HTMLElement).style.opacity))
+            .toBe('0');
+    });
+
+    test('typing the opening fence in a paragraph opens the picker', async ({ page }) => {
+        // The selector also listens on `paragraph.content`: a fence prefix like
+        // ```pyth in a plain paragraph is parsed for the language token and
+        // drives the same fuse search.
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '```pyth');
+        const picker = page.locator(floats.codeBlockLanguageSelector);
+        await expect(picker).toBeVisible();
+        await expect(picker.locator('li.item[data-label="python"]')).toHaveCount(1);
+    });
+
+    test('selecting from the paragraph fence picker creates a fenced code block', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '```pyth');
+        await page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="python"]`).click();
+        // On a paragraph.content block selectItem replaces the paragraph with a
+        // freshly-created code-block (state.name === 'code-block').
+        await expect(page.locator(editor.codeBlock).first()).toBeVisible();
+        await expect(page.locator(editor.languageInput).first()).toHaveText('python');
+        await expect.poll(() => getMarkdown(page)).toContain('```python');
+    });
+});


### PR DESCRIPTION
## Summary
Backfills muya **real-browser e2e** coverage (Chromium) for behaviors left unprotected after the muyajs → @muyajs/core migration.

6 specs (2 new, 4 extended):
- `code-block-language-selector` (new) — fuzzy query opens the picker, lists matches, click applies the language + serializes the fence
- `code-block` — Prism highlights a lazily-loaded language; typing 4 leading spaces → indented code block
- `table-column-toolbar` (new) — hover reveals the per-column align toolbar, clicking align updates `data-align` + the delimiter, and it hides under the inline format picker
- `table` — inline `code` / `[x](url)` link render live in a cell and round-trip
- `markdown-to-html` (export) — exported HTML emits `.plantuml` / `.vega-lite` containers, not bare fences
- `mermaid` — quick-insert mermaid/vega render

## Verification
All 6 files green against a clean host (39 tests incl. pre-existing), via the project's Playwright runner. Verified locally because CI's port 5174 differs from a stale local dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)