### PR TITLE
fix(muya): clamp selection offset to the node's legal range

### DIFF
--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -15,6 +15,7 @@ import { getCursorCoords } from './cursorCoords';
 import {
     compareParagraphsOrder,
     findContentDOM,
+    getLegalOffset,
     getNodeAndOffset,
     getOffsetOfParagraph,
 } from './dom';
@@ -333,9 +334,9 @@ class TextSelection {
         endOffset?: number,
     ) {
         const range = this._doc.createRange();
-        range.setStart(startNode, startOffset);
+        range.setStart(startNode, getLegalOffset(startNode, startOffset));
         if (endNode && typeof endOffset === 'number')
-            range.setEnd(endNode, endOffset);
+            range.setEnd(endNode, getLegalOffset(endNode, endOffset));
         else
             range.collapse(true);
 
@@ -347,7 +348,7 @@ class TextSelection {
     private _setFocus(focusNode: Node, focusOffset: number) {
         const selection = this._doc.getSelection();
         if (selection)
-            selection.extend(focusNode, focusOffset);
+            selection.extend(focusNode, getLegalOffset(focusNode, focusOffset));
     }
 
     private _updateSelection() {

--- a/packages/muya/src/selection/__tests__/offsetClamp.spec.ts
+++ b/packages/muya/src/selection/__tests__/offsetClamp.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { getLegalOffset, getNodeAndOffset } from '../dom';
+
+// Regression coverage for the `Failed to execute 'setStart' on 'Range'`
+// crashes reported in #4575 / #4464 (offset past the rendered text after a
+// re-render) and #4458 (offset 4294967295 = unsigned -1 from a corrupted
+// browser selection). The legacy engine clamped the recorded offset to the
+// node's legal range before touching the DOM Range API; the rewrite dropped
+// that guard. `getLegalOffset` restores it.
+describe('getLegalOffset', () => {
+    it('clamps a text-node offset to the text length', () => {
+        const text = document.createTextNode('abc');
+
+        expect(getLegalOffset(text, 99)).toBe(3);
+    });
+
+    it('clamps an element-node offset to childNodes.length', () => {
+        const el = document.createElement('span');
+        el.appendChild(document.createTextNode('a'));
+        el.appendChild(document.createElement('b'));
+
+        expect(getLegalOffset(el, 99)).toBe(2);
+    });
+
+    it('coerces a negative offset to 0', () => {
+        const text = document.createTextNode('abc');
+
+        expect(getLegalOffset(text, -1)).toBe(0);
+    });
+
+    it('clamps the unsigned -1 offset (4294967295) to the text length', () => {
+        const text = document.createTextNode('abc');
+
+        expect(getLegalOffset(text, 4294967295)).toBe(3);
+    });
+
+    it('leaves an in-range offset unchanged', () => {
+        const text = document.createTextNode('abcde');
+
+        expect(getLegalOffset(text, 2)).toBe(2);
+    });
+
+    it('produces an offset Range.setStart accepts when getNodeAndOffset overflows', () => {
+        const p = document.createElement('p');
+        p.appendChild(document.createTextNode('hello'));
+        document.body.appendChild(p);
+
+        const { node, offset } = getNodeAndOffset(p, 999);
+        const legal = getLegalOffset(node, offset);
+
+        expect(legal).toBeLessThanOrEqual(
+            node.nodeType === Node.TEXT_NODE
+                ? (node as Text).length
+                : node.childNodes.length,
+        );
+        expect(legal).toBeGreaterThanOrEqual(0);
+
+        p.remove();
+    });
+});

--- a/packages/muya/src/selection/dom.ts
+++ b/packages/muya/src/selection/dom.ts
@@ -188,3 +188,14 @@ export function getNodeAndOffset(
 
     return { node, offset };
 }
+
+export function getLegalOffset(node: Node, offset: number): number {
+    if (!node || typeof offset !== 'number' || !Number.isFinite(offset) || offset < 0)
+        return 0;
+
+    const max = node.nodeType === Node.TEXT_NODE
+        ? (node as Text).length
+        : node.childNodes.length;
+
+    return Math.min(offset, max);
+}


### PR DESCRIPTION
## What

Restores `getLegalOffset` in the muya selection layer and applies it before every DOM `Range`/`Selection` call in `TextSelection._select` and `_setFocus`.

## Why

The legacy `muyajs` engine clamped a recorded selection offset to the target node's legal range before touching the DOM Range API. The `@muyajs/core` rewrite dropped that guard, so renderer crashes from out-of-range offsets came back:

- When a captured text offset exceeds the re-rendered DOM (e.g. typing an ordered list on the line right after a code block), `getNodeAndOffset` falls through and returns an oversized offset, then `range.setStart`/`setEnd`/`selection.extend` throw `Failed to execute 'setStart' on 'Range': There is no child at offset N` / `The offset N is larger than the node's length`.
- A corrupted browser selection can also leak `offset 4294967295` (unsigned `-1`).

## Fix

`getLegalOffset(node, offset)` clamps to the node's legal range — text node → text length, element node → `childNodes.length`, and negative / non-finite → `0` — mirroring the old engine's `clampLegalOffset`. It is applied at the DOM choke points so every caret restore is bounded.

## Tests

New `src/selection/__tests__/offsetClamp.spec.ts` (RED→GREEN) covers the overflow (#4575/#4464) and unsigned-`-1` (#4458) cases plus the in-range pass-through. Full selection suite (9 files / 43 tests), typecheck, lint, and circular-dep check all pass.

Fixes #4575
Fixes #4464
Fixes #4458

🤖 Generated with [Claude Code](https://claude.com/claude-code)