### PR TITLE
perf(muya): cache reference-definition labels by document revision

### DIFF
--- a/packages/muya/src/inlineRenderer/index.ts
+++ b/packages/muya/src/inlineRenderer/index.ts
@@ -15,6 +15,13 @@ class InlineRenderer {
     public labels: Labels = new Map();
     public renderer: Renderer;
 
+    // jsonState revision the cached `labels` were collected at. Collecting walks
+    // the whole document, and `patch` runs once per content block, so without
+    // this guard the initial render (and every re-render) was O(n^2): a full
+    // document deep-clone + walk per block. The labels only change when the
+    // document does, so recompute only when the revision advances.
+    private _labelsRevision = -1;
+
     constructor(public muya: Muya) {
         this.renderer = new Renderer(muya, this);
     }
@@ -75,7 +82,12 @@ class InlineRenderer {
     }
 
     private _collectReferenceDefinitions() {
-        const state = this.muya.editor.jsonState.getState();
+        const { jsonState } = this.muya.editor;
+        // The document hasn't changed since we last collected — reuse the cache.
+        if (this._labelsRevision === jsonState.revision)
+            return;
+
+        const state = jsonState.getState();
         const labels = new Map();
 
         const travel = (sts: TState[]) => {
@@ -96,6 +108,7 @@ class InlineRenderer {
         travel(state);
 
         this.labels = labels;
+        this._labelsRevision = jsonState.revision;
     }
 
     getLabelInfo(blockOrState: ParagraphContent | IParagraphState) {

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -52,8 +52,19 @@ class JSONState {
 
     private _state: TState[] = [];
 
+    // Monotonic revision bumped on every `_state` reassignment (the only way
+    // `_state` ever changes — there is no in-place mutation). Consumers that
+    // derive data from the whole document (e.g. the inline renderer's reference
+    // -definition labels) cache against it and recompute only when it changes,
+    // instead of re-deriving on every access.
+    private _revision = 0;
+
     constructor(private _muya: Muya, stateOrMarkdown: TState[] | string) {
         this.setContent(stateOrMarkdown);
+    }
+
+    get revision() {
+        return this._revision;
     }
 
     private _apply(op: JSONOp) {
@@ -63,6 +74,7 @@ class JSONState {
         if (op === null)
             return;
         this._state = asState(json1.type.apply(asDoc(this._state), op));
+        this._revision++;
     }
 
     setContent(content: TState[] | string) {
@@ -84,10 +96,12 @@ class JSONState {
 
     private _setState(state: TState[]) {
         this._state = state;
+        this._revision++;
     }
 
     private _setMarkdown(markdown: string) {
         this._state = this.markdownToState(markdown);
+        this._revision++;
     }
 
     // Parse markdown into a block-state array with the editor's current


### PR DESCRIPTION
Refs #3640, #3211

## Summary

Opening a non-trivial document is dominated by an avoidable O(n²) cost in the inline renderer.

`InlineRenderer.patch()` runs once per content block, and it starts by calling `_collectReferenceDefinitions()`, which deep-clones the **entire** document state (`JSONState.getState()`) and walks it to collect `[ref]: url` link/image definitions. Because this runs for every block, rendering a document is quadratic: for a ~38 KB / ~1800-block file the collection alone runs **1801 times** and accounts for **~9.6 s** of a **~15.7 s** `ScrollPage.create`.

Reference definitions only change when the document changes, so this caches them instead of re-deriving per block:

- `JSONState` exposes a monotonic `revision`, incremented at the three (and only) sites where `_state` is reassigned (`_apply`, `_setState`, `_setMarkdown`).
- `InlineRenderer` recomputes the labels only when the revision has advanced since the last collection; otherwise it reuses the cached `Map`.

This is **behavior-preserving** — every state change still forces a recompute, exactly as before — but turns a per-block recompute into one recompute per render pass.

### Measured impact (38 KB document)

| | before | after |
|---|---|---|
| `ScrollPage.create` | ~15,754 ms | **~408 ms** (~38×) |
| label collections during open | 1801 | **1** |

## Type of change

- [x] Performance improvement (non-breaking)

## Test plan

- [x] CommonMark 0.31 + GFM conformance (`pnpm -C packages/muya test:spec`): unchanged vs `develop` (same pass count).
- [x] Reference link/image still render with the definition's URL in the live editor (verified by opening a doc with `[t][r]` / `![a][img]` + defs).
- [x] `lint:types`, `check-circular`, and lint pass on the changed files.
- [x] Perf re-measured via instrumentation (numbers above), then instrumentation removed.

## Notes for reviewers

- The cache key is `JSONState.revision`. `_state` is only ever reassigned (never mutated in place), and all three reassignment sites bump the revision, so the labels can never go stale relative to the document.
- Scope is limited to `packages/muya` (`state/index.ts`, `inlineRenderer/index.ts`).
