### PR TITLE
fix: export PDF/HTML/print in the editor's text direction (RTL)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1258,7 +1258,8 @@ const handleExport = async (options: unknown) => {
           title: htmlTitle || '',
           printOptimization: false,
           extraCss,
-          toc: htmlToc
+          toc: htmlToc,
+          dir: props.textDirection
         })
         editorStore.EXPORT({ type, content })
       } catch (err) {
@@ -1290,7 +1291,8 @@ const handleExport = async (options: unknown) => {
           toc: htmlToc,
           header,
           footer,
-          headerFooterStyled: headerFooterStyled as boolean | undefined
+          headerFooterStyled: headerFooterStyled as boolean | undefined,
+          dir: props.textDirection
         })
         printer!.renderMarkdown(html, true)
         editorStore.EXPORT({ type, pageOptions })
@@ -1315,7 +1317,8 @@ const handleExport = async (options: unknown) => {
           toc: htmlToc,
           header,
           footer,
-          headerFooterStyled: headerFooterStyled as boolean | undefined
+          headerFooterStyled: headerFooterStyled as boolean | undefined,
+          dir: props.textDirection
         })
         printer!.renderMarkdown(html, true)
         editorStore.PRINT_RESPONSE()

--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -30,6 +30,8 @@ export interface ExportStyledHtmlOptions {
   header?: HeaderFooterPart | null
   footer?: HeaderFooterPart | null
   headerFooterStyled?: boolean
+  /** Editor text direction ('ltr' | 'rtl' | 'auto'); set on the exported <html>. */
+  dir?: string
 }
 
 // Ported verbatim from legacy muyajs `headerFooterStyle.css` so the page
@@ -143,7 +145,7 @@ export const exportStyledHTML = async(
   markdown: string,
   options: ExportStyledHtmlOptions = {}
 ): Promise<string> => {
-  const { title = '', toc = '', header, footer, headerFooterStyled } = options
+  const { title = '', toc = '', header, footer, headerFooterStyled, dir } = options
   let { extraCss = '' } = options
 
   // The header/footer page table needs its own stylesheet — fold it into
@@ -156,7 +158,11 @@ export const exportStyledHTML = async(
 
   // Render the engine's full HTML document. We re-extract its <article> body so
   // we can inject the TOC / header-footer, then re-emit the document shell.
-  const fullDoc = await new MarkdownToHtml(markdown, muya).generate({ title, extraCSS: extraCss })
+  const fullDoc = await new MarkdownToHtml(markdown, muya).generate({
+    title,
+    extraCSS: extraCss,
+    dir
+  })
 
   // Pull out the rendered <article class="markdown-body">…</article> body.
   const articleMatch = /<article class="markdown-body">([\s\S]*)<\/article>/.exec(fullDoc)

--- a/packages/desktop/src/types/muya-core.d.ts
+++ b/packages/desktop/src/types/muya-core.d.ts
@@ -74,7 +74,12 @@ declare module '@muyajs/core' {
     markdown: string
     constructor(markdown: string, muya?: unknown)
     renderHtml(): Promise<string>
-    generate(options?: { title?: string; extraCSS?: string }): Promise<string>
+    generate(options?: {
+      title?: string
+      extraCSS?: string
+      inlineStyles?: boolean
+      dir?: string
+    }): Promise<string>
   }
 
   export function renderToStaticHTML(...args: any[]): any

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -215,6 +215,29 @@ describe('exportStyledHTML — header/footer assembly', () => {
   })
 })
 
+describe('exportStyledHTML — text direction (issue #4553)', () => {
+  it('sets dir="rtl" on the exported <html> when dir is "rtl"', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# سلام\n\nمتن', { dir: 'rtl' })
+
+    expect(out).toMatch(/<html lang="en" dir="rtl">/)
+  })
+
+  it('forwards dir="auto" to the exported <html>', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', { dir: 'auto' })
+
+    expect(out).toMatch(/<html lang="en" dir="auto">/)
+  })
+
+  it('leaves the default LTR export without a dir attribute', async() => {
+    const ltr = await exportStyledHTML(NO_MUYA, '# Hi', { dir: 'ltr' })
+    const none = await exportStyledHTML(NO_MUYA, '# Hi', {})
+
+    expect(ltr).toContain('<html lang="en">')
+    expect(ltr).not.toMatch(/<html[^>]+dir=/)
+    expect(none).not.toMatch(/<html[^>]+dir=/)
+  })
+})
+
 describe('exportStyledHTML — relative image paths', () => {
   it('rewrites a relative img src to an absolute file:// URL (issue 230)', async() => {
     // window.DIRNAME is stubbed to '/docs', so `./a.png` resolves against it.

--- a/packages/muya/src/state/__tests__/exportHtmlDir.spec.ts
+++ b/packages/muya/src/state/__tests__/exportHtmlDir.spec.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownToHtml } from '../markdownToHtml';
+
+// `generate({ dir })` controls the text direction of the exported document.
+// RTL documents must export with `dir="rtl"` on the root <html> so the PDF /
+// HTML / print output flows right-to-left (issue #4553). LTR is the HTML
+// default, so it is left implicit to keep existing exports byte-identical.
+
+const SAMPLE = '# سلام\n\nمتن نمونه.\n';
+
+describe('markdownToHtml.generate — text direction', () => {
+    it('emits dir="rtl" on <html> when dir is "rtl"', async () => {
+        const out = await new MarkdownToHtml(SAMPLE).generate({ dir: 'rtl' });
+        expect(out).toMatch(/<html lang="en" dir="rtl">/);
+    });
+
+    it('emits dir="auto" on <html> when dir is "auto"', async () => {
+        const out = await new MarkdownToHtml(SAMPLE).generate({ dir: 'auto' });
+        expect(out).toMatch(/<html lang="en" dir="auto">/);
+    });
+
+    it('omits the dir attribute for the default LTR direction', async () => {
+        const ltr = await new MarkdownToHtml(SAMPLE).generate({ dir: 'ltr' });
+        const none = await new MarkdownToHtml(SAMPLE).generate({});
+        expect(ltr).toContain('<html lang="en">');
+        expect(ltr).not.toMatch(/<html[^>]+dir=/);
+        expect(none).toContain('<html lang="en">');
+        expect(none).not.toMatch(/<html[^>]+dir=/);
+    });
+});

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -231,14 +231,26 @@ export class MarkdownToHtml {
      * @param options.inlineStyles Inline the core stylesheets so the output is
      * self-contained and renders offline (default `true`); pass `false` to fall
      * back to CDN `<link>` tags.
+     * @param options.dir Text direction set on the root `<html>` (`rtl` / `auto`);
+     * `ltr` is the HTML default and stays implicit.
      */
     async generate(
-        options: { title?: string; extraCSS?: string; inlineStyles?: boolean } = {},
+        options: {
+            title?: string;
+            extraCSS?: string;
+            inlineStyles?: boolean;
+            dir?: string;
+        } = {},
     ) {
         const html = await this.renderHtml();
 
         // `extraCSS` may changed in the mean time.
-        const { title = '', extraCSS = '', inlineStyles = true } = options;
+        const { title = '', extraCSS = '', inlineStyles = true, dir } = options;
+
+        // Mirror the editor's text direction onto the exported document so RTL
+        // documents export right-to-left (#4553). LTR is the HTML default, so it
+        // stays implicit to keep existing exports byte-identical.
+        const dirAttr = dir === 'rtl' || dir === 'auto' ? ` dir="${dir}"` : '';
 
         let baseStyles: string;
         if (inlineStyles) {
@@ -255,7 +267,7 @@ export class MarkdownToHtml {
         }
 
         return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en"${dirAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Summary

Fixes #4553 — documents authored in Right-to-Left (RTL) mode were exported as PDF (and styled-HTML / print) in **left-to-right**. The exported page ignored the editor's text-direction setting entirely.

## Root cause

The export pipeline never carried the text direction:

- The engine shell (`@muyajs/core` `MarkdownToHtml.generate`) hard-codes `<html lang="en">` with no `dir`.
- The desktop wrapper `exportStyledHTML` never received or forwarded the editor's `textDirection`.

So regardless of `Preferences → Editor → Text direction = Right to left`, every export rendered LTR.

## Fix

1. **Engine** (`markdownToHtml.ts`): `generate(options)` gains an optional `dir`. It emits `dir="rtl"` / `dir="auto"` on the root `<html>`; `ltr` is the HTML default and stays implicit, so existing LTR exports are byte-identical.
2. **Desktop** (`exportHtml.ts`, `editor.vue`): thread `textDirection` (`'ltr' | 'rtl' | 'auto'`) from the editor through `exportStyledHTML` into `generate({ dir })` for the `pdf`, `styledHtml`, and `print` export paths. The hand-written `@muyajs/core` ambient declaration is widened to match.

`dir="rtl"` on `<html>` cascades to the `.markdown-body` article, so paragraphs flow right-to-left and text aligns right in the exported PDF.

## Tests

- `packages/muya/.../exportHtmlDir.spec.ts` — engine emits `dir="rtl"`/`"auto"`, omits it for LTR.
- `packages/desktop/.../exportHtml.spec.ts` — the desktop wrapper forwards `dir` through the real engine end-to-end.
- `pnpm run typecheck`, muya + desktop lint, and the existing export regression suites pass.

## Verification

Rendered the exact export shell (`<html lang="en" dir="rtl">` + `.markdown-body`) in the Electron 42 Chromium binary: `getComputedStyle(body).direction === 'rtl'`, the paragraph's right edge hugs the article's right edge (RTL flow), and nested list items inset from the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)