### PR TITLE
fix(muya): let Shift+ArrowUp/Down extend selection while the inline toolbar is shown

### DIFF
--- a/packages/muya/src/ui/__tests__/uiHandleContentKeydown.spec.ts
+++ b/packages/muya/src/ui/__tests__/uiHandleContentKeydown.spec.ts
@@ -56,4 +56,28 @@ describe('ui.handleContentKeydown', () => {
         expect(ui.handleContentKeydown(event)).toBe(true);
         expect(event.preventDefault).toHaveBeenCalled();
     });
+
+    // #3645 / #3824: Shift+ArrowUp/Down extends the native selection. Even when
+    // a capturing float (the inline format toolbar) is shown, that must not be
+    // swallowed, or selection extension freezes while the toolbar is visible.
+    it('does not preventDefault for Shift+ArrowUp/Down when a capturing float is shown', () => {
+        const ui = makeUi();
+        ui.shownFloat.add(fakeFloat(true));
+        const up = { key: 'ArrowUp', shiftKey: true, preventDefault: vi.fn() } as unknown as KeyboardEvent;
+        const down = { key: 'ArrowDown', shiftKey: true, preventDefault: vi.fn() } as unknown as KeyboardEvent;
+
+        expect(ui.handleContentKeydown(up)).toBe(false);
+        expect(up.preventDefault).not.toHaveBeenCalled();
+        expect(ui.handleContentKeydown(down)).toBe(false);
+        expect(down.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('still preventDefaults plain ArrowUp/Down for a capturing float', () => {
+        const ui = makeUi();
+        ui.shownFloat.add(fakeFloat(true));
+        const event = keyEvent('ArrowUp');
+
+        expect(ui.handleContentKeydown(event)).toBe(true);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
 });

--- a/packages/muya/src/ui/ui.ts
+++ b/packages/muya/src/ui/ui.ts
@@ -41,6 +41,13 @@ export class Ui {
         if (this.shownFloat.size === 0 || !CONTENT_NAV_KEYS.has(event.key))
             return false;
 
+        if (
+            event.shiftKey
+            && (event.key === EVENT_KEYS.ArrowUp || event.key === EVENT_KEYS.ArrowDown)
+        ) {
+            return false;
+        }
+
         for (const tool of this.shownFloat) {
             if (tool.capturesContentKeydown) {
                 event.preventDefault();


### PR DESCRIPTION
## Summary

When text is selected, the inline format toolbar appears and registers as a "capturing" float. `Ui.handleContentKeydown` then called `event.preventDefault()` for **ArrowUp/ArrowDown** unconditionally — so pressing **Shift+ArrowUp/Down** (or Ctrl+Shift+ArrowUp/Down) to *extend* the selection was swallowed, freezing the caret until the toolbar disappeared.

## Fix

Bail out of the capture for `Shift+ArrowUp/Down` (`packages/muya/src/ui/ui.ts`) so the browser's native selection extension proceeds. The toolbar still captures `Enter`/`Escape`/`Tab` and plain `ArrowUp/Down` for its own navigation — only selection-extending arrows are let through.

## Tests (TDD)

Added to `uiHandleContentKeydown.spec.ts` (verified RED before / GREEN after):

- does not preventDefault for Shift+ArrowUp/Down when a capturing float is shown
- still preventDefaults plain ArrowUp/Down for a capturing float (guard)

Verified: full muya unit suite **1181 tests pass**, `lint` and `lint:types` clean.

Fixes #3645
Fixes #3824

🤖 Generated with [Claude Code](https://claude.com/claude-code)