### PR TITLE
fix(muya): ArrowUp at document start moves the caret to offset 0 (#3193)

### DIFF
--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -138,6 +138,22 @@ describe('content arrowHandler — cross-block navigation up', () => {
         expect(event.preventDefault).not.toHaveBeenCalled();
         expect(event.stopPropagation).not.toHaveBeenCalled();
     });
+
+    // #3193: ArrowUp on the first visual line of the FIRST block (no previous
+    // block) used to preventDefault and return without moving the caret, so the
+    // caret stayed put. It should move to the start of the line (offset 0).
+    it('arrowUp in the first block (no previous) moves the caret to offset 0', async () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const alpha = contentByText(muya, 'alpha');
+
+        const event = arrowAt(muya, alpha, 'ArrowUp', 3);
+        await flush();
+
+        const cursor = alpha.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
 });
 
 describe('content arrowHandler — cross-block navigation down', () => {

--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -154,6 +154,39 @@ describe('content arrowHandler — cross-block navigation up', () => {
         expect(cursor!.start.offset).toBe(0);
         expect(event.preventDefault).toHaveBeenCalled();
     });
+
+    // #3193 follow-up: when the caret is ALREADY at offset 0 of the first block,
+    // ArrowUp has nowhere to go — it must not re-set the selection (which would
+    // emit a spurious selection-change and needlessly re-render the block).
+    it('arrowUp already at offset 0 of the first block does not emit selection-change', async () => {
+        const muya = bootMuya('alpha\n\nbeta\n');
+        const alpha = contentByText(muya, 'alpha');
+
+        // Land at offset 0 first; this setup emits its own change.
+        muya.editor.activeContentBlock = alpha;
+        alpha.setCursor(0, 0, true);
+        await flush();
+
+        // Only now start counting: the no-op ArrowUp must stay silent.
+        let emitted = 0;
+        muya.eventCenter.on('selection-change', () => {
+            emitted += 1;
+        });
+
+        const event = {
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+            key: 'ArrowUp',
+            shiftKey: false,
+        } as unknown as FakeArrowEvent;
+        alpha.arrowHandler(event);
+        await flush();
+
+        expect(emitted).toBe(0);
+        // The caret is untouched, and the native no-op scroll is still suppressed.
+        expect(alpha.getCursor()!.start.offset).toBe(0);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
 });
 
 describe('content arrowHandler — cross-block navigation down', () => {

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -458,8 +458,15 @@ class Content extends TreeNode {
             event.preventDefault();
             event.stopPropagation();
 
-            if (!previousContentBlock)
+            if (!previousContentBlock) {
+                // First block, no previous: ArrowUp moves the caret to the
+                // start of the line (offset 0) instead of staying put (#3193).
+                // A boundary ArrowLeft has nowhere to go, so leave it.
+                if (event.key === EVENT_KEYS.ArrowUp)
+                    this.setCursor(0, 0, true);
+
                 return;
+            }
 
             cursorBlock = previousContentBlock;
             offset = previousContentBlock.text.length;

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -461,8 +461,10 @@ class Content extends TreeNode {
             if (!previousContentBlock) {
                 // First block, no previous: ArrowUp moves the caret to the
                 // start of the line (offset 0) instead of staying put (#3193).
-                // A boundary ArrowLeft has nowhere to go, so leave it.
-                if (event.key === EVENT_KEYS.ArrowUp)
+                // A boundary ArrowLeft has nowhere to go, so leave it. Skip the
+                // re-set when the caret is already at offset 0, so a no-op
+                // ArrowUp doesn't emit a spurious selection-change or re-render.
+                if (event.key === EVENT_KEYS.ArrowUp && start.offset !== 0)
                     this.setCursor(0, 0, true);
 
                 return;


### PR DESCRIPTION
Fixes #3193

## Problem

Placing the caret in the middle of the first line of the first paragraph and pressing <kbd>↑</kbd> did nothing — the caret stayed put. Standard editor behavior is to move the caret to the start of the line.

## Root cause

`Content.arrowHandler` (`packages/muya/src/block/base/content.ts`): on ArrowUp at the first visual line, it called `preventDefault()`/`stopPropagation()` and then `return`ed early when there was no previous block — suppressing the browser's default caret-to-line-start without providing an alternative.

## Fix

When there is no previous block, ArrowUp now moves the caret to offset 0 of the current block. A boundary ArrowLeft (offset 0, no previous block) still has nowhere to go and is left to do nothing.

## Verification

- `arrowNavigation.spec.ts`: new test — ArrowUp from a mid-first-line caret moves to offset 0 (RED→GREEN); existing cross-block up/down navigation tests still pass.
- Full muya unit suite: 1235 tests pass.
- `lint:types` clean; ESLint clean (one pre-existing `arrowHandler` complexity warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)