### PR TITLE
fix(muya): auto-hide inline markers when holding an arrow key out of a token

### DIFF
--- a/packages/muya/e2e/tests/inline/marker-arrow-hold.spec.ts
+++ b/packages/muya/e2e/tests/inline/marker-arrow-hold.spec.ts
@@ -1,0 +1,62 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+// `**hello**bar`: source offsets — `**`(0-2) `hello`(2-7) `**`(7-9) `bar`(9-12).
+// The strong token spans [0, 9]. With the caret at offset 6 (`**hell|o**`) the
+// caret is inside the token, so the `**` markers render revealed (`.mu-gray`).
+// Moving the caret all the way to the end (offset 12, after `bar`) takes it
+// clear of the token, so the markers must collapse back to `.mu-hide`.
+const strongMarkerHidden = `${editor.paragraph} span.mu-remove.mu-hide`;
+const strongMarkerGray = `${editor.paragraph} span.mu-remove.mu-gray`;
+
+async function setupCaretInsideStrong(page: Page) {
+    await page.evaluate(() => window.muya!.setContent('**hello**bar'));
+    // Focus the contenteditable so subsequent keyboard events drive the caret.
+    await page.locator(editor.paragraph).first().click();
+    // Park the caret at offset 6 (`**hell|o**bar`), inside the strong token, so
+    // the markers render revealed.
+    await page.evaluate(() => {
+        const block = window.muya!.editor.scrollPage!.firstContentInDescendant();
+        block.setCursor(6, 6, true);
+    });
+    // Sanity: markers are revealed while the caret sits inside the token.
+    await expect(page.locator(strongMarkerGray)).toHaveCount(2);
+    await expect(page.locator(strongMarkerHidden)).toHaveCount(0);
+}
+
+async function caretOffset(page: Page): Promise<number | null> {
+    return page.evaluate(() => {
+        const sel = window.muya!.editor.selection.getSelection();
+        return sel ? sel.anchor.offset : null;
+    });
+}
+
+test.describe('emphasis markers auto-hide when arrowing out of the token', () => {
+    test('tapping ArrowRight to the line end hides the markers', async ({ page }) => {
+        await setupCaretInsideStrong(page);
+
+        // Tap (down + up per press) six times: offset 6 -> 12 (after `bar`).
+        for (let i = 0; i < 6; i++)
+            await page.keyboard.press('ArrowRight');
+
+        expect(await caretOffset(page)).toBe(12);
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(2);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(0);
+    });
+
+    test('holding ArrowRight to the line end hides the markers', async ({ page }) => {
+        await setupCaretInsideStrong(page);
+
+        // Hold: six trusted keydown events (autoRepeat) and a single keyup on
+        // release — the caret travels offset 6 -> 12 (after `bar`) but only one
+        // keyup fires, exactly like physically holding the arrow key.
+        for (let i = 0; i < 6; i++)
+            await page.keyboard.down('ArrowRight');
+        await page.keyboard.up('ArrowRight');
+
+        expect(await caretOffset(page)).toBe(12);
+        await expect(page.locator(strongMarkerHidden)).toHaveCount(2);
+        await expect(page.locator(strongMarkerGray)).toHaveCount(0);
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -554,7 +554,11 @@ class Format extends Content {
             anchor.offset !== oldAnchor?.offset
             || focus.offset !== oldFocus?.offset
         ) {
-            const needUpdate = this.checkNeedRender({ anchor, focus });
+            // Also check the previously committed selection (no-arg default):
+            // a held arrow fires one keyup on release, so the caret can leap
+            // clear of a token in a single step and leave its markers stuck
+            // revealed. Mirrors the guard in `clickHandler`.
+            const needUpdate = this.checkNeedRender({ anchor, focus }) || this.checkNeedRender();
             const cursor = { anchor, focus, block: this };
 
             if (needUpdate)


### PR DESCRIPTION
## Summary

Holding an arrow key to move the caret out of an inline emphasis/strong token (e.g. `**bold**`) left the syntax markers (`**`) revealed instead of collapsing. Tapping the arrow one press at a time hid them correctly.

Closes #4693

## Root cause

Within-block arrow navigation does not re-render in `Content.arrowHandler` (it returns and lets the browser move the caret). Inline marker show/hide is driven by `Format.keyupHandler`, which on each `keyup` re-renders based only on the **new** caret position via `checkNeedRender({ anchor, focus })`.

Key auto-repeat (holding) fires many `keydown` events but a single `keyup` on release. By then the caret has leapt clear of the token, so `checkNeedRender(newPosition)` no longer detects the token left behind → no re-render → the token's markers stay revealed. Tapping works because each intermediate `keyup` re-renders while the caret is still adjacent to the token.

## Fix

Also check the previously committed selection (the no-arg `checkNeedRender()` default, which reads `this.selection`), mirroring the existing guard in `clickHandler`:

```ts
const needUpdate = this.checkNeedRender({ anchor, focus }) || this.checkNeedRender()
```

When the old caret position was inside/adjacent to a token, the re-render still fires and the now-stale markers collapse. Direction-agnostic.

## Migration regression (parity with the legacy engine)

This is a regression introduced when the editor engine was rewritten from the legacy `muyajs` (`@marktext/muyajs`) to `@muyajs/core`. The legacy engine OR'd the previously-committed cursor with the new one in **both** its keyup and click handlers:

- keyup — `packages/muyajs/lib/eventHandler/keyboard.js:273-275`:
  ```js
  const needRender =
    contentState.checkNeedRender(contentState.cursor) ||   // old committed cursor
    contentState.checkNeedRender({ start, end })           // new cursor
  ```
- click — `packages/muyajs/lib/contentState/clickCtrl.js:194`:
  ```js
  this.checkNeedRender(this.cursor) || this.checkNeedRender({ start, end })
  ```

In `@muyajs/core`, `clickHandler` kept both checks but `keyupHandler` only kept the new-position check — so this change restores parity with the legacy engine (and with the rewrite's own `clickHandler`) rather than inventing new behavior. It also explains why tapping always worked: each intermediate keyup is still adjacent to the token, so the new-position check alone suffices.

## Testing

- Added `packages/muya/e2e/tests/inline/marker-arrow-hold.spec.ts`, covering both **tap** (`keyboard.press` ×N) and **held key** (`keyboard.down` ×N + a single `keyboard.up`, i.e. autorepeat) navigation out of the token, asserting `.mu-remove.mu-hide` markers collapse.
- Verified RED → GREEN in real-browser Chromium: the held-key case fails before the change and passes after; the tap case passes throughout.
- `tsc --noEmit` clean; ESLint clean on the changed file (only pre-existing unrelated warnings).
- Manually verified in the running Electron dev app (`**hello**bar`, caret before `o`, hold arrow past `bar`).
