### PR TITLE
fix: normalize first-row colspan table paste

### DIFF
--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -71,6 +71,21 @@ test.describe('clipboard paste', () => {
         expect(md).toMatch(/\|\s*r1c1\s*\|\s*r1c2\s*\|/);
     });
 
+    test('pasting a <table> with first-row colspan converts to a GFM table', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+        const html = '<table><tr><td colspan="2">A</td></tr><tr><td>B</td><td>C</td></tr></table>';
+        await pasteClipboard(page, html, 'A\nB\tC');
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toMatch(/\|\s*A\s*\|\s*\|/);
+
+        const md = await getMarkdown(page);
+        expect(md).toMatch(/\|\s*-+\s*\|\s*-+\s*\|/);
+        expect(md).toMatch(/\|\s*B\s*\|\s*C\s*\|/);
+    });
+
     test('pasting plain text without HTML falls back to text insertion', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/src/utils/__tests__/pastedHtmlTableColspan.spec.ts
+++ b/packages/muya/src/utils/__tests__/pastedHtmlTableColspan.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../../state/htmlToMarkdown';
+import { MarkdownToState } from '../../state/markdownToState';
+import { normalizePastedHTML } from '../paste';
+
+interface IStateLike {
+    name: string;
+    text?: string;
+    children?: IStateLike[];
+}
+
+async function pasteHtmlToState(html: string) {
+    const normalized = await normalizePastedHTML(html);
+    const markdown = new HtmlToMarkdown({ bulletListMarker: '-' }).generate(normalized);
+    const states = new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(markdown) as unknown as IStateLike[];
+
+    return { markdown, states };
+}
+
+function rowTexts(row: IStateLike) {
+    return row.children?.map(cell => cell.text ?? '') ?? [];
+}
+
+describe('normalizePastedHTML - table colspan paste', () => {
+    it('keeps a first-row colspan table parseable as a Markdown table', async () => {
+        const { markdown, states } = await pasteHtmlToState(
+            '<table><tr><td colspan="2">A</td></tr><tr><td>B</td><td>C</td></tr></table>',
+        );
+
+        expect(markdown).toMatch(/\|\s*A\s*\|\s*\|/);
+        expect(markdown).toMatch(/\|\s*B\s*\|\s*C\s*\|/);
+
+        expect(states[0].name).toBe('table');
+        expect(rowTexts(states[0].children![0])).toEqual(['A', '']);
+        expect(rowTexts(states[0].children![1])).toEqual(['B', 'C']);
+    });
+});

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -6,6 +6,29 @@ const TIMEOUT = 1500;
 
 export const isOnline = () => navigator.onLine === true;
 
+function expandTableColspans(table: HTMLTableElement) {
+    for (const row of Array.from(table.rows)) {
+        const cells = Array.from(row.cells);
+
+        for (const cell of cells) {
+            const colSpan = Math.max(1, Math.trunc(cell.colSpan || 1));
+            if (colSpan <= 1)
+                continue;
+
+            cell.removeAttribute('colspan');
+
+            const placeholders: HTMLTableCellElement[] = [];
+            for (let i = 1; i < colSpan; i++) {
+                placeholders.push(
+                    document.createElement(cell.tagName.toLowerCase()) as HTMLTableCellElement,
+                );
+            }
+
+            cell.after(...placeholders);
+        }
+    }
+}
+
 export async function getPageTitle(url: string) {
     // No need to request the title when it's not url.
     if (!url.startsWith('http'))
@@ -56,6 +79,8 @@ export async function normalizePastedHTML(html: string) {
     const tables = Array.from(tempWrapper.querySelectorAll('table'));
 
     for (const table of tables) {
+        expandTableColspans(table);
+
         const row = table.querySelector('tr');
         if (row && row.firstElementChild?.tagName !== 'TH') {
             [...row.children].forEach((cell) => {


### PR DESCRIPTION
Closes #4703

## Summary

Normalize pasted HTML tables that use `colspan` in the first row so they still become parseable GFM tables instead of plain pipe text.

The failure is specific to the first row. MarkText already preprocesses pasted tables by turning the first row into header cells before Turndown runs, but it preserves the original `colspan` structure. When the first row contains a merged cell, the resulting Markdown table is no longer rectangular: the header row has fewer logical columns than the body rows. Turndown still emits pipe-table syntax, but `MarkdownToState` does not recognize it as a valid table, so the paste falls back to a plain paragraph.

This PR fixes that upstream of Turndown by expanding each first-row `colspan` into empty placeholder cells first. That keeps the table rectangular, so the existing HTML-to-Markdown and Markdown-to-state pipeline can keep doing its job without a special-case parser change.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on Chromium clipboard paste via Playwright

The following checks passed:

```bash
pnpm --filter @muyajs/core test -- src/utils/__tests__/pastedHtmlTableColspan.spec.ts
pnpm --filter @muyajs/core test -- src/utils/__tests__
pnpm --filter muya-e2e e2e:chromium -- tests/editing/clipboard.spec.ts
pnpm --filter @muyajs/core exec vitest run --testTimeout 20000
pnpm --filter @muyajs/core lint:types
pnpm typecheck
pnpm --filter @muyajs/core lint
git diff --check
```

## Notes for reviewers [optional]

The fix is intentionally narrow:

- it only expands `colspan > 1`
- it only runs on pasted HTML tables
- it does not change the existing Markdown parser
- it does not touch `rowspan`
- it does not affect normal tables that are already rectangular

This keeps the table rectangular enough for Turndown to emit valid table Markdown, which the existing `MarkdownToState` parser can turn into a live table block.

The tests cover both sides of the behavior:

- a focused unit test that runs `normalizePastedHTML()` through `HtmlToMarkdown` and `MarkdownToState`
- a Chromium clipboard e2e test that pastes a real HTML table through the browser clipboard path

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.