### PR TITLE
fix(desktop): isolate the editor stacking context so previews stay under modals

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1965,6 +1965,10 @@ onBeforeUnmount(() => {
 .editor-wrapper {
   height: 100%;
   position: relative;
+  /* Contain the editor's z-indexed children (e.g. the math/diagram preview
+     popups at z-index 10000) in their own stacking context so they cannot
+     paint above modal dialogs rendered outside the editor. */
+  isolation: isolate;
   flex: 1;
   color: var(--editorColor);
 }


### PR DESCRIPTION
## Summary

The math / diagram preview popups use a very high `z-index` (10000). Because `.editor-wrapper` established no stacking-context boundary, that z-index competed with modal dialogs rendered **outside** the editor — so a preview could paint **above** an open dialog (the reported "Math Preview displays above modal dialog").

## Fix

Add `isolation: isolate` to `.editor-wrapper`. This creates a new stacking context for the editor subtree, containing its z-indexed children so they can't escape above sibling/overlay UI. The editor's own floats (preview popups, inline toolbar) live inside the wrapper and are unaffected; modals (Element Plus dialogs) render at the body level and now correctly stack above the editor.

## Verification

`isolation: isolate` is the standard fix for a high-z-index child escaping a modal, and is low-risk (scoping only, no layout change). It is a desktop-renderer CSS change with no lightweight automated harness — **a visual confirmation of the specific modal-over-math case is recommended on review**. `eslint` clean.

Fixes #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)