### PR TITLE
fix(muya): swap cross-block arrow boundary keys in RTL mode

### DIFF
--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -233,3 +233,52 @@ describe('content arrowHandler — trailing-paragraph creation at document end',
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 });
+
+// marktext #3568: in RTL mode the physical Left/Right arrows are visually
+// mirrored, so the cross-block boundary keys must swap. Offset 0 is the visual
+// RIGHT end of an RTL line (ArrowRight should go to the previous block); offset
+// === text.length is the visual LEFT end (ArrowLeft should go to the next).
+function bootMuyaRtl(markdown: string): Muya {
+    const muya = bootMuya(markdown);
+    muya.domNode.setAttribute('dir', 'rtl');
+    return muya;
+}
+
+describe('content arrowHandler — RTL cross-block navigation (#3568)', () => {
+    it('in RTL, ArrowRight at offset 0 moves the caret to the END of the previous paragraph', async () => {
+        const muya = bootMuyaRtl('alpha\n\nbeta\n');
+        const beta = contentByText(muya, 'beta');
+
+        const event = arrowAt(muya, beta, 'ArrowRight', 0);
+        await flush();
+
+        const alpha = contentByText(muya, 'alpha');
+        const cursor = alpha.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe('alpha'.length);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('in RTL, ArrowLeft at the end of a paragraph moves the caret to the next paragraph', async () => {
+        const muya = bootMuyaRtl('alpha\n\nbeta\n');
+        const alpha = contentByText(muya, 'alpha');
+
+        const event = arrowAt(muya, alpha, 'ArrowLeft', 'alpha'.length);
+        await flush();
+
+        const beta = contentByText(muya, 'beta');
+        expect(beta.getCursor()).not.toBeNull();
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('in RTL, ArrowLeft at offset 0 does NOT navigate cross-block', async () => {
+        const muya = bootMuyaRtl('alpha\n\nbeta\n');
+        const beta = contentByText(muya, 'beta');
+
+        const event = arrowAt(muya, beta, 'ArrowLeft', 0);
+        await flush();
+
+        expect(contentByText(muya, 'alpha').getCursor()).toBeNull();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -446,10 +446,15 @@ class Content extends TreeNode {
         const { muya } = this;
         let cursorBlock = null;
         let offset = 0;
+        // In RTL the physical Left/Right arrows are visually mirrored, so the
+        // cross-block boundary keys swap (offset 0 is the visual right end).
+        const isRtl = this.domNode?.closest('[dir]')?.getAttribute('dir') === 'rtl';
+        const prevKey = isRtl ? EVENT_KEYS.ArrowRight : EVENT_KEYS.ArrowLeft;
+        const nextKey = isRtl ? EVENT_KEYS.ArrowLeft : EVENT_KEYS.ArrowRight;
 
         if (
             event.key === EVENT_KEYS.ArrowUp
-            || (event.key === EVENT_KEYS.ArrowLeft && start.offset === 0)
+            || (event.key === prevKey && start.offset === 0)
         ) {
             event.preventDefault();
             event.stopPropagation();
@@ -462,7 +467,7 @@ class Content extends TreeNode {
         }
         else if (
             event.key === EVENT_KEYS.ArrowDown
-            || (event.key === EVENT_KEYS.ArrowRight && start.offset === this.text.length)
+            || (event.key === nextKey && start.offset === this.text.length)
         ) {
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
## Summary

`Content.arrowHandler` always treated **ArrowLeft at offset 0** as "go to the previous block" and **ArrowRight at end-of-text** as "go to the next block". In an RTL block the physical Left/Right arrows are visually mirrored — offset 0 is the visual *right* end — so at block boundaries the caret moved the wrong direction or got stuck (the reported "cursor moves weirdly").

## Fix

Read the effective text direction from the nearest `[dir]` ancestor (`this.domNode?.closest('[dir]')`) and swap the boundary keys when it is `rtl`:
- prev-block key: `ArrowRight` (RTL) / `ArrowLeft` (LTR) at offset 0
- next-block key: `ArrowLeft` (RTL) / `ArrowRight` (LTR) at end

ArrowUp/ArrowDown are visually unambiguous and unchanged.

## Tests (TDD)

Added to `arrowNavigation.spec.ts` (deterministic, verified RED→GREEN):
- in RTL, ArrowRight at offset 0 → END of previous paragraph
- in RTL, ArrowLeft at end → next paragraph
- in RTL, ArrowLeft at offset 0 does NOT navigate cross-block

All existing LTR navigation tests still pass.

Verified: full muya unit suite **1180 pass**, `lint`, `lint:types` clean.

Fixes #3568

🤖 Generated with [Claude Code](https://claude.com/claude-code)