### PR TITLE
fix(muya): convert typed diagram fences to diagram blocks on Enter (#2177)

### DIFF
--- a/packages/muya/src/block/content/paragraphContent/__tests__/enterConvert.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/enterConvert.spec.ts
@@ -164,6 +164,62 @@ describe('enter on ```` ```js ```` — converts to a fenced code-block', () => {
     });
 });
 
+// #2177: typing ```` ```mermaid ```` (or any diagram language) and pressing
+// Enter must produce a diagram block, the same as loading that fence from a
+// file. The file-load path (markdownToState) already routes the five diagram
+// languages to a `diagram` state; the live-typing path must match.
+describe('enter on ```` ```mermaid ```` — converts to a diagram block', () => {
+    it('replaces the paragraph with a single diagram block (not a code-block)', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```mermaid');
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('diagram');
+    });
+
+    it('records meta.type === "mermaid" and meta.lang === "yaml"', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```mermaid');
+
+        await flush();
+        const state = muya.getState();
+        const meta = (state[0] as { meta: { lang: string; type: string } }).meta;
+        expect(meta.type).toBe('mermaid');
+        expect(meta.lang).toBe('yaml');
+    });
+
+    it('uses meta.lang === "json" for a vega-lite fence', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```vega-lite');
+
+        await flush();
+        const state = muya.getState();
+        expect(state[0].name).toBe('diagram');
+        const meta = (state[0] as { meta: { lang: string; type: string } }).meta;
+        expect(meta.type).toBe('vega-lite');
+        expect(meta.lang).toBe('json');
+    });
+
+    it('still converts a non-diagram fence (```js) to a code-block', async () => {
+        const muya = bootMuya('seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState();
+        expect(state[0].name).toBe('code-block');
+    });
+});
+
 describe('enter on `<div>` — converts to an html-block', () => {
     it('replaces the paragraph with a single html-block', async () => {
         const muya = bootMuya('seed\n');

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -4,6 +4,7 @@ import type { IRenderCursor } from '../../../selection/types';
 import type {
     IBlockQuoteState,
     IBulletListState,
+    IDiagramMeta,
     IListItemState,
     IOrderListState,
     IParagraphState,
@@ -249,24 +250,48 @@ class ParagraphContent extends Format {
             mathBlock.firstContentInDescendant().setCursor(0, 0);
         }
         else if (codeBlockToken) {
-            // Convert to code block
             const lang = codeBlockToken[2];
-            const state = {
-                name: 'code-block',
-                meta: {
-                    lang,
-                    type: 'fenced',
-                },
-                text: '',
-            };
-            const codeBlock = ScrollPage.loadBlock(state.name).create(
-                this.muya,
-                state,
-            );
+            // Diagram fences (```mermaid etc.) become diagram blocks, mirroring
+            // the file-load path in markdownToState; everything else is a fenced
+            // code block.
+            const diagramMatch = /^(?:mermaid|vega-lite|plantuml|flowchart|sequence)$/.exec(lang);
+            if (diagramMatch) {
+                const type = lang as IDiagramMeta['type'];
+                const state = {
+                    name: 'diagram',
+                    text: '',
+                    meta: {
+                        type,
+                        lang: type === 'vega-lite' ? 'json' : 'yaml',
+                    },
+                };
+                const diagramBlock = ScrollPage.loadBlock(state.name).create(
+                    this.muya,
+                    state,
+                );
 
-            this.parent!.replaceWith(codeBlock);
+                this.parent!.replaceWith(diagramBlock);
 
-            codeBlock.lastContentInDescendant().setCursor(0, 0);
+                diagramBlock.firstContentInDescendant().setCursor(0, 0, true);
+            }
+            else {
+                const state = {
+                    name: 'code-block',
+                    meta: {
+                        lang,
+                        type: 'fenced',
+                    },
+                    text: '',
+                };
+                const codeBlock = ScrollPage.loadBlock(state.name).create(
+                    this.muya,
+                    state,
+                );
+
+                this.parent!.replaceWith(codeBlock);
+
+                codeBlock.lastContentInDescendant().setCursor(0, 0);
+            }
         }
         else if (
             tableMatch


### PR DESCRIPTION
Fixes #2177

## Problem

Typing a diagram fence — ```` ```mermaid ````, ```` ```vega-lite ````, ```` ```plantuml ````, ```` ```flowchart ````, ```` ```sequence ```` — and pressing <kbd>Enter</kbd> produced a plain fenced **code block**, not a diagram. Loading the exact same fence from a file *does* produce a diagram block, so the two entry points were inconsistent.

## Root cause

The file-load path (`packages/muya/src/state/markdownToState.ts`) matches the fence info string against `/^(mermaid|vega-lite|plantuml|flowchart|sequence)$/` and emits a `diagram` state. The live-typing path (`ParagraphContent._enterConvert`) unconditionally built a `code-block` and never checked the language.

## Fix

In `_enterConvert`, when the fence language is one of the five diagram types, build a `diagram` block instead — `meta.type` = the language, `meta.lang` = `json` for vega-lite else `yaml` (matching `markdownToState` and `buildDiagramBlock`) — and land the caret inside it. Non-diagram fences are unchanged.

## Verification

- New tests in `enterConvert.spec.ts`: ```` ```mermaid ```` / ```` ```vega-lite ```` → diagram block with correct meta; ```` ```js ```` still → code-block (RED→GREEN confirmed).
- Full muya unit suite: 161 files / 1224 tests pass.
- `lint:types` and ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)