### PR TITLE
fix(muya): center inline math vertically so it sits on the text baseline

### DIFF
--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -154,7 +154,7 @@ code.mu-inline-rule {
 
     color: var(--editor-color);
     font-family: monospace;
-    vertical-align: bottom;
+    vertical-align: middle;
 }
 
 .mu-math > .mu-math-render,


### PR DESCRIPTION
## What

Change `.mu-math` from `vertical-align: bottom` to `middle` so inline math (`$...$`) sits on the surrounding text's baseline instead of floating above it.

## Why

Inline math rendered noticeably too high. `.mu-math` is an `inline-block` whose monospace line box is ~12px taller than the KaTeX it wraps, so the formula sat in the **upper** part of an inflated line while the surrounding text aligned to the lower baseline. `vertical-align: bottom` (and `baseline`) pin that inflated box, keeping the math raised. (The file already documents this exact inline-block-baseline pitfall for the `.mu-math-error` case near `overflow: visible`.)

## Fix

`.mu-math { vertical-align: bottom → middle }` (one line). `middle` aligns the math box to the text centre, landing inline formulae on the line and centring tall math (fractions) naturally.

## Verification

This is a pure visual change with no headless unit surface, so it was verified by rendering in real Chromium and comparing alignment:

- before (`bottom`): `a ≠ b` floats above "Reference text … and tail text here"
- after (`middle`): `Income y = $10000 per year here` all on one baseline; `\frac{a}{b}` centres naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)