### PR TITLE
fix(muya): make links inside a raw HTML block clickable

### DIFF
--- a/packages/muya/e2e/tests/blocks/html-block-link-3836.spec.ts
+++ b/packages/muya/e2e/tests/blocks/html-block-link-3836.spec.ts
@@ -1,0 +1,38 @@
+import process from 'node:process';
+import { expect, test } from '../fixtures/muya';
+
+// marktext #3836: a link inside a *multi-line* raw HTML block renders into
+// `.mu-html-preview` as a plain `<a>` (no `mu-raw-html` wrapper class), so the
+// link click handler never matched it and Cmd/Ctrl-click did nothing. Inline
+// `<a href>text</a>` (rendered as `a.mu-raw-html`) already worked.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+test('Cmd/Ctrl-click a link inside a multi-line HTML block emits format-click', async ({ page }) => {
+    await page.evaluate(() => {
+        window.muya!.setContent('<a href="https://www.example.com/">\nMarkText\n</a>\n');
+        (window as unknown as { __fc: string[] }).__fc = [];
+        window.muya!.eventCenter.subscribe('format-click', (payload: { data?: { href?: string } }) => {
+            (window as unknown as { __fc: string[] }).__fc.push(payload?.data?.href ?? '');
+        });
+    });
+
+    await expect(page.locator('.mu-html-preview a[href]').first()).toBeVisible();
+
+    // Dispatch a real modifier-click on the anchor element itself. The anchor
+    // text is newline-wrapped inside the preview, so a positional click is
+    // unreliable; dispatching on the element exercises the delegated handler
+    // deterministically.
+    const fired = await page.evaluate((meta) => {
+        const a = document.querySelector('.mu-html-preview a[href]');
+        a?.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            metaKey: meta,
+            ctrlKey: !meta,
+        }));
+        return (window as unknown as { __fc: string[] }).__fc;
+    }, MOD === 'Meta');
+
+    expect(fired).toContain('https://www.example.com/');
+});

--- a/packages/muya/src/editor/linkMouseEvents.ts
+++ b/packages/muya/src/editor/linkMouseEvents.ts
@@ -129,8 +129,11 @@ export function attachLinkMouseHandlers(muya: Muya): void {
 
         // Suppress in-editor navigation for every real anchor variant. Place
         // the cursor instead of opening a tab (standard contenteditable
-        // rich-text pattern). This runs for plain clicks too.
-        const anchor = event.target.closest<HTMLElement>(ANCHOR_CLICK_SELECTOR);
+        // rich-text pattern). This runs for plain clicks too. Anchors inside a
+        // raw HTML block preview (`.mu-html-preview a`) have no wrapper class,
+        // so match them explicitly too.
+        const anchor = event.target.closest<HTMLElement>(ANCHOR_CLICK_SELECTOR)
+            ?? event.target.closest<HTMLElement>(`.${CLASS_NAMES.MU_HTML_PREVIEW} a[href]`);
         if (anchor)
             event.preventDefault();
 
@@ -147,8 +150,28 @@ export function attachLinkMouseHandlers(muya: Muya): void {
             return;
 
         const wrapper = findLinkWrapper(event.target);
-        if (!wrapper)
+        if (!wrapper) {
+            // A link inside a raw HTML block renders into `.mu-html-preview` as
+            // a plain `<a>` (no `mu-raw-html` wrapper), so it is not matched by
+            // LINK_SELECTOR. Emit the jump for it directly.
+            const previewAnchor = event.target.closest<HTMLAnchorElement>(
+                `.${CLASS_NAMES.MU_HTML_PREVIEW} a[href]`,
+            );
+            const previewHref = previewAnchor?.getAttribute('href');
+            if (previewAnchor && previewHref) {
+                eventCenter.emit('format-click', {
+                    event,
+                    formatType: 'link',
+                    data: {
+                        href: previewHref,
+                        raw: previewAnchor.outerHTML,
+                        text: previewAnchor.textContent ?? '',
+                    },
+                });
+            }
+
             return;
+        }
 
         const linkInfo = getLinkInfo(wrapper);
         if (!linkInfo || !linkInfo.href)


### PR DESCRIPTION
## Summary

A link in a **multi-line** raw HTML block, e.g.

```html
<a href="https://www.marktext.cc/">
MarkText
</a>
```

renders into `.mu-html-preview` as a plain `<a>` element with **no** `mu-raw-html` wrapper class. The link click handler's `LINK_SELECTOR` (`span.mu-link, a.mu-reference-link, a.mu-raw-html`) never matched it, so Cmd/Ctrl-click was silently swallowed. The single-line inline form (`<a href>text</a>`, rendered as `a.mu-raw-html`) already worked — exactly the asymmetry the reporter describes.

## Fix

In `linkMouseEvents.ts`, also match anchors inside `.mu-html-preview`:
- suppress their default in-editor navigation on click, and
- on a modifier-click, emit `format-click` with the anchor's `href` so the host opens it.

## Tests (TDD)

Added a muya-e2e spec (`tests/blocks/html-block-link-3836.spec.ts`) — verified RED before / GREEN after (stash-confirmed): a Cmd/Ctrl-click on a link inside a multi-line HTML block emits `format-click` with the href.

Verified: full muya unit suite **1177 pass**, editor link specs pass, `lint`, `lint:types` clean.

Fixes #3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)