### PR TITLE
fix: wrap selected text when typing auto-pair characters

### DIFF
--- a/packages/muya/e2e/tests/options/autopair.spec.ts
+++ b/packages/muya/e2e/tests/options/autopair.spec.ts
@@ -55,6 +55,21 @@ async function getFirstBlockText(page: Page): Promise<string> {
     });
 }
 
+async function setContentAndSelect(
+    page: Page,
+    initial: string,
+    start: number,
+    end: number,
+): Promise<void> {
+    await page.evaluate(({ initial, start, end }) => {
+        window.muya!.setContent(initial);
+        window.muya!.focus();
+        window.muya!.domNode.focus();
+        const block = window.muya!.editor.scrollPage!.firstContentInDescendant()!;
+        block.setCursor(start, end, true);
+    }, { initial, start, end });
+}
+
 test.describe('options / auto-pair matrix', () => {
     test('autoPairBracket: on → `(` produces `()`', async ({ page }) => {
         await rebuildAndFocus(page, {
@@ -148,5 +163,33 @@ test.describe('options / auto-pair matrix', () => {
         });
         await page.keyboard.type('"');
         await expect.poll(() => getFirstBlockText(page)).toBe('"');
+    });
+
+    test('typing an auto-pair character over a selection wraps the selected text', async ({ page }) => {
+        await rebuildAndFocus(page, {
+            autoPairBracket: true,
+            autoPairMarkdownSyntax: true,
+            autoPairQuote: true,
+        });
+
+        await setContentAndSelect(page, 'hello world', 0, 5);
+        await page.keyboard.type('(');
+        await expect.poll(() => getFirstBlockText(page)).toBe('(hello) world');
+
+        await setContentAndSelect(page, 'hello world', 0, 11);
+        await page.keyboard.type('"');
+        await expect.poll(() => getFirstBlockText(page)).toBe('"hello world"');
+
+        await setContentAndSelect(page, 'hello world', 0, 5);
+        await page.keyboard.type('*');
+        await expect.poll(() => getFirstBlockText(page)).toBe('*hello* world');
+
+        await setContentAndSelect(page, 'hello world', 0, 5);
+        await page.keyboard.type('`');
+        await expect.poll(() => getFirstBlockText(page)).toBe('`hello` world');
+
+        await setContentAndSelect(page, '中文文本', 0, 4);
+        await page.keyboard.type('"');
+        await expect.poll(() => getFirstBlockText(page)).toBe('"中文文本"');
     });
 });

--- a/packages/muya/e2e/tests/options/autopair.spec.ts
+++ b/packages/muya/e2e/tests/options/autopair.spec.ts
@@ -85,6 +85,27 @@ async function setContentAndSelect(
     });
 }
 
+async function expectSelectedText(
+    page: Page,
+    selectedText: string,
+    start: number,
+    end: number,
+): Promise<void> {
+    await expect.poll(() => page.evaluate(() => {
+        const live = window.muya!.editor.selection.getSelection();
+        const native = window.getSelection();
+        return {
+            anchorOffset: live?.anchor.offset ?? null,
+            focusOffset: live?.focus.offset ?? null,
+            selectedText: native?.toString() ?? '',
+        };
+    })).toEqual({
+        anchorOffset: start,
+        focusOffset: end,
+        selectedText,
+    });
+}
+
 test.describe('options / auto-pair matrix', () => {
     test('autoPairBracket: on → `(` produces `()`', async ({ page }) => {
         await rebuildAndFocus(page, {
@@ -190,21 +211,26 @@ test.describe('options / auto-pair matrix', () => {
         await setContentAndSelect(page, 'hello world', 0, 5);
         await page.keyboard.type('(');
         await expect.poll(() => getFirstBlockText(page)).toBe('(hello) world');
+        await expectSelectedText(page, 'hello', 1, 6);
 
         await setContentAndSelect(page, 'hello world', 0, 11);
         await page.keyboard.type('"');
         await expect.poll(() => getFirstBlockText(page)).toBe('"hello world"');
+        await expectSelectedText(page, 'hello world', 1, 12);
 
         await setContentAndSelect(page, 'hello world', 0, 5);
         await page.keyboard.type('*');
         await expect.poll(() => getFirstBlockText(page)).toBe('*hello* world');
+        await expectSelectedText(page, 'hello', 1, 6);
 
         await setContentAndSelect(page, 'hello world', 0, 5);
         await page.keyboard.type('`');
         await expect.poll(() => getFirstBlockText(page)).toBe('`hello` world');
+        await expectSelectedText(page, 'hello', 1, 6);
 
         await setContentAndSelect(page, '中文文本', 0, 4);
         await page.keyboard.type('"');
         await expect.poll(() => getFirstBlockText(page)).toBe('"中文文本"');
+        await expectSelectedText(page, '中文文本', 1, 5);
     });
 });

--- a/packages/muya/e2e/tests/options/autopair.spec.ts
+++ b/packages/muya/e2e/tests/options/autopair.spec.ts
@@ -68,6 +68,21 @@ async function setContentAndSelect(
         const block = window.muya!.editor.scrollPage!.firstContentInDescendant()!;
         block.setCursor(start, end, true);
     }, { initial, start, end });
+
+    const selectedText = initial.slice(start, end);
+    await expect.poll(() => page.evaluate(() => {
+        const live = window.muya!.editor.selection.getSelection();
+        const native = window.getSelection();
+        return {
+            anchorOffset: live?.anchor.offset ?? null,
+            focusOffset: live?.focus.offset ?? null,
+            selectedText: native?.toString() ?? '',
+        };
+    })).toEqual({
+        anchorOffset: start,
+        focusOffset: end,
+        selectedText,
+    });
 }
 
 test.describe('options / auto-pair matrix', () => {

--- a/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
@@ -54,6 +54,12 @@ function pressKey(content: Format, key: string): KeyboardEvent {
     return event;
 }
 
+function expectSelectedRange(content: Format, start: number, end: number) {
+    const cursor = content.getCursor();
+    expect(cursor?.start.offset).toBe(start);
+    expect(cursor?.end.offset).toBe(end);
+}
+
 describe('autoPair — wraps selected text on keydown before native replacement', () => {
     it('wraps a selected word with brackets', () => {
         const muya = bootMuya('hello world\n');
@@ -66,6 +72,7 @@ describe('autoPair — wraps selected text on keydown before native replacement'
         expect(event.defaultPrevented).toBe(true);
         expect(markInputBoundary).toHaveBeenCalledWith('insertText', '(');
         expect(content.text).toBe('(hello) world');
+        expectSelectedRange(content, 1, 6);
     });
 
     it('wraps a full-line selection with quotes', () => {
@@ -77,6 +84,7 @@ describe('autoPair — wraps selected text on keydown before native replacement'
 
         expect(event.defaultPrevented).toBe(true);
         expect(content.text).toBe('"hello world"');
+        expectSelectedRange(content, 1, 12);
     });
 
     it('wraps a selected word with markdown syntax markers', () => {
@@ -88,6 +96,7 @@ describe('autoPair — wraps selected text on keydown before native replacement'
 
         expect(event.defaultPrevented).toBe(true);
         expect(content.text).toBe('*hello* world');
+        expectSelectedRange(content, 1, 6);
     });
 
     it('wraps a selected word with backticks', () => {
@@ -99,6 +108,7 @@ describe('autoPair — wraps selected text on keydown before native replacement'
 
         expect(event.defaultPrevented).toBe(true);
         expect(content.text).toBe('`hello` world');
+        expectSelectedRange(content, 1, 6);
     });
 
     it('leaves ordinary selected-text replacement to the browser', () => {

--- a/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type Format from '../format';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Muya } from '../../../muya';
 
 const bootedHosts: HTMLElement[] = [];
@@ -59,10 +59,12 @@ describe('autoPair — wraps selected text on keydown before native replacement'
         const muya = bootMuya('hello world\n');
         const content = firstBlock(muya);
         content.setCursor(0, 5);
+        const markInputBoundary = vi.spyOn(muya.editor.history, 'markInputBoundary');
 
         const event = pressKey(content, '(');
 
         expect(event.defaultPrevented).toBe(true);
+        expect(markInputBoundary).toHaveBeenCalledWith('insertText', '(');
         expect(content.text).toBe('(hello) world');
     });
 

--- a/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(
+    markdown: string,
+    options: Partial<ConstructorParameters<typeof Muya>[1]> = {},
+): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function pressKey(content: Format, key: string): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+    });
+    content.keydownHandler(event);
+    return event;
+}
+
+describe('autoPair — wraps selected text on keydown before native replacement', () => {
+    it('wraps a selected word with brackets', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+
+        const event = pressKey(content, '(');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(content.text).toBe('(hello) world');
+    });
+
+    it('wraps a full-line selection with quotes', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 11);
+
+        const event = pressKey(content, '"');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(content.text).toBe('"hello world"');
+    });
+
+    it('wraps a selected word with markdown syntax markers', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+
+        const event = pressKey(content, '*');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(content.text).toBe('*hello* world');
+    });
+
+    it('wraps a selected word with backticks', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+
+        const event = pressKey(content, '`');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(content.text).toBe('`hello` world');
+    });
+
+    it('leaves ordinary selected-text replacement to the browser', () => {
+        const muya = bootMuya('hello world\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+
+        const event = pressKey(content, 'X');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(content.text).toBe('hello world');
+    });
+
+    it('does not wrap when the relevant auto-pair option is disabled', () => {
+        const muya = bootMuya('hello world\n', { autoPairBracket: false });
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+
+        const event = pressKey(content, '(');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(content.text).toBe('hello world');
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -784,8 +784,9 @@ class Content extends TreeNode {
                 + wrappedText
                 + this.text.substring(end.offset);
 
-        const offset = start.offset + wrappedText.length;
-        this.setCursor(offset, offset, true);
+        const selectionStart = start.offset + pair.open.length;
+        const selectionEnd = selectionStart + selectedText.length;
+        this.setCursor(selectionStart, selectionEnd, true);
 
         return true;
     }

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -149,6 +149,33 @@ function shouldInsertClosingPair(
     );
 }
 
+function selectionPairForKey(
+    key: string,
+    options: {
+        autoPairBracket: boolean;
+        autoPairMarkdownSyntax: boolean;
+        autoPairQuote: boolean;
+    },
+    type: string,
+) {
+    if (key.length !== 1)
+        return null;
+
+    const close = key === '`' ? '`' : BRACKET_HASH[key];
+    if (!close)
+        return null;
+
+    const { autoPairBracket, autoPairMarkdownSyntax, autoPairQuote } = options;
+    if (autoPairQuote && /['"]/.test(key))
+        return { open: key, close };
+    if (autoPairBracket && /[{[(]/.test(key))
+        return { open: key, close };
+    if (type === 'format' && autoPairMarkdownSyntax && /[*$~_`]/.test(key))
+        return { open: key, close };
+
+    return null;
+}
+
 interface IAutoPairCollapsedContext {
     blockText: string;
     options: {
@@ -318,6 +345,10 @@ class Content extends TreeNode {
 
     protected get inlineRenderer() {
         return this.muya.editor.inlineRenderer;
+    }
+
+    protected get autoPairType() {
+        return this.blockName;
     }
 
     get path(): TBlockPath {
@@ -684,6 +715,9 @@ class Content extends TreeNode {
         if (this.muya.ui.handleContentKeydown(event))
             return;
 
+        if (this._wrapSelectionWithAutoPair(event))
+            return;
+
         switch (event.key) {
             case EVENT_KEYS.Backspace:
                 this.backspaceHandler(event);
@@ -718,6 +752,42 @@ class Content extends TreeNode {
                 break;
         }
     };
+
+    private _wrapSelectionWithAutoPair(event: KeyboardEvent) {
+        if (
+            this.isComposed
+            || event.defaultPrevented
+            || event.ctrlKey
+            || event.metaKey
+            || event.altKey
+        ) {
+            return false;
+        }
+
+        const cursor = this.getCursor();
+        if (!cursor || cursor.start.offset === cursor.end.offset)
+            return false;
+
+        const pair = selectionPairForKey(event.key, this.muya.options, this.autoPairType);
+        if (!pair)
+            return false;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const { start, end } = cursor;
+        const selectedText = this.text.substring(start.offset, end.offset);
+        const wrappedText = `${pair.open}${selectedText}${pair.close}`;
+        this.text
+            = this.text.substring(0, start.offset)
+                + wrappedText
+                + this.text.substring(end.offset);
+
+        const offset = start.offset + wrappedText.length;
+        this.setCursor(offset, offset, true);
+
+        return true;
+    }
 
     blurHandler() {
         this.scrollPage?.handleBlurFromContent(this);

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -774,6 +774,7 @@ class Content extends TreeNode {
 
         event.preventDefault();
         event.stopPropagation();
+        this.muya.editor.history.markInputBoundary('insertText', event.key);
 
         const { start, end } = cursor;
         const selectedText = this.text.substring(start.offset, end.offset);

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -215,6 +215,10 @@ function checkTokenIsInlineFormat(token: Token) {
 class Format extends Content {
     static override blockName = 'format';
 
+    protected override get autoPairType() {
+        return 'format';
+    }
+
     private _checkCursorInTokenType(
         text: string,
         offset: number,


### PR DESCRIPTION
Closes #4684

## Summary

Fix auto-pair typing over a non-empty selection so the selected text is wrapped instead of discarded.

Previously, when text was selected and the user typed an auto-pair character such as `(`, `"`, `*`, or `` ` ``, the browser first replaced the selection with the typed character. MarkText then ran the collapsed-cursor auto-pair path and inserted only the closing character. The selected content was already gone, so the result was an empty pair:

```text
hello + (  ->  () world
hello world + "  ->  ""
hello + *  ->  ** world
```

This PR handles that interaction before native selection replacement happens. On `keydown`, when the selection is inside a single content block and the key is an enabled auto-pair character, MarkText prevents the native replacement and writes:

```text
open + selectedText + close
```

Examples after this change:

```text
hello + (  ->  (hello) world
hello world + "  ->  "hello world"
hello + *  ->  *hello* world
hello + `  ->  `hello` world
中文文本 + "  ->  "中文文本"
```

Ordinary selected-text replacement is still left to the browser. For example, selecting `hello` and typing `X` is not intercepted by this path.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 11 Pro 10.0.26200 with MarkText 0.20.0-beta.2 to reproduce the original issue; fix verified with targeted unit tests and Playwright validation on `develop`.

Test commands:

```bash
pnpm --filter @muyajs/core exec vitest run src/block/base/__tests__/selectionAutoPair.spec.ts src/block/base/__tests__/autoPair.spec.ts
pnpm --filter @muyajs/core lint:types
pnpm --filter muya-e2e exec playwright test tests/options/autopair.spec.ts --project=chromium
```

Results:

```text
selectionAutoPair.spec.ts + autoPair.spec.ts: 25 passed
lint:types: passed
Playwright options/autopair.spec.ts chromium: 8 passed
```


## Notes for reviewers [optional]

The fix is intentionally scoped to the same-block selection case handled by the existing content selection model.

Boundary behavior:

- Does not change collapsed-cursor auto-pair behavior.
- Does not intercept ordinary characters such as `X`; native selected-text replacement still applies.
- Does not run when the relevant auto-pair option is disabled.
- Does not run for `Ctrl` / `Meta` / `Alt` key combinations.
- Does not run during IME composition.
- Does not attempt to handle cross-block selections.

Implementation details:

- `packages/muya/src/block/base/content.ts` adds a `keydown`-time selection wrapping path before the browser can replace the selected text.
- `packages/muya/src/block/base/format.ts` exposes `autoPairType = 'format'` so Markdown syntax wrappers such as `*`, `_`, `$`, `~`, and `` ` `` use the same format-context gating as the existing auto-pair input path.
- `packages/muya/src/block/base/__tests__/selectionAutoPair.spec.ts` adds unit coverage for brackets, quotes, Markdown markers, backticks, ordinary character replacement, and disabled auto-pair options.
- `packages/muya/e2e/tests/options/autopair.spec.ts` adds Chromium coverage for the real keyboard/input path, including ASCII and CJK text.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.