### PR TITLE
test(desktop): pin autosave's recreate-missing-directory behavior (#3509)

### DIFF
--- a/packages/desktop/src/main/filesystem/index.ts
+++ b/packages/desktop/src/main/filesystem/index.ts
@@ -32,5 +32,8 @@ export const writeFile = (
   }
   pathname = !extension || pathname.endsWith(extension) ? pathname : `${pathname}${extension}`
 
+  // `outputFile` creates any missing parent directories before writing, so a
+  // save whose folder was moved/deleted recreates it and still succeeds —
+  // matching VS Code, and keeping (auto)save from ever silently failing (#3509).
   return outputFile(pathname, content, options)
 }

--- a/packages/desktop/test/unit/specs/write-file-missing-dir.spec.ts
+++ b/packages/desktop/test/unit/specs/write-file-missing-dir.spec.ts
@@ -1,0 +1,44 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { writeFile } from 'main_renderer/filesystem'
+
+// #3509: with autosave on, moving/deleting a file's folder while it is open
+// makes the save target a now-missing directory. MarkText intentionally
+// recreates the directory tree and writes the file (via fs-extra `outputFile`),
+// matching VS Code, so an (auto)save never silently fails or loses edits. These
+// tests pin that behavior.
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'mt-3509-'))
+  dirs.push(d)
+  return d
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe('writeFile — missing parent directory (#3509)', () => {
+  it('recreates a directory that no longer exists and writes the file', async() => {
+    const base = tempDir()
+    const missingDir = path.join(base, 'moved-away')
+    const target = path.join(missingDir, 'note.md')
+
+    await writeFile(target, 'hello', undefined)
+
+    expect(existsSync(missingDir)).toBe(true)
+    expect(readFileSync(target, 'utf-8')).toBe('hello')
+  })
+
+  it('writes normally when the parent directory exists', async() => {
+    const base = tempDir()
+    const target = path.join(base, 'note.md')
+
+    await writeFile(target, 'hello', undefined)
+
+    expect(readFileSync(target, 'utf-8')).toBe('hello')
+  })
+})


### PR DESCRIPTION
## Summary

Re: #3509 — autosave "re-creates files and folders when they are moved away".

After review we decided this behavior is **intentional and correct**: when a file's parent folder has been moved or deleted while the file is open, saving (including autosave) **recreates the directory tree and writes the file**, rather than failing. This matches **VS Code**, which also recreates a deleted parent directory on save, and it ensures an (auto)save never silently fails or loses the user's edits.

This PR therefore makes **no behavior change**. It just:

- Adds unit coverage pinning the intended behavior (`writeFile` recreates a missing parent directory and writes the file; and writes normally when the directory exists).
- Adds a short comment on the `outputFile` call documenting *why* it's used, so the behavior isn't mistaken for the bug in #3509 and "fixed" by switching to a plain write.

## Test

```
pnpm -C packages/desktop exec vitest run test/unit/specs/write-file-missing-dir.spec.ts
```
Both cases pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)