### PR TITLE
fix(muya): keep the inline-math parse-error message on one line

### DIFF
--- a/packages/muya/e2e/tests/blocks/math-error-nowrap-4100.spec.ts
+++ b/packages/muya/e2e/tests/blocks/math-error-nowrap-4100.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '../fixtures/muya';
+
+// marktext #4100: an invalid inline-math formula renders a KaTeX parse-error
+// message inside the narrow inline-math popup; without `white-space: nowrap`
+// the message wrapped across several lines and overflowed.
+test('invalid inline math error message stays on one line (#4100)', async ({ page }) => {
+    await page.evaluate(() => window.muya!.setContent('inline $\\g$ math'));
+
+    const err = page.locator('.mu-math-error').first();
+    await expect(err).toBeAttached();
+
+    const whiteSpace = await err.evaluate(el => getComputedStyle(el).whiteSpace);
+    expect(whiteSpace).toBe('nowrap');
+});

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -179,6 +179,10 @@ div .mu-math-error,
     font-size: 14px;
     font-family: monospace;
     font-style: italic;
+
+    /* Keep the KaTeX parse-error message on one line instead of wrapping
+       across the narrow inline-math popup. */
+    white-space: nowrap;
 }
 
 .mu-math > .mu-math-render .katex-display {


### PR DESCRIPTION
## Summary

An invalid inline-math formula (e.g. `$\g$`) renders a KaTeX parse-error message inside the narrow inline-math popup. Without `white-space: nowrap` the message wrapped across several lines and overflowed.

## Fix

Add `white-space: nowrap` to the `.mu-math-error` rule in `inlineSyntax.css`.

## Tests (TDD)

Added a muya-e2e spec asserting the rendered `.mu-math-error` element's computed `white-space` is `nowrap` (verified RED→GREEN — fails without the rule).

Fixes #4100

🤖 Generated with [Claude Code](https://claude.com/claude-code)