### PR TITLE
fix(muya): typed diagram fences create diagram blocks via the language selector (#2177)

### DIFF
--- a/packages/muya/e2e/tests/blocks/diagram-fence-2177.spec.ts
+++ b/packages/muya/e2e/tests/blocks/diagram-fence-2177.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { loadMarkdown, slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #2177: typing a diagram fence (```mermaid etc.) and pressing Enter must
+// create a diagram block. The real typing flow goes through the
+// CodeBlockLanguageSelector float (it opens on ```lang and consumes Enter),
+// so the conversion must happen there — not only in
+// ParagraphContent._enterConvert. This end-to-end test drives the real
+// keystroke path that the desktop app uses.
+
+async function typeFenceAndEnter(page: import('@playwright/test').Page, lang: string) {
+    await page.goto('/');
+    await loadMarkdown(page, 'seed\n');
+    const seed = page.locator(editor.paragraph).filter({ hasText: 'seed' }).first();
+    await seed.click();
+    await page.keyboard.press('End');
+    for (let i = 0; i < 4; i++)
+        await page.keyboard.press('Backspace');
+    await slowType(page, `\`\`\`${lang}`);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(200);
+    return page.evaluate(() => window.muya!.getState()[0] as { name: string; meta?: { type?: string; lang?: string } });
+}
+
+test('typing ```mermaid + Enter creates a mermaid diagram block', async ({ page }) => {
+    const block = await typeFenceAndEnter(page, 'mermaid');
+    expect(block.name).toBe('diagram');
+    expect(block.meta?.type).toBe('mermaid');
+    expect(block.meta?.lang).toBe('yaml');
+});
+
+test('typing ```vega-lite + Enter creates a vega-lite diagram block (lang json)', async ({ page }) => {
+    const block = await typeFenceAndEnter(page, 'vega-lite');
+    expect(block.name).toBe('diagram');
+    expect(block.meta?.type).toBe('vega-lite');
+    expect(block.meta?.lang).toBe('json');
+});
+
+for (const lang of ['flowchart', 'sequence', 'plantuml']) {
+    test(`typing \`\`\`${lang} + Enter creates a ${lang} diagram block`, async ({ page }) => {
+        const block = await typeFenceAndEnter(page, lang);
+        expect(block.name).toBe('diagram');
+        expect(block.meta?.type).toBe(lang);
+    });
+}
+
+test('typing ```js + Enter still creates a fenced code block', async ({ page }) => {
+    const block = await typeFenceAndEnter(page, 'js');
+    expect(block.name).toBe('code-block');
+});

--- a/packages/muya/src/ui/codeBlockLanguageSelector/index.ts
+++ b/packages/muya/src/ui/codeBlockLanguageSelector/index.ts
@@ -21,6 +21,34 @@ const defaultOptions = {
     showArrow: false,
 };
 
+const DIAGRAM_LANGS = new Set(['mermaid', 'vega-lite', 'plantuml', 'flowchart', 'sequence']);
+
+// The language the user actually typed after the ``` fence. The selector's
+// fuzzy search may resolve a non-code language (e.g. `vega-lite`) to an
+// unrelated Prism language, so the diagram check keys off this raw text.
+function typedFenceLang(text: string): string {
+    return text.match(/`{3,}\s*([\w-]+)/)?.[1] ?? '';
+}
+
+// Build the state for the block a ```lang fence becomes. Diagram languages
+// (from the typed text) become a diagram block, mirroring markdownToState's
+// file-load path; GitLab math becomes a math-block; everything else a fenced
+// code block highlighted with the selector's matched language.
+function newBlockStateForLang(typedLang: string, matchedLang: string, isGitlabMath: boolean) {
+    if (isGitlabMath)
+        return { name: 'math-block', meta: { mathStyle: 'gitlab' }, text: '' };
+
+    if (DIAGRAM_LANGS.has(typedLang)) {
+        return {
+            name: 'diagram',
+            meta: { type: typedLang, lang: typedLang === 'vega-lite' ? 'json' : 'yaml' },
+            text: '',
+        };
+    }
+
+    return { name: 'code-block', meta: { lang: matchedLang, type: 'fenced' }, text: '' };
+}
+
 export class CodeBlockLanguageSelector extends BaseScrollFloat {
     static pluginName = 'codePicker';
     public override capturesContentKeydown = true;
@@ -149,23 +177,9 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
         }
 
         if (isParagraphContent(block)) {
-            const state
-                = muya.options.isGitlabCompatibilityEnabled && name === 'math'
-                    ? {
-                            name: 'math-block',
-                            meta: {
-                                mathStyle: 'gitlab',
-                            },
-                            text: '',
-                        }
-                    : {
-                            name: 'code-block',
-                            meta: {
-                                lang: name,
-                                type: 'fenced',
-                            },
-                            text: '',
-                        };
+            const isGitlabMath
+                = muya.options.isGitlabCompatibilityEnabled && name === 'math';
+            const state = newBlockStateForLang(typedFenceLang(block.text), name, isGitlabMath);
 
             const newBlock = ScrollPage.loadBlock(state.name).create(
                 this.muya,
@@ -173,7 +187,7 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
             );
             block.parent?.replaceWith(newBlock);
             const codeContent = newBlock.lastContentInDescendant();
-            codeContent.setCursor(0, 0);
+            codeContent?.setCursor(0, 0);
         }
         else {
             block.text = name;


### PR DESCRIPTION
Fixes #2177

## Why a second PR

#4635 added diagram routing to `ParagraphContent._enterConvert`, with a unit test that drove `enterHandler` directly — so it passed. But **manual verification in the desktop app showed it didn't work**: typing ` ```mermaid `+Enter still produced a code block.

Root cause: the real typing path doesn't reach `_enterConvert`. Typing ` ```lang ` opens the **CodeBlockLanguageSelector** float, whose `handleContentKeydown` consumes the Enter (before the block's enter handler runs) and `selectItem` always built a `code-block`.

## Fix

Route diagram languages to a diagram block in `CodeBlockLanguageSelector.selectItem`.

The diagram type is read from the **text the user typed** after the fence, not the selector's fuzzy-matched item: the fuzzy search resolves non-code languages to unrelated Prism entries (e.g. `vega-lite` → `keepalived`), which would misdetect the type. Non-diagram fences keep the matched language for syntax highlighting. (The `_enterConvert` branch from #4635 stays as the fallback when no selector item matches.)

## Verification

- New e2e test `diagram-fence-2177.spec.ts` drives the **real desktop typing path** (system Chrome): ` ```mermaid `/`vega-lite`/`plantuml`/`flowchart`/`sequence` + Enter → diagram block (correct `meta.type`; `vega-lite` → `lang: json`), and ` ```js ` → code-block control. 6/6 pass.
- muya unit suite: 163 files / 1234 tests pass; `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)