### PR TITLE
fix(keybinding): sync menu bar and command palette when keybindings change

### DIFF
--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -828,12 +828,20 @@ class App {
     })
 
     ipcMain.handle('mt::keybinding-save-user-keybindings', async(_event, userKeybindings) => {
-      const { keybindings } = this._accessor
+      const { keybindings, menu } = this._accessor
       const editorWindows = this._windowManager
         .getWindowsByType(WindowType.EDITOR)
         .map(({ win }) => win.browserWindow)
         .filter((win): win is BrowserWindow => win != null)
-      return keybindings.setUserKeybindings(userKeybindings, editorWindows)
+      const saved = await keybindings.setUserKeybindings(userKeybindings, editorWindows)
+
+      menu.updateKeybindings()
+      const keybindingMap = Object.fromEntries(keybindings.keys)
+      for (const win of editorWindows) {
+        win.webContents.send('mt::keybindings-response', keybindingMap)
+      }
+
+      return saved
     })
 
     ipcMain.handle('mt::fs-trash-item', async(_event, fullPath: string) => {

--- a/packages/desktop/src/main/menu/index.ts
+++ b/packages/desktop/src/main/menu/index.ts
@@ -310,6 +310,42 @@ class AppMenu {
   }
 
   /**
+   * Rebuild every window menu so updated keybinding accelerators are reflected
+   * wherever shortcuts are shown: the menu bar on Windows/Linux and the macOS
+   * application menu for both editor and settings windows.
+   */
+  updateKeybindings(): void {
+    const recentUsedDocuments = this.getRecentlyUsedDocuments()
+    this.windowMenus.forEach((value, key) => {
+      const { menu: oldMenu, type } = value
+
+      let newMenu: Menu | null = null
+      if (type === MenuType.EDITOR) {
+        if (!oldMenu) return
+        const { menu: rebuilt } = this._buildEditorMenu(recentUsedDocuments)
+        if (!rebuilt) return
+
+        updateMenuItem(oldMenu, rebuilt, 'sourceCodeModeMenuItem')
+        updateMenuItem(oldMenu, rebuilt, 'typewriterModeMenuItem')
+        updateMenuItem(oldMenu, rebuilt, 'focusModeMenuItem')
+        updateMenuItem(oldMenu, rebuilt, 'sideBarMenuItem')
+        updateMenuItem(oldMenu, rebuilt, 'tabBarMenuItem')
+        newMenu = rebuilt
+      } else if (type === MenuType.SETTINGS) {
+        newMenu = this._buildSettingMenu().menu
+        if (!newMenu) return
+      } else {
+        return
+      }
+
+      value.menu = newMenu
+      if (this.activeWindowId === key) {
+        this._setApplicationMenu(newMenu)
+      }
+    })
+  }
+
+  /**
    * Update line ending menu items.
    *
    * @param windowId The window id.

--- a/packages/desktop/test/unit/specs/keybinding-menu-rebuild.spec.ts
+++ b/packages/desktop/test/unit/specs/keybinding-menu-rebuild.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Main-process slice: after the user saves new keybindings the application menu
+// must be rebuilt so the menu bar shows the updated accelerators (#3998). Drive
+// `AppMenu.updateKeybindings()` with a fake Electron `Menu` and stubbed menu
+// templates and assert every window menu (editor + macOS settings) is rebuilt
+// from the current keybindings and the active window's menu is re-applied.
+
+const { buildFromTemplate, setApplicationMenu, configureMenu, configSettingMenu } = vi.hoisted(
+  () => ({
+    buildFromTemplate: vi.fn((template: unknown) => ({
+      template,
+      getMenuItemById: () => ({ checked: false, enabled: true })
+    })),
+    setApplicationMenu: vi.fn(),
+    configureMenu: vi.fn(() => ['EDITOR_TEMPLATE']),
+    configSettingMenu: vi.fn(() => ['SETTINGS_TEMPLATE'])
+  })
+)
+
+vi.mock('electron', () => ({
+  app: { addRecentDocument: vi.fn(), clearRecentDocuments: vi.fn() },
+  ipcMain: { on: vi.fn(), handle: vi.fn(), emit: vi.fn() },
+  Menu: { buildFromTemplate, setApplicationMenu, getApplicationMenu: vi.fn() }
+}))
+
+vi.mock('common/filesystem', () => ({
+  ensureDirSync: vi.fn(),
+  isDirectory2: () => false,
+  isFile2: () => false
+}))
+
+// macOS so the settings window also owns a (non-null) menu that must rebuild.
+vi.mock('main_renderer/config', () => ({ isLinux: false, isOsx: true, isWindows: false }))
+
+vi.mock('main_renderer/menu/actions/edit', () => ({ updateSidebarMenu: vi.fn() }))
+vi.mock('main_renderer/menu/actions/format', () => ({ updateFormatMenu: vi.fn() }))
+vi.mock('main_renderer/menu/actions/paragraph', () => ({ updateSelectionMenus: vi.fn() }))
+vi.mock('main_renderer/menu/actions/view', () => ({ viewLayoutChanged: vi.fn() }))
+vi.mock('main_renderer/utils/internalIpc', () => ({ onInternalChannel: vi.fn() }))
+vi.mock('main_renderer/i18n.js', () => ({ setLanguage: vi.fn() }))
+vi.mock('main_renderer/menu/templates', () => ({
+  default: configureMenu,
+  configSettingMenu
+}))
+
+import AppMenu from 'main_renderer/menu'
+import type Preference from 'main_renderer/preferences'
+import type Keybindings from 'main_renderer/keyboard/shortcutHandler'
+
+const makeAppMenu = () => {
+  const preferences = { getItem: () => 'en' } as unknown as Preference
+  const keybindings = { registerEditorKeyHandlers: vi.fn() } as unknown as Keybindings
+  return new AppMenu(preferences, keybindings, '/tmp/mt-test')
+}
+
+describe('AppMenu.updateKeybindings rebuilds menus after a keybinding change (#3998)', () => {
+  beforeEach(() => {
+    buildFromTemplate.mockClear()
+    setApplicationMenu.mockClear()
+    configureMenu.mockClear()
+    configSettingMenu.mockClear()
+  })
+
+  it('rebuilds the active editor menu and re-applies it as the application menu', () => {
+    const appMenu = makeAppMenu()
+    const editorWin = { id: 1 } as never
+    appMenu.addEditorMenu(editorWin)
+    appMenu.setActiveWindow(1)
+
+    configureMenu.mockClear()
+    setApplicationMenu.mockClear()
+
+    appMenu.updateKeybindings()
+
+    // The editor menu is rebuilt from the current keybindings...
+    expect(configureMenu).toHaveBeenCalled()
+    // ...and pushed to the OS as the active application menu.
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1)
+  })
+
+  it('also rebuilds the settings-window menu so its accelerators refresh', () => {
+    const appMenu = makeAppMenu()
+    const settingWin = { id: 2 } as never
+    appMenu.addSettingMenu(settingWin)
+
+    configSettingMenu.mockClear()
+
+    appMenu.updateKeybindings()
+
+    expect(configSettingMenu).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #3998 — after a user customizes a keyboard shortcut in Preferences, the change was persisted and re-registered, but the **application menu bar** (and the command palette) kept showing the old accelerator until the app was restarted.

Root cause: the application menu is built once at startup with accelerators baked in from `keybindings.getAccelerator(id)`. The save handler (`mt::keybinding-save-user-keybindings` → `Keybindings.setUserKeybindings`) updated the in-memory key map and re-registered the local shortcuts, but never rebuilt the menu.

## Changes

- **`AppMenu.updateKeybindings()`** (new): rebuilds every window menu — editor menus on all platforms and the macOS settings-window menu — so accelerators are re-read from the live keybinding map, and re-applies the active window's menu. Editor menus preserve their runtime toggle state (source-code / typewriter / focus / sidebar / tab-bar).
- **Save handler**: after `setUserKeybindings`, calls `menu.updateKeybindings()` and pushes the refreshed accelerator map to editor windows via `mt::keybindings-response`, so the **command palette** (which renders `entry.shortcut`) updates too.

## Places that now update live (no restart)

- Editor menu bar (Windows / Linux) and macOS application menu
- macOS settings-window application menu
- Command palette shortcut hints

## Known limitation (not addressed here)

muya's **inline format toolbar** (the floating bold/italic/… bar) shows shortcut hints that are **hardcoded** in `packages/muya/src/ui/inlineFormatToolbar/config.ts` and decoupled from the desktop keybinding system (they're hand-aligned to the *default* bindings). Those hints do not follow user customizations. This spans the self-contained `@muyajs/core` engine (whose design keeps the engine unaware of the desktop key map) and is intentionally left out of this PR. There is also a latent behavior nuance there: muya's internal `FORMAT_SHORTCUTS` can still fire the *old* default format shortcut after a rebind. Tracked as a follow-up.

## Testing

- New unit test `keybinding-menu-rebuild.spec.ts` (TDD: red → green) covering editor + settings menu rebuild and re-application of the active menu.
- Existing `keybinding-reload.spec.ts` and `application-menu-state.spec.ts` pass; `typecheck` and `lint` clean.
- Manually verified in `electron dev`: changing a shortcut updates the menu bar and command palette without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)