### PR TITLE
fix(muya): load mhchem onto the same katex instance so \ce renders (#4670)

### DIFF
--- a/packages/muya/src/block/extra/math/__tests__/mhchem.spec.ts
+++ b/packages/muya/src/block/extra/math/__tests__/mhchem.spec.ts
@@ -1,0 +1,13 @@
+import katex from 'katex';
+import { describe, expect, it } from 'vitest';
+import '../mathPreview';
+
+describe('mhchem (\\ce) extension registration', () => {
+    it('patches the same katex instance the renderers use', () => {
+        expect(() =>
+            katex.renderToString('\\ce{Zn^2+ <=> Zn(OH)2}', {
+                displayMode: true,
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/muya/src/block/extra/math/mathPreview.ts
+++ b/packages/muya/src/block/extra/math/mathPreview.ts
@@ -5,7 +5,7 @@ import { fromEvent } from 'rxjs';
 import { CLASS_NAMES } from '../../../config';
 import logger from '../../../utils/logger';
 import Parent from '../../base/parent';
-import 'katex/dist/contrib/mhchem.min.js';
+import 'katex/dist/contrib/mhchem.mjs';
 
 const debug = logger('mathPreview:');
 

--- a/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
+++ b/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
@@ -3,7 +3,7 @@ import type Renderer from './index';
 import katex from 'katex';
 import { CLASS_NAMES } from '../../config';
 import { htmlToVNode } from '../../utils/snabbdom';
-import 'katex/dist/contrib/mhchem.min.js';
+import 'katex/dist/contrib/mhchem.mjs';
 
 import 'katex/dist/katex.min.css';
 

--- a/packages/muya/src/utils/marked/extensions/math.ts
+++ b/packages/muya/src/utils/marked/extensions/math.ts
@@ -1,4 +1,5 @@
 import katex from 'katex';
+import 'katex/dist/contrib/mhchem.mjs';
 
 export interface IMathToken {
     type: 'inlineMath' | 'multiplemath';


### PR DESCRIPTION
## Problem

Closes #4670. Chemistry formulas written with mhchem syntax (`\ce{...}`) render as **`< Invalid Mathematical Formula >`** in MarkText, while Typora renders them correctly.

## Root cause — KaTeX dual-package hazard

The math renderers loaded the chemistry extension via a deep path:

```ts
import katex from 'katex'                       // → ESM build  dist/katex.mjs
import 'katex/dist/contrib/mhchem.min.js'       // → UMD build, require("katex") → CJS  dist/katex.js
```

`katex/dist/contrib/mhchem.min.js` is not in katex's `exports` map, so it falls through the `"./*"` fallback to the minified **UMD** bundle. That bundle's internal `require("katex")` resolves to the **CommonJS** build (`dist/katex.js`) — a *different module instance* from the **ESM** `katex` (`dist/katex.mjs`) the renderers actually call `renderToString` on.

Result: mhchem registers the `\ce` macro on the CJS instance, rendering happens on the ESM instance, so `\ce` stays an undefined control sequence (`KaTeX parse error: Undefined control sequence: \ce`) and falls back to the error placeholder.

## Fix

Import the ESM extension build `katex/dist/contrib/mhchem.mjs`, which internally does `import katex from 'katex'` and therefore patches the same deduped instance the renderers use. Applied to:

- `block/extra/math/mathPreview.ts` — math block preview (the path in the issue screenshot)
- `inlineRenderer/renderer/inlineMath.ts` — inline `$...$` math
- `utils/marked/extensions/math.ts` — HTML-export render path, which was **missing the mhchem import entirely**

## Test

Added `block/extra/math/__tests__/mhchem.spec.ts` — asserts `\ce{...}` renders without throwing on the shared katex instance. Fails on `develop` (reproduces the bug under Vite resolution), passes with this fix. Existing 316 math/katex/export tests still pass.

## Notes / out of scope

The issue also mentions a Maxwell-equation block and `<iframe>` rendering. The Maxwell block uses `\ ` (backslash-space) instead of `\\` for row breaks — a document authoring issue that renders the same single-line way in Typora too. `<iframe>` is intentionally not rendered in the sandboxed renderer. Neither is a regression; this PR scopes to the mhchem root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)