### PR TITLE
fix(muya): apply inline format across paragraphs nested in one blockquote (#3462)

### DIFF
--- a/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
+++ b/packages/muya/src/block/base/__tests__/crossBlockFormat.spec.ts
@@ -82,6 +82,30 @@ describe('cross-block format', () => {
         expect(sel.focusBlock!.text).toContain('bravo');
     });
 
+    it('bolds two paragraphs nested in the same blockquote (#3462)', async () => {
+        const muya = boot('> alpha\n>\n> bravo\n');
+        const sp = muya.editor.scrollPage!;
+        const first = sp.firstContentInDescendant()!;
+        const second = sp.lastContentInDescendant()!;
+        // Both leaves live inside the SAME outmost block (the blockquote), so an
+        // outmost-block-granular same-block check wrongly reports "same block".
+        expect(first).not.toBe(second);
+        expect(first.outMostBlock).toBe(second.outMostBlock);
+        stubFullRange(first);
+        stubFullRange(second);
+        muya.editor.activeContentBlock = second;
+        muya.editor.selection.setSelection(
+            { offset: 0, block: first, path: first.path },
+            { offset: second.text.length, block: second, path: second.path },
+        );
+        muya.format('strong');
+        await vi.waitFor(() => {
+            const md = muya.getMarkdown();
+            expect(md).toContain('**alpha**');
+            expect(md).toContain('**bravo**');
+        });
+    });
+
     it('skips a code block inside the range', async () => {
         const muya = boot('alpha\n\n```\ncode\n```\n\nbravo\n');
         const sp = muya.editor.scrollPage!;

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -389,10 +389,12 @@ export class Muya {
     format(type: string) {
         const { selection } = this.editor;
 
-        // Cross-block selection: apply to each formattable leaf in range. The
+        // Cross-leaf selection: apply to each formattable leaf in range. The
         // live DOM selection collapses across blocks, so detect via the cached
-        // endpoints (the same ones the menu/IPC round-trip relies on).
-        if (!this._selectionInSameBlock()) {
+        // endpoints (the same ones the menu/IPC round-trip relies on). Compare
+        // at the LEAF level, not the outmost block: two paragraphs nested in the
+        // same blockquote share an outmost block but are distinct leaves (#3462).
+        if (!this._selectionInSameLeaf()) {
             this._formatAcrossBlocks(type);
             return;
         }
@@ -719,6 +721,28 @@ export class Muya {
             return true;
 
         return endpoints.anchor === endpoints.focus;
+    }
+
+    /**
+     * Whether the current selection stays within a single content leaf. Unlike
+     * `_selectionInSameBlock` (outmost-block granularity, for paragraph-menu
+     * dispatch), this compares the actual leaves so a selection spanning two
+     * paragraphs nested in one blockquote is correctly treated as cross-leaf
+     * for inline formatting (#3462).
+     */
+    private _selectionInSameLeaf(): boolean {
+        const sel = this.editor.selection;
+        const liveSel = sel.getSelection();
+        const liveAnchor = liveSel?.anchor.block;
+        const liveFocus = liveSel?.focus.block;
+        if (liveAnchor && liveFocus && liveAnchor !== liveFocus)
+            return false;
+        const cachedAnchor = sel.anchorBlock;
+        const cachedFocus = sel.focusBlock;
+        if (cachedAnchor && cachedFocus && cachedAnchor !== cachedFocus)
+            return false;
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #3462 — applying an inline format (bold/italic/highlight/…) to a selection spanning **two paragraphs nested inside the same blockquote** applied no formatting at all.

## Root cause

`format()` decides between the single-leaf and cross-block paths via `_selectionInSameBlock()`, which compares the selection endpoints at **outmost-block** granularity. Two paragraphs in the same blockquote share one outmost block (the blockquote), so the check reported "same block" and routed to the single-leaf path. That path then early-returns because the anchor and focus leaves are actually different — so nothing got formatted.

## Fix

Dispatch inline formatting on **leaf** equality via a new `_selectionInSameLeaf()` helper (mirrors `_selectionEndpoints` but at leaf granularity, preferring the live DOM selection and falling back to the cached endpoints). `_formatAcrossBlocks` already walks every formattable leaf between anchor and focus via `nextContentInContext()`, so it handles the blockquote-nested case unchanged. The paragraph-menu dispatch (`_handleCrossBlockParagraph`) keeps its outmost-block check, since "wrap each block" semantics are correctly block-granular.

## Test

Added a regression test to `crossBlockFormat.spec.ts` that bolds two paragraphs nested in one blockquote and asserts both receive `**…**`. It also asserts the two leaves share an outmost block, pinning the exact condition that previously misrouted.

- RED verified (no formatting before the fix), GREEN after.
- Full muya unit suite: 1235 passed.
- `lint:types` + ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)