### PR TITLE
fix: preserve Google Docs CSS formatting on paste

### DIFF
--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -45,6 +45,30 @@ test.describe('clipboard paste', () => {
         }).toMatch(/\*\*foo\*\*/);
     });
 
+    test('pasting Google Docs CSS formatting preserves the real bold and italic ranges', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+        const html = [
+            '<b style="font-weight:normal" id="docs-internal-guid-abc">',
+            '<p dir="ltr">',
+            '<span style="font-weight:700">Bold</span>',
+            '<span> normal </span>',
+            '<span style="font-style:italic">italic</span>',
+            '</p>',
+            '</b>',
+        ].join('');
+
+        await pasteClipboard(page, html, 'Bold normal italic');
+
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe('**Bold** normal *italic*\n');
+
+        const md = await getMarkdown(page);
+        expect(md).not.toContain('**\n\n');
+    });
+
     test('pasting <a href> converts to markdown link', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/src/state/__tests__/htmlToMarkdown.spec.ts
+++ b/packages/muya/src/state/__tests__/htmlToMarkdown.spec.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../htmlToMarkdown';
+
+function convert(html: string): string {
+    return new HtmlToMarkdown().generate(html);
+}
+
+describe('htmlToMarkdown — Google Docs style inline formatting', () => {
+    it('preserves CSS bold and italic ranges from Google Docs without bolding the wrapper', () => {
+        const html = [
+            '<b style="font-weight:normal" id="docs-internal-guid-abc">',
+            '<p dir="ltr">',
+            '<span style="font-weight:700">Bold</span>',
+            '<span> normal </span>',
+            '<span style="font-style:italic">italic</span>',
+            '</p>',
+            '</b>',
+        ].join('');
+
+        expect(convert(html)).toBe('**Bold** normal *italic*');
+    });
+
+    it('does not treat a non-bold Google Docs wrapper as strong across paragraphs', () => {
+        const html = [
+            '<b style="font-weight:normal" id="docs-internal-guid-abc">',
+            '<p>First para.</p>',
+            '<p><span style="font-weight:700">Second bold para.</span></p>',
+            '</b>',
+        ].join('');
+
+        expect(convert(html)).toBe('First para.\n\n**Second bold para.**');
+    });
+
+    it('preserves CSS formatting inside headings and list items', () => {
+        expect(
+            convert([
+                '<h1><span>Heading </span><span style="font-weight:700">Bold</span></h1>',
+                '<ul>',
+                '<li><span>bullet </span><span style="font-weight:700">bold</span></li>',
+                '<li><span>bullet </span><span style="font-style:italic">italic</span></li>',
+                '</ul>',
+            ].join('')),
+        ).toBe('# Heading **Bold**\n\n- bullet **bold**\n- bullet *italic*');
+    });
+
+    it('preserves CSS formatting inside links', () => {
+        expect(
+            convert([
+                '<p>',
+                'Plain <a href="https://example.com/plain"><span>link</span></a>',
+                ' and <a href="https://example.com/bold">',
+                '<span style="font-weight:700">boldlink</span>',
+                '</a>',
+                '</p>',
+            ].join('')),
+        ).toBe('Plain [link](https://example.com/plain) and [**boldlink**](https://example.com/bold)');
+    });
+
+    it('recognizes common CSS strong weights without treating medium weights as bold', () => {
+        expect(
+            convert([
+                '<p>',
+                '<span style="font-weight:bold">Bold keyword</span>',
+                '<span> </span>',
+                '<span style="font-weight:600">Bold numeric</span>',
+                '<span> </span>',
+                '<span style="font-weight:500">Medium</span>',
+                '</p>',
+            ].join('')),
+        ).toBe('**Bold keyword** **Bold numeric** Medium');
+    });
+
+    it('combines CSS bold and italic when both styles are on the same span', () => {
+        expect(
+            convert('<p><span style="font-weight:700;font-style:italic">Bold italic</span></p>'),
+        ).toBe('***Bold italic***');
+    });
+
+    it('lets explicit normal CSS override semantic bold and italic wrappers', () => {
+        expect(
+            convert([
+                '<p>',
+                '<b style="font-weight:normal">Not bold</b>',
+                '<span> </span>',
+                '<i style="font-style:normal">Not italic</i>',
+                '</p>',
+            ].join('')),
+        ).toBe('Not bold Not italic');
+    });
+
+    it('does not duplicate formatting when CSS spans are already inside semantic tags', () => {
+        expect(
+            convert([
+                '<p>',
+                '<strong><span style="font-weight:700">bold</span></strong>',
+                ' ',
+                '<em><span style="font-style:italic">italic</span></em>',
+                ' ',
+                '<strong><span style="font-style:italic">bold italic</span></strong>',
+                '</p>',
+            ].join('')),
+        ).toBe('**bold** *italic* ***bold italic***');
+    });
+
+    it('still applies CSS spans inside semantic tags disabled by normal CSS', () => {
+        expect(
+            convert([
+                '<p>',
+                '<b style="font-weight:normal">',
+                '<span style="font-weight:700">Bold</span>',
+                '</b>',
+                ' ',
+                '<i style="font-style:normal">',
+                '<span style="font-style:italic">italic</span>',
+                '</i>',
+                '</p>',
+            ].join('')),
+        ).toBe('**Bold** *italic*');
+    });
+
+    it('keeps normal semantic strong and emphasis HTML unchanged', () => {
+        expect(
+            convert('<p>Plain <strong>boldword</strong> and <em>italicword</em> end.</p>'),
+        ).toBe('Plain **boldword** and *italicword* end.');
+    });
+});

--- a/packages/muya/src/state/__tests__/htmlToMarkdown.spec.ts
+++ b/packages/muya/src/state/__tests__/htmlToMarkdown.spec.ts
@@ -120,6 +120,16 @@ describe('htmlToMarkdown — Google Docs style inline formatting', () => {
         ).toBe('**Bold** *italic*');
     });
 
+    it('does not duplicate formatting through disabled semantic wrappers inside active ancestors', () => {
+        expect(
+            convert('<p><strong><b style="font-weight:normal"><span style="font-weight:700">Bold</span></b></strong></p>'),
+        ).toBe('**Bold**');
+
+        expect(
+            convert('<p><em><i style="font-style:normal"><span style="font-style:italic">italic</span></i></em></p>'),
+        ).toBe('*italic*');
+    });
+
     it('keeps normal semantic strong and emphasis HTML unchanged', () => {
         expect(
             convert('<p>Plain <strong>boldword</strong> and <em>italicword</em> end.</p>'),

--- a/packages/muya/src/utils/turndownService/index.ts
+++ b/packages/muya/src/utils/turndownService/index.ts
@@ -5,6 +5,103 @@ import { identity, isHTMLElement, isHTMLInputElement } from '../../utils';
 
 const DEFAULT_KEEPS: Filter = ['u', 'mark', 'ruby', 'rt', 'sub', 'sup'];
 
+function inlineStyleValue(node: Node, name: keyof CSSStyleDeclaration): string {
+    return isHTMLElement(node) ? String(node.style[name]).trim().toLowerCase() : '';
+}
+
+function hasStrongFontWeight(node: Node): boolean {
+    const fontWeight = inlineStyleValue(node, 'fontWeight');
+    if (/^(?:bold|bolder)$/.test(fontWeight))
+        return true;
+
+    const numericWeight = Number.parseInt(fontWeight, 10);
+    return Number.isFinite(numericWeight) && numericWeight >= 600;
+}
+
+function hasNonStrongFontWeight(node: Node): boolean {
+    const fontWeight = inlineStyleValue(node, 'fontWeight');
+    if (!fontWeight)
+        return false;
+    if (/^(?:normal|lighter)$/.test(fontWeight))
+        return true;
+
+    const numericWeight = Number.parseInt(fontWeight, 10);
+    return Number.isFinite(numericWeight) && numericWeight < 600;
+}
+
+function hasItalicFontStyle(node: Node): boolean {
+    return /^(?:italic|oblique)/.test(inlineStyleValue(node, 'fontStyle'));
+}
+
+function hasNormalFontStyle(node: Node): boolean {
+    return inlineStyleValue(node, 'fontStyle') === 'normal';
+}
+
+function isStyledSpan(node: Node): boolean {
+    return isHTMLElement(node) && node.nodeName === 'SPAN';
+}
+
+function isSemanticStrong(node: Node): boolean {
+    return isHTMLElement(node) && /^(?:B|STRONG)$/.test(node.nodeName);
+}
+
+function isSemanticEmphasis(node: Node): boolean {
+    return isHTMLElement(node) && /^(?:I|EM)$/.test(node.nodeName);
+}
+
+function hasSemanticAncestor(
+    node: Node,
+    isSemantic: (node: Node) => boolean,
+    isDisabled: (node: Node) => boolean,
+): boolean {
+    let current = node.parentElement;
+    while (current) {
+        if (isSemantic(current))
+            return !isDisabled(current);
+        current = current.parentElement;
+    }
+
+    return false;
+}
+
+function hasStrongSemanticAncestor(node: Node): boolean {
+    return hasSemanticAncestor(node, isSemanticStrong, hasNonStrongFontWeight);
+}
+
+function hasEmphasisSemanticAncestor(node: Node): boolean {
+    return hasSemanticAncestor(node, isSemanticEmphasis, hasNormalFontStyle);
+}
+
+function strongDelimiter(options: TurndownService.Options): string {
+    return options.strongDelimiter ?? '**';
+}
+
+function emDelimiter(options: TurndownService.Options): string {
+    return options.emDelimiter ?? '*';
+}
+
+function formatContent(
+    content: string,
+    options: TurndownService.Options,
+    strong: boolean,
+    emphasis: boolean,
+): string {
+    if (!content)
+        return '';
+
+    let result = content;
+    if (emphasis) {
+        const delimiter = emDelimiter(options);
+        result = `${delimiter}${result}${delimiter}`;
+    }
+    if (strong) {
+        const delimiter = strongDelimiter(options);
+        result = `${delimiter}${result}${delimiter}`;
+    }
+
+    return result;
+}
+
 export function usePluginsAddRules(turndownService: TurndownService) {
     // Use the gfm plugin
     const { strikethrough, tables } = turndownPluginGfm;
@@ -16,6 +113,42 @@ export function usePluginsAddRules(turndownService: TurndownService) {
         filter: ['del', 's'], // <strike> is not support by the web standard, so I remove the use `strike` in filter...
         replacement(content: string) {
             return `~~${content}~~`;
+        },
+    });
+
+    turndownService.addRule('nonStrongSemantic', {
+        filter(node: Node) {
+            return isSemanticStrong(node) && hasNonStrongFontWeight(node);
+        },
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            return formatContent(content, options, false, hasItalicFontStyle(node));
+        },
+    });
+
+    turndownService.addRule('nonEmphasisSemantic', {
+        filter(node: Node) {
+            return isSemanticEmphasis(node) && hasNormalFontStyle(node);
+        },
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            return formatContent(content, options, hasStrongFontWeight(node), false);
+        },
+    });
+
+    turndownService.addRule('cssInlineStyle', {
+        filter(node: Node) {
+            return isStyledSpan(node)
+                && (
+                    (hasStrongFontWeight(node) && !hasStrongSemanticAncestor(node))
+                    || (hasItalicFontStyle(node) && !hasEmphasisSemanticAncestor(node))
+                );
+        },
+        replacement(content: string, _node: Node, options: TurndownService.Options) {
+            return formatContent(
+                content,
+                options,
+                hasStrongFontWeight(_node) && !hasStrongSemanticAncestor(_node),
+                hasItalicFontStyle(_node) && !hasEmphasisSemanticAncestor(_node),
+            );
         },
     });
 

--- a/packages/muya/src/utils/turndownService/index.ts
+++ b/packages/muya/src/utils/turndownService/index.ts
@@ -56,8 +56,8 @@ function hasSemanticAncestor(
 ): boolean {
     let current = node.parentElement;
     while (current) {
-        if (isSemantic(current))
-            return !isDisabled(current);
+        if (isSemantic(current) && !isDisabled(current))
+            return true;
         current = current.parentElement;
     }
 
@@ -100,6 +100,13 @@ function formatContent(
     }
 
     return result;
+}
+
+function getInlineStyleFormatting(node: Node) {
+    return {
+        strong: hasStrongFontWeight(node) && !hasStrongSemanticAncestor(node),
+        emphasis: hasItalicFontStyle(node) && !hasEmphasisSemanticAncestor(node),
+    };
 }
 
 function isTaskListCheckbox(node: unknown) {
@@ -154,18 +161,19 @@ export function usePluginsAddRules(turndownService: TurndownService) {
 
     turndownService.addRule('cssInlineStyle', {
         filter(node: Node) {
-            return isStyledSpan(node)
-                && (
-                    (hasStrongFontWeight(node) && !hasStrongSemanticAncestor(node))
-                    || (hasItalicFontStyle(node) && !hasEmphasisSemanticAncestor(node))
-                );
+            if (!isStyledSpan(node))
+                return false;
+
+            const formatting = getInlineStyleFormatting(node);
+            return formatting.strong || formatting.emphasis;
         },
-        replacement(content: string, _node: Node, options: TurndownService.Options) {
+        replacement(content: string, node: Node, options: TurndownService.Options) {
+            const formatting = getInlineStyleFormatting(node);
             return formatContent(
                 content,
                 options,
-                hasStrongFontWeight(_node) && !hasStrongSemanticAncestor(_node),
-                hasItalicFontStyle(_node) && !hasEmphasisSemanticAncestor(_node),
+                formatting.strong,
+                formatting.emphasis,
             );
         },
     });


### PR DESCRIPTION
Closes #4688

## Summary

Fix Google Docs rich-text paste fidelity for CSS-based bold and italic ranges.

Google Docs commonly places copied content inside an outer wrapper like:

```html
<b style="font-weight:normal" id="docs-internal-guid-...">
```

That wrapper is not visually bold, but Turndown's default `<b>` rule treated it as semantic strong and wrapped the entire pasted paragraph in `**`.

At the same time, the real Google Docs formatting ranges are represented on inner spans with CSS, for example:

```html
<span style="font-weight:700">Bold</span>
<span style="font-style:italic">italic</span>
```

Those CSS-based ranges were previously converted as plain text, so the actual bold and italic formatting was lost.

This PR adds a narrow Turndown compatibility layer for inline CSS formatting:

- Treat semantic `<b>/<strong>` as transparent when inline CSS explicitly says the font weight is not strong.
- Treat semantic `<i>/<em>` as transparent when inline CSS explicitly says the font style is normal.
- Convert styled spans with strong `font-weight` values into Markdown strong emphasis.
- Convert styled spans with italic/oblique `font-style` into Markdown emphasis.
- Avoid double-wrapping when CSS-formatted spans are already inside semantic `<strong>` or `<em>` ancestors.

For the reported Google Docs case, paste output changes from:

```markdown
**

Bold normal italic

**
```

to:

```markdown
**Bold** normal *italic*
```

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 11 Pro 10.0.26200 with real Google Docs copy/paste into the Muya e2e host on the current branch.

Test commands:

```bash
pnpm --filter @muyajs/core exec vitest run src/state/__tests__/htmlToMarkdown.spec.ts
pnpm --filter @muyajs/core lint:types
pnpm --filter @muyajs/core lint
pnpm --filter muya-e2e exec playwright test tests/editing/clipboard.spec.ts --project=chromium
git diff --check
```

Results:

```text
htmlToMarkdown.spec.ts: 10 passed
lint:types: passed
lint: 0 errors, 5 existing warnings
clipboard.spec.ts chromium: 6 passed
git diff --check: passed
```

The remaining lint warnings are pre-existing warnings in `content.ts` and `format.ts`; this PR does not modify those files.

Additional real Google Docs validation:

- Created Google Docs content using real keyboard shortcuts, copied with `Ctrl+A` / `Ctrl+C`, pasted into the local Muya e2e host, and inspected `window.muya.getMarkdown()`.
- Verified paragraph inline formatting:

```markdown
**Bold** normal *italic*

***BoldItalic*** plain

a **bold** b *italic* c ***both*** d
```

- Verified heading and list formatting:

```markdown
# Heading **Bold**

- bullet **bold**

- bullet *italic*
```

- Verified links and formatted links:

```markdown
Plain [link](https://example.com/plain) and [**boldlink**](https://example.com/bold)
```

- Verified standard HTML paste behavior still works for existing semantic tags:

```markdown
Plain **bold** *italic* <u>under</u> ~~strike~~ <mark>mark</mark> <sub>sub</sub> <sup>sup</sup> [link](https://example.com/)
```

- Verified CSS boundary behavior:

```markdown
Not bold Not italic Medium **SemiBold** ***StrongItalic***
```

This confirms `font-weight:normal`, `font-style:normal`, and `font-weight:500` are not treated as bold/italic, while `font-weight:600+` and combined bold+italic styles are preserved.

## Notes for reviewers [optional]

The fix is in `packages/muya/src/utils/turndownService/index.ts`.

The root cause is that Turndown's default rules are tag-based:

- `<b>` / `<strong>` become Markdown strong.
- `<i>` / `<em>` become Markdown emphasis.
- Generic `<span>` elements are transparent unless a custom rule handles them.

Google Docs uses both of these patterns in a way that breaks the default conversion:

1. The outer document wrapper is a `<b>` tag, but its inline style says `font-weight:normal`, so it should not produce `**`.
2. The actual bold/italic ranges are CSS styles on inner spans, so they need explicit style-based conversion.

The new rules are intentionally scoped:

- CSS formatting conversion applies only to `SPAN` elements.
- Existing standard HTML tags such as `<strong>`, `<em>`, `<u>`, `<del>`, `<mark>`, `<sub>`, `<sup>`, and `<a>` keep their existing behavior.
- CSS spans inside semantic strong/emphasis ancestors do not receive duplicate Markdown markers.
- If a semantic ancestor is explicitly disabled with normal CSS, an inner CSS span can still provide the actual formatting range.

During manual testing, Google Docs underline and strikethrough were also inspected. Google Docs copies them as CSS `text-decoration:underline` and `text-decoration:line-through` on spans. Those are not included in this PR because issue #4688 is specifically about bold/italic corruption, and underline/strikethrough CSS text-decoration support is a separate paste-fidelity enhancement.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.