### PR TITLE
fix(muya): create a code-block when typing ``` + Enter inside block-quotes and lists

### DIFF
--- a/packages/muya/src/block/content/paragraphContent/__tests__/enterConvertNested.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/enterConvertNested.spec.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// ENTER-CONVERT INSIDE CONTAINERS — pressing Enter on a paragraph whose text is
+// a code-fence trigger (```` ```lang ````) must convert it to a fenced
+// code-block IN PLACE, even when the paragraph lives inside a block-quote or a
+// list item. The conversion replaces the paragraph node within its container,
+// so the code-block stays nested (matching the legacy muyajs behaviour). Before
+// this, the block-quote/list Enter handlers only split or unwrapped the
+// paragraph and never reached `_enterConvert`, so ```` ```js ```` + Enter
+// produced a plain paragraph instead of a code-block.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+function enterWithText(muya: Muya, content: Content, text: string): { preventDefault: ReturnType<typeof vi.fn> } {
+    muya.editor.activeContentBlock = content;
+    content.text = text;
+    content.update();
+    const offset = content.text.length;
+    content.setCursor(offset, offset, true);
+    const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        shiftKey: false,
+        key: 'Enter',
+    } as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+    content.enterHandler(event);
+    return event;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+interface IStateNode {
+    name: string;
+    meta?: { lang?: string; type?: string };
+    children?: IStateNode[];
+}
+
+describe('enter on ```` ```js ```` inside a block-quote — converts to a nested code-block', () => {
+    it('replaces the paragraph with a code-block kept inside the block-quote', async () => {
+        const muya = bootMuya('> seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState() as IStateNode[];
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('block-quote');
+        const children = state[0].children!;
+        expect(children.length).toBe(1);
+        expect(children[0].name).toBe('code-block');
+        expect(children[0].meta!.lang).toBe('js');
+        expect(children[0].meta!.type).toBe('fenced');
+    });
+});
+
+describe('enter on ```` ```js ```` inside a list item — converts to a nested code-block', () => {
+    it('replaces the paragraph with a code-block kept inside the list item', async () => {
+        const muya = bootMuya('- seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```js');
+
+        await flush();
+        const state = muya.getState() as IStateNode[];
+        expect(state.length).toBe(1);
+        expect(state[0].name).toBe('bullet-list');
+        const listItem = state[0].children![0];
+        expect(listItem.name).toBe('list-item');
+        expect(listItem.children!.length).toBe(1);
+        expect(listItem.children![0].name).toBe('code-block');
+        expect(listItem.children![0].meta!.lang).toBe('js');
+    });
+});
+
+describe('enter on ```` ```mermaid ```` inside a block-quote — converts to a nested diagram', () => {
+    it('replaces the paragraph with a diagram kept inside the block-quote', async () => {
+        const muya = bootMuya('> seed\n');
+        const content = contentByText(muya, 'seed');
+
+        enterWithText(muya, content, '```mermaid');
+
+        await flush();
+        const state = muya.getState() as IStateNode[];
+        expect(state[0].name).toBe('block-quote');
+        const children = state[0].children!;
+        expect(children.length).toBe(1);
+        expect(children[0].name).toBe('diagram');
+        expect(children[0].meta!.type).toBe('mermaid');
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -40,6 +40,7 @@ enum UnindentType {
 const debug = logger('paragraph:content');
 
 const HTML_BLOCK_REG = /^<([a-z\d-]+)(?=\s|>)[^<>]*>$/i;
+const CODE_BLOCK_REG = /(^ {0,3}`{3,})([^` ]*)/;
 
 const BOTH_SIDES_FORMATS = [
     'strong',
@@ -227,7 +228,7 @@ class ParagraphContent extends Format {
         const TABLE_BLOCK_REG = /^\|.*?(\\*)\|.*?(\\*)\|/;
         const MATH_BLOCK_REG = /^\$\$/;
         const { text } = this;
-        const codeBlockToken = text.match(/(^ {0,3}`{3,})([^` ]*)/);
+        const codeBlockToken = text.match(CODE_BLOCK_REG);
         const tableMatch = TABLE_BLOCK_REG.exec(text);
         const htmlMatch = HTML_BLOCK_REG.exec(text);
         const mathMath = MATH_BLOCK_REG.exec(text);
@@ -522,6 +523,12 @@ class ParagraphContent extends Format {
 
         if (event.shiftKey)
             return this.shiftEnterHandler(event);
+
+        // A code fence (```` ```lang ````) always converts the paragraph in
+        // place, even inside a block-quote or list item — the resulting
+        // code-block stays nested in its container (matches muyajs).
+        if (CODE_BLOCK_REG.test(this.text))
+            return this._enterConvert(event);
 
         const type = this._paragraphParentType();
 


### PR DESCRIPTION
Closes #4690

## Summary

Typing a code fence (```` ```lang ````) and pressing Enter only converted the paragraph into a fenced code-block at the **top level**. Inside a block-quote or a list item, `ParagraphContent.enterHandler` routed to the container-specific handlers (`_enterInBlockQuote` / `_enterInListItem`), which only **split or unwrapped** the paragraph and never reached `_enterConvert`. As a result, ```` ```js ```` + Enter inside a quote/list produced a plain paragraph instead of a nested code-block.

The legacy `muyajs` engine converts in any context — `codeBlockUpdate()` transforms the paragraph in place while keeping its parent, so the code-block stays nested in the quote/list. This restores that behaviour on `@muyajs/core`.

## Fix

- Check the code fence in `enterHandler` **before** routing by container type, and delegate to `_enterConvert`. `_enterConvert`'s `this.parent!.replaceWith(...)` swaps the paragraph node within its container, so the resulting code-block (or diagram, for `` ```mermaid `` etc.) stays nested — matching muyajs.
- Hoist the fence regex to a shared `CODE_BLOCK_REG` constant so the conversion and the new gate stay in sync.

### Coverage vs. muyajs (checked for other gaps)
- Top level — already worked.
- Block-quote / list-item / task-list-item — fixed here.
- Nested containers (list-in-quote, quote-in-list) — covered, since the check runs before parent-type routing.
- Fence char: muyajs triggers on backticks only (not `~~~`); `CODE_BLOCK_REG` matches backticks only — consistent, nothing to add.

## Testing

- New `enterConvertNested.spec.ts`: ```` ```js ```` → nested code-block inside a block-quote and inside a list item; ```` ```mermaid ```` → nested diagram inside a block-quote.
- `pnpm -C packages/muya test` → 1280/1280 pass.
- `pnpm -C packages/muya lint` → 0 errors; `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)