### PR TITLE
fix: preserve nested HTML lists under ordered parents

### DIFF
--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -86,6 +86,8 @@ test.describe('clipboard paste', () => {
             timeout: 5_000,
             intervals: [50, 100, 250, 500],
         }).toContain('1. one\n   1. two\n2. three');
+    });
+
     test('pasting a <table> with first-row colspan converts to a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -71,6 +71,23 @@ test.describe('clipboard paste', () => {
         expect(md).toMatch(/\|\s*r1c1\s*\|\s*r1c2\s*\|/);
     });
 
+    test('pasting nested HTML lists under ordered parents preserves nesting', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+
+        await pasteClipboard(page, '<ol><li>one<ul><li>two</li></ul></li><li>three</li></ol>', 'one\ntwo\nthree');
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toContain('1. one\n   - two\n2. three');
+
+        await pasteClipboard(page, '<ol><li>one<ol><li>two</li></ol></li><li>three</li></ol>', 'one\ntwo\nthree');
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toContain('1. one\n   1. two\n2. three');
+    });
+
     test('pasting plain text without HTML falls back to text insertion', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/src/utils/__tests__/htmlNestedListPaste.spec.ts
+++ b/packages/muya/src/utils/__tests__/htmlNestedListPaste.spec.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../../state/htmlToMarkdown';
+import { MarkdownToState } from '../../state/markdownToState';
+
+interface IStateLike {
+    name: string;
+    text?: string;
+    children?: IStateLike[];
+}
+
+function htmlToState(html: string) {
+    const markdown = new HtmlToMarkdown({ bulletListMarker: '-' }).generate(html);
+    const states = new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(markdown) as unknown as IStateLike[];
+
+    return { markdown, states };
+}
+
+function firstItemChildren(states: IStateLike[]) {
+    return states[0].children?.[0].children?.map(child => child.name) ?? [];
+}
+
+describe('htmlToMarkdown - nested HTML lists under ordered parents', () => {
+    it('keeps a bullet child list nested under an ordered parent item', () => {
+        const { markdown, states } = htmlToState(
+            '<ol><li>one<ul><li>two</li></ul></li><li>three</li></ol>',
+        );
+
+        expect(markdown).toContain('1. one\n   - two');
+        expect(states.map(state => state.name)).toEqual(['order-list']);
+        expect(firstItemChildren(states)).toEqual(['paragraph', 'bullet-list']);
+    });
+
+    it('keeps an ordered child list nested under an ordered parent item', () => {
+        const { markdown, states } = htmlToState(
+            '<ol><li>one<ol><li>two</li></ol></li><li>three</li></ol>',
+        );
+
+        expect(markdown).toContain('1. one\n   1. two');
+        expect(states.map(state => state.name)).toEqual(['order-list']);
+        expect(firstItemChildren(states)).toEqual(['paragraph', 'order-list']);
+    });
+
+    it('uses the ordered marker width when the parent starts at a two-digit number', () => {
+        const { markdown, states } = htmlToState(
+            '<ol start="10"><li>ten<ul><li>child</li></ul></li><li>eleven</li></ol>',
+        );
+
+        expect(markdown).toContain('10. ten\n    - child');
+        expect(states.map(state => state.name)).toEqual(['order-list']);
+        expect(firstItemChildren(states)).toEqual(['paragraph', 'bullet-list']);
+    });
+});

--- a/packages/muya/src/utils/turndownService/index.ts
+++ b/packages/muya/src/utils/turndownService/index.ts
@@ -82,11 +82,6 @@ export function usePluginsAddRules(turndownService: TurndownService) {
             node: Node,
             options: { bulletListMarker?: string },
         ) {
-            content = content
-                .replace(/^\n+/, '') // remove leading newlines
-                .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
-                .replace(/\n/g, '\n  '); // indent
-
             let prefix = `${options.bulletListMarker} `;
             const parent = node.parentNode;
             if (isHTMLElement(parent) && parent.nodeName === 'OL') {
@@ -94,6 +89,12 @@ export function usePluginsAddRules(turndownService: TurndownService) {
                 const index = Array.prototype.indexOf.call(parent.children, node);
                 prefix = `${start ? Number(start) + index : index + 1}. `;
             }
+
+            const continuationIndent = ' '.repeat(prefix.length);
+            content = content
+                .replace(/^\n+/, '') // remove leading newlines
+                .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+                .replace(/\n/g, `\n${continuationIndent}`); // indent
 
             return (
                 prefix


### PR DESCRIPTION
Closes #4704

## Summary

Preserve nested HTML lists when the parent list is ordered.

The paste pipeline converts clipboard HTML to Markdown before `MarkdownToState` builds editor state. The custom Turndown `listItem` rule previously indented every continuation line with a fixed two spaces. That works for unordered parents because `- ` is two characters wide, but it is too narrow for ordered parents such as `1. `.

For example, this HTML:

```html
<ol><li>one<ul><li>two</li></ul></li><li>three</li></ol>
```

was converted to:

```markdown
1. one
  - two
2. three
```

That indentation is not enough for the nested child list to remain inside the `one` item, so the paste flattened the structure. The ordered-child variant had the same root cause and could become one flat ordered list.

This PR computes the continuation indentation from the actual list marker width instead of hard-coding two spaces:

- `- ` keeps a two-space continuation indent
- `1. ` uses three spaces
- `10. ` uses four spaces

That keeps the generated Markdown valid for nested lists under ordered parents without changing the Markdown parser.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on Chromium clipboard paste via Playwright

The following checks passed:

```bash
pnpm --filter @muyajs/core test -- src/utils/__tests__/htmlNestedListPaste.spec.ts
pnpm --filter @muyajs/core test -- src/utils/__tests__
pnpm --filter muya-e2e e2e:chromium -- tests/editing/clipboard.spec.ts
pnpm --filter @muyajs/core exec vitest run --testTimeout 20000
pnpm --filter @muyajs/core lint:types
pnpm typecheck
pnpm --filter @muyajs/core lint
git diff --check
```

## Notes for reviewers [optional]

The fix is intentionally scoped to the HTML-to-Markdown list-item conversion. It does not change `MarkdownToState`, paste merging, or list serialization.

Regression coverage includes:

- ordered parent with bullet child: `<ol><li>one<ul>...`
- ordered parent with ordered child: `<ol><li>one<ol>...`
- ordered parent starting at a two-digit number: `<ol start="10">...`
- a real Chromium clipboard paste test that exercises the browser `text/html` clipboard path

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.