### PR TITLE
fix(muya): destroy UI plugins on Muya.destroy() to stop leaking DOM nodes (#3315)

### DIFF
--- a/packages/muya/src/__tests__/muyaDestroyPlugins.spec.ts
+++ b/packages/muya/src/__tests__/muyaDestroyPlugins.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../muya';
+
+// #3315: Muya.destroy() hid visible float tools but never invoked each UI
+// plugin's destroy(), so nodes appended to document.body in plugin
+// constructors/init (float boxes, the image resize bar) leaked permanently.
+// destroy() must iterate the registered plugins and call destroy() on each.
+
+const bootedHosts: HTMLElement[] = [];
+let hadVersion = false;
+let originalVersion: string | undefined;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('muya.destroy — UI plugin cleanup (#3315)', () => {
+    it('calls destroy() on every registered UI plugin', () => {
+        const muya = bootMuya('hello\n');
+        const destroyA = vi.fn();
+        const destroyB = vi.fn()
+    ;(muya as unknown as { _uiPlugins: Record<string, unknown> })._uiPlugins = {
+            a: { destroy: destroyA },
+            b: { destroy: destroyB },
+        };
+
+        muya.destroy();
+
+        expect(destroyA).toHaveBeenCalledTimes(1);
+        expect(destroyB).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw for a plugin without a destroy() method', () => {
+        const muya = bootMuya('hello\n')
+    ;(muya as unknown as { _uiPlugins: Record<string, unknown> })._uiPlugins = {
+            legacy: {},
+        };
+
+        expect(() => muya.destroy()).not.toThrow();
+    });
+});

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1622,6 +1622,15 @@ export class Muya {
         // Hide all float tools.
         if (this.ui)
             this.ui.hideAllFloatTools();
+
+        // Destroy every registered UI plugin so the nodes they appended to
+        // `document.body` (float boxes, the image resize bar, tooltips) are
+        // removed rather than leaked (#3315).
+        for (const plugin of Object.values(this._uiPlugins)) {
+            const destroy = (plugin as { destroy?: unknown })?.destroy;
+            if (typeof destroy === 'function')
+                (destroy as () => void).call(plugin);
+        }
     }
 }
 

--- a/packages/muya/src/ui/imageResizeBar/index.ts
+++ b/packages/muya/src/ui/imageResizeBar/index.ts
@@ -207,4 +207,10 @@ export class ImageResizeBar {
         this._status = false;
         eventCenter.emit('muya-float', this, false);
     }
+
+    // Remove the `.mu-transformer` container appended to document.body in the
+    // constructor; invoked by `Muya.destroy()` so it is not leaked (#3315).
+    destroy() {
+        this._container.remove();
+    }
 }


### PR DESCRIPTION
Fixes #3315

## Problem

`Muya.destroy()` did not clean up DOM nodes that UI plugins append to `document.body`. Toggling to browser/source mode (which destroys and rebuilds the editor) leaked a `.mu-transformer` / float-box node on every cycle.

## Root cause

`packages/muya/src/muya.ts` — `destroy()` called `ui.hideAllFloatTools()` (which only `hide()`s visible tools) but never iterated `_uiPlugins` to call each plugin's `destroy()`. Every `BaseFloat` subclass *has* a `destroy()` that removes its `floatBox`, but it was never invoked; `ImageResizeBar` appends its container at construction and had **no** `destroy()` at all.

## Fix

- `Muya.destroy()` now iterates `_uiPlugins` and calls each plugin's `destroy()` (guarding plugins without one).
- Added `ImageResizeBar.destroy()` to remove its `.mu-transformer` container.

## Verification

- New `muyaDestroyPlugins.spec.ts`: `destroy()` calls `destroy()` on every registered plugin; doesn't throw for a plugin lacking one (RED→GREEN — toggling the loop off fails it).
- Full muya unit suite: 1236 tests pass.
- `lint:types` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)