### PR TITLE
fix(muya): keep the caret on Shift+Tab list unindent (REPLACEMENT path) (#3223)

### DIFF
--- a/packages/muya/src/block/content/paragraphContent/__tests__/unindentReplacement.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/unindentReplacement.spec.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #3223: Shift+Tab on a list item whose containing list is the FIRST child of
+// an outer list item takes the REPLACEMENT path in `_unindentListItem`. That
+// branch promoted the paragraph but — unlike the INDENT branch — never called
+// setCursor, so the caret was left on the detached original block and lost.
+// These tests boot real Muya, drive Shift+Tab through the handler, and assert
+// the caret lands on the promoted paragraph.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+function tabAt(muya: Muya, content: Content, offset: number, shiftKey = false): void {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Tab',
+        shiftKey,
+    } as unknown as KeyboardEvent;
+    content.tabHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('paragraphContent.tabHandler — Shift+Tab REPLACEMENT keeps the caret (#3223)', () => {
+    // `- - A\n  - B\n`: the outer list item's first (and only) child is the
+    // inner list [A, B], so `list.prev` is null -> REPLACEMENT path.
+    it('promotes B and lands the caret on the promoted paragraph', async () => {
+        const muya = bootMuya('- - A\n  - B\n');
+        const b = contentByText(muya, 'B');
+
+        tabAt(muya, b, 1, true);
+
+        await flush();
+
+        const promoted = contentByText(muya, 'B');
+        const cursor = promoted.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(1);
+        // The promoted block is the active content block.
+        expect(muya.editor.activeContentBlock).toBe(promoted);
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -649,6 +649,10 @@ class ParagraphContent extends Format {
         return list && /ol|ul/.test(list.tagName) && listItem.prev;
     }
 
+    private _placeCursorIn(block: Nullable<Parent>, startOffset: number, endOffset: number) {
+        block?.firstContentInDescendant()?.setCursor(startOffset, endOffset, true);
+    }
+
     private _unindentListItem(type: UnindentType) {
         const { parent } = this;
         const listItem = parent?.parent;
@@ -678,6 +682,8 @@ class ParagraphContent extends Format {
                 list.remove();
             else
                 listItem.remove();
+
+            this._placeCursorIn(paragraph, start.offset, end.offset);
         }
         else if (type === UnindentType.INDENT) {
             const newListItem = listItem.clone() as Parent;
@@ -741,11 +747,11 @@ class ParagraphContent extends Format {
                 return;
             }
 
-            const cursorBlock = (
-                newListItem.find(cursorParagraphOffset) as Parent
-            ).firstContentInDescendant();
-
-            cursorBlock?.setCursor(start.offset, end.offset, true);
+            this._placeCursorIn(
+                newListItem.find(cursorParagraphOffset) as Parent,
+                start.offset,
+                end.offset,
+            );
         }
     }
 


### PR DESCRIPTION
Fixes #3223

## Problem

When you press <kbd>Shift</kbd>+<kbd>Tab</kbd> to unindent a list item whose containing list is the **first child of an outer list item**, the caret was lost — it jumped out of the document. In some cases the stale selection (still pointing at the now-removed block) crashed history recording while resolving the block's path.

## Root cause

`_unindentListItem` has two paths:
- **INDENT** (the list has a previous sibling) — correctly calls `setCursor` on the promoted block.
- **REPLACEMENT** (`list.prev` is null) — promoted the paragraph out of the list but **never** called `setCursor`, leaving the caret on the detached original block.

## Fix

Place the caret on the promoted paragraph in the REPLACEMENT path, mirroring INDENT. The shared "find the content block and set the caret" step is extracted into a small `_placeCursorIn` helper used by both paths (which also keeps `_unindentListItem` under the complexity limit).

## Verification

- New real-Muya test (`unindentReplacement.spec.ts`): `- - A\n  - B\n`, Shift+Tab on `B` → the caret lands on the promoted `B` paragraph at the right offset and it becomes the active content block. Without the fix the test errors out in history recording (the exact crash users could hit). RED→GREEN confirmed.
- Full muya unit suite: 162 files / 1221 tests pass.
- `lint:types` and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)