### PR TITLE
fix(muya): allow inline style in the html-block live preview

### DIFF
--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -406,8 +406,11 @@ export const URL_REG
 export const DATA_URL_REG
     = /^data:image\/[\w+-]+(?:;[\w-]+=[\w-]+|;base64)*,[a-zA-Z0-9+/]+={0,2}$/;
 export const PREVIEW_DOMPURIFY_CONFIG = {
-    // do not forbid `class` because `code` element use class to present language
-    FORBID_ATTR: ['style', 'contenteditable'],
+    // do not forbid `class` because `code` element use class to present language.
+    // `style` is allowed (matching EXPORT_DOMPURIFY_CONFIG) so inline-styled HTML
+    // blocks render the same in the editor as on export; DOMPurify still
+    // sanitizes the style values themselves.
+    FORBID_ATTR: ['contenteditable'],
     ALLOW_DATA_ATTR: false,
     USE_PROFILES: {
         html: true,

--- a/packages/muya/src/utils/__tests__/dompurifyXss.spec.ts
+++ b/packages/muya/src/utils/__tests__/dompurifyXss.spec.ts
@@ -2,7 +2,7 @@
 
 import type { Config } from '../dompurify';
 import { describe, expect, it } from 'vitest';
-import { EXPORT_DOMPURIFY_CONFIG } from '../../config';
+import { EXPORT_DOMPURIFY_CONFIG, PREVIEW_DOMPURIFY_CONFIG } from '../../config';
 import sanitize, { isValidAttribute } from '../dompurify';
 
 // Lock the DOMPurify config to the typed contract so a regression in shape
@@ -93,5 +93,30 @@ describe('marktext 0baf2e9e/7de33f11 — inline html tag XSS defenses', () => {
             const cleaned = sanitize(html, EXPORT_CONFIG) as unknown as string;
             expect(cleaned).toContain('data-align="center"');
         });
+    });
+});
+
+// marktext #3594 / #3697: the editor's live HTML-block preview forbade the
+// `style` attribute while export allowed it, so inline-styled HTML rendered
+// unstyled in the editor. The preview config now matches export — `style`
+// survives, but DOMPurify still strips dangerous attributes.
+describe('preview config — inline style in html blocks (#3594 #3697)', () => {
+    const PREVIEW_CONFIG: Config = PREVIEW_DOMPURIFY_CONFIG;
+
+    it('keeps the style attribute on a styled element', () => {
+        const out = sanitize(
+            '<div style="color: SteelBlue; text-align: center;">centered</div>',
+            PREVIEW_CONFIG,
+        ) as string;
+        expect(out).toContain('style=');
+        expect(out).toContain('text-align');
+    });
+
+    it('still strips event-handler attributes from a styled element', () => {
+        const out = sanitize(
+            '<div style="color: red" onclick="alert(1)">x</div>',
+            PREVIEW_CONFIG,
+        ) as string;
+        expect(out).not.toContain('onclick');
     });
 });


### PR DESCRIPTION
## Summary

The editor's live HTML-block **preview** forbade the `style` attribute (`PREVIEW_DOMPURIFY_CONFIG` had `FORBID_ATTR: ['style', 'contenteditable']`) while the **export** config allowed it. So an inline-styled HTML block such as

```html
<div style="color: SteelBlue; text-align: center;">centered</div>
```

rendered **unstyled** in the editor but **styled** on export — i.e. "CSS styling has no effect inside an HTML block" (#3697) and the preview/export mismatch in #3594.

## Fix

Drop `style` from the preview `FORBID_ATTR`, aligning it with `EXPORT_DOMPURIFY_CONFIG`.

## Security tradeoff (please weigh on review)

This lets inline `style` through DOMPurify in the **live editor** surface, not just export. DOMPurify still:
- sanitizes the CSS in the `style` value (it has a CSS sanitizer; `url(javascript:…)` etc. don't execute in modern Chromium anyway), and
- strips event-handler attributes and `javascript:`/`vbscript:` URLs (asserted by the existing XSS tests, which still pass).

The export surface already trusted DOMPurify's style sanitization, so this only brings the preview to parity. If you'd prefer to keep `style` banned in the live editor for defense-in-depth, this PR can be closed — it's a deliberate policy call.

## Tests (TDD)

Added to `dompurifyXss.spec.ts` (jsdom, verified RED→GREEN):
- preview config keeps `style` on a styled element
- preview config still strips `onclick` from a styled element

Verified: `lint`, `lint:types` clean; existing XSS defenses unchanged.

Fixes #3594
Fixes #3697

🤖 Generated with [Claude Code](https://claude.com/claude-code)