### PR TITLE
fix(muya): allow trailing whitespace after a math block's closing $$ (#1931)

### DIFF
--- a/packages/muya/src/state/__tests__/mathTrailingSpace.spec.ts
+++ b/packages/muya/src/state/__tests__/mathTrailingSpace.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
+
+// #1931: a display-math block whose closing `$$` has trailing whitespace
+// (e.g. `$$ `) was not recognized as math — the block regex required the
+// closing marker to be immediately followed by a newline or end-of-input, so
+// any trailing space made it fall through to plain text. Fenced code blocks
+// already tolerate trailing spaces; math should too.
+
+interface IBlock { name: string; text?: string }
+
+function parse(markdown: string): IBlock[] {
+    return new MarkdownToState({
+        footnote: false,
+        math: true,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    } as never).generate(markdown) as unknown as IBlock[];
+}
+
+describe('block math — closing $$ with trailing whitespace (#1931)', () => {
+    it('parses a math block whose closing $$ has a trailing space', () => {
+        const states = parse('$$\nx = 1\n$$ \n\nbar\n');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+    });
+
+    it('parses a math block whose closing $$ has a trailing tab', () => {
+        const states = parse('$$\nx = 1\n$$\t\n\nbar\n');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+    });
+
+    it('still parses a math block with no trailing space (regression)', () => {
+        const states = parse('$$\nx = 1\n$$\n\nbar\n');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+    });
+});

--- a/packages/muya/src/utils/marked/extensions/math.ts
+++ b/packages/muya/src/utils/marked/extensions/math.ts
@@ -16,7 +16,7 @@ interface IOptions {
 const inlineStartRule = /(\s|^)\${1,2}(?!\$)/;
 const inlineRule
     = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:]|$)/;
-const blockRule = /^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1(?:\n|$)/;
+const blockRule = /^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1[ \t]*(?:\n|$)/;
 
 const DEFAULT_OPTIONS = {
     throwOnError: false,


### PR DESCRIPTION
Fixes #1931

## Problem

A display-math block whose closing `$$` had any trailing whitespace was not recognized as math and fell through to plain text:

```
$$
x = 1
$$␠     ← trailing space here
```

Fenced code blocks already tolerate trailing spaces after the closing fence; math did not.

## Root cause

`packages/muya/src/utils/marked/extensions/math.ts` — the block rule required the closing backreference to be immediately followed by a newline or end-of-input:

```
/^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1(?:\n|$)/
```

## Fix

Allow optional spaces/tabs after the closing marker:

```
/^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1[ \t]*(?:\n|$)/
```

## Verification

- New `mathTrailingSpace.spec.ts`: closing `$$ ` (space) and `$$\t` (tab) now parse to a `math-block`; no-trailing-space case still works (RED→GREEN).
- Full muya unit suite: 164 files / 1237 tests pass.
- CommonMark + GFM conformance: 1347 pass (unchanged).
- `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)