### PR TITLE
fix(renderer): keep find-bar prefill from being clobbered on open

### DIFF
--- a/packages/desktop/src/renderer/src/components/search/index.vue
+++ b/packages/desktop/src/renderer/src/components/search/index.vue
@@ -170,12 +170,27 @@ watch(searchValue, () => {
 })
 
 watch(searchMatches, (newValue, oldValue) => {
+  // Once the search bar is open it owns the query. Ignore editor
+  // selection-changes while open — notably the spurious selection-change the
+  // engine emits when the bar steals editor focus, which would otherwise
+  // clobber the just-prefilled value (e.g. leaving a stale single character).
+  if (showSearch.value) return
   if (!newValue || !oldValue) return
   const { value } = newValue
   if (value !== oldValue.value) {
     searchValue.value = value
   }
 })
+
+// Seed the find input from the current selection synchronously, before the bar
+// opens and steals focus. Relying on the reactive `searchMatches` watch alone
+// races with the focus-steal selection-change and can drop the prefill.
+const prefillFromSelection = () => {
+  const selected = searchMatches.value?.value
+  if (selected) {
+    searchValue.value = selected
+  }
+}
 
 const highlightIndex = computed(() => {
   if (searchMatches.value) {
@@ -229,6 +244,7 @@ const toggleCtrl = (ctrl: 'isCaseSensitive' | 'isWholeWord' | 'isRegexp') => {
 }
 
 const listenFind = () => {
+  prefillFromSelection()
   showSearch.value = true
   type.value = 'search'
   nextTick(() => {
@@ -240,6 +256,7 @@ const listenFind = () => {
 }
 
 const listenReplace = () => {
+  prefillFromSelection()
   showSearch.value = true
   type.value = 'replace'
 }

--- a/packages/desktop/test/unit/specs/search-prefill.spec.ts
+++ b/packages/desktop/test/unit/specs/search-prefill.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { parse, compileScript } from 'vue/compiler-sfc'
+import ts from 'typescript'
+import { ref, computed, watch, nextTick } from 'vue'
+
+// Regression guard for the find-bar prefill race (issue: the input showed a
+// stale single char like "T" instead of the selection). The bug lives entirely
+// in search/index.vue's reactive logic: `watch(searchMatches)` mirrors the
+// editor selection into the input, but when the find bar opens it steals focus
+// and the engine emits a spurious selection-change pointing at the document
+// start, which clobbers the just-prefilled value.
+//
+// The desktop unit runner ships no @vitejs/plugin-vue / @vue/test-utils, so we
+// compile the real <script setup> at runtime, swap its imports for injected
+// stubs (but keep Vue's *real* ref/computed/watch/nextTick), run setup() to grab
+// the live bindings, and drive the actual reactive code. This mirrors the
+// approach in source-code-image-action.spec.ts.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const vuePath = resolve(here, '../../../src/renderer/src/components/search/index.vue')
+
+interface Bindings {
+  searchValue: { value: string }
+  showSearch: { value: boolean }
+  listenFind: () => void
+}
+
+const loadComponent = (deps: Record<string, unknown>) => {
+  const src = readFileSync(vuePath, 'utf8')
+  const { descriptor } = parse(src)
+  const compiled = compileScript(descriptor, { id: 'test' })
+  const noImports = compiled.content
+    .split('\n')
+    .filter((l) => !/^\s*import\s/.test(l))
+    .join('\n')
+  const js = ts.transpileModule(noImports, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+  }).outputText
+  // eslint-disable-next-line no-new-func
+  const factory = new Function(
+    '__deps',
+    'exports',
+    'module',
+    `const { _defineComponent, ref, computed, watch, onMounted, onBeforeUnmount,
+      nextTick, bus, FindCaseIcon, FindWordIcon, FindRegexIcon, useEditorStore,
+      storeToRefs, useI18n, debounce, ArrowDown, ArrowUp, RefreshRight, Switch } = __deps
+    ${js}
+    return module.exports`
+  ) as (deps: Record<string, unknown>, exports: object, module: object) => {
+    default: { setup: (props: unknown, ctx: { expose: () => void }) => Bindings }
+  }
+  const m = { exports: {} as Record<string, unknown> }
+  return factory(deps, m.exports, m).default
+}
+
+const makeBindings = () => {
+  // currentFile.searchMatches is the channel SELECTION_CHANGE writes the
+  // selected text into; storeToRefs hands the component a ref to it.
+  const currentFile = ref<{ searchMatches: { matches: unknown[]; index: number; value: string } } | null>({
+    searchMatches: { matches: [], index: -1, value: '' }
+  })
+  const deps = {
+    _defineComponent: (o: unknown) => o,
+    ref,
+    computed,
+    watch,
+    nextTick,
+    onMounted: () => {},
+    onBeforeUnmount: () => {},
+    bus: { on: () => {}, off: () => {}, emit: vi.fn() },
+    FindCaseIcon: {},
+    FindWordIcon: {},
+    FindRegexIcon: {},
+    ArrowDown: {},
+    ArrowUp: {},
+    RefreshRight: {},
+    Switch: {},
+    useEditorStore: () => new Proxy({}, { get: () => () => {} }),
+    storeToRefs: () => ({ currentFile }),
+    useI18n: () => ({ t: (k: string) => k }),
+    debounce: (fn: (...a: unknown[]) => unknown) => fn
+  }
+  const comp = loadComponent(deps)
+  const ret = comp.setup({}, { expose: () => {} })
+  const setSelection = (value: string) => {
+    currentFile.value = { searchMatches: { matches: [], index: -1, value } }
+  }
+  return { ret, setSelection }
+}
+
+describe('find-bar prefill from selection', () => {
+  it('prefills the input with the selected text when the bar opens', async() => {
+    const { ret, setSelection } = makeBindings()
+    setSelection('fox')
+    await nextTick()
+    ret.listenFind()
+    await nextTick()
+    expect(ret.searchValue.value).toBe('fox')
+  })
+
+  it('does not let the focus-steal selection-change clobber the prefill', async() => {
+    const { ret, setSelection } = makeBindings()
+    // User selects a word in the editor.
+    setSelection('fox')
+    await nextTick()
+    // Find bar opens (prefills "fox") and steals focus.
+    ret.listenFind()
+    await nextTick()
+    expect(ret.searchValue.value).toBe('fox')
+    // Opening the bar steals editor focus → the engine emits a spurious
+    // selection-change pointing at the document start ("T"). It must NOT
+    // overwrite the prefilled query now that the bar owns it.
+    setSelection('T')
+    await nextTick()
+    expect(ret.showSearch.value).toBe(true)
+    expect(ret.searchValue.value).toBe('fox')
+  })
+})


### PR DESCRIPTION
## Summary

Selecting a word and opening the find bar is supposed to prefill the find input with the selection. It often left a stale single character (e.g. `T`) instead.

The prefill is driven reactively by `watch(searchMatches)` in `search/index.vue`, which mirrors the editor's current selection into the input. When the find bar opens it steals focus from the editor, and the engine emits a spurious `selection-change` pointing at the document start. Because the watch is async, that change coalesces with the intended one and cancels it, leaving the stale value.

Fix, in two parts:
- **Seed synchronously on open** (`prefillFromSelection`): read the current selection into the input before the bar steals focus, so the prefill can't lose the race.
- **Gate the watch while open**: once `showSearch` is true the bar owns the query, so editor selection-changes (notably the focus-steal one) no longer overwrite the prefilled/typed value. After open, `searchFn` already keeps `searchMatches.value` in sync with the input, so the watch was a no-op there anyway.

This was surfaced by the existing e2e regression guard `test/e2e/search-prefill-from-selection.spec.ts`, which had started failing on `develop` (it reproduces only under the Linux/xvfb CI environment, and `e2e.yml` had not run on the `develop` branch since 2026-06-04, so it went unnoticed). It is independent of #4645, but it is what turns that PR's `e2e` check red.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)

## Test plan

- [x] New test added: `test/e2e/.../search-prefill-from-selection.spec.ts` already guards this end-to-end. In addition, this PR adds a **deterministic** unit guard `test/unit/specs/search-prefill.spec.ts` that compiles the real `<script setup>`, runs `setup()` with Vue's real reactivity, and asserts the focus-steal selection-change can't clobber the prefill. It fails on `develop` (`expected 'T' to be 'fox'`) and passes with this fix — so the regression is now caught cross-platform in the fast `unit` suite, not only on Linux e2e.
- [x] `pnpm run lint`, `pnpm run typecheck` pass.

## Notes for reviewers

- The unit test follows the runtime-SFC-compile pattern already used by `test/unit/specs/source-code-image-action.spec.ts` (the desktop unit runner has no `@vue/test-utils`).
