### PR TITLE
fix(muya): prevent renderer crash when deleting consecutive thematic breaks

### DIFF
--- a/packages/muya/src/block/content/thematicBreakContent/__tests__/handlers.spec.ts
+++ b/packages/muya/src/block/content/thematicBreakContent/__tests__/handlers.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScrollPage } from '../../../scrollPage';
+import ThematicBreakContent from '../index';
+
+// Regression #4559: deleting consecutive blocks crashed the renderer with
+// `NotFoundError: ... is not a child of this node`. Backspace at offset 0 of a
+// thematic break (and Enter at offset 0) convert/insert a block but used to
+// forget `event.preventDefault()`. Because the mu-container is contenteditable,
+// the browser's native edit then mutated the DOM out from under muya's block
+// tree, so a later `insertBefore` on the now-detached node threw. The fix
+// mirrors the existing AtxHeadingContent guard.
+//
+// Exercised with a structurally-typed `this` so no Muya bootstrap is needed.
+interface IFakeTBContent {
+    text: string;
+    muya: unknown;
+    cursor: { start: number; end: number };
+    parent: { parent: { insertBefore: (block: unknown, ref: unknown) => void } };
+    getCursor: () => { start: { offset: number }; end: { offset: number } };
+    setCursor: (start: number, end: number) => void;
+    convertToParagraph: () => void;
+}
+
+function makeFakeContent(cursorAt: number): IFakeTBContent {
+    return {
+        text: '---',
+        muya: {},
+        cursor: { start: cursorAt, end: cursorAt },
+        parent: { parent: { insertBefore: vi.fn() } },
+        getCursor() {
+            return {
+                start: { offset: this.cursor.start },
+                end: { offset: this.cursor.end },
+            };
+        },
+        setCursor(start, end) {
+            this.cursor = { start, end };
+        },
+        convertToParagraph: vi.fn(),
+    };
+}
+
+function makeKeyEvent() {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+}
+
+describe('thematicBreakContent handlers — block native DOM mutation (#4559)', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('backspaceHandler at offset 0 calls preventDefault before converting', () => {
+        const content = makeFakeContent(0);
+        const event = makeKeyEvent();
+
+        ThematicBreakContent.prototype.backspaceHandler.call(
+            content as unknown as ThematicBreakContent,
+            event,
+        );
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(content.convertToParagraph).toHaveBeenCalledTimes(1);
+    });
+
+    it('enterHandler at offset 0 calls preventDefault and stopPropagation before inserting', () => {
+        const create = vi.fn().mockReturnValue({});
+        vi.spyOn(ScrollPage, 'loadBlock').mockReturnValue({ create } as never);
+
+        const content = makeFakeContent(0);
+        const event = makeKeyEvent();
+
+        ThematicBreakContent.prototype.enterHandler.call(
+            content as unknown as ThematicBreakContent,
+            event,
+        );
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+        expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+        expect(content.parent.parent.insertBefore).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/muya/src/block/content/thematicBreakContent/index.ts
+++ b/packages/muya/src/block/content/thematicBreakContent/index.ts
@@ -35,6 +35,8 @@ class ThematicBreakContent extends Format {
         const { text, muya } = this;
         const { start, end } = this.getCursor()!;
         if (start.offset === end.offset && start.offset === 0) {
+            event.preventDefault();
+            event.stopPropagation();
             const newState = {
                 name: 'paragraph',
                 text: '',
@@ -56,6 +58,7 @@ class ThematicBreakContent extends Format {
     override backspaceHandler(event: Event) {
         const { start, end } = this.getCursor()!;
         if (start.offset === 0 && end.offset === 0) {
+            event.preventDefault();
             // Remove the text content and convert it to paragraph
             this.text = '';
             this.convertToParagraph();


### PR DESCRIPTION
## What

`ThematicBreakContent.backspaceHandler` and `enterHandler` now call `event.preventDefault()` in their offset-0 branches (and `stopPropagation()` in `enterHandler`), matching the existing `AtxHeadingContent` guard.

## Why (crash)

Deleting consecutive blocks could crash the renderer with `NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node`.

The mu-container is `contenteditable`, so when Backspace at offset 0 of a thematic break converts it to a paragraph **without** `preventDefault()`, the browser's native Backspace still runs afterward and DOM-removes the freshly created empty paragraph from `ScrollPage`'s node. Muya's `LinkedList` is not updated by that native removal, so the tree and DOM desync. A subsequent Enter then routes through `insertAfter → insertBefore`, calling `domNode.insertBefore(newNode.domNode, ref.domNode)` where `ref.domNode` was already detached — throwing `NotFoundError`. (Enter at offset 0 had the same unguarded native-mutation hazard.)

## Fix

Add `event.preventDefault()` to `backspaceHandler` (offset 0) and `event.preventDefault()` + `event.stopPropagation()` to `enterHandler` (offset 0), so muya remains the sole mutator of the DOM — the same pattern `AtxHeadingContent` already uses.

## Tests

New `thematicBreakContent/__tests__/handlers.spec.ts` (RED→GREEN): both handlers must call `preventDefault` at offset 0. Full muya unit suite (159 files / 1212 tests), typecheck, lint, circular-dep all pass.

Fixes #4559

🤖 Generated with [Claude Code](https://claude.com/claude-code)