### PR TITLE
fix: preserve empty task list items when parsing markdown

### DIFF
--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
-import type Content from '../content';
 import type { TState } from '../../../state/types';
+import type Content from '../content';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../../muya';
 

--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import type Content from '../content';
+import type { TState } from '../../../state/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../../muya';
 
@@ -42,6 +43,15 @@ function bootMuya(markdown: string): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
     const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function bootMuyaState(json: TState[]): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { json } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
     bootedHosts.push(muya.domNode);
     return muya;
@@ -313,8 +323,19 @@ describe('content arrowHandler — trailing-paragraph creation at document end',
 // its only paragraph is removed during editing) sitting between two items used
 // to make previous/nextContentInContext return null, so ArrowUp/ArrowDown could
 // not cross it and the caret got stuck. Navigation must skip the empty container
-// and reach the content beyond it. `*  ` (a bullet marker with no text) parses to
-// exactly such a childless list item.
+// and reach the content beyond it.
+function listWithChildlessMiddleItem(): TState[] {
+    return [{
+        name: 'bullet-list',
+        meta: { marker: '*', loose: false },
+        children: [
+            { name: 'list-item', children: [{ name: 'paragraph', text: 'A' }] },
+            { name: 'list-item', children: [] },
+            { name: 'list-item', children: [{ name: 'paragraph', text: 'B' }] },
+        ],
+    }];
+}
+
 function allContentTexts(muya: Muya): string[] {
     const texts: string[] = [];
     const visit = (block: {
@@ -332,7 +353,7 @@ function allContentTexts(muya: Muya): string[] {
 
 describe('content arrowHandler — skips empty sibling containers (#4644)', () => {
     it('arrowUp at offset 0 skips an empty list item and lands at the END of the item above', async () => {
-        const muya = bootMuya('* A\n*  \n* B\n');
+        const muya = bootMuyaState(listWithChildlessMiddleItem());
         // Precondition: the middle item holds NO content block, so a passing
         // caret assertion below can only mean the empty item was skipped.
         expect(allContentTexts(muya)).toEqual(['A', 'B']);
@@ -351,7 +372,7 @@ describe('content arrowHandler — skips empty sibling containers (#4644)', () =
     });
 
     it('arrowDown at end of an item skips an empty list item and lands at offset 0 of the item below', async () => {
-        const muya = bootMuya('* A\n*  \n* B\n');
+        const muya = bootMuyaState(listWithChildlessMiddleItem());
         expect(allContentTexts(muya)).toEqual(['A', 'B']);
 
         const a = contentByText(muya, 'A');

--- a/packages/muya/src/block/gfm/taskListItem/__tests__/emptyTaskItemRender.spec.ts
+++ b/packages/muya/src/block/gfm/taskListItem/__tests__/emptyTaskItemRender.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import type Parent from '../../../base/parent';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, {} as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    muya.setContent(markdown);
+    bootedHosts.push(muya.domNode);
+
+    return muya;
+}
+
+function taskListItems(muya: Muya): Parent[] {
+    const result: Parent[] = [];
+
+    const visit = (block: Parent) => {
+        if (block.blockName === 'task-list-item')
+            result.push(block);
+
+        block.children?.forEach((child) => {
+            if (child.isParent())
+                visit(child as Parent);
+        });
+    };
+
+    visit(muya.editor.scrollPage as unknown as Parent);
+
+    return result;
+}
+
+describe('task-list-item rendering', () => {
+    it('renders empty task items with editable content blocks', () => {
+        const muya = bootMuya('- [ ] a\n\n- [ ] \n- [ ] \n- [ ] \ntext\n');
+
+        const items = taskListItems(muya);
+        expect(items).toHaveLength(4);
+        expect(muya.domNode.querySelectorAll('li.mu-task-list-item')).toHaveLength(4);
+        expect(muya.domNode.querySelectorAll('.mu-task-list-checkbox')).toHaveLength(4);
+
+        const contentTexts = items.map(item =>
+            (item.firstContentInDescendant() as Content | null)?.text,
+        );
+        expect(contentTexts).toEqual(['a', '', '', 'text']);
+    });
+});

--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -17,6 +17,17 @@ function roundTrip(md: string, listIndentation: number | string = 1): string {
     return new ExportMarkdown({ listIndentation }).generate(states);
 }
 
+describe('stateToMarkdown — empty list item serialization', () => {
+    it('keeps consecutive empty task items on separate lines', () => {
+        expect(roundTrip('- [ ] \n- [ ] \n')).toBe('- [ ] \n- [ ] \n');
+        expect(roundTrip('- [ ] \n- [x] \n')).toBe('- [ ] \n- [x] \n');
+    });
+
+    it('keeps consecutive empty bullet items on separate lines', () => {
+        expect(roundTrip('- \n- \n')).toBe('- \n- \n');
+    });
+});
+
 // Regression baseline ported from marktext's
 // test/unit/specs/markdown-list-indentation.spec.js, the suite touched by
 // commit 02841ffd (fix: subsequent list paragraphs, PR #916). marktext used

--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -33,6 +33,29 @@ describe('stateToMarkdown — empty list item serialization', () => {
     it('keeps consecutive empty bullet items on separate lines', () => {
         expect(roundTrip('- \n- \n')).toBe('- \n- \n');
     });
+
+    it('keeps adjacent empty bullet items before a following paragraph', () => {
+        const md = '- \n- \n- \n\nz\n';
+        const out = roundTrip(md, 1);
+        expect(out).toBe(md);
+
+        const reparsed = parseMarkdown(out);
+        expect(reparsed[0].name).toBe('bullet-list');
+        expect((reparsed[0] as IBulletListState).children).toHaveLength(3);
+        expect(reparsed[1].name).toBe('paragraph');
+    });
+
+    it('keeps an empty bullet item between populated sibling items', () => {
+        const md = '- a\n- \n- c\n';
+        const out = roundTrip(md, 1);
+        expect(out).toBe(md);
+
+        const reparsed = parseMarkdown(out);
+        const list = reparsed[0] as IBulletListState;
+        expect(list.name).toBe('bullet-list');
+        expect(list.children).toHaveLength(3);
+        expect(list.children[1].children).toEqual([{ name: 'paragraph', text: '' }]);
+    });
 });
 
 function parseMarkdown(md: string): TState[] {

--- a/packages/muya/src/state/__tests__/markdownToState.spec.ts
+++ b/packages/muya/src/state/__tests__/markdownToState.spec.ts
@@ -37,6 +37,41 @@ function generate(
 // the correct nesting so a future list refactor can't quietly re-introduce
 // the flattening.
 describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
+    it('keeps an empty unchecked task item after a populated task item', () => {
+        const states = generate('- [ ] a\n- [ ] \n');
+
+        expect(states.length).toBe(1);
+        const list = states[0];
+        expect(list.name).toBe('task-list');
+        expect(list.children).toHaveLength(2);
+        expect(list.children!.map(c => c.name)).toEqual(['task-list-item', 'task-list-item']);
+        expect(list.children!.map(c => c.meta?.checked)).toEqual([false, false]);
+        expect(list.children![0].children!.find(c => c.name === 'paragraph')?.text).toBe('a');
+        expect(list.children![1].children).toHaveLength(0);
+    });
+
+    it('parses a single empty unchecked task item as a task list item', () => {
+        const states = generate('- [ ] \n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('task-list');
+        expect(states[0].children).toHaveLength(1);
+        expect(states[0].children![0].name).toBe('task-list-item');
+        expect(states[0].children![0].meta?.checked).toBe(false);
+        expect(states[0].children![0].children).toHaveLength(0);
+    });
+
+    it('parses a single empty checked task item as a checked task list item', () => {
+        const states = generate('- [x] \n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('task-list');
+        expect(states[0].children).toHaveLength(1);
+        expect(states[0].children![0].name).toBe('task-list-item');
+        expect(states[0].children![0].meta?.checked).toBe(true);
+        expect(states[0].children![0].children).toHaveLength(0);
+    });
+
     it('keeps three levels of task-list nesting', () => {
         const md = `- [ ] task1
 

--- a/packages/muya/src/state/__tests__/markdownToState.spec.ts
+++ b/packages/muya/src/state/__tests__/markdownToState.spec.ts
@@ -47,7 +47,7 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         expect(list.children!.map(c => c.name)).toEqual(['task-list-item', 'task-list-item']);
         expect(list.children!.map(c => c.meta?.checked)).toEqual([false, false]);
         expect(list.children![0].children!.find(c => c.name === 'paragraph')?.text).toBe('a');
-        expect(list.children![1].children).toHaveLength(0);
+        expect(list.children![1].children).toEqual([{ name: 'paragraph', text: '' }]);
     });
 
     it('parses a single empty unchecked task item as a task list item', () => {
@@ -58,7 +58,7 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         expect(states[0].children).toHaveLength(1);
         expect(states[0].children![0].name).toBe('task-list-item');
         expect(states[0].children![0].meta?.checked).toBe(false);
-        expect(states[0].children![0].children).toHaveLength(0);
+        expect(states[0].children![0].children).toEqual([{ name: 'paragraph', text: '' }]);
     });
 
     it('parses a single empty checked task item as a checked task list item', () => {
@@ -69,7 +69,56 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         expect(states[0].children).toHaveLength(1);
         expect(states[0].children![0].name).toBe('task-list-item');
         expect(states[0].children![0].meta?.checked).toBe(true);
-        expect(states[0].children![0].children).toHaveLength(0);
+        expect(states[0].children![0].children).toEqual([{ name: 'paragraph', text: '' }]);
+    });
+
+    it('parses an empty task marker with lazy continuation text as a task item', () => {
+        const states = generate('- [ ] \ntext\n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('task-list');
+        expect(states[0].children).toHaveLength(1);
+        expect(states[0].children![0].name).toBe('task-list-item');
+        expect(states[0].children![0].meta?.checked).toBe(false);
+        expect(states[0].children![0].children).toHaveLength(1);
+        expect(states[0].children![0].children![0]).toEqual({ name: 'paragraph', text: 'text' });
+    });
+
+    it('keeps lazy continuation text on the final empty task marker in a task list', () => {
+        const states = generate('- [ ] a\n\n- [ ] \n- [ ] \n- [ ] \ntext\n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('task-list');
+        expect(states[0].children).toHaveLength(4);
+        expect(states[0].children!.map(c => c.name)).toEqual([
+            'task-list-item',
+            'task-list-item',
+            'task-list-item',
+            'task-list-item',
+        ]);
+        expect(states[0].children!.map(c => c.meta?.checked)).toEqual([false, false, false, false]);
+        expect(states[0].children![0].children![0]).toEqual({ name: 'paragraph', text: 'a' });
+        expect(states[0].children![1].children).toEqual([{ name: 'paragraph', text: '' }]);
+        expect(states[0].children![2].children).toEqual([{ name: 'paragraph', text: '' }]);
+        expect(states[0].children![3].children![0]).toEqual({ name: 'paragraph', text: 'text' });
+    });
+
+    it('does not treat `- []` as an empty task item', () => {
+        const states = generate('- []\n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('bullet-list');
+        expect(states[0].children![0].name).toBe('list-item');
+        expect(states[0].children![0].children![0]).toEqual({ name: 'paragraph', text: '[]' });
+    });
+
+    it('does not treat `- [ ]text` as a task item without a marker separator', () => {
+        const states = generate('- [ ]text\n');
+
+        expect(states.length).toBe(1);
+        expect(states[0].name).toBe('bullet-list');
+        expect(states[0].children![0].name).toBe('list-item');
+        expect(states[0].children![0].children![0]).toEqual({ name: 'paragraph', text: '[ ]text' });
     });
 
     it('keeps three levels of task-list nesting', () => {

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -100,7 +100,10 @@ export class MarkdownToState {
                 // Fix #1735 the blockquote maybe empty. like bellow:
                 // >
                 // bar
-                if (parentList[0].length === 0 && token.tokenType === 'blockquote') {
+                if (
+                    parentList[0].length === 0
+                    && (token.tokenType === 'blockquote' || token.tokenType === 'list-item')
+                ) {
                     state = {
                         name: 'paragraph' as const,
                         text: '',

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -564,6 +564,9 @@ export default class ExportMarkdown {
         if (name === 'task-list-item')
             itemMarker += state.meta.checked ? '[x] ' : '[ ] ';
 
+        if (!children.length)
+            return `${indent}${itemMarker}\n`;
+
         result.push(`${indent}${itemMarker}`);
         result.push(
             this._convertStatesToMarkdown(children, newIndent, listIndent).substring(

--- a/packages/muya/src/utils/marked/compatibleTaskList.ts
+++ b/packages/muya/src/utils/marked/compatibleTaskList.ts
@@ -6,6 +6,7 @@ function isListToken(token: Token | ListToken): token is ListToken {
 }
 
 const BULL_REG = /^ {0,3}([*+-]|\d{1,9}(?:\.|\)))/;
+const EMPTY_TASK_REG = /^ {0,3}[*+-]\s+\[( |x|X)\]\s*$/;
 
 // marked >=17 keeps the GFM task marker inside the item content: a leading
 // `checkbox` token, plus the literal "[ ] " / "[x] " prefix in the first
@@ -30,6 +31,24 @@ function stripTaskMarker(item: ListItemToken) {
         if (typeof first.raw === 'string' && first.raw.startsWith(raw))
             first.raw = first.raw.slice(raw.length);
     }
+}
+
+function normalizeEmptyTaskItem(item: ListItemToken) {
+    if (item.task)
+        return;
+
+    const matches = EMPTY_TASK_REG.exec(item.raw);
+    if (!matches)
+        return;
+
+    const text = typeof item.text === 'string' ? item.text.trimEnd() : '';
+    if (text !== `[${matches[1]}]`)
+        return;
+
+    item.task = true;
+    item.checked = matches[1] !== ' ';
+    item.text = '';
+    item.tokens = [];
 }
 
 // If bullet list contains task list items, split the bullet list into bullet lists and task lists.
@@ -65,6 +84,7 @@ function compatibleTaskList(tokens: (Token | ListToken | ListItemToken)[] = []) 
 
                 for (const item of token.items) {
                     item.tokens = compatibleTaskList(item.tokens);
+                    normalizeEmptyTaskItem(item);
                     const listItemType = item.task ? 'task' : 'bullet';
                     item.listItemType = listItemType;
                     if (item.task)

--- a/packages/muya/src/utils/marked/compatibleTaskList.ts
+++ b/packages/muya/src/utils/marked/compatibleTaskList.ts
@@ -6,8 +6,8 @@ function isListToken(token: Token | ListToken): token is ListToken {
 }
 
 const BULL_REG = /^ {0,3}([*+-]|\d{1,9}(?:\.|\)))/;
-const EMPTY_TASK_REG = /^ {0,3}[*+-]\s+\[([ x])\]\s*$/i;
-const TASK_MARKER_PREFIX_REG = /^ {0,3}[*+-]\s+\[([ x])\]\s+/i;
+const EMPTY_TASK_REG = /^ {0,3}[*+-][ \t]+\[([ x])\][ \t]*$/i;
+const TASK_MARKER_PREFIX_REG = /^ {0,3}[*+-][ \t]+\[([ x])\][ \t]+/i;
 
 function stripTaskTextPrefix(value: string, marker: string) {
     if (!value.startsWith(marker))

--- a/packages/muya/src/utils/marked/compatibleTaskList.ts
+++ b/packages/muya/src/utils/marked/compatibleTaskList.ts
@@ -7,6 +7,40 @@ function isListToken(token: Token | ListToken): token is ListToken {
 
 const BULL_REG = /^ {0,3}([*+-]|\d{1,9}(?:\.|\)))/;
 const EMPTY_TASK_REG = /^ {0,3}[*+-]\s+\[([ x])\]\s*$/i;
+const TASK_MARKER_PREFIX_REG = /^ {0,3}[*+-]\s+\[([ x])\]\s+/i;
+
+function stripTaskTextPrefix(value: string, marker: string) {
+    if (!value.startsWith(marker))
+        return value;
+
+    const rest = value.slice(marker.length);
+    const newlinePrefix = /^[ \t]*\r?\n/.exec(rest);
+    if (newlinePrefix)
+        return rest.slice(newlinePrefix[0].length);
+
+    return rest.replace(/^[ \t]+/, '');
+}
+
+function stripSyntheticTaskMarker(item: ListItemToken, marker: string) {
+    const first = item.tokens?.[0] as Token & { raw?: string; text?: string; tokens?: Token[] } | undefined;
+    if (!first)
+        return;
+
+    if (typeof first.text === 'string')
+        first.text = stripTaskTextPrefix(first.text, marker);
+    if (typeof first.raw === 'string')
+        first.raw = stripTaskTextPrefix(first.raw, marker);
+
+    const inner = first.type === 'paragraph'
+        ? first.tokens?.[0] as Token & { raw?: string; text?: string } | undefined
+        : undefined;
+    if (inner) {
+        if (typeof inner.text === 'string')
+            inner.text = stripTaskTextPrefix(inner.text, marker);
+        if (typeof inner.raw === 'string')
+            inner.raw = stripTaskTextPrefix(inner.raw, marker);
+    }
+}
 
 // marked >=17 keeps the GFM task marker inside the item content: a leading
 // `checkbox` token, plus the literal "[ ] " / "[x] " prefix in the first
@@ -37,18 +71,22 @@ function normalizeEmptyTaskItem(item: ListItemToken) {
     if (item.task)
         return;
 
-    const matches = EMPTY_TASK_REG.exec(item.raw);
+    const matches = EMPTY_TASK_REG.exec(item.raw) || TASK_MARKER_PREFIX_REG.exec(item.raw);
     if (!matches)
         return;
 
-    const text = typeof item.text === 'string' ? item.text.trimEnd() : '';
-    if (text !== `[${matches[1]}]`)
+    const marker = `[${matches[1]}]`;
+    const text = typeof item.text === 'string' ? item.text : '';
+    if (text.trimEnd() !== marker && !text.startsWith(marker))
         return;
 
     item.task = true;
     item.checked = matches[1] !== ' ';
-    item.text = '';
-    item.tokens = [];
+    item.text = stripTaskTextPrefix(text, marker);
+    if (item.text === '')
+        item.tokens = [];
+    else
+        stripSyntheticTaskMarker(item, marker);
 }
 
 // If bullet list contains task list items, split the bullet list into bullet lists and task lists.

--- a/packages/muya/src/utils/marked/compatibleTaskList.ts
+++ b/packages/muya/src/utils/marked/compatibleTaskList.ts
@@ -6,7 +6,7 @@ function isListToken(token: Token | ListToken): token is ListToken {
 }
 
 const BULL_REG = /^ {0,3}([*+-]|\d{1,9}(?:\.|\)))/;
-const EMPTY_TASK_REG = /^ {0,3}[*+-]\s+\[( |x|X)\]\s*$/;
+const EMPTY_TASK_REG = /^ {0,3}[*+-]\s+\[([ x])\]\s*$/i;
 
 // marked >=17 keeps the GFM task marker inside the item content: a leading
 // `checkbox` token, plus the literal "[ ] " / "[x] " prefix in the first


### PR DESCRIPTION
Closes #4680

## Summary

Fix Markdown parsing for empty task list items.

Previously, empty task items such as `- [ ] ` and `- [x] ` were parsed as normal bullet list items whose text was the literal string `[ ]` or `[x]`. As a result, MarkText rendered them without a checkbox, and a single task list could be split into a task list plus a normal bullet list.

For example:

```markdown
- [ ] a
- [ ] 
```

was parsed as:

- one task list item for `- [ ] a`
- one normal bullet list item containing `[ ]`

This PR fixes the token compatibility layer so empty checkbox markers are restored as task list items before `markdownToState` builds the document state.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 11 Pro 10.0.26200 with MarkText 0.20.0-beta.2 to reproduce the original issue; fix verified with targeted unit tests and Playwright validation on `develop`.

Test commands:

```bash
pnpm --filter @muyajs/core exec vitest run src/state/__tests__/markdownToState.spec.ts
pnpm --filter @muyajs/core exec vitest run src/state/__tests__/markdownToState.spec.ts src/state/__tests__/listSerialization.spec.ts
pnpm --filter @muyajs/core lint:types
```

Results:

```text
markdownToState.spec.ts: 28 passed
markdownToState.spec.ts + listSerialization.spec.ts: 48 passed
lint:types: passed
```

Additional Playwright validation:

- Started the Muya e2e host in Chromium.
- Loaded `- [ ] a\n- [ ] \n`, `- [ ] \n`, and `- [x] \n` into the editor.
- Verified the editor rendered task lists, task list items, and checkboxes for all cases.
- Verified the parsed state preserved `task-list-item` semantics and the correct checked value.
- Verified no normal bullet list was rendered for the mixed empty-task case.

Full `@muyajs/core` test note:

```text
1279 passed, 1 failed
```

The remaining failure was an unrelated existing 5s timeout in `src/ui/tableChessboard/__tests__/tableChessboard.spec.ts` when importing the package entrypoint.

## Notes for reviewers [optional]

The root cause is in the parsing compatibility path:

- `packages/muya/src/utils/marked/lexBlock.ts`
- `packages/muya/src/utils/marked/compatibleTaskList.ts`
- `packages/muya/src/state/markdownToState.ts`

For non-empty task items, marked provides `task: true`, so `compatibleTaskList.ts` classifies the item as a task item.

For empty task items such as `- [ ] `, marked provides a normal list item with `task: false` and text `[ ]`. Because the compatibility layer only checked `item.task`, `markdownToState` had no way to recover the intended checkbox semantics.

This PR adds a narrow normalization step in `compatibleTaskList.ts`: if an unordered list item's raw Markdown is only a bullet marker plus an empty task checkbox marker, and the parsed text is only `[ ]`, `[x]`, or `[X]`, it restores the token to a task item and clears the marker text before state conversion.

Regression tests cover:

- An empty unchecked task item after a populated task item.
- A single empty unchecked task item.
- A single empty checked task item.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.