### PR TITLE
fix(muya): keep list item non-empty on Enter in empty first paragraph (#4644)

### DIFF
--- a/packages/muya/e2e/tests/blocks/list-nav-4644.spec.ts
+++ b/packages/muya/e2e/tests/blocks/list-nav-4644.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import { loadMarkdown, slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #4644 — a sequence of list edits used to leave a `list-item` with zero
+// content children behind. An empty list item has no content descendant, so
+// cross-block arrow navigation (`previousContentInContext`) could not step
+// over it and Up arrow stopped moving the caret up a line.
+//
+// Repro sequence: * [space] A [return] B [up] [return] [backspace] [up]
+//                 [return] [return] [return]
+
+// Index of the active content block among all `.content` leaves, plus the
+// total content-block count — enough to tell whether the caret actually moved.
+async function caretProbe(page: import('@playwright/test').Page) {
+    return page.evaluate(() => {
+        const muya = window.muya!;
+        const leaves: unknown[] = [];
+        const visit = (block: {
+            constructor: { blockName?: string };
+            children?: { forEach: (cb: (b: unknown) => void) => void };
+        }) => {
+            if (block.constructor?.blockName?.endsWith('.content'))
+                leaves.push(block);
+            block.children?.forEach(b => visit(b as typeof block));
+        };
+        visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+        return {
+            activeIndex: leaves.indexOf(muya.editor.activeContentBlock as unknown),
+            leafCount: leaves.length,
+        };
+    });
+}
+
+async function runSequence(page: import('@playwright/test').Page) {
+    await page.goto('/');
+    await loadMarkdown(page, 'seed\n');
+    const seed = page.locator(editor.paragraph).filter({ hasText: 'seed' }).first();
+    await seed.click();
+    await page.keyboard.press('End');
+    for (let i = 0; i < 4; i++)
+        await page.keyboard.press('Backspace');
+
+    await slowType(page, '* ');
+    await slowType(page, 'A');
+    await page.keyboard.press('Enter');
+    await slowType(page, 'B');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(100);
+}
+
+test('list edit sequence never leaves an empty list item', async ({ page }) => {
+    await runSequence(page);
+
+    const hasEmptyListItem = await page.evaluate(() => {
+        const state = window.muya!.getState();
+        const found: boolean[] = [];
+        const walk = (node: { name?: string; children?: unknown[] }) => {
+            if (node.name === 'list-item' || node.name === 'task-list-item')
+                found.push(!node.children || node.children.length === 0);
+            node.children?.forEach(c => walk(c as typeof node));
+        };
+        state.forEach(n => walk(n as { name?: string; children?: unknown[] }));
+        return found.some(Boolean);
+    });
+
+    expect(hasEmptyListItem).toBe(false);
+});
+
+test('Up arrow still moves the caret up after the list edit sequence', async ({ page }) => {
+    await runSequence(page);
+
+    const before = await caretProbe(page);
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(100);
+    const after = await caretProbe(page);
+
+    // The caret must land on an earlier content block, not stay put.
+    expect(after.activeIndex).toBeLessThan(before.activeIndex);
+});

--- a/packages/muya/src/block/content/paragraphContent/__tests__/enterListItemEmptyFirst.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/enterListItemEmptyFirst.spec.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import type { TState } from '../../../../state/types';
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #4644 — pressing Enter on the EMPTY FIRST paragraph of a loose list item
+// (one that holds more than one paragraph) must not strip every paragraph out
+// of the list item. `_enterInListItem`'s "empty paragraph, not only child"
+// branch moved every paragraph from the caret's index to the end into a new
+// sibling list item; when the caret sat on the first paragraph (index 0) that
+// emptied the original list item, leaving a `list-item` with zero children.
+//
+// An empty list item has no content descendant, so
+// `previousContentInContext()`/`nextContentInContext()` return null when arrow
+// navigation tries to cross it — the symptom reported in #4644 where Up arrow
+// can no longer move the caret up a line.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+// A loose bullet list whose single list item holds two paragraphs: an empty
+// first paragraph followed by `tail`.
+const LOOSE_ITEM_STATE: TState[] = [
+    {
+        name: 'bullet-list',
+        meta: { loose: true, marker: '*' },
+        children: [
+            {
+                name: 'list-item',
+                children: [
+                    { name: 'paragraph', text: '' },
+                    { name: 'paragraph', text: 'tail' },
+                ],
+            },
+        ],
+    },
+] as unknown as TState[];
+
+function bootMuya(content: TState[]): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {} as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    muya.setContent(content);
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+function enterAt(muya: Muya, content: Content, offset: number) {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        shiftKey: false,
+        key: 'Enter',
+    } as unknown as KeyboardEvent;
+    content.enterHandler(event);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+interface IListItemLike { name: string; children?: unknown[] }
+
+describe('#4644 enter on empty first paragraph of a multi-paragraph list item', () => {
+    it('never produces a list-item with zero content children', async () => {
+        const muya = bootMuya(LOOSE_ITEM_STATE);
+        const emptyFirst = contentByText(muya, '');
+
+        enterAt(muya, emptyFirst, 0);
+        await flush();
+
+        const state = muya.getState();
+        const list = state[0] as { children: IListItemLike[] };
+        for (const item of list.children) {
+            expect(item.name).toBe('list-item');
+            expect(item.children && item.children.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('splits into two non-empty list items (empty stays, tail moves down)', async () => {
+        const muya = bootMuya(LOOSE_ITEM_STATE);
+        const emptyFirst = contentByText(muya, '');
+
+        enterAt(muya, emptyFirst, 0);
+        await flush();
+
+        const state = muya.getState();
+        const list = state[0] as { children: { children: { name: string; text: string }[] }[] };
+        expect(list.children.length).toBe(2);
+        expect(list.children[0].children.map(p => p.text)).toEqual(['']);
+        expect(list.children[1].children.map(p => p.text)).toEqual(['tail']);
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -469,7 +469,11 @@ class ParagraphContent extends Format {
                         : { name: 'list-item', children: [] };
 
                 const offset = listItem.offset(parent!);
-                listItem.forEachAt(offset, undefined, (node) => {
+                // Splitting from index 0 would empty the original list item,
+                // leaving a childless list-item that breaks arrow navigation
+                // (#4644). Keep the empty first paragraph and split below it.
+                const from = offset === 0 ? 1 : offset;
+                listItem.forEachAt(from, undefined, (node) => {
                     if (node.isParent())
                         newListItemState.children.push(node.getState());
                     node.remove();


### PR DESCRIPTION
## Summary

Fixes #4644 — after a series of list edits, the Up arrow stops moving the caret up a line and the user has to click instead.

## Root cause

`ParagraphContent._enterInListItem` handles pressing Enter on an **empty paragraph that is not the only child** of a loose list item by moving every paragraph from the caret's index to the end of the item into a new sibling list item:

```ts
const offset = listItem.offset(parent!)
listItem.forEachAt(offset, undefined, (node) => { /* move to new item */ })
```

When the caret sits on the **first** paragraph (`offset === 0`), this moves *all* paragraphs out and leaves the original `list-item` with `children: []`. A childless list item has no content descendant, so `previousContentInContext`/`nextContentInContext` return `null` when arrow navigation tries to step over it — `Content.arrowHandler` then `preventDefault`s the Up arrow but finds no previous block to land on, so the caret cannot move up.

The reported sequence (`* ␣ A ⏎ B ↑ ⏎ ⌫ ↑ ⏎ ⏎ ⏎`) walks the document into exactly this state.

## Fix

When the empty paragraph is the first child, split from the *next* paragraph instead, keeping the empty first paragraph in the original item. This mirrors the established plain-paragraph "Enter at offset 0" behaviour and keeps every list item valid (≥1 content child).

## Tests

- **Unit** (`enterListItemEmptyFirst.spec.ts`) — pins the engine invariant: Enter on the empty first paragraph of a multi-paragraph list item never yields a childless list item, and splits into two non-empty items.
- **E2E** (`list-nav-4644.spec.ts`) — drives the exact reported keystroke sequence in a real browser and asserts (1) no empty list item remains and (2) Up arrow still moves the caret to an earlier content block. Both tests were confirmed to fail on the unfixed source and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)