### PR TITLE
test(muya): poll for the html_tag mount instead of waiting a single frame

### DIFF
--- a/packages/muya/src/block/base/__tests__/formatToggleHtmlTagMount.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggleHtmlTagMount.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type Format from '../format';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CLASS_NAMES } from '../../../config';
 import { Muya } from '../../../muya';
 
@@ -65,23 +65,31 @@ describe('format.format() mounts the html_tag into the live editor DOM', () => {
         const muya = bootMuya('abc\n');
         const content = selectInFirstBlock(muya, 0, 3);
         content.format('u');
-        await new Promise(r => requestAnimationFrame(r));
-        const u = content.domNode!.querySelector<HTMLElement>(
-            `u.${CLASS_NAMES.MU_INLINE_RULE}`,
-        );
-        expect(u).toBeTruthy();
-        expect(u!.textContent).toBe('abc');
+        // The html_tag mounts on a later render tick; poll rather than wait a
+        // single rAF (one frame is not always enough under CI load → flaky).
+        const u = await vi.waitFor(() => {
+            const el = content.domNode!.querySelector<HTMLElement>(
+                `u.${CLASS_NAMES.MU_INLINE_RULE}`,
+            );
+            expect(el).toBeTruthy();
+            return el!;
+        });
+        expect(u.textContent).toBe('abc');
     });
 
     it('mark: applying renders a live `<mark>` element wrapping `abc`', async () => {
         const muya = bootMuya('abc\n');
         const content = selectInFirstBlock(muya, 0, 3);
         content.format('mark');
-        await new Promise(r => requestAnimationFrame(r));
-        const mark = content.domNode!.querySelector<HTMLElement>(
-            `mark.${CLASS_NAMES.MU_INLINE_RULE}`,
-        );
-        expect(mark).toBeTruthy();
-        expect(mark!.textContent).toBe('abc');
+        // The html_tag mounts on a later render tick; poll rather than wait a
+        // single rAF (one frame is not always enough under CI load → flaky).
+        const mark = await vi.waitFor(() => {
+            const el = content.domNode!.querySelector<HTMLElement>(
+                `mark.${CLASS_NAMES.MU_INLINE_RULE}`,
+            );
+            expect(el).toBeTruthy();
+            return el!;
+        });
+        expect(mark.textContent).toBe('abc');
     });
 });


### PR DESCRIPTION
## Summary

`formatToggleHtmlTagMount.spec.ts` (the `<u>`/`<mark>` live-DOM mount tests, split onto jsdom for the DOMPurify-3.4.8+ behavior) applied a format, waited a **single `requestAnimationFrame`**, then synchronously queried for the mounted element. The html_tag mounts on a *later* render tick, so one frame is not always enough under CI load — the query returned `null` intermittently (`expected null to be truthy`), flaking the muya `unit` job on otherwise-unrelated PRs (e.g. #4603).

## Fix

Poll with `vi.waitFor` until the element mounts. It passes immediately when one frame was already enough and retries (up to the default timeout) when it was not — removing the race without weakening the assertion.

## Verification

Ran the spec 5× locally — green every time; `lint` and `lint:types` clean. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)