### PR TITLE
fix(muya): render inline math containing an escaped dollar sign

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/inlineMathEscape.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/inlineMathEscape.spec.ts
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+
+import type { CodeEmojiMathToken } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+// #4555: an escaped dollar `\$` inside an inline math span ($...$) broke the
+// block's rendering. The inline_math content group did not allow backslash
+// escapes, so the inner `\$` was read as the closing delimiter and the math
+// expression was truncated / mis-tokenized.
+function mathContent(src: string): string | undefined {
+    const token = tokenizer(src).find(t => t.type === 'inline_math') as
+        | CodeEmojiMathToken
+        | undefined;
+    return token?.content;
+}
+
+describe('inline math — escaped dollar (#4555)', () => {
+    it('keeps an escaped \\$ inside the math expression', () => {
+        expect(mathContent('$y = \\$10000$')).toBe('y = \\$10000');
+    });
+
+    it('still tokenizes a plain $a+b$ unchanged', () => {
+        expect(mathContent('$a+b$')).toBe('a+b');
+    });
+});

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -63,7 +63,8 @@ export type GfmRules = typeof gfmRules;
 
 // Markdown extensions (not belongs to GFM and Commonmark)
 export const inlineExtensionRules = {
-    inline_math: /^(\$)([^$]*?[^$\\])(\\*)\1(?!\1)/,
+    // eslint-disable-next-line regexp/no-super-linear-backtracking
+    inline_math: /^(\$)((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/,
     // This is not the best regexp, because it not support `2^2\\^`.
     superscript: /^(\^)((?:[^^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,
     subscript: /^(~)((?:[^~\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,


### PR DESCRIPTION
## What

Widen the `inline_math` content group so an escaped `\$` inside `$...$` is treated as part of the expression instead of as the closing delimiter.

## Why

`$y = \$10000$` rendered broken. The content group `([^$]*?[^$\\])` excluded `$` entirely, so the inner escaped `\$` was read as the closing `$`. The match was then rejected by the `isLengthEven` gate (odd trailing backslash), and the lexer fell back to mis-tokenizing the line — the math no longer rendered.

## Fix

`rules.ts`: change the content group from `[^$]*?[^$\\]` to `(?:[^$\\]|\\.)+`, so backslash escapes (`\$`, `\\`) are consumed as content. The `(\\*)` trailing-backslash group and the lexer's `isLengthEven(to[3])` gate still correctly reject a genuinely escaped closing `$`. The `eslint-disable regexp/no-super-linear-backtracking` mirrors the sibling `del` rule, which uses the same `(\\*)\1` delimiter idiom.

## Tests

New `inlineRenderer/__tests__/inlineMathEscape.spec.ts` (RED→GREEN): `$y = \$10000$` tokenizes with content `y = \$10000`; plain `$a+b$` unchanged. Full muya unit suite (159 files / 1212 tests) and CommonMark+GFM conformance (1347) pass — no tokenizer regression.

Fixes #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)