### PR TITLE
fix(desktop): prevent data loss when closing after Source Code mode edits

### DIFF
--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1421,7 +1421,7 @@ export const useEditorStore = defineStore('editor', {
         typeof lastEditIndex === 'number' && lastEditIndex >= 0
           ? tab.history.stack[lastEditIndex]
           : undefined
-      if (
+      const historyMarksDirty =
         (typeof lastEditIndex === 'number' &&
           lastEditIndex >= 0 &&
           editEntry !== undefined &&
@@ -1429,7 +1429,8 @@ export const useEditorStore = defineStore('editor', {
         (lastEditIndex === -1 &&
           tab.lastSavedHistoryId !== -1 &&
           tab.lastSavedHistoryId !== tab.history.lastInitIndex) // Edge Case: Undo to original content (lastEditIndex === -1) after saving means we cant use the lastEditIndex. Compare it against the lastInitIndex instead.
-      ) {
+      const isDirty = history === undefined ? markdown !== oldMarkdown : historyMarksDirty
+      if (isDirty) {
         tab.isSaved = false
         if (pathname && autoSave) {
           const options = getOptionsFromState(tab)
@@ -1441,7 +1442,7 @@ export const useEditorStore = defineStore('editor', {
             options
           })
         }
-      } else if (tab.lastSavedHistoryId !== -1) {
+      } else if (history !== undefined && tab.lastSavedHistoryId !== -1) {
         // Check here is to prevent it from overriding a restored .isSaved state
         tab.isSaved = true // An undo can trigger this
       }

--- a/packages/desktop/test/unit/specs/source-mode-dirty.spec.ts
+++ b/packages/desktop/test/unit/specs/source-mode-dirty.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: {
+        clipboard: { writeText: (s: string) => void }
+        ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void }
+      }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+
+// #4455: editing in Source Code mode and closing without switching back to
+// WYSIWYG silently dropped the save prompt. Source-mode content changes reach
+// LISTEN_FOR_CONTENT_CHANGE WITHOUT an editor `history`, and the history-based
+// dirty check never flips `isSaved` (it can even reset it to true), so the
+// close path saw nothing unsaved. Decide dirty state from the content instead.
+describe('useEditorStore LISTEN_FOR_CONTENT_CHANGE — source-mode dirty tracking (#4455)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const makeSavedTab = (store: ReturnType<typeof useEditorStore>) => {
+    const tab = {
+      id: 'tab-1',
+      filename: 'a.md',
+      pathname: '/x/a.md',
+      markdown: 'hello',
+      trimTrailingNewline: 0,
+      isSaved: true,
+      lastSavedHistoryId: 7,
+      history: { stack: [{ id: 7 }], lastEditIndex: 0, lastInitIndex: -1 }
+    }
+    store.tabs = [tab] as unknown as typeof store.tabs
+    store.tabIdToIndex = { 'tab-1': 0 }
+    return tab
+  }
+
+  it('marks the tab unsaved when source-mode content changes (no history in payload)', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+
+    store.LISTEN_FOR_CONTENT_CHANGE({ id: 'tab-1', markdown: 'hello world' })
+
+    expect(tab.isSaved).toBe(false)
+  })
+
+  it('keeps the tab saved when source-mode fires with unchanged content (caret move)', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+
+    store.LISTEN_FOR_CONTENT_CHANGE({ id: 'tab-1', markdown: 'hello' })
+
+    expect(tab.isSaved).toBe(true)
+  })
+
+  it('leaves the WYSIWYG history-based path unchanged (history present, edit matches saved id)', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+
+    store.LISTEN_FOR_CONTENT_CHANGE({
+      id: 'tab-1',
+      markdown: 'hello world',
+      history: { stack: [{ id: 7 }], lastEditIndex: 0, lastInitIndex: -1 } as never
+    })
+
+    expect(tab.isSaved).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Source Code mode edits now mark the tab dirty, so closing the window after editing in Source Code mode shows the unsaved-changes prompt instead of silently discarding the edits.

## Why (data loss)

`LISTEN_FOR_CONTENT_CHANGE` decides `isSaved` entirely from the editor `history` (`lastEditIndex` / `editEntry.id` vs `lastSavedHistoryId`). Source Code mode (`sourceCode.vue`) commits content **without** a `history` field, so:

- the history branch never flips `isSaved` to `false`, and
- the change instead falls into the `else if` restore branch and resets `isSaved` to `true`.

The close path (`LISTEN_FOR_CLOSE`) collects `tabs.filter(t => !t.isSaved)`; with `isSaved` still `true`, it finds nothing unsaved and closes the window with no save dialog. Editing in Source Code mode and closing without switching back to WYSIWYG therefore loses the edits. (A source-mode caret move could even clear a dirty flag set earlier in WYSIWYG, via the same restore branch.)

## Fix

When the content-change carries no `history` (the Source Code path), decide dirty state from a content comparison (`markdown !== oldMarkdown`). The history-based branch is unchanged for WYSIWYG, and the "restore `isSaved = true`" branch now only runs when a history is present, so a source-mode caret move can no longer clear a pending dirty flag.

## Tests

New `test/unit/specs/source-mode-dirty.spec.ts` (RED→GREEN): source-mode edit → dirty; source-mode caret move (unchanged content) → stays saved; WYSIWYG history path → unchanged. Full desktop unit suite (28 files / 653 tests), lint, and `vue-tsc` typecheck pass.

Fixes #4455

🤖 Generated with [Claude Code](https://claude.com/claude-code)