### PR TITLE
test(desktop): fix inline code/math shortcut tests failing on develop after #4611

### DIFF
--- a/packages/desktop/test/unit/specs/format-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/format-menu-state.spec.ts
@@ -166,7 +166,7 @@ describe('Format-menu accelerators vs muya inlineFormatToolbar shortcuts', () =>
 
   // strong/em are the requested reconcilable mapping, plus the rest of the set
   // that agrees once notation is normalized.
-  const RECONCILABLE = ['strong', 'em', 'u', 'del', 'mark', 'link', 'image', 'clear'] as const
+  const RECONCILABLE = ['strong', 'em', 'u', 'del', 'mark', 'inline_math', 'link', 'image', 'clear'] as const
 
   it.each(RECONCILABLE)(
     'toolbar shortcut for "%s" matches the Format-menu accelerator (Windows + Linux)',
@@ -179,32 +179,21 @@ describe('Format-menu accelerators vs muya inlineFormatToolbar shortcuts', () =>
     }
   )
 
-  // CHARACTERIZATION of a real drift (see suspectedBugs): the @muyajs/core toolbar
-  // advertises Ctrl+E / ⇧+Ctrl+E for inline code / inline math, but the Format
-  // menu binds Ctrl+` (Win) / Ctrl+Y (Linux) and Ctrl+Shift+M respectively.
-  it('inlineCode shortcut DIVERGES between toolbar and menu accelerator', () => {
+  // After #4611 the toolbar advertises the real defaults — Ctrl+` for inline code
+  // and ⇧+Ctrl+M for inline math — so the tooltips agree with the keybindings.
+  // inline_math now matches the Format menu on every platform (covered by
+  // RECONCILABLE above). inline_code matches on Windows (Ctrl+`) but still
+  // diverges on Linux, which intentionally binds Ctrl+Y (see #4611 / #3630).
+  it('inlineCode toolbar matches Windows but diverges from the Linux accelerator (Ctrl+Y)', () => {
     const toolbar = normalizeShortcut(toolbarShortcutOf('inline_code'))
-    expect(toolbar).toBe(normalizeShortcut('Ctrl+E'))
-    expect(normalizeShortcut(keybindingsWindows.get('format.inline-code'))).toBe(
-      normalizeShortcut('Ctrl+`')
-    )
+    expect(toolbar).toBe(normalizeShortcut('Ctrl+`'))
+    // Windows binds Ctrl+` too, so toolbar and menu now agree there.
+    expect(normalizeShortcut(keybindingsWindows.get('format.inline-code'))).toBe(toolbar)
+    // Linux intentionally binds Ctrl+Y, which still diverges from the toolbar.
     expect(normalizeShortcut(keybindingsLinux.get('format.inline-code'))).toBe(
       normalizeShortcut('Ctrl+Y')
     )
-    expect(normalizeShortcut(keybindingsWindows.get('format.inline-code'))).not.toBe(toolbar)
     expect(normalizeShortcut(keybindingsLinux.get('format.inline-code'))).not.toBe(toolbar)
-  })
-
-  it('inlineMath shortcut DIVERGES between toolbar and menu accelerator', () => {
-    const toolbar = normalizeShortcut(toolbarShortcutOf('inline_math'))
-    expect(toolbar).toBe(normalizeShortcut('Shift+Ctrl+E'))
-    expect(normalizeShortcut(keybindingsWindows.get('format.inline-math'))).toBe(
-      normalizeShortcut('Ctrl+Shift+M')
-    )
-    expect(normalizeShortcut(keybindingsLinux.get('format.inline-math'))).toBe(
-      normalizeShortcut('Ctrl+Shift+M')
-    )
-    expect(normalizeShortcut(keybindingsWindows.get('format.inline-math'))).not.toBe(toolbar)
   })
 })
 


### PR DESCRIPTION
## Summary

The `Test / test` CI job currently fails on `develop` (and therefore on every open PR). The two failing cases are the inline-code / inline-math "DIVERGES" characterization tests in `test/unit/specs/format-menu-state.spec.ts`.

They were pinning a known bug where the muya inline-format toolbar advertised `Ctrl+E` / `Shift+Ctrl+E` for inline code / inline math even though no platform bound those keys. #4611 fixed that bug — the toolbar now shows the real defaults (`Ctrl+\`` for inline code, `Shift+Ctrl+M` for inline math) — but the tests weren't updated, so they still assert the old values and fail.

This updates the tests to the corrected behavior:

- **inline_math** now agrees with the Format-menu accelerator on both Windows and Linux (`Ctrl+Shift+M`), so it moves into the reconcilable ("matches") set.
- **inline_code** now matches on Windows (`Ctrl+\``); Linux intentionally binds `Ctrl+Y` (noted in #4611 / #3630), so the test is rewritten to pin that remaining Linux-only divergence instead of the old both-platforms divergence.

Values were read from source, not guessed: toolbar `packages/muya/src/ui/inlineFormatToolbar/config.ts`, keybindings `keybindingsWindows.ts` / `keybindingsLinux.ts`.

## Type of change

- [x] Bug fix (non-breaking, fixes failing tests on `develop`)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan

- [x] Manually tested on: macOS

`pnpm run test:unit` — full desktop unit suite green (642 tests; the 2 previously-failing cases now pass). `pnpm run lint` and `pnpm run typecheck` pass.

## Notes for reviewers [optional]

Pure test change, no production code touched. Related: #4611.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
