### PR TITLE
fix(muya): keep emphasis intact when a line contains escaped dollar signs

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -262,3 +262,21 @@ describe('inline lexer — link / image dest with parens (marktext 57af8304 / #1
         expect(image.raw).not.toContain('parens');
     });
 });
+
+// Regression for marktext #3778. `lowerPriority` scanned every position for a
+// higher-priority construct (inline math/code/links) that would overlap the
+// emphasis, but treated an escaped `\$` as a real `$` math delimiter — so the
+// first `**bold**` on a line that also contained a later `\$` was suppressed.
+describe('inline lexer — bold with escaped dollar signs (#3778)', () => {
+    it('emits a strong token for every `**`-wrapped span containing an escaped `$`', () => {
+        const tokens = tokenizer('It costs **\\$20** to **\\$30** online.');
+        const strongs = tokens.filter(t => t.type === 'strong');
+        expect(strongs.length, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBe(2);
+    });
+
+    it('still emits em for `*`-wrapped spans containing an escaped `$`', () => {
+        const tokens = tokenizer('a *\\$1* and *\\$2* b');
+        const ems = tokens.filter(t => t.type === 'em');
+        expect(ems.length, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBe(2);
+    });
+});

--- a/packages/muya/src/inlineRenderer/utils.ts
+++ b/packages/muya/src/inlineRenderer/utils.ts
@@ -145,6 +145,15 @@ export function lowerPriority(src: string, offset: number, rules: Rules) {
         if (ignoreIndex.includes(i))
             continue;
 
+        // A character preceded by an odd number of backslashes is escaped
+        // (e.g. `\$`), so it cannot open a higher-priority construct such as
+        // inline math/code and must not lower the surrounding emphasis.
+        let backslashes = 0;
+        for (let j = i - 1; j >= 0 && src[j] === '\\'; j--)
+            backslashes++;
+        if (backslashes % 2 === 1)
+            continue;
+
         const text = src.substring(i);
 
         for (const [, regexp] of Object.entries(rules)) {


### PR DESCRIPTION
## Summary

On a line such as `It costs **\$20** to **\$30** online.`, the first `**\$20**` rendered as plain text instead of bold. `lowerPriority` (`inlineRenderer/utils.ts`) scans each position before an emphasis run for a higher-priority construct (inline math/code/links) that would overlap the emphasis, but it treated an escaped `\$` as a real `$` math delimiter — so the later `\$` produced a spurious "math" match that suppressed the earlier emphasis. The second `**\$30**` rendered fine because no further `$` followed it.

## Fix

Skip positions whose character is escaped (preceded by an odd number of backslashes) when scanning for overlapping higher-priority constructs.

## Tests (TDD)

Added to `commonmarkExamples.spec.ts` (token-level, deterministic — verified RED before / GREEN after):

- emits a `strong` token for every `**`-wrapped span containing an escaped `$` (was 1, now 2)
- still emits `em` for `*`-wrapped spans containing an escaped `$`

Verified: full muya unit suite **1182 tests pass**, `lint` and `lint:types` clean. The change is conformance-neutral (CommonMark/GFM `test:spec` deltas: none).

Fixes #3778

🤖 Generated with [Claude Code](https://claude.com/claude-code)