### PR TITLE
fix(muya): align serialized table columns by visual width (#1983)

### DIFF
--- a/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
+++ b/packages/muya/src/state/__tests__/stateToMarkdown.spec.ts
@@ -74,6 +74,42 @@ describe('serializeTable — row width mismatch', () => {
     });
 });
 
+// Regression for #1983. Column padding used String.prototype.length, so a
+// cell containing a combining mark (its code units exceed its visual width)
+// was over-measured and broke alignment. Padding must use visual column width.
+describe('serializeTable — visual column width (#1983)', () => {
+    it('aligns a column whose cells contain combining marks', () => {
+        const state = table([
+            row([cell('A')]),
+            row([cell('nɔx')]),
+            row([cell('aʊ̯x')]), // a, ʊ, U+032F combining mark, x — 4 code units, 3 columns
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+        const lines = md.split('\n');
+
+        expect(lines[0]).toBe('| A   |');
+        expect(lines[1]).toBe('| --- |');
+        expect(lines[2]).toBe('| nɔx |');
+        expect(lines[3]).toBe('| aʊ̯x |');
+    });
+
+    it('widens a column to fit East-Asian wide characters', () => {
+        const state = table([
+            row([cell('id')]),
+            row([cell('中文')]), // two wide characters → 4 columns
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+        const lines = md.split('\n');
+
+        // Column width is max(visual): 'id' = 2, '中文' = 4 → inner width 4.
+        expect(lines[0]).toBe('| id   |');
+        expect(lines[1]).toBe('| ---- |');
+        expect(lines[2]).toBe('| 中文 |');
+    });
+});
+
 // `align` lives on every cell's `meta.align` ('none' | 'left' | 'center' |
 // 'right'). The serializer renders the delimiter row from the *header* row's
 // cell aligns: left → ':---', center → ':---:', right → '---:', none → '---'.

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -32,6 +32,7 @@ import type {
 import { deepClone } from '../utils';
 
 import logger from '../utils/logger';
+import stringWidth from '../utils/stringWidth';
 import { isAnyListState } from './types';
 
 const debug = logger('export markdown: ');
@@ -433,7 +434,7 @@ export default class ExportMarkdown {
             for (j = 0; j < cells; j++) {
                 columnWidth[j].width = Math.max(
                     columnWidth[j].width,
-                    tableData[i][j].length + 2,
+                    stringWidth(tableData[i][j]) + 2,
                 ); // add 2, because have two space around text
             }
         }
@@ -445,9 +446,12 @@ export default class ExportMarkdown {
                     r
                         .slice(0, columnWidth.length)
                         .map((cell, j) => {
-                            const raw = ` ${cell + ' '.repeat(columnWidth[j].width)}`;
+                            // Pad by visual column width, not code-unit length,
+                            // so combining marks and wide characters stay
+                            // aligned (#1983). One leading space + cell + fill.
+                            const fill = columnWidth[j].width - 1 - stringWidth(cell);
 
-                            return raw.substring(0, columnWidth[j].width);
+                            return ` ${cell}${' '.repeat(Math.max(fill, 0))}`;
                         })
                         .join('|')
                 }|`;

--- a/packages/muya/src/utils/__tests__/stringWidth.spec.ts
+++ b/packages/muya/src/utils/__tests__/stringWidth.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import stringWidth from '../stringWidth';
+
+// `stringWidth` returns the number of monospace columns a string occupies, used
+// by the markdown table serializer to align columns (#1983). It must count
+// combining marks as zero width and East-Asian wide / fullwidth code points as
+// two, rather than counting UTF-16 code units like String.prototype.length.
+
+describe('stringWidth', () => {
+    it('counts plain ASCII as one column per character', () => {
+        expect(stringWidth('abc')).toBe(3);
+        expect(stringWidth('')).toBe(0);
+    });
+
+    it('counts a combining diacritic as zero width (#1983 IPA case)', () => {
+        // `aʊ̯x` = a, ʊ, COMBINING INVERTED BREVE BELOW (U+032F), x.
+        // length is 4 code units but it occupies 3 columns.
+        const ipa = 'aʊ̯x';
+        expect(ipa.length).toBe(4);
+        expect(stringWidth(ipa)).toBe(3);
+        // and it must align with the other plain 3-column cell.
+        expect(stringWidth('nɔx')).toBe(3);
+    });
+
+    it('counts East-Asian wide characters as two columns', () => {
+        expect(stringWidth('中')).toBe(2);
+        expect(stringWidth('中文')).toBe(4);
+        expect(stringWidth('a中')).toBe(3);
+    });
+
+    it('counts fullwidth forms as two columns', () => {
+        // U+FF21 FULLWIDTH LATIN CAPITAL LETTER A
+        expect(stringWidth('Ａ')).toBe(2);
+    });
+
+    it('counts zero-width formatting characters as zero', () => {
+        expect(stringWidth('a​b')).toBe(2);
+    });
+
+    it('counts astral wide code points (CJK Ext B) by code point, not surrogate pair', () => {
+        // U+20000 (𠀀) is a single wide ideograph encoded as a surrogate pair.
+        const ext = '\u{20000}';
+        expect(ext.length).toBe(2);
+        expect(stringWidth(ext)).toBe(2);
+    });
+});

--- a/packages/muya/src/utils/stringWidth.ts
+++ b/packages/muya/src/utils/stringWidth.ts
@@ -1,0 +1,60 @@
+// East-Asian Wide (W) and Fullwidth (F) code-point ranges. JavaScript's Unicode
+// property escapes do not expose East_Asian_Width, so the ranges are inlined
+// from the Unicode East Asian Width table. Each pair is an inclusive [start,
+// end] range whose code points occupy two monospace columns.
+const WIDE_RANGES: readonly [number, number][] = [
+    [0x1100, 0x115F], // Hangul Jamo
+    [0x2E80, 0x303E], // CJK Radicals .. Kangxi Radicals .. CJK symbols
+    [0x3041, 0x33FF], // Hiragana, Katakana, CJK symbols and punctuation
+    [0x3400, 0x4DBF], // CJK Unified Ideographs Extension A
+    [0x4E00, 0x9FFF], // CJK Unified Ideographs
+    [0xA000, 0xA4CF], // Yi Syllables / Radicals
+    [0xAC00, 0xD7A3], // Hangul Syllables
+    [0xF900, 0xFAFF], // CJK Compatibility Ideographs
+    [0xFE10, 0xFE19], // Vertical forms
+    [0xFE30, 0xFE6F], // CJK Compatibility Forms / Small Form Variants
+    [0xFF00, 0xFF60], // Fullwidth Forms
+    [0xFFE0, 0xFFE6], // Fullwidth signs
+    [0x1F300, 0x1F64F], // Emoticons / Misc symbols and pictographs
+    [0x1F900, 0x1F9FF], // Supplemental symbols and pictographs
+    [0x20000, 0x3FFFD], // CJK Unified Ideographs Extension B and beyond
+];
+
+// Nonspacing (Mn) and enclosing (Me) combining marks render with zero advance.
+const COMBINING_MARK = /\p{Mn}|\p{Me}/u;
+
+// Format characters that occupy no columns (zero-width space family and BOM).
+function isZeroWidth(codePoint: number): boolean {
+    return (
+        codePoint === 0x200B // zero width space
+        || (codePoint >= 0x200C && codePoint <= 0x200F) // ZWNJ/ZWJ/marks
+        || codePoint === 0xFEFF // zero width no-break space (BOM)
+    );
+}
+
+function isWide(codePoint: number): boolean {
+    return WIDE_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
+}
+
+/**
+ * The number of monospace columns `str` occupies. Combining marks and
+ * zero-width formatting characters contribute 0; East-Asian wide / fullwidth
+ * code points contribute 2; everything else contributes 1.
+ *
+ * Iterating with `for...of` walks the string by code point, so astral
+ * characters (surrogate pairs) are measured once rather than per code unit.
+ */
+export default function stringWidth(str: string): number {
+    let width = 0;
+
+    for (const char of str) {
+        const codePoint = char.codePointAt(0)!;
+
+        if (isZeroWidth(codePoint) || COMBINING_MARK.test(char))
+            continue;
+
+        width += isWide(codePoint) ? 2 : 1;
+    }
+
+    return width;
+}


### PR DESCRIPTION
Fixes #1983

## Problem

When MarkText prettifies a table's markdown source, columns containing certain Unicode were misaligned. The serializer measured column width with `String.prototype.length` (UTF-16 code units):

- **Combining marks** (the reported IPA case `aʊ̯x` — `a`, `ʊ`, U+032F combining mark, `x`) count as 4 code units but occupy 3 columns, so the column was padded too wide.
- **East-Asian wide characters** (`中文`) count as 2 code units but occupy 4 columns, so the column was padded too narrow.

```
# before (misaligned)        # after
| A    |                     | A   |
| ---- |                     | --- |
| nɔx  |                     | nɔx |
| aʊ̯x |                      | aʊ̯x |
```

## Fix

- New dependency-free `packages/muya/src/utils/stringWidth.ts`: returns monospace column count — zero-width combining marks (`\p{Mn}`/`\p{Me}`) and zero-width formatting characters count 0; East-Asian Wide/Fullwidth code-point ranges count 2; everything else 1. Iterates by code point so astral characters (surrogate pairs) are measured once.
- `_serializeTable` uses `stringWidth` for both the column-width computation and the cell padding. Padding now fills to the visual width rather than truncating by code-unit index.

## Verification

- New unit tests for `stringWidth` (ASCII, combining mark, wide, fullwidth, zero-width, astral) and for the serializer (the issue's IPA table + a CJK-wide table) — RED→GREEN.
- Full muya unit suite: 162 files / 1228 tests pass.
- CommonMark + GFM conformance: 1347 pass (unchanged).
- `lint:types`, ESLint, and `check-circular` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)