### PR TITLE
fix(desktop): apply custom keybinding changes without an app restart

### DIFF
--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -829,7 +829,11 @@ class App {
 
     ipcMain.handle('mt::keybinding-save-user-keybindings', async(_event, userKeybindings) => {
       const { keybindings } = this._accessor
-      return keybindings.setUserKeybindings(userKeybindings)
+      const editorWindows = this._windowManager
+        .getWindowsByType(WindowType.EDITOR)
+        .map(({ win }) => win.browserWindow)
+        .filter((win): win is BrowserWindow => win != null)
+      return keybindings.setUserKeybindings(userKeybindings, editorWindows)
     })
 
     ipcMain.handle('mt::fs-trash-item', async(_event, fullPath: string) => {

--- a/packages/desktop/src/main/keyboard/shortcutHandler.ts
+++ b/packages/desktop/src/main/keyboard/shortcutHandler.ts
@@ -118,10 +118,37 @@ class Keybindings {
    * @param userKeybindings New user key bindings.
    */
   async setUserKeybindings(
-    userKeybindings: Map<string, string> | Iterable<readonly [string, string]>
+    userKeybindings: Map<string, string> | Iterable<readonly [string, string]>,
+    windows: BrowserWindow[] = []
   ): Promise<boolean> {
     this.userKeybindings = new Map(userKeybindings)
-    return this._saveUserKeybindings()
+    const saved = await this._saveUserKeybindings()
+    this._reloadKeybindings(windows)
+    return saved
+  }
+
+  /**
+   * Rebuilds the active key map from the defaults plus the persisted user
+   * keybindings and re-registers shortcuts on the given windows, so a change
+   * takes effect without restarting the application.
+   */
+  _reloadKeybindings(windows: BrowserWindow[]): void {
+    const previousAccelerators = [...this.keys.values()].filter(
+      (accelerator) => accelerator && accelerator.length > 1
+    )
+
+    this.keys = this.getDefaultKeybindings()
+    this._loadLocalKeybindings()
+
+    for (const win of windows) {
+      if (!win || win.isDestroyed()) {
+        continue
+      }
+      for (const accelerator of previousAccelerators) {
+        this.unregisterAccelerator(win, accelerator)
+      }
+      this.registerEditorKeyHandlers(win)
+    }
   }
 
   // --- private --------------------------------

--- a/packages/desktop/test/unit/specs/keybinding-reload.spec.ts
+++ b/packages/desktop/test/unit/specs/keybinding-reload.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+
+// Main-process slice: instantiate the real `Keybindings` against a temp config
+// dir and a fake window, then verify that saving new user keybindings applies
+// them live (re-registers shortcuts) rather than only persisting to disk.
+
+const { register, unregister } = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  shell: { openPath: vi.fn(), openExternal: vi.fn() }
+}))
+
+vi.mock('@hfelix/electron-localshortcut', () => ({
+  electronLocalshortcut: {
+    register,
+    unregister,
+    setKeyboardLayout: vi.fn()
+  },
+  isValidElectronAccelerator: () => true
+}))
+
+vi.mock('main_renderer/keyboard', () => ({
+  getKeyboardInfo: () => ({ layout: {}, keymap: {} }),
+  keyboardLayoutMonitor: { addListener: vi.fn() }
+}))
+
+import Keybindings from 'main_renderer/keyboard/shortcutHandler'
+
+type CommandManagerArg = ConstructorParameters<typeof Keybindings>[0]
+type AppEnvironmentArg = ConstructorParameters<typeof Keybindings>[1]
+type WinArg = Parameters<Keybindings['registerEditorKeyHandlers']>[0]
+
+const tmpDirs: string[] = []
+
+const makeKeybindings = () => {
+  const userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'mt-keybindings-'))
+  tmpDirs.push(userDataPath)
+  const commandManager = {
+    has: () => true,
+    execute: vi.fn()
+  } as unknown as CommandManagerArg
+  const appEnvironment = {
+    paths: { userDataPath },
+    isDevMode: false
+  } as unknown as AppEnvironmentArg
+  return new Keybindings(commandManager, appEnvironment)
+}
+
+afterEach(() => {
+  register.mockClear()
+  unregister.mockClear()
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Keybindings.setUserKeybindings live re-registration (#3681)', () => {
+  it('re-registers shortcuts on open windows so changes apply without a restart', async() => {
+    const kb = makeKeybindings()
+    const win = { isDestroyed: () => false } as unknown as WinArg
+    register.mockClear()
+    unregister.mockClear()
+
+    const NEW_ACCEL = 'CmdOrCtrl+Alt+Shift+S'
+    await kb.setUserKeybindings(new Map([['file.save', NEW_ACCEL]]), [win])
+
+    // The active key map reflects the new binding immediately.
+    expect(kb.getAccelerator('file.save')).toBe(NEW_ACCEL)
+    // The changed accelerator is registered live on the open window.
+    expect(register).toHaveBeenCalledWith(win, NEW_ACCEL, expect.any(Function))
+    // The previously registered accelerators were torn down first.
+    expect(unregister).toHaveBeenCalled()
+  })
+
+  it('skips destroyed windows', async() => {
+    const kb = makeKeybindings()
+    const win = { isDestroyed: () => true } as unknown as WinArg
+    register.mockClear()
+
+    await kb.setUserKeybindings(new Map([['file.save', 'CmdOrCtrl+Alt+Shift+S']]), [win])
+
+    expect(register).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #3681 — changing a custom keybinding in Preferences did not take effect until the app was restarted.

`Keybindings.setUserKeybindings` (`packages/desktop/src/main/keyboard/shortcutHandler.ts`) only wrote the new bindings to disk. The active `keys` map and the `electron-localshortcut` accelerators registered on each open window were rebuilt **only** by the `Keybindings` constructor, so a change applied solely on the next launch.

## Changes

- `setUserKeybindings(userKeybindings, windows = [])` now, after persisting, calls a new `_reloadKeybindings(windows)` that:
  - **resets `this.keys` to the platform defaults first**, then re-runs `_loadLocalKeybindings()`. This reset is required because `_loadLocalKeybindings` *merges* user accelerators onto the current map rather than recomputing from scratch — without the reset, a removed/changed binding would leave the old accelerator behind.
  - re-registers shortcuts on each open editor window. `@hfelix/electron-localshortcut` exposes no `unregisterAll`, so the previously registered accelerators are unregistered individually before the new set is registered, and destroyed windows are skipped.
- The IPC handler `mt::keybinding-save-user-keybindings` (`app/index.ts`) now passes the open editor windows (`getWindowsByType(WindowType.EDITOR)`) so the reload targets live editor windows only (not the settings window).

## Test

`packages/desktop/test/unit/specs/keybinding-reload.spec.ts` instantiates the real `Keybindings` against a temp config dir + a fake window and verifies:
- after `setUserKeybindings`, the active map reflects the new accelerator and it is registered live on the open window (with the previous accelerators torn down first);
- destroyed windows are skipped.

Written test-first (red → green). `pnpm run typecheck` and ESLint are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)