### PR TITLE
perf(renderer): reduce startup bundle via on-demand Element Plus + lazy preference routes

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -3,6 +3,8 @@ import type { PluginOption } from 'vite'
 import { defineConfig } from 'electron-vite'
 import vue from '@vitejs/plugin-vue'
 import svgLoader from 'vite-svg-loader'
+import Components from 'unplugin-vue-components/vite'
+import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 import postcssPresetEnv from 'postcss-preset-env'
 import packageJson from './package.json' with { type: 'json' }
 import { fileURLToPath } from 'url'
@@ -95,7 +97,22 @@ export default defineConfig({
         }
       }
     },
-    plugins: [vue(), svgLoader()] as PluginOption[],
+    plugins: [
+      vue(),
+      svgLoader(),
+      // On-demand import of Element Plus components + their styles. Replaces the
+      // global `app.use(ElementPlus)` + full `element-plus/dist/index.css`, so
+      // each window only bundles the `<el-*>` components it actually renders.
+      Components({
+        dts: false,
+        // Only auto-import Element Plus via the resolver. Disable the default
+        // `src/components` directory scan so local components keep using their
+        // explicit imports (the scan otherwise globally registers them and
+        // triggers naming conflicts, e.g. two `Search` components).
+        dirs: [],
+        resolvers: [ElementPlusResolver()]
+      })
+    ] as PluginOption[],
     css: {
       postcss: {
         plugins: [

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -139,6 +139,7 @@
     "postcss-preset-env": "^11.3.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "unplugin-vue-components": "^32.1.0",
     "vite": "^7.3.5",
     "vite-svg-loader": "^5.1.1",
     "vitest": "^4.1.9",

--- a/packages/desktop/src/renderer/src/main.ts
+++ b/packages/desktop/src/renderer/src/main.ts
@@ -5,10 +5,11 @@ import axios from './axios'
 import pinia from './store'
 import './assets/symbolIcon'
 
-// Element Plus instead of Element UI for Vue 3
-import ElementPlus from 'element-plus'
-import 'element-plus/dist/index.css'
-import en from 'element-plus/es/locale/lang/en'
+// Element Plus components are auto-imported on demand (see the Components()
+// plugin in electron.vite.config.ts), which also pulls in each component's
+// styles. Only the base reset/index variables stylesheet must be loaded
+// globally; per-component CSS is injected by the resolver.
+import 'element-plus/theme-chalk/base.css'
 
 // I18n translation system
 import i18nPlugin from './i18n'
@@ -31,11 +32,6 @@ bootstrapRenderer()
 
 // Create Vue app
 const app: App<Element> = createApp(Main)
-
-// Configure Element Plus with locale
-app.use(ElementPlus, {
-  locale: en
-})
 
 const envType = window.marktext?.env?.type as string | undefined
 

--- a/packages/desktop/src/renderer/src/router/index.ts
+++ b/packages/desktop/src/renderer/src/router/index.ts
@@ -1,16 +1,22 @@
 import type { RouteRecordRaw } from 'vue-router'
-// .vue extensions are explicit so TS resolves them through the *.vue module
-// shim in src/types/renderer.d.ts. Vite handles extension-less imports at
-// runtime, but vue-tsc needs the suffix.
+// The editor page is imported eagerly: the editor window's `mt::bootstrap-editor`
+// IPC is a fire-and-forget push sent by the main process on `did-finish-load`,
+// and the listener is registered when app.vue mounts (store/editor.ts). Lazy-
+// loading app.vue would defer that mount past did-finish-load and miss the
+// message, leaving the window stuck on its placeholder. The preference page and
+// its panels stay lazy: the settings window uses a pull model (the renderer
+// requests its data on mount), so there is no message to miss, and editor
+// windows then never download/parse the preference UI code.
+// .vue extension is explicit so vue-tsc resolves it via the *.vue module shim.
 import App from '@/pages/app.vue'
-import Preference from '@/pages/preference.vue'
-import General from '@/prefComponents/general/index.vue'
-import Editor from '@/prefComponents/editor/index.vue'
-import Markdown from '@/prefComponents/markdown/index.vue'
-import SpellChecker from '@/prefComponents/spellchecker/index.vue'
-import Theme from '@/prefComponents/theme/index.vue'
-import Image from '@/prefComponents/image/index.vue'
-import Keybindings from '@/prefComponents/keybindings/index.vue'
+const Preference = () => import('@/pages/preference.vue')
+const General = () => import('@/prefComponents/general/index.vue')
+const Editor = () => import('@/prefComponents/editor/index.vue')
+const Markdown = () => import('@/prefComponents/markdown/index.vue')
+const SpellChecker = () => import('@/prefComponents/spellchecker/index.vue')
+const Theme = () => import('@/prefComponents/theme/index.vue')
+const Image = () => import('@/prefComponents/image/index.vue')
+const Keybindings = () => import('@/prefComponents/keybindings/index.vue')
 
 const parseSettingsPage = (type: string | null | undefined): string => {
   let pageUrl = '/preference'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      unplugin-vue-components:
+        specifier: ^32.1.0
+        version: 32.1.0(vue@3.5.38(typescript@6.0.3))
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0)
@@ -8971,9 +8974,27 @@ packages:
       webpack:
         optional: true
 
+  unplugin-utils@0.3.1:
+    resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
+    engines: {node: '>=20.19.0'}
+
+  unplugin-vue-components@32.1.0:
+    resolution: {integrity: sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.2 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -19321,10 +19342,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  unplugin-utils@0.3.1:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.4
+
+  unplugin-vue-components@32.1.0(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      chokidar: 5.0.0
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      obug: 2.1.3
+      picomatch: 4.0.4
+      tinyglobby: 0.2.17
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.5.38(typescript@6.0.3)
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.17.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 


### PR DESCRIPTION
Refs #2300

## Summary

The renderer imported Element Plus in full (`app.use(ElementPlus)` + `element-plus/dist/index.css`), so **every** window bundled, parsed and registered the entire component library and all of its CSS, even though only a handful of `<el-*>` components are used.

This PR:

- **On-demand Element Plus** via `unplugin-vue-components` + `ElementPlusResolver`: only the components actually rendered are bundled, each with its own styles. The base reset/variables stylesheet stays global. `dirs: []` scopes the plugin to the Element Plus resolver so local components keep their explicit imports.
- **Lazy-loads the preference page and its panels** (`() => import(...)`), so editor windows no longer download/parse the preferences UI. The **editor route stays eager on purpose**: the editor window's `mt::bootstrap-editor` IPC is a fire-and-forget push sent on `did-finish-load`, and its listener registers when `app.vue` mounts — lazy-loading it would defer that mount past `did-finish-load` and miss the message. The settings window uses a pull model, so its routes are safe to lazy-load.

### Measured impact

- **Eager renderer bundle: −1.7 MB** (JS −1.46 MB, CSS −0.26 MB) per window — deterministic, read from the built `index.html` asset graph.
- **~135 ms faster to first contentful paint** and **~155 ms to editor-ready** (A-B-A protocol, median of 11 runs, blank document, Windows).

This is an incremental, low-risk improvement toward #2300; it does not by itself close the gap described there (the dominant cold-start cost on Electron is the Chromium process spawn, and large-file open time is bounded by the engine's block-tree build — both out of scope here).

## Type of change

- [x] Performance / build refactor (non-breaking, no behavior change)

## Test plan

- [x] No new automated tests: this is a build-config + import-site change with no behavior change. It is covered by existing E2E — the command-palette spec exercises an auto-imported `<el-dialog>`, and `all-blocks-roundtrip` exercises the full editor mount. I additionally verified manually that the editor window, sidebar (el-icons), and the lazy-loaded preferences window all render correctly.
- [x] Manually tested on: Windows
- Local checks green: `pnpm run lint` (0 errors), `pnpm run typecheck`, `pnpm run validate-licenses`, and the editor/command-palette/all-blocks/layout/sidebar E2E specs.

## Notes for reviewers

- Adds one devDependency: `unplugin-vue-components` (MIT).
- No source/behavior change in `packages/muya`.
