### PR TITLE
fix(muya): keep inline links that are followed by a bare URL or text (#4671)

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/linkFollowedByAutolink.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/linkFollowedByAutolink.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+
+import type { Token } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+// #4671: a well-formed inline/reference link must not be vetoed just because
+// its destination URL also matches the GFM extended (bare-URL) autolink rule.
+// Extended autolinks are a post-process over plain text and bind LESS tightly
+// than a link, so they must never override `[text](url)`.
+
+function linkTokens(src: string) {
+    return tokenizer(src).filter(t => t.type === 'link') as Array<Token & { href?: string; anchor?: string }>;
+}
+
+describe('inline link followed by trailing punctuation (#4671)', () => {
+    it('recognizes a link whose closing paren is followed by a CJK comma', () => {
+        const links = linkTokens('支持[CommonMark 规范](https://spec.commonmark.org/)、其他');
+        expect(links).toHaveLength(1);
+        expect(links[0].href).toBe('https://spec.commonmark.org/');
+        expect(links[0].raw).toBe('[CommonMark 规范](https://spec.commonmark.org/)');
+    });
+
+    it('recognizes the first of two links on one line', () => {
+        const links = linkTokens(
+            '支持[CommonMark 规范](https://spec.commonmark.org/)、 [GitHub Flavored Markdown 规范](https://github.github.com/gfm/)',
+        );
+        expect(links).toHaveLength(2);
+        expect(links[0].href).toBe('https://spec.commonmark.org/');
+        expect(links[1].href).toBe('https://github.github.com/gfm/');
+    });
+
+    it('recognizes a link whose destination URL is immediately followed by text', () => {
+        const links = linkTokens('see [docs](https://example.com/path)next');
+        expect(links).toHaveLength(1);
+        expect(links[0].href).toBe('https://example.com/path');
+        expect(links[0].raw).toBe('[docs](https://example.com/path)');
+    });
+});

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -6,7 +6,7 @@ import type {
     Token,
 } from './types';
 import { isLengthEven, union } from '../utils';
-import { beginRules, inlineRules, validateRules } from './rules';
+import { beginRules, inlineRules, linkValidateRules, validateRules } from './rules';
 import {
     correctUrl,
     getAttributes,
@@ -361,7 +361,7 @@ function tryLink(state: ILexState): boolean {
             // than links. If a higher-priority inline rule matches a span
             // that extends past the tentative link's range, defer to it.
             // Covers CM 0.29 examples 520 (HTML tag) and 521 (code span).
-            && lowerPriority(state.src, linkTo[0].length, validateRules)
+            && lowerPriority(state.src, linkTo[0].length, linkValidateRules)
         )
     ) {
         return false;
@@ -414,7 +414,7 @@ function tryReferenceLink(state: ILexState): boolean {
             && state.labels.has((rLinkTo[3] || rLinkTo[1]).toLowerCase())
             && isLengthEven(rLinkTo[2])
             && isLengthEven(rLinkTo[4])
-            && lowerPriority(state.src, rLinkTo[0].length, validateRules)
+            && lowerPriority(state.src, rLinkTo[0].length, linkValidateRules)
         )
     ) {
         return false;

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -110,3 +110,17 @@ export const validateRules: ValidateRules = (Object.keys(inlineRules) as InlineR
         };
     }
 }, {} as ValidateRules);
+
+// Veto set used when validating a tentative `[text](url)` / reference link.
+// Per CommonMark §6.6 only code spans, raw HTML tags and `<...>` autolinks bind
+// more tightly than a link, so only those may defer a link that overlaps them
+// (CM 0.29 examples 520/521). Using the full `validateRules` here is wrong: a
+// GFM extended (bare-URL) autolink or the link rule's own greedy destination
+// match would extend past the tentative link and veto it, dropping links such
+// as `[t](https://x)、` or `[t](https://x)foo` and the first of two links on a
+// line (#4671).
+export const linkValidateRules: Pick<InlineRules, 'inline_code' | 'html_tag' | 'auto_link'> = {
+    inline_code: inlineRules.inline_code,
+    html_tag: inlineRules.html_tag,
+    auto_link: inlineRules.auto_link,
+};


### PR DESCRIPTION
Fixes #4671 (the hyperlink-rendering half).

## Problem

A well-formed `[text](url)` (or reference) link was dropped — rendered as raw markdown with the link styling bleeding into the following text — whenever its destination URL also matched the GFM extended (bare-URL) autolink rule **and** was immediately followed by more content:

- a CJK comma after the link: `[t](https://x)、`
- trailing text: `[t](https://x)foo`
- the first of two links on one line (as in the project's own README features list, per the issue screenshot)

## Root cause

`tryLink` / `tryReferenceLink` validate a tentative link with `lowerPriority(..., validateRules)` using the **full** inline-rule set. Two of those rules can match a span that runs *past* the link and falsely veto it:

- `auto_link_extension` matches the bare destination URL plus any trailing punctuation/text, extending beyond the link's closing paren.
- `link` / `image` themselves use a greedy `.*` destination and (before `correctUrl` runs) match across to a *later* link on the same line.

Per CommonMark §6.6, only code spans, raw HTML tags and `<...>` autolinks bind more tightly than a link, so only those may defer it (the documented CM 0.29 examples 520/521).

## Fix

Introduce `linkValidateRules` containing exactly `inline_code`, `html_tag` and `auto_link`, and use it as the veto set in both link validators.

## Verification

- New regression spec `linkFollowedByAutolink.spec.ts` (3 cases) — fails before, passes after.
- Full muya unit suite: **1274 passing**.
- CommonMark + GFM conformance suites: **1347 passing** (locked against `expected-failures.json`, so nothing regressed or silently flipped).
- Manually confirmed precedence is preserved: CM 521 code span still wins over a link, `<...>` angle autolinks and bare extended autolinks in plain text still tokenize correctly.

## Not addressed here

The issue also reports blurry font rendering on Windows. That is OS/display-scaling specific, not reproducible on macOS, and unrelated to this parser bug — left for separate investigation rather than shipping an unverifiable guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)