### PR TITLE
fix(desktop): remove duplicate title when using the native title bar

### DIFF
--- a/packages/desktop/src/renderer/src/components/titleBar/index.vue
+++ b/packages/desktop/src/renderer/src/components/titleBar/index.vue
@@ -1,10 +1,12 @@
 <template>
   <div>
     <div
+      v-if="showTitleBar"
       class="title-bar-editor-bg"
       :class="{ 'tabs-visible': showTabBar }"
     />
     <div
+      v-if="showTitleBar"
       class="title-bar"
       :class="[
         { active: active },
@@ -142,6 +144,7 @@ import { storeToRefs } from 'pinia'
 import { minimizePath, restorePath, maximizePath, closePath } from '../../assets/window-controls.js'
 import { PATH_SEPARATOR } from '../../config'
 import { isOsx as isOsxPlatform } from '@/util'
+import { shouldShowInAppTitleBar } from './visibility'
 import { useEditorStore } from '@/store/editor'
 import { useI18n } from 'vue-i18n'
 import { ArrowRight } from '@element-plus/icons-vue'
@@ -217,6 +220,10 @@ const paths = computed(() => {
 
 const showCustomTitleBar = computed(() => {
   return titleBarStyle.value === 'custom' && !isOsx
+})
+
+const showTitleBar = computed(() => {
+  return shouldShowInAppTitleBar(titleBarStyle.value, isOsx)
 })
 
 watch(

--- a/packages/desktop/src/renderer/src/components/titleBar/visibility.ts
+++ b/packages/desktop/src/renderer/src/components/titleBar/visibility.ts
@@ -1,0 +1,3 @@
+export function shouldShowInAppTitleBar(titleBarStyle: string, isOsx: boolean): boolean {
+  return titleBarStyle !== 'native' || isOsx
+}

--- a/packages/desktop/test/unit/specs/titlebar-visibility.spec.ts
+++ b/packages/desktop/test/unit/specs/titlebar-visibility.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowInAppTitleBar } from '@/components/titleBar/visibility'
+
+// #4210: with the native title bar (non-macOS, `frame: true`), the OS draws a
+// title bar showing document.title AND the in-app custom title bar rendered the
+// same filename — the title appeared twice. The in-app bar must be hidden when
+// the native title bar is active. On macOS the window is always frameless, so
+// the in-app bar must still show.
+describe('shouldShowInAppTitleBar (#4210)', () => {
+  it('hides the in-app title bar for the native style on non-macOS', () => {
+    expect(shouldShowInAppTitleBar('native', false)).toBe(false)
+  })
+
+  it('still shows the in-app title bar on macOS even with the native style', () => {
+    expect(shouldShowInAppTitleBar('native', true)).toBe(true)
+  })
+
+  it('shows the in-app title bar for the custom style', () => {
+    expect(shouldShowInAppTitleBar('custom', false)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Hide the in-app custom title bar when the **native** title bar style is active on non-macOS, so the window title is no longer shown twice.

## Why

With `Title Bar Style → Native` (non-macOS), the main process creates the `BrowserWindow` with `frame: true`, so the OS draws a native title bar showing `document.title` (the filename). But the renderer still mounted `<title-bar>` unconditionally, which renders the same filename in its `.title` element — the title appeared both in the OS bar and the in-app bar. (The preferences page already guards its `TitleBar` with `v-if`; the editor page did not.)

## Fix

Gate the in-app title-bar DOM (`.title-bar-editor-bg` and `.title-bar`) behind a new `showTitleBar` computed backed by the pure helper `shouldShowInAppTitleBar(titleBarStyle, isOsx)` — hidden when the style is `native` and not macOS; macOS windows are always frameless so it still shows. The `document.title` watcher stays in `<script setup>`, so the native OS title bar keeps updating on tab switch / rename while the in-app bars are hidden.

## Tests

The desktop unit runner has no `@vue/test-utils`/template rendering, so the show/hide decision is extracted into a pure helper and unit-tested directly. New `test/unit/specs/titlebar-visibility.spec.ts` (RED→GREEN): `native` + non-macOS → hidden; `native` + macOS → shown; `custom` → shown. Full desktop unit suite (28 files / 653 tests), `vue-tsc`, and lint pass.

Fixes #4210

🤖 Generated with [Claude Code](https://claude.com/claude-code)