### PR TITLE
fix: normalize HTML task-list paste

### DIFF
--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -71,6 +71,39 @@ test.describe('clipboard paste', () => {
         expect(md).toMatch(/\|\s*r1c1\s*\|\s*r1c2\s*\|/);
     });
 
+    test('pasting HTML task-list items creates task-list Markdown', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+
+        await pasteClipboard(
+            page,
+            '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" disabled=""><span>&nbsp;</span>task</li></ul>',
+            ' task',
+        );
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toContain('- [ ] task');
+        await expect.poll(async () => page.evaluate(() => window.muya!.getState()[0].name), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe('task-list');
+
+        await pasteClipboard(
+            page,
+            '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked="" disabled=""><span>&nbsp;</span>done</li></ul>',
+            ' done',
+        );
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toContain('- [x] done');
+        await expect.poll(async () => page.evaluate(() => window.muya!.getState()[0].name), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe('task-list');
+    });
+
     test('pasting plain text without HTML falls back to text insertion', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -102,6 +102,8 @@ test.describe('clipboard paste', () => {
             timeout: 5_000,
             intervals: [50, 100, 250, 500],
         }).toBe('task-list');
+    });
+
     test('pasting a <table> with first-row colspan converts to a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/src/utils/__tests__/htmlTaskListPaste.spec.ts
+++ b/packages/muya/src/utils/__tests__/htmlTaskListPaste.spec.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../../state/htmlToMarkdown';
+import { MarkdownToState } from '../../state/markdownToState';
+
+interface IStateLike {
+    name: string;
+    text?: string;
+    meta?: { checked?: boolean };
+    children?: IStateLike[];
+}
+
+function htmlToState(html: string) {
+    const markdown = new HtmlToMarkdown({ bulletListMarker: '-' }).generate(html);
+    const states = new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(markdown) as unknown as IStateLike[];
+
+    return { markdown, states };
+}
+
+function firstTask(states: IStateLike[]) {
+    const item = states[0].children?.[0];
+    return {
+        checked: item?.meta?.checked,
+        text: item?.children?.find(child => child.name === 'paragraph')?.text,
+    };
+}
+
+describe('htmlToMarkdown - task-list HTML paste', () => {
+    it('normalizes a direct unchecked checkbox inside a list item', () => {
+        const { markdown, states } = htmlToState(
+            '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" disabled=""><span>&nbsp;</span>task</li></ul>',
+        );
+
+        expect(markdown).toContain('- [ ] task');
+        expect(markdown).not.toContain('\u00A0');
+        expect(states[0].name).toBe('task-list');
+        expect(firstTask(states)).toEqual({ checked: false, text: 'task' });
+    });
+
+    it('normalizes a direct checked checkbox inside a list item', () => {
+        const { markdown, states } = htmlToState(
+            '<ul class="contains-task-list"><li class="task-list-item"><input type="checkbox" checked="" disabled=""><span>&nbsp;</span>done</li></ul>',
+        );
+
+        expect(markdown).toContain('- [x] done');
+        expect(markdown).not.toContain('\u00A0');
+        expect(states[0].name).toBe('task-list');
+        expect(firstTask(states)).toEqual({ checked: true, text: 'done' });
+    });
+
+    it('keeps paragraph-wrapped task-list checkboxes normalized', () => {
+        const { markdown, states } = htmlToState(
+            '<ul><li><p><input type="checkbox" checked=""><span>&nbsp;</span>done</p></li></ul>',
+        );
+
+        expect(markdown).toContain('- [x] done');
+        expect(markdown).not.toContain('\u00A0');
+        expect(states[0].name).toBe('task-list');
+        expect(firstTask(states)).toEqual({ checked: true, text: 'done' });
+    });
+
+    it('does not normalize a parent list item only because a nested child item has a checkbox', () => {
+        const { markdown, states } = htmlToState(
+            '<ul><li>[x]&nbsp;parent<ul><li><input type="checkbox" disabled=""><span>&nbsp;</span>child</li></ul></li></ul>',
+        );
+
+        expect(markdown).toContain('- [x]\u00A0parent');
+        expect(markdown).toContain('  - [ ] child');
+        expect(states[0].name).toBe('bullet-list');
+    });
+});

--- a/packages/muya/src/utils/turndownService/index.ts
+++ b/packages/muya/src/utils/turndownService/index.ts
@@ -5,6 +5,24 @@ import { identity, isHTMLElement, isHTMLInputElement } from '../../utils';
 
 const DEFAULT_KEEPS: Filter = ['u', 'mark', 'ruby', 'rt', 'sub', 'sup'];
 
+function isTaskListCheckbox(node: unknown) {
+    return (
+        isHTMLInputElement(node)
+        && node.type === 'checkbox'
+        && (node.parentNode?.nodeName === 'P' || node.parentNode?.nodeName === 'LI')
+    );
+}
+
+function normalizeTaskMarkerSpacing(content: string) {
+    return content.replace(/^(\[[ x]\])[ \t\u00A0]+/i, (_, marker: string) => `${marker.toLowerCase()} `);
+}
+
+function containsOwnTaskListCheckbox(node: Node) {
+    return isHTMLElement(node)
+        && Array.from(node.querySelectorAll('input[type="checkbox"]'))
+            .some(input => isTaskListCheckbox(input) && input.closest('li') === node);
+}
+
 export function usePluginsAddRules(turndownService: TurndownService) {
     // Use the gfm plugin
     const { strikethrough, tables } = turndownPluginGfm;
@@ -50,11 +68,7 @@ export function usePluginsAddRules(turndownService: TurndownService) {
 
     turndownService.addRule('taskListItems', {
         filter(node) {
-            return (
-                isHTMLInputElement(node)
-                && node.type === 'checkbox'
-                && node.parentNode?.nodeName === 'P'
-            );
+            return isTaskListCheckbox(node);
         },
         replacement(_content, node) {
             return `${isHTMLInputElement(node) && node.checked ? '[x]' : '[ ]'} `;
@@ -86,6 +100,8 @@ export function usePluginsAddRules(turndownService: TurndownService) {
                 .replace(/^\n+/, '') // remove leading newlines
                 .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
                 .replace(/\n/g, '\n  '); // indent
+            if (containsOwnTaskListCheckbox(node))
+                content = normalizeTaskMarkerSpacing(content);
 
             let prefix = `${options.bulletListMarker} `;
             const parent = node.parentNode;


### PR DESCRIPTION
Closes #4702

## Summary

Normalize pasted HTML task lists so they become real MarkText task-list items instead of plain bullet items.

The paste pipeline already supports Markdown task-list syntax such as:

```markdown
- [ ] task
- [x] done
```

The bug was in the HTML-to-Markdown conversion before that parser step. The custom Turndown `taskListItems` rule only recognized checkbox inputs when the checkbox was inside a `<p>`. Common clipboard HTML from GitHub-style task lists places the checkbox directly under the `<li>`:

```html
<ul class="contains-task-list">
  <li class="task-list-item">
    <input type="checkbox" disabled=""><span>&nbsp;</span>task
  </li>
</ul>
```

That shape skipped the task-list rule, so the pasted item became a normal bullet with the checkbox marker missing. Paragraph-wrapped task-list HTML could keep `[x]`, but still preserved `&nbsp;` after the marker and produced non-normalized Markdown.

This PR fixes the conversion at the Turndown layer by:

- recognizing task-list checkboxes under either `<li>` or `<p>`
- normalizing task marker spacing to exactly one regular space after `[ ]` or `[x]`
- applying that spacing normalization only when the source HTML list item actually contains a checkbox

No Markdown parser change is needed; the generated Markdown now matches the task-list syntax that MarkText already parses correctly.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on Chromium clipboard paste via Playwright

The following checks passed:

```bash
pnpm --filter @muyajs/core test -- src/utils/__tests__/htmlTaskListPaste.spec.ts
pnpm --filter @muyajs/core test -- src/utils/__tests__
pnpm --filter muya-e2e e2e:chromium -- tests/editing/clipboard.spec.ts
pnpm --filter @muyajs/core exec vitest run --testTimeout 20000
pnpm --filter @muyajs/core lint:types
pnpm typecheck
pnpm --filter @muyajs/core lint
git diff --check upstream/develop
```

## Notes for reviewers [optional]

The fix is intentionally scoped to pasted HTML task-list conversion. It does not change task-list parsing, list serialization, or plain Markdown editing.

The false-positive boundary is important here: marker spacing is normalized only for list items that contain an actual checkbox in the source HTML. A normal HTML list item whose text happens to start with `[x]` should remain normal list content, not be reinterpreted as a task item by this conversion rule.

Regression coverage includes:

- unchecked checkbox directly inside `<li>`
- checked checkbox directly inside `<li>`
- paragraph-wrapped checked checkbox with `&nbsp;` after the marker
- a parent list item that contains a nested task item but does not have its own checkbox
- real Chromium clipboard paste through the browser `text/html` path

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.