### PR TITLE
fix: preserve empty list items when serializing markdown

### DIFF
--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -17,6 +17,43 @@ function roundTrip(md: string, listIndentation: number | string = 1): string {
     return new ExportMarkdown({ listIndentation }).generate(states);
 }
 
+describe('stateToMarkdown — empty list items', () => {
+    it('keeps adjacent empty bullet items on separate lines', () => {
+        const md = '- \n- \n- \n\nz\n';
+        const out = roundTrip(md, 1);
+        expect(out).toBe(md);
+
+        const reparsed = new MarkdownToState({
+            footnote: false,
+            math: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+        }).generate(out);
+        expect(reparsed[0].name).toBe('bullet-list');
+        expect((reparsed[0] as IBulletListState).children).toHaveLength(3);
+        expect(reparsed[1].name).toBe('paragraph');
+    });
+
+    it('keeps an empty bullet item between populated sibling items', () => {
+        const md = '- a\n- \n- c\n';
+        const out = roundTrip(md, 1);
+        expect(out).toBe(md);
+
+        const reparsed = new MarkdownToState({
+            footnote: false,
+            math: false,
+            isGitlabCompatibilityEnabled: false,
+            trimUnnecessaryCodeBlockEmptyLines: false,
+            frontMatter: false,
+        }).generate(out);
+        const list = reparsed[0] as IBulletListState;
+        expect(list.name).toBe('bullet-list');
+        expect(list.children).toHaveLength(3);
+        expect(list.children[1].children).toHaveLength(0);
+    });
+});
+
 // Regression baseline ported from marktext's
 // test/unit/specs/markdown-list-indentation.spec.js, the suite touched by
 // commit 02841ffd (fix: subsequent list paragraphs, PR #916). marktext used

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -564,6 +564,9 @@ export default class ExportMarkdown {
         if (name === 'task-list-item')
             itemMarker += state.meta.checked ? '[x] ' : '[ ] ';
 
+        if (children.length === 0)
+            return `${indent}${itemMarker}\n`;
+
         result.push(`${indent}${itemMarker}`);
         result.push(
             this._convertStatesToMarkdown(children, newIndent, listIndent).substring(


### PR DESCRIPTION
Closes #4679

## Summary

Fix Markdown serialization for empty list items.

Previously, an empty list item emitted only its marker, for example `- `, without a terminating newline. In a tight list, adjacent empty list items were then concatenated into one physical Markdown line.

For example:

```markdown
- 
- 
- 

z
```

could be serialized as:

```markdown
- - - 
z
```

After reopening the document, CommonMark parses `- - -` as a thematic break, so the original list structure is lost. A similar issue happens when an empty item appears between populated sibling items, where the following sibling can be reparsed as a nested list item.

This PR fixes the serializer invariant directly: a list item with no children still terminates its own Markdown line.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 11 Pro 10.0.26200 with MarkText 0.20.0-beta.2 to reproduce the original issue; fix verified with targeted unit tests on `develop`.

Test command:

```bash
pnpm --filter @muyajs/core exec vitest run src/state/__tests__/listSerialization.spec.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       22 passed (22)
```

Additional Playwright validation:

- Started the Muya e2e host in Chromium.
- Loaded the two issue examples into the editor.
- Performed a real keyboard edit (`z` -> `zy`, `c` -> `cx`).
- Verified `window.muya.getMarkdown()` preserved the empty list item lines.
- Re-loaded the saved Markdown and verified the parsed state remained a 3-item bullet list, with no thematic break and no unintended nested list.

## Notes for reviewers [optional]

The root cause is in `packages/muya/src/state/stateToMarkdown.ts`.

`_serializeListItem()` wrote the item marker first and then appended the serialized children:

```ts
result.push(`${indent}${itemMarker}`);
result.push(
    this._convertStatesToMarkdown(children, newIndent, listIndent).substring(
        newIndent.length,
    ),
);
```

For an empty list item, `children` is an empty array, so `_convertStatesToMarkdown([])` returns an empty string. The serialized output for that item was therefore only the marker with no trailing newline.

The fix is intentionally small: if a list item has no children, return `${indent}${itemMarker}\n` before entering the normal child serialization path.

Regression tests cover:

- Adjacent empty bullet items remaining separate lines after serialization.
- An empty bullet item between populated sibling items remaining a sibling, not turning the following item into a nested list.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.