### PR TITLE
fix(muya): absorb a manually typed closing markdown marker after text

### DIFF
--- a/packages/muya/src/block/base/__tests__/autoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/autoPair.spec.ts
@@ -301,3 +301,30 @@ describe('autoPair — per-option opt-out', () => {
         expect(needRender).toBe(false);
     });
 });
+
+// ── marktext #3573 absorb manually typed closing markdown marker ──────────
+// With auto-pair on, typing `_` inserts `_|_`. Typing text then the closing
+// `_` should "type over" the auto-paired closing marker (-> `_text_`), but
+// the old `shouldRemoveClosingChar` only absorbed when the char two before
+// the caret was itself a formatting char, so a closing `_` after normal text
+// left a stray trailing `_` (`_text__`).
+describe('autoPair — #3573 absorb manually typed closing markdown marker', () => {
+    it('absorbs the closing `_` typed over the auto-paired one after text', () => {
+        // "_something|_" + type "_" -> browser yields "_something__" @ offset 11
+        const fakeThis = makeFakeThis('_something_', 10);
+        const event = makeInputEvent('insertText', '_');
+        const { text, needRender } = invokeAutoPair(fakeThis, event, '_something__', 11);
+
+        expect(text).toBe('_something_');
+        expect(needRender).toBe(true);
+    });
+
+    it('still doubles `*` into a bold opener (does not absorb marker doubling)', () => {
+        // "*|*" (auto-paired italic) + type "*" -> "***"; must NOT collapse to "**"
+        const fakeThis = makeFakeThis('**', 1);
+        const event = makeInputEvent('insertText', '*');
+        const { text } = invokeAutoPair(fakeThis, event, '***', 2);
+
+        expect(text).not.toBe('**');
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -95,7 +95,7 @@ function extractWord(
 
 function shouldRemoveClosingChar(
     inputChar: string,
-    prePreInputChar: string,
+    preInputChar: string,
     options: { autoPairBracket: boolean; autoPairMarkdownSyntax: boolean; autoPairQuote: boolean },
 ) {
     const { autoPairBracket, autoPairMarkdownSyntax, autoPairQuote } = options;
@@ -107,7 +107,7 @@ function shouldRemoveClosingChar(
         || (autoPairMarkdownSyntax && /\$/.test(inputChar))
         || (autoPairMarkdownSyntax
             && /[*$`~_]/.test(inputChar)
-            && /[_*~]/.test(prePreInputChar))
+            && preInputChar !== inputChar)
     );
 }
 
@@ -207,7 +207,6 @@ function collapsedInputAutoPair(
     const { offset } = start;
     const inputChar = text.charAt(+offset - 1);
     const preInputChar = text.charAt(+offset - 2);
-    const prePreInputChar = text.charAt(+offset - 3);
     const postInputChar = text.charAt(+offset);
     let needRender = false;
 
@@ -217,7 +216,7 @@ function collapsedInputAutoPair(
     if (
         !event.inputType.includes('delete')
         && inputChar === postInputChar
-        && shouldRemoveClosingChar(inputChar, prePreInputChar, options)
+        && shouldRemoveClosingChar(inputChar, preInputChar, options)
     ) {
         needRender = true;
         text = text.substring(0, offset) + text.substring(offset + 1);


### PR DESCRIPTION
## Summary

With auto-pair enabled, typing `_` inserts the pair `_|_`. When the user then types text and the **closing** `_` (a habit many people have), the editor should "type over" the auto-paired closing marker, producing `_text_`. Instead it left a stray trailing marker (`_text__`).

The cause is in `shouldRemoveClosingChar` (`block/base/content.ts`): the markdown-syntax branch only absorbed the typed closing marker when the character **two** positions before the caret was itself a formatting char (`/[_*~]/.test(prePreInputChar)`), which is false for a marker closing a normal word.

## Fix

Gate the markdown-syntax branch on `preInputChar !== inputChar` instead:

- a typed marker matching the next character is absorbed when it closes a span after content (`_word_`, `*word*`, `` `code` ``, `$x$`), and
- doubling an adjacent **opening** marker (`*` → `**`, `_` → `__`, `~` → `~~`) is left intact, so bold / strikethrough still form correctly.

## Tests (TDD)

Added to `autoPair.spec.ts` (verified RED on the old code, GREEN after):

- absorbs the closing `_` typed over the auto-paired one after text
- still doubles `*` into a bold opener (does not absorb marker doubling)

Verified: full muya unit suite **1182 tests pass** (incl. all 19 autoPair cases), muya-e2e autopair + inline specs pass (one triple-click Cmd+B case is pre-existing flaky — passes on re-run, unrelated to this change; it exercises the format-toolbar path, not typing), `lint` and `lint:types` clean.

Fixes #3573

🤖 Generated with [Claude Code](https://claude.com/claude-code)