### PR TITLE
fix(muya): escape pipes at cell start and consecutive pipes in table serialization

### DIFF
--- a/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
+++ b/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
@@ -142,3 +142,56 @@ describe('serializeTable — column alignment', () => {
         expect(secondPass.split('\n')[1]).toBe(delimiterRow);
     });
 });
+
+// Regression for marktext #3563. Typing a literal `|` into a table cell stores
+// a bare pipe in the cell's text. `escapeText` used `/([^\\])\|/g`, which
+// requires a non-backslash character *before* the pipe, so a pipe at the start
+// of a cell — or the second of two consecutive pipes (`||`) — was never escaped.
+// On reopening the saved file that unescaped pipe was read as a column
+// separator and the following text was dropped (the cell content "eaten").
+interface INavNode {
+    name: string;
+    text?: string;
+    children?: INavNode[];
+}
+
+describe('serializeTable — pipe escaping (#3563)', () => {
+    it('escapes a pipe at the very start of a cell', () => {
+        const md = new ExportMarkdown().generate([
+            table([row([cell('|lead'), cell('b')])]),
+        ]);
+
+        expect(md).toContain('\\|lead');
+    });
+
+    it('escapes both of two consecutive pipes in a cell', () => {
+        const md = new ExportMarkdown().generate([
+            table([row([cell('a||b'), cell('c')])]),
+        ]);
+
+        expect(md).toContain('a\\|\\|b');
+    });
+
+    it('round-trips a cell starting with a pipe byte-stably without losing columns', () => {
+        const built = table([
+            row([cell('head1'), cell('head2')]),
+            row([cell('|danger'), cell('keep')]),
+        ]);
+        const md = new ExportMarkdown().generate([built]);
+        expect(md).toContain('\\|danger');
+
+        const reparsed = gen(md) as unknown as INavNode[];
+        const tableNode = reparsed.find(n => n.name === 'table')!;
+        const bodyRow = tableNode.children![1];
+
+        // No phantom column, no content loss or shift into the next cell.
+        expect(bodyRow.children).toHaveLength(2);
+        expect(bodyRow.children![0].text).toContain('danger');
+        expect(bodyRow.children![1].text).toBe('keep');
+
+        // Save -> reopen -> save must be byte-stable; #3563's "reopen eats a
+        // chunk" was progressive corruption across this cycle.
+        const reserialized = new ExportMarkdown().generate(gen(md));
+        expect(reserialized).toBe(md);
+    });
+});

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -36,7 +36,7 @@ import { isAnyListState } from './types';
 
 const debug = logger('export markdown: ');
 function escapeText(str: string) {
-    return str.replace(/([^\\])\|/g, '$1\\|');
+    return str.replace(/(?<!\\)\|/g, '\\|');
 }
 
 export interface IExportMarkdownOptions {


### PR DESCRIPTION
## Summary

Typing a literal `|` into a table cell stores a **bare pipe** in the cell's text. `escapeText` (`stateToMarkdown.ts`) escaped pipes with `/([^\\])\|/g`, which requires a non-backslash character **before** the pipe. As a result:

- a pipe at the **start** of a cell was never escaped, and
- the **second** of two consecutive pipes (`||`) was never escaped.

On reopening the saved file, that unescaped pipe was read as a column separator and the following text was dropped — the cell content was "eaten". This is exactly what the **#3563** reporter describes: *"if the last column has `||`, it keeps only `|` and swallows everything after it."*

## Fix

Switch to a negative-lookbehind `/(?<!\\)\|/g`, which escapes every unescaped pipe regardless of position while leaving already-escaped `\|` untouched. Table round-trips stay byte-stable.

## Tests (TDD)

Added 3 regression tests in `stateToMarkdown.spec.ts` (verified RED on the old regex, GREEN after):

- escapes a pipe at the very start of a cell
- escapes both of two consecutive pipes in a cell
- round-trips a cell starting with a pipe byte-stably without losing columns

Verified: full muya unit suite passes, `test:spec` (CommonMark + GFM) unchanged, `lint`, `lint:types` clean.

## Scope note

This fixes the **table content-loss** part of #3563 (the reproducible bug). The issue's other symptom — text from one document showing in another when several files are open — is a separate, old-engine state-sharing concern not in scope here.

This PR does **not** address #3933: that report writes `中文{some\|` + a **bare** `|` directly in *source*, where the bare pipe is a legitimate GFM cell separator and the extra cell beyond the header is correctly dropped. That is standard parsing, not a serialization bug (handled separately on the issue).

Fixes #3563