### PR TITLE
fix(muya): preserve nested-list indentation in RTL mode

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -101,7 +101,14 @@ export default defineConfig({
         plugins: [
           postcssPresetEnv({
             stage: 0,
-            features: { 'nesting-rules': true }
+            features: {
+              'nesting-rules': true,
+              // Electron ships Chromium, which supports CSS logical properties
+              // natively. Leave them untouched so `padding-inline-start` /
+              // `inset-inline-start` mirror correctly under `dir="rtl"` instead
+              // of being down-compiled to hard-coded LTR physical props (#4673).
+              'logical-properties-and-values': false
+            }
           })
         ]
       }

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -375,10 +375,11 @@ span.mu-language-input {
     padding: 0;
 }
 
-/* order list and bullet list */
+/* order list and bullet list — logical `inline-start` so nested-list
+   indentation mirrors correctly under `dir="rtl"` (#4673) */
 ol.mu-order-list,
 ul.mu-bullet-list {
-    padding-left: 30px;
+    padding-inline-start: 30px;
 }
 
 ol.mu-order-list {
@@ -449,7 +450,7 @@ ol.mu-order-list ol.mu-order-list ul.mu-bullet-list {
 
 /* task list */
 ul.mu-task-list {
-    padding-left: 30px;
+    padding-inline-start: 30px;
 }
 
 li.mu-task-list-item {
@@ -462,7 +463,7 @@ li.mu-task-list-item > input[type='checkbox'],
 li.mu-task-list-item > span.mu-task-list-checkbox {
     position: absolute;
     top: 0.3em;
-    left: -23px;
+    inset-inline-start: -23px;
 
     width: 12px;
     height: 12px;


### PR DESCRIPTION
## Summary

Fixes #4673 — nested lists lost their indentation in Right-to-Left (RTL) mode; every level collapsed onto the same right-hand axis (only the bullet shapes distinguished hierarchy).

## Root cause (two layers)

1. **CSS used physical properties.** List indentation in `blockSyntax.css` used `padding-left: 30px` (and the task-list checkbox used `left: -23px`). Physical properties don't follow `dir="rtl"`, so the indentation stayed on the left while markers flipped right.

2. **The build pipeline flattened logical properties to LTR.** The deeper reason the obvious fix didn't work: `postcssPresetEnv({ stage: 0 })` in `electron.vite.config.ts` enables the `logical-properties-and-values` transform (postcss-logical), which **down-compiles** `padding-inline-start` → `padding-left` and `inset-inline-start` → `left` at build time, hard-coded to LTR. So even after switching the CSS to logical properties, the renderer still received LTR physical values. Confirmed by inspecting the dev server's served CSS.

## Fix

- `blockSyntax.css`: `padding-left` → `padding-inline-start` (ordered / bullet / task lists), checkbox outer `left` → `inset-inline-start`.
- `electron.vite.config.ts`: disable the `logical-properties-and-values` feature so Chromium (which Electron bundles and which supports logical properties natively) resolves them at runtime. Everything else in preset-env is unchanged; under LTR the result is byte-identical, under RTL it mirrors correctly.

## Verification

Rendered muya's real nested-list DOM with the **actual post-PostCSS served CSS** inside the Electron 42 Chromium binary under `dir="rtl"`:

| list level | computed padding | right edge (px) |
|---|---|---|
| L1 | `padding-right: 30px` | 800 |
| L2 | `padding-right: 30px` | 770 |
| L3 | `padding-right: 30px` | 740 |

Each nesting level is indented 30px further from the right edge — the hierarchy is restored. Before the fix the served CSS resolved to `padding-left` (all levels flush to the right). CSS-only + build-config change; no behavior change under LTR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)