### PR TITLE
test(e2e): replace fixed waits with expect.poll in editor-input

### DIFF
--- a/packages/desktop/test/e2e/editor-input.spec.ts
+++ b/packages/desktop/test/e2e/editor-input.spec.ts
@@ -47,9 +47,7 @@ test.describe('Editor input and source-mode roundtrip', () => {
 
   test('Typing into the editor appends content', async() => {
     await typeIntoEditor(page, ' typed-token')
-    await page.waitForTimeout(400)
-    const markdown = await getMarkdownContent(page, app)
-    expect(markdown).toContain('typed-token')
+    await expect.poll(async() => await getMarkdownContent(page, app)).toContain('typed-token')
   })
 })
 
@@ -127,7 +125,6 @@ test.describe('Title-bar word counter (item 24)', () => {
     // add a word).
     await placeCaretInEditor(page)
     await typeIntoEditor(page, ' four five 你好')
-    await page.waitForTimeout(400)
 
     // The counter updates async after the json-change round-trip; it must have
     // strictly increased over the pre-typing baseline.


### PR DESCRIPTION
## Summary

Audited **all ~130 `page.waitForTimeout(...)` calls** in the desktop e2e suite to see which could become deterministic waits (`expect.poll` / auto-retrying locator assertions — the pattern the suite already prefers; cf. `waitForRendererError`'s *"Prefer this over a fixed `waitForTimeout`"*). Only **two** are a clear, safe win. This PR converts those two, both in `editor-input.spec.ts`. Everything else is intentionally left as-is; the reasoning is below so the audit doesn't have to be redone.

## Changes

- **"Typing into the editor appends content"**: `waitForTimeout(400)` + read + assert →
  `await expect.poll(async() => await getMarkdownContent(page, app)).toContain('typed-token')`.
  Deterministic: polls until the async json-change commit lands, fails fast, no wall-clock bet.
- **"word count raises"**: dropped a `waitForTimeout(400)` sitting **immediately before** an existing `expect.poll(counterValue, { timeout: 5000 })`. The poll already retries — the wait was pure dead time.

## Why only these two

The static signal *"fixed wait followed by an auto-retry assertion"* looks like it flags redundancy, but it produces **false positives**:

- **Absence assertions** — e.g. `find-replace.spec.ts` asserts the search bar is *not* mounted (`toHaveCount(0)`), `anchor-link-scroll.spec.ts` asserts `scrollTop === 0` after a click that must not scroll. `toHaveCount(0)`/`toBe(0)` pass *immediately* even if the (incorrect) thing appears a moment later, so the fixed wait is load-bearing: it gives the wrong behavior time to manifest. You can't poll for an absence.
- **Already covered** — many waits sit right before an existing `expect.poll`, or *inside* a polled callback (pacing). Harmless redundancy, not worth the churn/risk.
- **Wall-clock load-bearing** — most waits cover a real renderer settle window (selection → store → re-render/search), often spanning *several* following assertions, not just the next line. Converting one assertion to `expect.poll` can let a later non-polled assertion run too early and reintroduce flakiness.

## Why `focusEditor` keeps its `waitForTimeout(150)`

`focusEditor`/`placeCaretInEditor` (`helpers.ts`) look like the obvious target, but they are a different mechanism. They dispatch a synthetic `keyup`, which muya routes (`editor/index.ts`) to `content.ts` `keyupHandler` — **a no-op**. Unlike the double-click path (`clickHandler`, which defers `setCursor` via `requestAnimationFrame` at `content.ts:383`), this path triggers **no rAF and no synchronous selection commit**. The 150 ms covers a wall-clock renderer-side propagation, not an animation frame.

Verified empirically (`find-replace` + `parity-cursor-lang`, `--repeat-each`):

| `focusEditor` wait | result |
| --- | --- |
| `waitForTimeout(150)` (current) | 19/19 pass |
| removed (`0`) | 2/57 fail → wait is load-bearing |
| double-rAF | 9/12 fail on the sensitive tests → **worse** |

A double-rAF (the right fix for the double-click/`clickHandler` path) is therefore the *wrong* fix here, and `expect.poll` has nothing observable to poll (the committed selection isn't exposed to the page). `focusEditor` stays a fixed wait.

## Test plan

- `editor-input.spec.ts`: baseline `--repeat-each=3` → 24/24; after the change `--repeat-each=5` → 40/40. No regression.
- `pnpm run lint` and `pnpm run typecheck` pass.
- No production code touched (test-only).
