### PR TITLE
fix(release): support immutable releases (draft-then-promote) + docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,15 +203,24 @@ jobs:
             echo '```'
           } > release_body.md
 
-      - name: Publish release
+      # Immutable-release repos forbid adding assets to an already-published
+      # release, and action-gh-release publishes before uploading the assets.
+      # Create the release as a draft (assets allowed), then promote it to a
+      # published release in the next step.
+      - name: Create draft release with assets
         uses: softprops/action-gh-release@v2.6.2
         with:
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           name: ${{ github.ref_name }}
           body_path: release_body.md
           fail_on_unmatched_files: true
           files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote draft to published release
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --repo "${GITHUB_REPOSITORY}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/website/content/docs/dev/RELEASE.md
+++ b/packages/website/content/docs/dev/RELEASE.md
@@ -1,6 +1,6 @@
 # Releasing MarkText
 
-The release pipeline is triggered by pushing a `v*` tag. The `Release MarkText` workflow (`.github/workflows/release.yml`) then runs **validate → build (4-platform matrix) → publish** and creates a GitHub Release with installers and `SHA256SUMS.txt`.
+The release pipeline is triggered by pushing a `v*` tag. The `Release MarkText` workflow (`.github/workflows/release.yml`) then runs **validate → build (5-platform matrix) → publish** and creates a GitHub Release with installers and `SHA256SUMS.txt`.
 
 The flow below covers both release candidates and stable releases — same steps, only the version string differs.
 
@@ -63,7 +63,7 @@ gh run list --workflow=release.yml --limit 3
 gh run watch <run-id> --exit-status
 ```
 
-Approximate timing: validate ~30 s · build matrix ~15–30 min (4 platforms in parallel) · publish ~1 min.
+Approximate timing: validate ~30 s · build matrix ~15–30 min (5 platforms in parallel) · publish ~1 min.
 
 ## 7. Verify the published release
 


### PR DESCRIPTION
## Why

The repository has GitHub's **immutable releases** enabled. `softprops/action-gh-release` publishes the release *before* uploading assets, and immutable releases forbid adding assets to an already-published release. As a result the `release` job fails with `Cannot upload asset ... to an immutable release`, leaving a published pre-release with **0 assets**. This broke the `v0.20.0-beta.1` publish.

This fix was validated on the `release/v0.20.0` branch: `v0.20.0-beta.2` published successfully with all 24 assets.

## What

- **`.github/workflows/release.yml`** — the publish step now creates the GitHub Release as a **draft** (assets attach to a draft, which is allowed), then a follow-up step promotes it to published via `gh release edit "$TAG" --draft=false`. The `prerelease` flag carries over, so pre-releases stay pre-releases. The step itself carries a comment explaining why; the operational gotchas are intentionally kept out of RELEASE.md to keep that doc a clean release tutorial.
- **`RELEASE.md`** — corrects the build matrix from 4 to 5 platforms (windows-arm64 was added). No other doc changes.

## Notes

- The same fix already lives on `release/v0.20.0` (tracking PR #4664); this PR lands it on `develop` so all future releases get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)