### PR TITLE
fix(muya): don't cut a cross-block selection on Ctrl+<key> (Windows/Linux) (#3491)

### DIFF
--- a/packages/muya/src/clipboard/__tests__/crossBlockCutGuard.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/crossBlockCutGuard.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { shouldCrossBlockCut } from '../index';
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim (same stub as sibling specs).
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+// #3491: on a cross-block selection, the keydown handler cuts (replaces) the
+// selection for an editing keystroke. It must NOT cut on a modifier combo —
+// in particular Ctrl+C (copy) on Windows/Linux, which previously deleted the
+// selected text because only metaKey (macOS Cmd) was excluded.
+
+describe('shouldCrossBlockCut (#3491)', () => {
+    it('does NOT cut on Ctrl+C (Windows/Linux copy)', () => {
+        expect(shouldCrossBlockCut('c', false, true)).toBe(false);
+    });
+
+    it('does NOT cut on Cmd+C (macOS copy)', () => {
+        expect(shouldCrossBlockCut('c', true, false)).toBe(false);
+    });
+
+    it('does NOT cut on Ctrl+V / Ctrl+X / any Ctrl combo', () => {
+        expect(shouldCrossBlockCut('v', false, true)).toBe(false);
+        expect(shouldCrossBlockCut('x', false, true)).toBe(false);
+    });
+
+    it('cuts on a plain printable key (type-to-replace the selection)', () => {
+        expect(shouldCrossBlockCut('c', false, false)).toBe(true);
+        expect(shouldCrossBlockCut('a', false, false)).toBe(true);
+    });
+
+    it('cuts on Backspace / Delete', () => {
+        expect(shouldCrossBlockCut('Backspace', false, false)).toBe(true);
+        expect(shouldCrossBlockCut('Delete', false, false)).toBe(true);
+    });
+
+    it('does NOT cut on navigation / modifier-only keys', () => {
+        expect(shouldCrossBlockCut('ArrowDown', false, false)).toBe(false);
+        expect(shouldCrossBlockCut('Shift', false, false)).toBe(false);
+    });
+});

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -7,6 +7,21 @@ import { pastePlainText, pasteSelection } from './paste';
 import { pasteImageSrc } from './pasteImage';
 import { CopyType, PasteType } from './types';
 
+// After the table/same-block guards, decide whether a keydown over a
+// cross-block selection should cut (replace) the selected text. Non-editing
+// keys and any modifier combo must NOT cut — in particular Ctrl+<key> (e.g.
+// Ctrl+C copy on Windows/Linux), which was previously not excluded and
+// silently deleted the selection (#3491). Mirrors the macOS metaKey guard.
+export function shouldCrossBlockCut(key: string, metaKey: boolean, ctrlKey: boolean): boolean {
+    if (/Alt|Option|Meta|Shift|CapsLock|ArrowUp|ArrowDown|ArrowLeft|ArrowRight/.test(key))
+        return false;
+
+    if (metaKey || ctrlKey)
+        return false;
+
+    return true;
+}
+
 class Clipboard {
     public copyType: CopyType = CopyType.NORMAL;
     public pasteType: PasteType = PasteType.NORMAL;
@@ -63,16 +78,7 @@ class Clipboard {
             if (isSelectionInSameBlock)
                 return;
 
-            // TODO: Is there any way to identify these key bellow?
-            if (
-                /Alt|Option|Meta|Shift|CapsLock|ArrowUp|ArrowDown|ArrowLeft|ArrowRight/.test(
-                    key,
-                )
-            ) {
-                return;
-            }
-
-            if (metaKey)
+            if (!shouldCrossBlockCut(key, metaKey, event.ctrlKey))
                 return;
 
             if (key === 'Backspace' || key === 'Delete')


### PR DESCRIPTION
Fixes #3491

## Problem

On Windows/Linux, selecting text across two or more blocks and pressing <kbd>Ctrl</kbd>+<kbd>C</kbd> to copy **deleted** the selected text.

## Root cause

`packages/muya/src/clipboard/index.ts` — the cross-block keydown handler cuts (replaces) the selection for any editing keystroke, bailing out only for non-editing keys and macOS `metaKey`. It never checked `ctrlKey`, so Ctrl+C (`key='c'`, `metaKey=false`, `ctrlKey=true`) fell through to `cutHandler()` and removed the selection before the browser's copy event wrote to the clipboard.

## Fix

Extract the modifier/key decision into a pure `shouldCrossBlockCut(key, metaKey, ctrlKey)` helper and exclude `ctrlKey` as well (mirroring the existing `metaKey` guard). Any Ctrl/Cmd combo now leaves the selection intact.

## Verification

- New `crossBlockCutGuard.spec.ts`: Ctrl+C / Cmd+C / Ctrl+V/X don't cut; plain keys and Backspace/Delete do; nav/modifier-only keys don't. RED→GREEN confirmed (toggling off the `ctrlKey` exclusion fails the Ctrl cases).
- Full muya unit suite: 1240 tests pass.
- `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)