### PR TITLE
fix(muya): break undo entries at word and edit-kind boundaries

### DIFF
--- a/packages/muya/e2e/tests/editing/undo-redo.spec.ts
+++ b/packages/muya/e2e/tests/editing/undo-redo.spec.ts
@@ -30,4 +30,42 @@ test.describe('undo / redo', () => {
         await page.locator(toolbar.redo).click();
         await expect(para).toContainText('alphabeta');
     });
+
+    // #3825: undo coalesced every keystroke typed within History's 1s window
+    // into one entry, so a single undo wiped out a whole sentence instead of
+    // the most recent action. A correction after typing should be its own
+    // undo step.
+    test('undo after a correction reverts only the correction, not the whole run (#3825)', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        const para = page.locator(editor.paragraph).first();
+        await para.click();
+        await slowType(page, 'hello world');
+        // A correction is a deliberate, separate action — let the typed run
+        // commit (History batches per animation frame) before deleting.
+        await page.waitForTimeout(80);
+        await page.keyboard.press('Backspace');
+        await expect(para).toContainText('hello worl');
+
+        await page.evaluate(() => window.muya!.undo());
+        // Only the deletion is undone — the full typed text comes back.
+        await expect(para).toContainText('hello world');
+        expect(await getMarkdown(page)).toContain('hello world');
+    });
+
+    test('typed words split into separate undo steps (#3825)', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        const para = page.locator(editor.paragraph).first();
+        await para.click();
+        await slowType(page, 'hello world');
+        await expect(para).toContainText('hello world');
+
+        // First undo drops the second word only.
+        await page.evaluate(() => window.muya!.undo());
+        await expect(para).not.toContainText('world');
+        await expect(para).toContainText('hello');
+
+        // Second undo drops the first word.
+        await page.evaluate(() => window.muya!.undo());
+        await expect(para).not.toContainText('hello');
+    });
 });

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -632,6 +632,9 @@ class Format extends Content {
         if (this._checkNotSameToken(this.text, text))
             needRender = true;
 
+        const inputData = 'data' in event && typeof event.data === 'string' ? event.data : null;
+        this.muya.editor.history.markInputBoundary(inputType, inputData);
+
         this.text = text;
 
         const cursor = {
@@ -1294,6 +1297,8 @@ class Format extends Content {
         if (!start || !end || start?.offset !== end?.offset)
             return;
 
+        this.muya.editor.history.markInputBoundary('deleteContentBackward', null);
+
         // fix: #897 in marktext repo
         const { text } = this;
         const { footnote, superSubScript } = this.muya.options;
@@ -1454,6 +1459,8 @@ class Format extends Content {
         if (start.offset !== end.offset || start.offset !== text.length)
             return;
 
+        this.muya.editor.history.markInputBoundary('deleteContentForward', null);
+
         const nextBlock = this.nextContentInContext();
         if (!nextBlock || nextBlock.blockName !== 'paragraph.content') {
             // If the next block is code content or table cell, nothing need to do.
@@ -1492,6 +1499,7 @@ class Format extends Content {
 
     override enterHandler(event: KeyboardEvent): void {
         event.preventDefault();
+        this.muya.editor.history.markInputBoundary('insertParagraph', '\n');
         const { text: oldText, muya, parent } = this;
         const { start, end } = this.getCursor()!;
         this.text = oldText.substring(0, start.offset);

--- a/packages/muya/src/history/__tests__/undoGrouping.spec.ts
+++ b/packages/muya/src/history/__tests__/undoGrouping.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { classifyInputKind, shouldBreakUndoGroup } from '../index';
+
+// Undo grouping is otherwise time-based only (History.delay = 1s), so a fast
+// typed sentence coalesces into a single undo entry (#3825). These helpers
+// drive the boundary decision the input pipeline feeds to History.cutoff().
+
+describe('classifyInputKind', () => {
+    it('classifies insertion input types as "insert"', () => {
+        expect(classifyInputKind('insertText')).toBe('insert');
+        expect(classifyInputKind('insertFromPaste')).toBe('insert');
+        expect(classifyInputKind('insertReplacementText')).toBe('insert');
+    });
+
+    it('classifies deletion input types as "delete"', () => {
+        expect(classifyInputKind('deleteContentBackward')).toBe('delete');
+        expect(classifyInputKind('deleteContentForward')).toBe('delete');
+        expect(classifyInputKind('deleteByCut')).toBe('delete');
+    });
+
+    it('returns null for non insert/delete input types', () => {
+        expect(classifyInputKind('formatBold')).toBeNull();
+        expect(classifyInputKind('historyUndo')).toBeNull();
+        expect(classifyInputKind('')).toBeNull();
+    });
+});
+
+describe('shouldBreakUndoGroup', () => {
+    it('does not break while typing non-whitespace characters', () => {
+        expect(shouldBreakUndoGroup('insert', 'insert', 'a')).toBe(false);
+        expect(shouldBreakUndoGroup(null, 'insert', 'h')).toBe(false);
+    });
+
+    it('breaks on a typed whitespace (word boundary)', () => {
+        expect(shouldBreakUndoGroup('insert', 'insert', ' ')).toBe(true);
+        expect(shouldBreakUndoGroup('insert', 'insert', '\t')).toBe(true);
+    });
+
+    it('breaks when switching between inserting and deleting', () => {
+        expect(shouldBreakUndoGroup('insert', 'delete', null)).toBe(true);
+        expect(shouldBreakUndoGroup('delete', 'insert', 'a')).toBe(true);
+    });
+
+    it('does not break for consecutive deletions', () => {
+        expect(shouldBreakUndoGroup('delete', 'delete', null)).toBe(false);
+    });
+
+    it('never breaks when the new kind is unknown', () => {
+        expect(shouldBreakUndoGroup('insert', null, null)).toBe(false);
+    });
+});

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -78,8 +78,35 @@ const DEFAULT_OPTIONS = {
     userOnly: false,
 };
 
+export type TInputKind = 'insert' | 'delete';
+
+// Undo grouping is otherwise purely time-based (`delay`), so a fast typed
+// sentence coalesces into a single entry. These helpers let the input pipeline
+// hint a boundary: a switch between inserting and deleting, or typing a
+// whitespace (word boundary), starts a fresh undo entry.
+export function classifyInputKind(inputType: string): Nullable<TInputKind> {
+    if (inputType.startsWith('insert'))
+        return 'insert';
+    if (inputType.startsWith('delete'))
+        return 'delete';
+    return null;
+}
+
+export function shouldBreakUndoGroup(
+    prevKind: Nullable<TInputKind>,
+    kind: Nullable<TInputKind>,
+    data: Nullable<string>,
+): boolean {
+    if (kind == null)
+        return false;
+    const isWordBoundary = kind === 'insert' && data != null && /\s/.test(data);
+    const switchedKind = prevKind != null && prevKind !== kind;
+    return isWordBoundary || switchedKind;
+}
+
 class History {
     private _lastRecorded: number = 0;
+    private _lastInputKind: Nullable<TInputKind> = null;
     private _ignoreChange: boolean = false;
     private _selectionStack: (Nullable<IHistorySelection>)[] = [];
     private _stack: IStack = {
@@ -250,6 +277,15 @@ class History {
 
     cutoff() {
         this._lastRecorded = 0;
+    }
+
+    markInputBoundary(inputType: string, data: Nullable<string>): void {
+        const kind = classifyInputKind(inputType);
+        if (kind == null)
+            return;
+        if (shouldBreakUndoGroup(this._lastInputKind, kind, data))
+            this.cutoff();
+        this._lastInputKind = kind;
     }
 
     private _getLastSelection() {


### PR DESCRIPTION
## Summary

Fixes #3825 — a single undo reverted a whole paragraph instead of just the last action.

`History` (`packages/muya/src/history/index.ts`) coalesces every edit recorded within its `delay` window (1s) into one undo entry, and `cutoff()` — the only thing that forces a new entry — was **never called anywhere** in the engine. So a sentence typed faster than 1s/keystroke collapsed into a single undo entry, and one Ctrl+Z wiped it all out.

## Changes

- **`history/index.ts`**: add `markInputBoundary(inputType, data)`. It forces a fresh undo entry (`cutoff()`) when:
  - a **whitespace** character is typed (word boundary), or
  - the edit kind **switches between inserting and deleting** (e.g. typing then a correction).

  The decision is split into two pure, exported helpers — `classifyInputKind` and `shouldBreakUndoGroup` — so it is unit-testable without booting the editor.
- **`block/base/format.ts`**: call `markInputBoundary` from the edit handlers, before the text mutation that gets recorded:
  - `inputHandler` — typed input and native deletions that flow through `input` events (real `inputType` / `data`).
  - `backspaceHandler`, `deleteHandler`, `enterHandler` — these `preventDefault` and set `this.text` directly, bypassing `inputHandler`, so they pass the corresponding synthetic `inputType` (`deleteContentBackward` / `deleteContentForward` / `insertParagraph`).

## Heuristic & trade-offs

This implements the conventional editor heuristic (break on word boundary + insert↔delete transition) rather than pure time-based grouping. Trade-offs, for reviewer visibility:

- **Granularity choice.** Whitespace + edit-kind switches are the least controversial break points and directly match the issue's repro ("type a multi-word text, then delete the last symbol → undo should revert only the deletion"). Punctuation boundaries and selection-jump boundaries are intentionally **not** included to keep the change small and predictable; they can be layered on later.
- **Same-frame fast edits.** `JSONState` batches and composes ops per animation frame, so typing a character and deleting it within the same ~16ms frame still cancel out (the keystroke was effectively never committed). This is acceptable — the reported problem is undoing a whole sentence, which is fixed. The e2e correction test inserts a realistic pause before the correction for determinism.
- **No effect on block-level history** (insertParagraph etc.) or on the existing getHistory/setHistory serialization — those paths don't call the new hook.

## Tests

- Unit (`src/history/__tests__/undoGrouping.spec.ts`): the two decision helpers.
- E2E (`e2e/tests/editing/undo-redo.spec.ts`, real Chromium): undo after a correction reverts only the correction; consecutive typed words split into separate undo steps. The existing undo/redo tests still pass.

`lint:types`, `check-circular`, the history unit suite, and a typing-e2e regression slice are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)