### PR TITLE
fix(muya): paste a URL into link parentheses without nesting a markdown link

### DIFF
--- a/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteBlockMerge.spec.ts
@@ -163,3 +163,17 @@ describe('paste — NEWLINE into an emptied non-paragraph wrapper (muyajs remove
         expect(muya.editor.scrollPage!.length()).toBe(1);
     });
 });
+
+// marktext #3848: pasting a URL (which the clipboard delivers as a smart-link
+// `[Title](url)`) inside an existing link's parentheses `[text](|)` produced a
+// nested `[text]([Title](url))`. When the caret is in a link destination, a
+// pasted whole markdown link should contribute only its URL.
+describe('paste — markdown link into a link destination uses only the URL (#3848)', () => {
+    it('pasting `[title](url)` inside `[text](|)` yields `[text](url)`, not a nested link', async () => {
+        const muya = bootMuya('[my text]()\n');
+        const block = contentBlocks(muya)[0];
+        // caret between the parentheses of `[my text]()` (offset 10)
+        const md = await paste(muya, block, 10, 10, '[Some Page Title](https://example.com/page)');
+        expect(md).toBe('[my text](https://example.com/page)\n');
+    });
+});

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -361,7 +361,16 @@ function applyParsedPaste(
     if (tryMergeListPaste(clipboard, ctx, states, head, tail))
         return;
 
-    const mergeText = inlineMergeText(states[0], head.length > 0);
+    let mergeText = inlineMergeText(states[0], head.length > 0);
+
+    // Pasting into a link destination `[text](|)`: a pasted whole markdown link
+    // (e.g. a URL the clipboard delivered as a smart-link `[Title](url)`) must
+    // contribute only its URL, otherwise it nests as `[text]([Title](url))`.
+    if (mergeText != null && head.endsWith('](') && tail.startsWith(')')) {
+        const linkMatch = mergeText.match(/^\[.*?\]\((.*)\)$/);
+        if (linkMatch)
+            mergeText = linkMatch[1];
+    }
 
     if (mergeText != null)
         pasteInlineMerge(muya, ctx, states, mergeText, head, tail);


### PR DESCRIPTION
## Summary

Pasting a URL inside an existing link's destination — caret at `[text](|)` — produced a **nested** link `[text]([Title](url))`. The clipboard delivers a copied web URL as a smart-link `<a href="url">Title</a>` → `[Title](url)`, and `applyParsedPaste` spliced that whole markdown link between the parentheses verbatim.

## Fix

In `applyParsedPaste` (`clipboard/paste.ts`), when the caret is in a link destination (`head` ends with `](` and `tail` starts with `)`) and the pasted content is a single whole markdown link, use only its URL — yielding `[text](url)`.

## Tests (TDD)

Added to `pasteBlockMerge.spec.ts` (deterministic, uses the existing plain-text paste harness — verified RED before / GREEN after):

- pasting `[title](url)` inside `[text](|)` yields `[text](url)`, not a nested link

Verified: full muya unit suite **1178 tests pass**, `lint` and `lint:types` clean.

Fixes #3848

🤖 Generated with [Claude Code](https://claude.com/claude-code)