### PR TITLE
fix(muya): take the list marker from a line start in _convertToList (#2429)

### DIFF
--- a/packages/muya/src/block/base/__tests__/convertToListAfterStrong.spec.ts
+++ b/packages/muya/src/block/base/__tests__/convertToListAfterStrong.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import type { Muya } from '../../../muya';
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya as MuyaClass } from '../../../muya';
+
+vi.mock('../../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => Promise.resolve([]),
+    search: () => [],
+}));
+
+// #2429: typing a list marker on a new (soft-line-break) line after bold text
+// converted the wrong character. `_convertToList`'s regex used a lazy pre-group
+// that grabbed the `*` inside the closing `**` of the bold text as the bullet
+// marker (because two trailing spaces followed it), instead of the `-` the user
+// just typed on the next line — corrupting the bold syntax. The marker must be
+// taken from the start of a line.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new MuyaClass(host, { markdown } as ConstructorParameters<typeof MuyaClass>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+interface ILiveBlock {
+    blockName?: string;
+    meta?: { marker?: string };
+    firstContentInDescendant: () => { text: string };
+    children?: { forEach: (cb: (b: ILiveBlock) => void) => void };
+}
+
+// Collect the top-level blocks of the live block tree after conversion.
+function convert(text: string): ILiveBlock[] {
+    const muya = bootMuya('seed\n');
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as Format;
+    content.text = text;
+    content.checkInlineUpdate();
+
+    const top: ILiveBlock[] = [];
+    (muya.editor.scrollPage as unknown as ILiveBlock).children!.forEach(b => top.push(b));
+    return top;
+}
+
+describe('_convertToList after bold text + soft-line-break (#2429)', () => {
+    it('uses the `-` on the new line as the marker, not the `*` inside `**`', () => {
+        // `**foo:**` + two spaces + soft-line-break + `- `
+        const blocks = convert('**foo:**  \n- ');
+
+        const list = blocks.find(b => b.blockName === 'bullet-list');
+        expect(list).toBeDefined();
+        // marker is the dash typed on the new line, not a `*` from the bold run.
+        expect(list!.meta!.marker).toBe('-');
+
+        // the bold text is preserved intact as a leading paragraph, not corrupted
+        // into `**foo:*`.
+        const para = blocks.find(b => b.blockName === 'paragraph');
+        expect(para).toBeDefined();
+        expect(para!.firstContentInDescendant().text).toBe('**foo:**');
+    });
+
+    it('still converts a plain single-line `- ` to a bullet list', () => {
+        const blocks = convert('- ');
+        expect(blocks.some(b => b.blockName === 'bullet-list')).toBe(true);
+        // no spurious leading paragraph
+        expect(blocks.some(b => b.blockName === 'paragraph')).toBe(false);
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -819,8 +819,12 @@ class Format extends Content {
     private _convertToList() {
         const { text, parent, muya, hasSelection } = this;
         const { preferLooseListItem } = muya.options;
+        // The marker must start a line: the pre-group captures whole lines up to
+        // (and including) the newline before the marker, so a `*` inside e.g.
+        // `**bold**` on an earlier soft-line is never mistaken for the bullet
+        // marker (#2429).
         const matches = text.match(
-            /^([\s\S]*?) {0,3}([*+-]|\d{1,9}(?:\.|\))) {1,4}([\s\S]*)$/,
+            /^([\s\S]*\n)? {0,3}([*+-]|\d{1,9}(?:\.|\))) {1,4}([\s\S]*)$/,
         );
         const isOrdered = /\d/.test(matches![2]);
 


### PR DESCRIPTION
Fixes #2429

## Problem

Typing a list marker on a new line after bold text didn't create a list and corrupted the bold syntax:

1. Type `**foo:**` followed by two spaces
2. Press <kbd>Shift</kbd>+<kbd>Enter</kbd> (soft line break)
3. Type `-` then space

Instead of a paragraph `**foo:**` + a new bullet list, you got a malformed paragraph `**foo:*` and a `*`-marker list.

## Root cause

`_convertToList` (`packages/muya/src/block/base/format.ts`) re-parsed the block text with a lazy pre-group:

```
/^([\s\S]*?) {0,3}([*+-]|\d{1,9}(?:\.|\))) {1,4}([\s\S]*)$/
```

For `**foo:**  \n- `, the lazy `([\s\S]*?)` matched `**foo:*` and captured the second `*` of the closing `**` as the bullet marker (the two trailing spaces satisfied the ` {1,4}` after it).

## Fix

Anchor the marker to a line start — the pre-group now captures whole lines up to and including the newline before the marker:

```
/^([\s\S]*\n)? {0,3}([*+-]|\d{1,9}(?:\.|\))) {1,4}([\s\S]*)$/
```

So an earlier `*` (inside bold/italic on a previous soft-line) can never be taken as the bullet.

## Verification

- New `convertToListAfterStrong.spec.ts`: `**foo:**  \n- ` → bullet list with marker `-` and an intact leading paragraph `**foo:**` (RED→GREEN); plain single-line `- ` still converts (no spurious paragraph).
- Full muya unit suite: 164 files / 1236 tests pass.
- CommonMark + GFM conformance: 1347 pass (unchanged).
- `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)