### PR TITLE
fix: opaque light-theme editor text colors for crisp antialiasing

### DIFF
--- a/packages/desktop/src/renderer/src/assets/styles/index.css
+++ b/packages/desktop/src/renderer/src/assets/styles/index.css
@@ -19,14 +19,14 @@
 
   --highlightColor: rgba(33, 181, 111, 0.4);
   --selectionColor: rgba(0, 0, 0, 0.1);
-  --editorColor: rgba(0, 0, 0, 0.7);
-  --editorColor80: rgba(0, 0, 0, 0.8);
-  --editorColor60: rgba(0, 0, 0, 0.6);
-  --editorColor50: rgba(0, 0, 0, 0.5);
-  --editorColor40: rgba(0, 0, 0, 0.4);
-  --editorColor30: rgba(0, 0, 0, 0.3);
-  --editorColor10: rgba(0, 0, 0, 0.1);
-  --editorColor04: rgba(0, 0, 0, 0.03);
+  --editorColor: #4d4d4d;
+  --editorColor80: #333333;
+  --editorColor60: #666666;
+  --editorColor50: #808080;
+  --editorColor40: #999999;
+  --editorColor30: #b3b3b3;
+  --editorColor10: #e6e6e6;
+  --editorColor04: #f7f7f7;
   --editorBgColor: rgba(255, 255, 255, 1);
   --deleteColor: #ff6969;
   --iconColor: #6b737b;

--- a/packages/desktop/test/unit/specs/light-theme-opaque-colors.spec.ts
+++ b/packages/desktop/test/unit/specs/light-theme-opaque-colors.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// #4466: the light-theme editor TEXT colors used a semi-transparent alpha
+// channel (`rgba(0,0,0,0.7)` …). Alpha-composited text forces Chromium into
+// grayscale antialiasing, so body text rendered aliased / thinner on FHD
+// (96 dpi) displays. Keep the light-theme editor text colors opaque so font
+// rendering stays crisp. (Translucent overlays — selection / highlight — keep
+// their alpha and are intentionally not covered here.)
+const here = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(
+  resolve(here, '../../../src/renderer/src/assets/styles/index.css'),
+  'utf8'
+)
+
+const TEXT_COLOR_VARS = [
+  '--editorColor',
+  '--editorColor80',
+  '--editorColor60',
+  '--editorColor50',
+  '--editorColor40',
+  '--editorColor30',
+  '--editorColor10',
+  '--editorColor04'
+]
+
+describe('light-theme editor text colors are opaque (#4466)', () => {
+  for (const name of TEXT_COLOR_VARS) {
+    it(`${name} has no alpha channel`, () => {
+      const match = css.match(new RegExp(`${name}:\\s*([^;]+);`))
+      expect(match, `${name} declaration not found`).toBeTruthy()
+      const value = match![1].trim()
+      expect(value, `${name} = ${value}`).not.toMatch(/rgba|hsla|\/\s*[\d.]+\s*\)/i)
+    })
+  }
+})

--- a/packages/muya/src/assets/styles/__tests__/opaqueEditorColors.spec.ts
+++ b/packages/muya/src/assets/styles/__tests__/opaqueEditorColors.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// #4466: the light-theme editor TEXT colors used a semi-transparent alpha
+// channel (`rgb(0 0 0 / 70%)` …). Alpha-composited text forces Chromium into
+// grayscale antialiasing, so body text rendered aliased / thinner on FHD
+// displays. Keep the @muyajs/core light-theme editor text colors opaque so
+// font rendering stays crisp. Translucent overlays (selection / highlight)
+// intentionally keep their alpha and are not covered here.
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(here, '../index.css'), 'utf8');
+
+const TEXT_COLOR_VARS = [
+    '--editor-color',
+    '--editor-color-80',
+    '--editor-color-50',
+    '--editor-color-30',
+    '--editor-color-10',
+    '--editor-color-04',
+];
+
+describe('light-theme editor text colors are opaque (#4466)', () => {
+    for (const name of TEXT_COLOR_VARS) {
+        it(`${name} has no alpha channel`, () => {
+            const match = css.match(new RegExp(`${name}:\\s*([^;]+);`));
+            expect(match, `${name} declaration not found`).toBeTruthy();
+            const value = match![1].trim();
+            expect(value, `${name} = ${value}`).not.toMatch(/rgba|hsla|\//i);
+        });
+    }
+});

--- a/packages/muya/src/assets/styles/index.css
+++ b/packages/muya/src/assets/styles/index.css
@@ -3,12 +3,12 @@
     --theme-color: rgb(33 181 111 / 100%);
     --highlight-color: rgb(33 181 111 / 40%);
     --selection-color: rgb(45 170 219 / 30%);
-    --editor-color: rgb(0 0 0 / 70%);
-    --editor-color-80: rgb(0 0 0 / 80%);
-    --editor-color-50: rgb(0 0 0 / 50%);
-    --editor-color-30: rgb(0 0 0 / 30%);
-    --editor-color-10: rgb(0 0 0 / 10%);
-    --editor-color-04: rgb(0 0 0 / 3%);
+    --editor-color: #4d4d4d;
+    --editor-color-80: #333;
+    --editor-color-50: #808080;
+    --editor-color-30: #b3b3b3;
+    --editor-color-10: #e6e6e6;
+    --editor-color-04: #f7f7f7;
     --editor-bg-color: rgb(255 255 255 / 100%);
 
     /* width of the centered editing column (`.mu-container` max-width) */


### PR DESCRIPTION
## What

Make the **light-theme** editor text-color variables opaque (hex) instead of semi-transparent black, in both the desktop shell and the `@muyajs/core` engine.

## Why

The reporter (#4466) found that on a FullHD (96 dpi) IPS display, body text in the light theme looks aliased/thinner while every other theme looks fine — and diagnosed the cause themselves: the **alpha channel**. The light-theme editor text used `rgba(0,0,0,0.7)` / `rgb(0 0 0 / 70%)`. Alpha-composited text can't use subpixel hinting, so Chromium falls back to grayscale antialiasing and the strokes render lighter/jagged. The reporter fixed it locally by removing the alpha channel and asked for the same in the default theme.

## Fix

Replace the editor **text** color variables with their opaque hex equivalents on the white editor background (`rgba(0,0,0,0.7)` → `#4d4d4d`, etc.):
- `packages/desktop/src/renderer/src/assets/styles/index.css` — `--editorColor*`
- `packages/muya/src/assets/styles/index.css` — `--editor-color*`

Translucent **overlays** (selection / highlight) intentionally keep their alpha — they're meant to composite over text. Scope is the built-in light theme only: dark themes and the gogh light variants override their own color variables, so they're unaffected.

## Tests

Pure visual AA can't be asserted headlessly, so each package gets a regression guard that locks the fix's intent — the light-theme editor text-color variables must have **no alpha channel** (`light-theme-opaque-colors.spec.ts` / `opaqueEditorColors.spec.ts`, RED→GREEN). Full muya (1216) and desktop (653) unit suites, typecheck, and lint pass; no new stylelint problems.

Fixes #4466

🤖 Generated with [Claude Code](https://claude.com/claude-code)