### PR TITLE
fix(desktop): scroll to non-heading in-document anchors on Ctrl/Cmd-click

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1205,6 +1205,12 @@ const scrollToHeader = (slug: unknown) => {
   scrollElementIntoView(resolveTocHeadingElement(container, editorStore.listToc, slug))
 }
 
+// Scrolls to a non-heading in-document anchor target (e.g. a custom
+// `<a id="...">`) resolved by `FORMAT_LINK_CLICK` via `getElementById`.
+const scrollToAnchorElement = (element: unknown) => {
+  if (element instanceof Element) scrollElementIntoView(element)
+}
+
 const scrollToElement = (selector: string) => {
   // Scroll to search highlight word
   scrollElementIntoView(document.querySelector(selector))
@@ -1781,6 +1787,7 @@ onMounted(() => {
   bus.on('deleteParagraph', handleParagraph)
   bus.on('insertParagraph', handleInsertParagraph)
   bus.on('scroll-to-header', scrollToHeader)
+  bus.on('scroll-to-anchor-element', scrollToAnchorElement)
   bus.on('screenshot-captured', handleScreenShot)
   bus.on('show-command-palette', handleModalOpening)
   bus.on('switch-spellchecker-language', switchSpellcheckLanguage)
@@ -1929,6 +1936,7 @@ onBeforeUnmount(() => {
   bus.off('deleteParagraph', handleParagraph)
   bus.off('insertParagraph', handleInsertParagraph)
   bus.off('scroll-to-header', scrollToHeader)
+  bus.off('scroll-to-anchor-element', scrollToAnchorElement)
   bus.off('screenshot-captured', handleScreenShot)
   bus.off('show-command-palette', handleModalOpening)
   bus.off('switch-spellchecker-language', switchSpellcheckLanguage)

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -417,6 +417,13 @@ export const useEditorStore = defineStore('editor', {
           }
         }
 
+        // Fall back to a non-heading target: a custom `<a id="...">` (or any
+        // element with a matching id) rendered in the document.
+        const anchorElement = document.getElementById(anchorSlug)
+        if (anchorElement) {
+          bus.emit('scroll-to-anchor-element', anchorElement)
+        }
+
         return
       }
 

--- a/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-store-anchor.spec.ts
@@ -52,17 +52,38 @@ describe('useEditorStore FORMAT_LINK_CLICK (anchor links)', () => {
     expect(sendSpy).not.toHaveBeenCalled()
   })
 
-  it('does nothing for an anchor that matches no TOC github-slug', () => {
+  it('does nothing for an anchor that matches no TOC github-slug and no DOM id', () => {
     const store = useEditorStore()
     store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
 
     const emitSpy = vi.spyOn(bus, 'emit')
     const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+    const getByIdSpy = vi.spyOn(document, 'getElementById').mockReturnValue(null)
 
     store.FORMAT_LINK_CLICK({ data: { href: '#nope' }, dirname: '' })
 
     expect(emitSpy).not.toHaveBeenCalled()
     expect(sendSpy).not.toHaveBeenCalled()
+    getByIdSpy.mockRestore()
+  })
+
+  // marktext #3609: `[text](#id)` where `#id` is a custom `<a id="id">` (not a
+  // heading) was silently swallowed — it isn't in the TOC. Fall back to the DOM.
+  it('emits scroll-to-anchor-element for a non-heading anchor id found in the DOM', () => {
+    const store = useEditorStore()
+    store.listToc = [{ githubSlug: 'installation', slug: 'uid-1', lvl: 2 }]
+
+    const fakeEl = document.createElement('a')
+    const getByIdSpy = vi.spyOn(document, 'getElementById').mockReturnValue(fakeEl)
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FORMAT_LINK_CLICK({ data: { href: '#jump' }, dirname: '' })
+
+    expect(getByIdSpy).toHaveBeenCalledWith('jump')
+    expect(emitSpy).toHaveBeenCalledWith('scroll-to-anchor-element', fakeEl)
+    expect(sendSpy).not.toHaveBeenCalled()
+    getByIdSpy.mockRestore()
   })
 
   it('ignores a bare "#" (empty anchor slug) without emit or IPC', () => {


### PR DESCRIPTION
## Summary

Ctrl/Cmd-clicking an in-document link `[text](#id)` only worked when `#id` matched a **heading**'s github-slug in the TOC. A link pointing at a custom `<a id="id">` (or any non-heading element) was **silently swallowed** — `FORMAT_LINK_CLICK` looped `listToc` (headings only), found nothing, and returned.

## Fix

After the TOC lookup misses, fall back to `document.getElementById(slug)`. If an element is found, emit a new `scroll-to-anchor-element` bus event; `editor.vue` handles it by scrolling the element into view via the existing shared `scrollElementIntoView` helper (with bus `on`/`off` lifecycle alongside `scroll-to-header`).

## Tests (TDD)

`editor-store-anchor.spec.ts` (deterministic, verified RED→GREEN):
- emits `scroll-to-anchor-element` for a non-heading anchor id found in the DOM
- still a no-op when neither a TOC slug nor a DOM id matches

Verified: desktop unit suite passes, `eslint` clean on the changed files, `typecheck` clean.

Fixes #3609

🤖 Generated with [Claude Code](https://claude.com/claude-code)