### PR TITLE
fix(muya): prevent undo/redo exceptions from permanently disabling history (#4685)

### DIFF
--- a/packages/muya/e2e/tests/editing/undo-redo-wedge-4685.spec.ts
+++ b/packages/muya/e2e/tests/editing/undo-redo-wedge-4685.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #4685: redo after a cross-block paragraph -> ATX heading -> bullet list
+// sequence threw an unhandled renderer error, corrupted the document, and
+// could leave History._ignoreChange stuck true so later edits were never
+// recorded (Undo permanently dead).
+test.describe('#4685 redo after cross-block edits', () => {
+    test('redo restores content without crashing and Undo keeps working', async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on('pageerror', err => pageErrors.push(err.message));
+
+        await page.evaluate(() => window.muya!.setContent('start'));
+        const root = page.locator(editor.root);
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.press('End');
+
+        await page.keyboard.press('Enter');
+        await slowType(page, '# heading');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await slowType(page, '- list item');
+
+        await expect(root.locator(editor.atxHeading)).toContainText('heading');
+        await expect(root.locator(editor.bulletList)).toContainText('list item');
+
+        // Undo all the way back to "start".
+        for (let i = 0; i < 20; i++) {
+            const md = await getMarkdown(page);
+            if (md.trim() === 'start')
+                break;
+            await page.evaluate(() => window.muya!.undo());
+        }
+        expect((await getMarkdown(page)).trim()).toBe('start');
+
+        // Redo many times — the reported crash path.
+        for (let i = 0; i < 15; i++)
+            await page.evaluate(() => window.muya!.redo());
+
+        const redone = await getMarkdown(page);
+        expect(pageErrors, `renderer errors: ${pageErrors.join(' | ')}`).toEqual([]);
+        expect(redone).toContain('# heading');
+        expect(redone).toContain('- list item');
+
+        // History must not be wedged: a fresh edit has to be undoable.
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.press('End');
+        await slowType(page, ' MORE');
+        await expect(page.locator(editor.paragraph).first()).toContainText('start MORE');
+
+        await page.evaluate(() => window.muya!.undo());
+        await expect(page.locator(editor.paragraph).first()).not.toContainText('MORE');
+        expect(pageErrors, `renderer errors: ${pageErrors.join(' | ')}`).toEqual([]);
+    });
+});

--- a/packages/muya/src/history/__tests__/historyWedgeRecovery.spec.ts
+++ b/packages/muya/src/history/__tests__/historyWedgeRecovery.spec.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import type Format from '../../block/base/format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstContent(muya: Muya): Format {
+    return muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+}
+
+function undoDepth(muya: Muya): number {
+    // @ts-expect-error — reach into the private stack for test assertions.
+    return muya.editor.history._stack.undo.length;
+}
+
+function ignoreChange(muya: Muya): boolean {
+    // @ts-expect-error — reach into the private flag for test assertions.
+    return muya.editor.history._ignoreChange;
+}
+
+async function editText(muya: Muya, text: string): Promise<void> {
+    const content = firstContent(muya) as unknown as { text: string; checkInlineUpdate: () => void };
+    content.text = text;
+    content.checkInlineUpdate();
+    await vi.waitFor(() => {
+        expect(muya.getMarkdown()).toContain(text);
+    });
+}
+
+describe('history recorder recovery after an undo/redo exception', () => {
+    it('resets _ignoreChange and keeps recording when updateContents throws', async () => {
+        const muya = bootMuya('seed\n');
+
+        await editText(muya, 'seedX');
+        await vi.waitFor(() => expect(undoDepth(muya)).toBe(1));
+
+        const spy = vi
+            .spyOn(muya.editor, 'updateContents')
+            .mockImplementationOnce(() => {
+                throw new Error('simulated replay failure');
+            });
+
+        expect(() => muya.undo()).toThrow('simulated replay failure');
+
+        // The recorder must not be wedged: the in-flight guard has to be
+        // released even though the apply threw.
+        expect(ignoreChange(muya)).toBe(false);
+
+        spy.mockRestore();
+
+        // A subsequent edit must still reach the undo stack.
+        await editText(muya, 'seedXY');
+        await vi.waitFor(() => expect(undoDepth(muya)).toBeGreaterThan(0));
+    });
+
+    it('clear() resets a stuck _ignoreChange guard', () => {
+        const muya = bootMuya('seed\n');
+
+        // Simulate a guard left stuck on by a prior exception.
+        // @ts-expect-error — force the private flag for the test.
+        muya.editor.history._ignoreChange = true;
+
+        muya.editor.history.clear();
+
+        expect(ignoreChange(muya)).toBe(false);
+    });
+});

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -164,11 +164,15 @@ class History {
 
         this._lastRecorded = 0;
         this._ignoreChange = true;
-        if (rebuild)
-            this._muya.editor.rebuildContents(operation, selection, 'user');
-        else
-            this._muya.editor.updateContents(operation, selection, 'user');
-        this._ignoreChange = false;
+        try {
+            if (rebuild)
+                this._muya.editor.rebuildContents(operation, selection, 'user');
+            else
+                this._muya.editor.updateContents(operation, selection, 'user');
+        }
+        finally {
+            this._ignoreChange = false;
+        }
 
         this._getLastSelection();
     }
@@ -177,6 +181,7 @@ class History {
         this._stack = { undo: [], redo: [] };
         this._selectionStack = [];
         this._lastRecorded = 0;
+        this._ignoreChange = false;
     }
 
     getHistory(): ISerializedHistory {


### PR DESCRIPTION
## Summary

Addresses part of #4685.

`History._change` set `_ignoreChange = true` before applying an undo/redo op and only cleared it on the line *after* the apply, with no `try/finally`. If the apply threw, the flag stayed `true` for the rest of the session: the `json-change` listener then ignored every later user edit, so nothing reached the undo stack and **Undo was permanently dead**. `clear()` didn't reset the flag either, so even reloading the document couldn't recover the recorder.

This wraps the apply in `try/finally` so the guard is always released, and resets `_ignoreChange` in `clear()` as a recovery hatch.

## Relationship to #4669

The **user-visible crash and content corruption** reported in #4685 (`Cannot read properties of undefined (reading 'blockName')` / `The op is too long for this document`) were already fixed by #4669 (`d37bc01e`), which landed after the reporter's `0.20.0-beta.2` build. I confirmed this by reproducing #4685's exact steps against the real engine — it no longer crashes or corrupts.

What #4669 did **not** address is #4685's second, explicitly-raised concern:

> Internal exceptions during undo/redo should also not leave the history recorder in a permanently disabled state.

That structural guard is what this PR adds — defense-in-depth so that *any* future internal exception in the apply path can no longer wedge the undo recorder.

## Testing

- **Unit** (`historyWedgeRecovery.spec.ts`): forces `updateContents` to throw during `_change` and asserts `_ignoreChange` is released and a subsequent edit is still recorded; also asserts `clear()` resets a stuck guard. Verified failing before the fix.
- **E2E** (`undo-redo-wedge-4685.spec.ts`): drives #4685's reported sequence (paragraph → ATX heading → bullet list → undo to start → redo ×15 → edit → undo) through real keystrokes in a real browser, asserting no renderer error, lossless restore, and that Undo keeps working.
- Full muya suite: 1282 passing; `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)