### PR TITLE
fix(muya): stop ArrowDown from endlessly creating empty paragraphs (#3520)

### DIFF
--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -212,6 +212,32 @@ describe('content arrowHandler — trailing-paragraph creation at document end',
         expect(event.stopPropagation).toHaveBeenCalled();
     });
 
+    // #3520: pressing ArrowDown on an already-empty trailing paragraph must NOT
+    // keep appending new empty paragraphs on every keypress. A trailing
+    // paragraph is created only when the current (last) block has content.
+    it('does not append another paragraph when ArrowDown is pressed in an already-empty trailing paragraph (#3520)', async () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const beta = contentByText(muya, 'beta');
+
+        // First ArrowDown at the end of a non-empty last block appends one
+        // trailing empty paragraph (existing, desired behavior).
+        arrowAt(muya, beta, 'ArrowDown', 'beta'.length);
+        await flush();
+        expect(muya.getState().length).toBe(3);
+
+        const appended = muya.editor.scrollPage!.lastContentInDescendant() as Content;
+        expect(appended.text).toBe('');
+
+        // Pressing ArrowDown again, now inside the empty trailing paragraph,
+        // must NOT create a fourth block — the caret stays put.
+        const event = arrowAt(muya, appended, 'ArrowDown', 0);
+        await flush();
+
+        expect(muya.getState().length).toBe(3);
+        expect(appended.getCursor()).not.toBeNull();
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
     it('shiftKey held suppresses cross-block navigation (selection extend, not move)', async () => {
         const muya = bootMuya('alpha\n\nbeta\n');
         const alpha = contentByText(muya, 'alpha');

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -473,7 +473,10 @@ class Content extends TreeNode {
             if (nextContentBlock) {
                 cursorBlock = nextContentBlock;
             }
-            else {
+            // Only append a trailing paragraph when the last block has content.
+            // Otherwise ArrowDown in an already-empty last paragraph would keep
+            // creating empty paragraphs on every keypress (#3520).
+            else if (this.text.length > 0) {
                 const newNodeState = {
                     name: 'paragraph',
                     text: '',
@@ -485,7 +488,8 @@ class Content extends TreeNode {
                 this.scrollPage?.append(newNode, 'user');
                 cursorBlock = newNode.children.head;
             }
-            offset = adjustOffset(0, cursorBlock, event);
+            if (cursorBlock)
+                offset = adjustOffset(0, cursorBlock, event);
         }
 
         if (cursorBlock) {


### PR DESCRIPTION
Fixes #3520

## Problem

In an empty (or trailing-empty) document, pressing <kbd>↓</kbd> repeatedly created a new empty paragraph on **every** keypress.

## Root cause

`Content.arrowHandler` (`packages/muya/src/block/base/content.ts`) appends a trailing paragraph whenever ArrowDown is pressed at the end of the last block and there is no next block — with no check on whether the current block is itself already empty. An empty last paragraph (`text = ''`, caret at offset 0) satisfies the condition, so each ArrowDown appends another empty paragraph. (The `getCursorYOffset` early-return doesn't help: an empty single-line paragraph yields `bottomOffset = 0`.)

## Fix

Append the trailing paragraph only when the current block has content (`this.text.length > 0`); otherwise the caret stays put. The offset computation is guarded since the cursor target can now be absent.

The existing behavior — ArrowDown at the end of a **non-empty** last block appends one trailing paragraph — is preserved (covered by an existing test).

## Verification

- `arrowNavigation.spec.ts`: new test — ArrowDown in an already-empty trailing paragraph does **not** create another block (RED→GREEN); the existing non-empty-last-block test still passes.
- Full muya unit suite: 163 files / 1235 tests pass.
- `lint:types` clean; ESLint clean (one pre-existing `arrowHandler` complexity warning, unchanged policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)