### PR TITLE
fix(desktop): restore vue-tsc typecheck (vite 7 PluginOption)

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -1,4 +1,5 @@
 import { resolve, dirname } from 'path'
+import type { PluginOption } from 'vite'
 import { defineConfig } from 'electron-vite'
 import vue from '@vitejs/plugin-vue'
 import svgLoader from 'vite-svg-loader'
@@ -94,7 +95,7 @@ export default defineConfig({
         }
       }
     },
-    plugins: [vue(), svgLoader()],
+    plugins: [vue(), svgLoader()] as PluginOption[],
     css: {
       postcss: {
         plugins: [


### PR DESCRIPTION
## Why

`pnpm typecheck` (vue-tsc) currently fails on `develop`:

```
electron.vite.config.ts(97,22): error TS2769: No overload matches this call.
```

After the vite 7 bump, `@vitejs/plugin-vue` and `vite-svg-loader` resolve their own copies of vite's types, so the elements of the renderer `plugins: [vue(), svgLoader()]` array no longer line up with the `PluginOption[]` that electron-vite expects. The runtime build is unaffected (esbuild ignores the type mismatch — all 5 platform builds pass), but the typecheck — and therefore the `lint` CI job — is red.

## What

Cast the renderer plugins array to vite's `PluginOption[]`. Minimal, type-only change; no runtime effect.

## Verification

CI `lint` job (runs `vue-tsc --noEmit`) should go green. The error reproduced on a clean `develop` checkout; this PR is the targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)