### PR TITLE
fix(muya): correct inline code/math shortcut labels in the format toolbar

### DIFF
--- a/packages/muya/src/ui/inlineFormatToolbar/__tests__/config.spec.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/__tests__/config.spec.ts
@@ -46,3 +46,21 @@ describe('inlineFormatToolbar config — required inline format types', () => {
         }
     });
 });
+
+// marktext #3630: the inline_code / inline_math tooltips advertised Cmd/Ctrl+E
+// and Shift+Cmd/Ctrl+E, but no platform binds those — the defaults are
+// Cmd/Ctrl+` (inline code) and Shift+Cmd/Ctrl+M (inline math). The label must
+// match the actual keybinding.
+describe('inlineFormatToolbar config — shortcut labels match default keybindings (#3630)', () => {
+    it('inline_code advertises the backtick key, not E', () => {
+        const entry = icons.find(i => i.type === 'inline_code')!;
+        expect(entry.shortcut).toContain('`');
+        expect(entry.shortcut).not.toMatch(/\+E$/i);
+    });
+
+    it('inline_math advertises the M key, not E', () => {
+        const entry = icons.find(i => i.type === 'inline_math')!;
+        expect(entry.shortcut).toMatch(/\+M$/);
+        expect(entry.shortcut).not.toMatch(/\+E$/i);
+    });
+});

--- a/packages/muya/src/ui/inlineFormatToolbar/config.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/config.ts
@@ -46,13 +46,15 @@ const icons = [
     {
         type: 'inline_code',
         tooltip: 'Inline Code',
-        shortcut: `${COMMAND_KEY}+E`,
+        // Default keybinding is Cmd/Ctrl+` (Linux uses Ctrl+Y); was wrongly +E.
+        shortcut: `${COMMAND_KEY}+\``,
         icon: codeIcon,
     },
     {
         type: 'inline_math',
         tooltip: 'Inline Math',
-        shortcut: `⇧+${COMMAND_KEY}+E`,
+        // Default keybinding is Shift+Cmd/Ctrl+M; was wrongly +E.
+        shortcut: `⇧+${COMMAND_KEY}+M`,
         icon: mathIcon,
     },
     {


### PR DESCRIPTION
## Summary

The inline format toolbar's tooltips advertised **`Cmd/Ctrl+E`** for inline code and **`Shift+Cmd/Ctrl+E`** for inline math, but **no platform binds those keys**. The actual defaults (in `keybindings{Darwin,Windows,Linux}.ts`) are:

- inline code: `Cmd+\`` / `Ctrl+\`` (Linux: `Ctrl+Y`)
- inline math: `Shift+Cmd+M` / `Ctrl+Shift+M`

So the popup's shortcuts disagreed with the keyboard-shortcut settings — exactly the reporter's complaint.

## Fix

Update the two labels in `inlineFormatToolbar/config.ts` to the backtick (inline code) and `M` (inline math) defaults.

## Scope

This corrects the **displayed labels** (the reported mismatch). The toolbar's separate in-editor key-interception layer (`index.ts` `FORMAT_SHORTCUTS`) and propagation of user-*customized* keybindings into muya are a deeper concern tracked under #3681 — out of scope here.

## Tests (TDD)

Added to `config.spec.ts` (deterministic, verified RED→GREEN):
- inline_code advertises the backtick key, not E
- inline_math advertises M, not E

Verified: `lint`, `lint:types` clean.

Fixes #3630

🤖 Generated with [Claude Code](https://claude.com/claude-code)