### PR TITLE
fix(muya): strip trailing punctuation from extended autolinks (#2096)

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/autoLinkTrailingPunct.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/autoLinkTrailingPunct.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import type { Token } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+// #2096: an extended (bare) autolink swallowed trailing punctuation because the
+// path component matched `\S+`. Per GFM §6.9, trailing punctuation
+// (?!.,:*_~) must not be part of the link.
+
+function autoLinkExt(src: string) {
+    const token = tokenizer(src).find(t => t.type === 'auto_link_extension') as
+        | (Token & { url?: string; www?: string; raw: string })
+        | undefined;
+    return token;
+}
+
+describe('extended autolink — trailing punctuation (#2096)', () => {
+    it('excludes a trailing colon from the link', () => {
+        const token = autoLinkExt('http://some.domain.name/path/to/resource: rest');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('http://some.domain.name/path/to/resource');
+        expect(token!.raw).toBe('http://some.domain.name/path/to/resource');
+    });
+
+    it('excludes a trailing period (sentence end)', () => {
+        const token = autoLinkExt('https://example.com/a/b. Next sentence.');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/a/b');
+    });
+
+    it('keeps interior punctuation, only trims the trailing run', () => {
+        const token = autoLinkExt('https://example.com/a:b:c! end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/a:b:c');
+    });
+
+    it('leaves a clean URL untouched', () => {
+        const token = autoLinkExt('https://example.com/a/b end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/a/b');
+    });
+});

--- a/packages/muya/src/inlineRenderer/__tests__/autoLinkTrailingPunct.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/autoLinkTrailingPunct.spec.ts
@@ -41,3 +41,49 @@ describe('extended autolink — trailing punctuation (#2096)', () => {
         expect(token!.url).toBe('https://example.com/a/b');
     });
 });
+
+// GFM §6.9 also trims the link extent for three further cases. The match is
+// greedy (`\S+`) so these all need post-match trimming, not regex.
+describe('extended autolink — GFM §6.9 extent trimming', () => {
+    // Rule: an unmatched trailing `)` is excluded when the link has more `)`
+    // than `(`, so an autolink can sit inside parentheses.
+    it('excludes a trailing ) when parens are unbalanced', () => {
+        const token = autoLinkExt('(https://en.wikipedia.org/wiki/Foo_(bar)) end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://en.wikipedia.org/wiki/Foo_(bar)');
+    });
+
+    it('keeps a trailing ) when parens are balanced', () => {
+        const token = autoLinkExt('https://example.com/foo(bar) end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/foo(bar)');
+    });
+
+    // Rule: a trailing `;` closing an `&entity;`-looking reference is excluded.
+    it('excludes a trailing &entity; reference', () => {
+        const token = autoLinkExt('https://example.com/foo?bar=1&amp; end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/foo?bar=1');
+    });
+
+    it('keeps a bare trailing ; that is not an entity', () => {
+        const token = autoLinkExt('https://example.com/a;b; end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/a;b;');
+    });
+
+    // Rule: a `<` ends the autolink.
+    it('ends the link at a < character', () => {
+        const token = autoLinkExt('https://example.com/a<b end');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/a');
+    });
+
+    // The rules interleave and apply repeatedly: ").": trim '.' then the now-
+    // unbalanced ')'.
+    it('applies the rules repeatedly (trailing ").")', () => {
+        const token = autoLinkExt('(see https://example.com/path). rest');
+        expect(token).toBeDefined();
+        expect(token!.url).toBe('https://example.com/path');
+    });
+});

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -515,6 +515,59 @@ function tryHtmlEscape(state: ILexState): boolean {
     return true;
 }
 
+// GFM §6.9: trim a www/url autolink's extent to drop characters that are not
+// part of the link. The match is greedy (`\S+`), so these are applied after the
+// regex, mirroring cmark-gfm's `autolink_delim`:
+//   - a `<` ends the autolink;
+//   - trailing punctuation `?!.,:*_~` is excluded (interior is kept);
+//   - a trailing `)` is excluded when the link has more `)` than `(`, so an
+//     autolink can sit inside parentheses;
+//   - a trailing `;` closing an `&entity;`-looking reference is excluded.
+// The last three rules interleave and are applied repeatedly (e.g. `).`).
+function trimAutoLinkExtent(raw: string): string {
+    let end = raw.length;
+
+    const lt = raw.indexOf('<');
+    if (lt !== -1)
+        end = lt;
+
+    let changed = true;
+    while (changed && end > 0) {
+        changed = false;
+        const c = raw[end - 1];
+
+        if ('?!.,:*_~'.includes(c)) {
+            end -= 1;
+            changed = true;
+        }
+        else if (c === ')') {
+            let opening = 0;
+            let closing = 0;
+            for (let i = 0; i < end; i++) {
+                if (raw[i] === '(')
+                    opening += 1;
+                else if (raw[i] === ')')
+                    closing += 1;
+            }
+            if (closing > opening) {
+                end -= 1;
+                changed = true;
+            }
+        }
+        else if (c === ';') {
+            let entityStart = end - 2;
+            while (entityStart >= 0 && /[a-z0-9]/i.test(raw[entityStart]))
+                entityStart -= 1;
+            if (entityStart >= 0 && entityStart < end - 2 && raw[entityStart] === '&') {
+                end = entityStart;
+                changed = true;
+            }
+        }
+    }
+
+    return raw.slice(0, end);
+}
+
 // auto link extension
 function tryAutoLinkExtension(state: ILexState): boolean {
     const autoLinkExtTo = state.inlineRules.auto_link_extension.exec(state.src);
@@ -533,18 +586,17 @@ function tryAutoLinkExtension(state: ILexState): boolean {
     let url = autoLinkExtTo[2];
     const email = autoLinkExtTo[3];
 
-    // GFM §6.9: trailing punctuation (?!.,:*_~) is not part of a www/url
-    // autolink — strip it from the match so it renders as plain text instead
-    // (#2096). Interior punctuation is kept; email autolinks are unaffected.
+    // GFM §6.9: trim characters that are not part of a www/url autolink so the
+    // leftover renders as plain text instead (#2096). Email autolinks are
+    // unaffected (their extent is fixed by the domain regex).
     if (!email) {
-        const trailing = /[?!.,:*_~]+$/.exec(raw);
-        if (trailing) {
-            const cut = trailing[0].length;
-            raw = raw.slice(0, -cut);
+        const trimmed = trimAutoLinkExtent(raw);
+        if (trimmed.length !== raw.length) {
+            raw = trimmed;
             if (www)
-                www = www.slice(0, -cut);
+                www = trimmed;
             if (url)
-                url = url.slice(0, -cut);
+                url = trimmed;
         }
     }
 

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -515,9 +515,10 @@ function tryHtmlEscape(state: ILexState): boolean {
     return true;
 }
 
-// GFM §6.9: trim a www/url autolink's extent to drop characters that are not
-// part of the link. The match is greedy (`\S+`), so these are applied after the
-// regex, mirroring cmark-gfm's `autolink_delim`:
+// GFM §6.9 (https://github.github.com/gfm/#autolinks-extension-): trim a
+// www/url autolink's extent to drop characters that are not part of the link.
+// The match is greedy (`\S+`), so these are applied after the regex, mirroring
+// cmark-gfm's `autolink_delim`:
 //   - a `<` ends the autolink;
 //   - trailing punctuation `?!.,:*_~` is excluded (interior is kept);
 //   - a trailing `)` is excluded when the link has more `)` than `(`, so an

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -528,22 +528,42 @@ function tryAutoLinkExtension(state: ILexState): boolean {
         return false;
     }
 
+    let raw = autoLinkExtTo[0];
+    let www = autoLinkExtTo[1];
+    let url = autoLinkExtTo[2];
+    const email = autoLinkExtTo[3];
+
+    // GFM §6.9: trailing punctuation (?!.,:*_~) is not part of a www/url
+    // autolink — strip it from the match so it renders as plain text instead
+    // (#2096). Interior punctuation is kept; email autolinks are unaffected.
+    if (!email) {
+        const trailing = /[?!.,:*_~]+$/.exec(raw);
+        if (trailing) {
+            const cut = trailing[0].length;
+            raw = raw.slice(0, -cut);
+            if (www)
+                www = www.slice(0, -cut);
+            if (url)
+                url = url.slice(0, -cut);
+        }
+    }
+
     pushPending(state);
     state.tokens.push({
         type: 'auto_link_extension',
-        raw: autoLinkExtTo[0],
-        www: autoLinkExtTo[1],
-        url: autoLinkExtTo[2],
-        email: autoLinkExtTo[3],
-        linkType: autoLinkExtTo[1] ? 'www' : autoLinkExtTo[2] ? 'url' : 'email',
+        raw,
+        www,
+        url,
+        email,
+        linkType: www ? 'www' : url ? 'url' : 'email',
         parent: state.tokens,
         range: {
             start: state.pos,
-            end: state.pos + autoLinkExtTo[0].length,
+            end: state.pos + raw.length,
         },
     });
-    state.src = state.src.substring(autoLinkExtTo[0].length);
-    state.pos = state.pos + autoLinkExtTo[0].length;
+    state.src = state.src.substring(raw.length);
+    state.pos = state.pos + raw.length;
 
     return true;
 }


### PR DESCRIPTION
## Summary

Fixes #2096 — an extended (bare) autolink swallowed trailing characters that GFM §6.9 says are not part of the link, because the path component is matched greedily (`\S+`).

This PR implements the **full GFM §6.9 autolink extent-trimming** for www/url autolinks, applied after the regex match (the rules can't be expressed in a regular expression — the parenthesis rule requires counting). Mirrors cmark-gfm's `autolink_delim`:

1. **`<` ends the autolink** — the link stops right before the first `<`.
2. **Trailing punctuation** `? ! . , : * _ ~` is excluded (interior punctuation is kept).
3. **Trailing `)` balancing** — a trailing `)` is excluded when the link contains more `)` than `(`, so an autolink can sit inside parentheses, e.g. `(https://en.wikipedia.org/wiki/Foo_(bar))` → link is `https://en.wikipedia.org/wiki/Foo_(bar)`.
4. **Trailing `&entity;`** — a trailing `;` that closes an `&`+alphanumeric reference is excluded.

Rules 2–4 interleave and are applied repeatedly (e.g. `).` trims the `.` then the now-unbalanced `)`). Extracted into a `trimAutoLinkExtent` helper. Email autolinks are unaffected — their extent is fixed by the domain regex.

## Tests

`autoLinkTrailingPunct.spec.ts` covers all four rules plus the interleaving case and the negative cases (balanced parens kept, bare non-entity `;` kept), TDD RED→GREEN.

- Full muya unit suite: 1244 passed.
- GFM conformance: 672 passed (no locked example flipped).
- `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)