### PR TITLE
fix: #4534 group theme menu into Light/Dark submenus

### DIFF
--- a/packages/desktop/src/main/menu/templates/theme.ts
+++ b/packages/desktop/src/main/menu/templates/theme.ts
@@ -3,10 +3,64 @@ import * as actions from '../actions/theme'
 import { t } from '../../i18n'
 import type Preference from '../../preferences'
 
+// [i18nLabelKey, themeId] for each selectable theme. The menu label is
+// `menu.theme.<labelKey>`; `themeId` is both the menu item id and the value
+// passed to `selectTheme` / compared against the saved theme. (A few light
+// themes keep historical ids, e.g. cadmiumLight -> 'light'.)
+const LIGHT_THEMES: ReadonlyArray<readonly [string, string]> = [
+  ['ayuLight', 'ayu-light'],
+  ['cadmiumLight', 'light'],
+  ['catppuccinLatte', 'catppuccin-latte'],
+  ['everforestLight', 'everforest-light'],
+  ['graphiteLight', 'graphite'],
+  ['gruvboxLight', 'gruvbox-light'],
+  ['rosePineDawn', 'rose-pine-dawn'],
+  ['solarizedLight', 'solarized-light'],
+  ['tokyoNightLight', 'tokyo-night-light'],
+  ['ulyssesLight', 'ulysses']
+]
+
+const DARK_THEMES: ReadonlyArray<readonly [string, string]> = [
+  ['ayuDark', 'ayu-dark'],
+  ['ayuMirage', 'ayu-mirage'],
+  ['cadmiumDark', 'dark'],
+  ['catppuccinMocha', 'catppuccin-mocha'],
+  ['cyberdream', 'cyberdream'],
+  ['dracula', 'dracula'],
+  ['everforestDark', 'everforest-dark'],
+  ['gruvboxDark', 'gruvbox-dark'],
+  ['horizonDark', 'horizon-dark'],
+  ['kanagawa', 'kanagawa'],
+  ['materialDark', 'material-dark'],
+  ['monokaiPro', 'monokai-pro'],
+  ['nightfox', 'nightfox'],
+  ['nord', 'nord'],
+  ['oneDark', 'one-dark'],
+  ['oxocarbonDark', 'oxocarbon-dark'],
+  ['palenight', 'palenight'],
+  ['rosePine', 'rose-pine'],
+  ['rosePineMoon', 'rose-pine-moon'],
+  ['solarizedDark', 'solarized-dark'],
+  ['synthwave84', 'synthwave-84'],
+  ['tokyoNight', 'tokyo-night'],
+  ['tokyoNightStorm', 'tokyo-night-storm']
+]
+
 export default function(userPreference: Preference): MenuItemConstructorOptions {
   const preferences = userPreference.getAll() as { theme?: string; followSystemTheme?: boolean }
   const { theme, followSystemTheme } = preferences
   const isThemeSelectionEnabled = !followSystemTheme
+
+  const themeRadio = ([labelKey, id]: readonly [string, string]): MenuItemConstructorOptions => ({
+    label: t(`menu.theme.${labelKey}`),
+    type: 'radio',
+    id,
+    enabled: isThemeSelectionEnabled,
+    checked: theme === id,
+    click() {
+      actions.selectTheme(id)
+    }
+  })
 
   const submenu: MenuItemConstructorOptions[] = [
     // Follow System Theme
@@ -28,349 +82,20 @@ export default function(userPreference: Preference): MenuItemConstructorOptions 
     })
   }
 
+  // Group themes into nested submenus so the top-level Theme menu stays short
+  // instead of expanding to the full window height with 30+ flat items (#4534).
   submenu.push(
-    // Light Themes (alphabetical)
+    { type: 'separator' },
     {
       label: t('menu.theme.lightThemes'),
-      enabled: false
+      submenu: LIGHT_THEMES.map(themeRadio)
     },
-    {
-      label: t('menu.theme.ayuLight'),
-      type: 'radio',
-      id: 'ayu-light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'ayu-light',
-      click() {
-        actions.selectTheme('ayu-light')
-      }
-    },
-    {
-      label: t('menu.theme.cadmiumLight'),
-      type: 'radio',
-      id: 'light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'light',
-      click() {
-        actions.selectTheme('light')
-      }
-    },
-    {
-      label: t('menu.theme.catppuccinLatte'),
-      type: 'radio',
-      id: 'catppuccin-latte',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'catppuccin-latte',
-      click() {
-        actions.selectTheme('catppuccin-latte')
-      }
-    },
-    {
-      label: t('menu.theme.everforestLight'),
-      type: 'radio',
-      id: 'everforest-light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'everforest-light',
-      click() {
-        actions.selectTheme('everforest-light')
-      }
-    },
-    {
-      label: t('menu.theme.graphiteLight'),
-      type: 'radio',
-      id: 'graphite',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'graphite',
-      click() {
-        actions.selectTheme('graphite')
-      }
-    },
-    {
-      label: t('menu.theme.gruvboxLight'),
-      type: 'radio',
-      id: 'gruvbox-light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'gruvbox-light',
-      click() {
-        actions.selectTheme('gruvbox-light')
-      }
-    },
-    {
-      label: t('menu.theme.rosePineDawn'),
-      type: 'radio',
-      id: 'rose-pine-dawn',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'rose-pine-dawn',
-      click() {
-        actions.selectTheme('rose-pine-dawn')
-      }
-    },
-    {
-      label: t('menu.theme.solarizedLight'),
-      type: 'radio',
-      id: 'solarized-light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'solarized-light',
-      click() {
-        actions.selectTheme('solarized-light')
-      }
-    },
-    {
-      label: t('menu.theme.tokyoNightLight'),
-      type: 'radio',
-      id: 'tokyo-night-light',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'tokyo-night-light',
-      click() {
-        actions.selectTheme('tokyo-night-light')
-      }
-    },
-    {
-      label: t('menu.theme.ulyssesLight'),
-      type: 'radio',
-      id: 'ulysses',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'ulysses',
-      click() {
-        actions.selectTheme('ulysses')
-      }
-    },
-    { type: 'separator' },
-    // Dark Themes (alphabetical)
     {
       label: t('menu.theme.darkThemes'),
-      enabled: false
-    },
-    {
-      label: t('menu.theme.ayuDark'),
-      type: 'radio',
-      id: 'ayu-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'ayu-dark',
-      click() {
-        actions.selectTheme('ayu-dark')
-      }
-    },
-    {
-      label: t('menu.theme.ayuMirage'),
-      type: 'radio',
-      id: 'ayu-mirage',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'ayu-mirage',
-      click() {
-        actions.selectTheme('ayu-mirage')
-      }
-    },
-    {
-      label: t('menu.theme.cadmiumDark'),
-      type: 'radio',
-      id: 'dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'dark',
-      click() {
-        actions.selectTheme('dark')
-      }
-    },
-    {
-      label: t('menu.theme.catppuccinMocha'),
-      type: 'radio',
-      id: 'catppuccin-mocha',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'catppuccin-mocha',
-      click() {
-        actions.selectTheme('catppuccin-mocha')
-      }
-    },
-    {
-      label: t('menu.theme.cyberdream'),
-      type: 'radio',
-      id: 'cyberdream',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'cyberdream',
-      click() {
-        actions.selectTheme('cyberdream')
-      }
-    },
-    {
-      label: t('menu.theme.dracula'),
-      type: 'radio',
-      id: 'dracula',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'dracula',
-      click() {
-        actions.selectTheme('dracula')
-      }
-    },
-    {
-      label: t('menu.theme.everforestDark'),
-      type: 'radio',
-      id: 'everforest-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'everforest-dark',
-      click() {
-        actions.selectTheme('everforest-dark')
-      }
-    },
-    {
-      label: t('menu.theme.gruvboxDark'),
-      type: 'radio',
-      id: 'gruvbox-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'gruvbox-dark',
-      click() {
-        actions.selectTheme('gruvbox-dark')
-      }
-    },
-    {
-      label: t('menu.theme.horizonDark'),
-      type: 'radio',
-      id: 'horizon-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'horizon-dark',
-      click() {
-        actions.selectTheme('horizon-dark')
-      }
-    },
-    {
-      label: t('menu.theme.kanagawa'),
-      type: 'radio',
-      id: 'kanagawa',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'kanagawa',
-      click() {
-        actions.selectTheme('kanagawa')
-      }
-    },
-    {
-      label: t('menu.theme.materialDark'),
-      type: 'radio',
-      id: 'material-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'material-dark',
-      click() {
-        actions.selectTheme('material-dark')
-      }
-    },
-    {
-      label: t('menu.theme.monokaiPro'),
-      type: 'radio',
-      id: 'monokai-pro',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'monokai-pro',
-      click() {
-        actions.selectTheme('monokai-pro')
-      }
-    },
-    {
-      label: t('menu.theme.nightfox'),
-      type: 'radio',
-      id: 'nightfox',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'nightfox',
-      click() {
-        actions.selectTheme('nightfox')
-      }
-    },
-    {
-      label: t('menu.theme.nord'),
-      type: 'radio',
-      id: 'nord',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'nord',
-      click() {
-        actions.selectTheme('nord')
-      }
-    },
-    {
-      label: t('menu.theme.oneDark'),
-      type: 'radio',
-      id: 'one-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'one-dark',
-      click() {
-        actions.selectTheme('one-dark')
-      }
-    },
-    {
-      label: t('menu.theme.oxocarbonDark'),
-      type: 'radio',
-      id: 'oxocarbon-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'oxocarbon-dark',
-      click() {
-        actions.selectTheme('oxocarbon-dark')
-      }
-    },
-    {
-      label: t('menu.theme.palenight'),
-      type: 'radio',
-      id: 'palenight',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'palenight',
-      click() {
-        actions.selectTheme('palenight')
-      }
-    },
-    {
-      label: t('menu.theme.rosePine'),
-      type: 'radio',
-      id: 'rose-pine',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'rose-pine',
-      click() {
-        actions.selectTheme('rose-pine')
-      }
-    },
-    {
-      label: t('menu.theme.rosePineMoon'),
-      type: 'radio',
-      id: 'rose-pine-moon',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'rose-pine-moon',
-      click() {
-        actions.selectTheme('rose-pine-moon')
-      }
-    },
-    {
-      label: t('menu.theme.solarizedDark'),
-      type: 'radio',
-      id: 'solarized-dark',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'solarized-dark',
-      click() {
-        actions.selectTheme('solarized-dark')
-      }
-    },
-    {
-      label: t('menu.theme.synthwave84'),
-      type: 'radio',
-      id: 'synthwave-84',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'synthwave-84',
-      click() {
-        actions.selectTheme('synthwave-84')
-      }
-    },
-    {
-      label: t('menu.theme.tokyoNight'),
-      type: 'radio',
-      id: 'tokyo-night',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'tokyo-night',
-      click() {
-        actions.selectTheme('tokyo-night')
-      }
-    },
-    {
-      label: t('menu.theme.tokyoNightStorm'),
-      type: 'radio',
-      id: 'tokyo-night-storm',
-      enabled: isThemeSelectionEnabled,
-      checked: theme === 'tokyo-night-storm',
-      click() {
-        actions.selectTheme('tokyo-night-storm')
-      }
+      submenu: DARK_THEMES.map(themeRadio)
     }
   )
+
   return {
     label: t('menu.theme.theme'),
     id: 'themeMenu',


### PR DESCRIPTION
Closes #4534

## Summary

The Theme menu built all 33 themes as a single flat submenu. Because this is a native Electron menu (`Menu.popup()` from the title-bar menu button / the system menu bar), it expands to the full window height on Windows — and a CSS `max-height` can't constrain a native menu, so the issue's primary suggestion isn't applicable. This implements the issue's alternative: group the themes into nested **Light Themes** / **Dark Themes** submenus, so the top-level Theme menu stays short (~5 items) and each group opens as its own submenu.

While here, the very repetitive per-theme blocks (10 lines each) are replaced by two small data tables plus a builder function, which is what makes the grouping a few lines.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan

- [x] Manually tested on: macOS

Verified on macOS (Apple Silicon):

- The refactor preserves the **exact** theme set: a script confirmed the new template produces the identical 33 `(i18n label key, theme id)` pairs, in the same order, as before — nothing dropped, added, or renamed.
- Inspected the built menu in the running app (`Menu.getApplicationMenu()`): the top-level Theme submenu now contains the Follow-System-Theme item, a separator, and two group submenus; the Light submenu has 10 entries and the Dark submenu has 23; `getMenuItemById('dracula' | 'nord' | 'ayu-light')` still resolves (Electron's lookup is recursive, so theme actions are unaffected).
- The radio `checked` state is unaffected: themes are still single-source-of-truth (`theme === id`) and the whole menu is rebuilt on `broadcast-preferences-changed`, so selecting a theme in either submenu shows the correct single check.
- Existing e2e suites pass: `menu-sanity`, `themes`, `parity-pg1-menu-state` (20 tests), plus `lint` and `typecheck`.

## Notes for reviewers [optional]

The group submenu labels reuse the existing `menu.theme.lightThemes` / `darkThemes` strings ("— Light Themes —" / "— Dark Themes —") to avoid touching every locale; happy to switch to plain "Light Themes" / "Dark Themes" labels (new i18n keys) if you'd prefer. The Dark group still has 23 entries; if even that should be shorter, splitting further (e.g. by family) is an easy follow-up.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
