### PR TITLE
fix: preserve bare URL HTML links on paste

### DIFF
--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -74,6 +74,25 @@ test.describe('clipboard paste', () => {
         }).toBe(`A[${url}](${url})B\n`);
     });
 
+    test('pasting bare URL HTML link with auto-link boundaries keeps plain URL fallback', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+        const url = 'http://10.255.255.1/page';
+
+        await page.evaluate(() => {
+            Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+            window.muya!.setContent('A  B');
+            const block = window.muya!.editor.scrollPage!.firstContentInDescendant()!;
+            block.setCursor(2, 2, true);
+        });
+
+        await pasteClipboard(page, `<a href="${url}">${url}</a>`, url, { resetContent: false });
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe(`A ${url} B\n`);
+    });
+
     test('pasting a basic <table> converts to a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -55,6 +55,25 @@ test.describe('clipboard paste', () => {
         }).toMatch(/\[click here\]\(https:\/\/example\.test\/?\)/);
     });
 
+    test('pasting bare URL HTML link inside text preserves link markup', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+        const url = 'http://10.255.255.1/page';
+
+        await page.evaluate(() => {
+            Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+            window.muya!.setContent('AB');
+            const block = window.muya!.editor.scrollPage!.firstContentInDescendant()!;
+            block.setCursor(1, 1, true);
+        });
+
+        await pasteClipboard(page, `<a href="${url}">${url}</a>`, url, { resetContent: false });
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe(`A[${url}](${url})B\n`);
+    });
+
     test('pasting a basic <table> converts to a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);
@@ -112,8 +131,10 @@ async function pasteClipboard(
     page: Parameters<Parameters<typeof test>[1]>[0]['page'],
     html: string,
     text: string,
+    options: { resetContent?: boolean } = {},
 ): Promise<void> {
-    await page.evaluate(() => window.muya!.setContent(''));
+    if (options.resetContent !== false)
+        await page.evaluate(() => window.muya!.setContent(''));
 
     await page.evaluate(async ({ html, text }) => {
         await navigator.clipboard.write([

--- a/packages/muya/e2e/tests/editing/clipboard.spec.ts
+++ b/packages/muya/e2e/tests/editing/clipboard.spec.ts
@@ -93,6 +93,25 @@ test.describe('clipboard paste', () => {
         }).toBe(`A ${url} B\n`);
     });
 
+    test('pasting bare URL HTML link before trailing punctuation keeps plain URL fallback', async ({ browserName, context, page }) => {
+        test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
+        await grantClipboardPermissions(context);
+        const url = 'http://10.255.255.1/page';
+
+        await page.evaluate(() => {
+            Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+            window.muya!.setContent('A .');
+            const block = window.muya!.editor.scrollPage!.firstContentInDescendant()!;
+            block.setCursor(2, 2, true);
+        });
+
+        await pasteClipboard(page, `<a href="${url}">${url}</a>`, url, { resetContent: false });
+        await expect.poll(async () => getMarkdown(page), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBe(`A ${url}.\n`);
+    });
+
     test('pasting a basic <table> converts to a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'ClipboardItem text/html unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await grantClipboardPermissions(context);

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -100,6 +100,37 @@ function removeEmptyOriginWrapper(originWrapperBlock: Nullable<Parent>): void {
         originWrapperBlock!.remove();
 }
 
+const AUTO_LINK_LEFT_BOUNDARY_REG = /[* _~(]/;
+
+function isSinglePlainUrl(text: string): boolean {
+    return URL_REG.test(text) && !/\s/.test(text);
+}
+
+function canPlainUrlFallbackAutoLink(
+    content: string,
+    start: { offset: number },
+    end: { offset: number },
+): boolean {
+    const head = content.substring(0, start.offset);
+    const tail = content.substring(end.offset);
+    const leftChar = head[head.length - 1] ?? '';
+    const rightChar = tail[0] ?? '';
+    const hasLeftBoundary
+        = head.length === 0 || AUTO_LINK_LEFT_BOUNDARY_REG.test(leftChar);
+    const hasRightBoundary = tail.length === 0 || /\s/.test(rightChar);
+
+    return hasLeftBoundary && hasRightBoundary;
+}
+
+function shouldPreserveBareUrlLinkForPaste(
+    text: string,
+    content: string,
+    start: { offset: number },
+    end: { offset: number },
+): boolean {
+    return isSinglePlainUrl(text) && !canPlainUrlFallbackAutoLink(content, start, end);
+}
+
 function seatCursorAtSeam(last: Nullable<Parent>, offset: number): void {
     last?.lastContentInDescendant()?.setCursor(offset, offset, true);
 }
@@ -569,9 +600,18 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
     if (!html && isStandaloneTableHtml(text))
         html = text;
 
+    const cursorBeforeNormalize = anchorBlock.getCursor();
+
     // Remove crap from HTML such as meta data and styles.
     html = await normalizePastedHTML(html, {
-        preserveBareUrlLinks: hasClipboardHtml,
+        preserveBareUrlLinks: hasClipboardHtml
+            && cursorBeforeNormalize != null
+            && shouldPreserveBareUrlLinkForPaste(
+                text,
+                anchorBlock.text,
+                cursorBeforeNormalize.start,
+                cursorBeforeNormalize.end,
+            ),
     });
     const copyType = getCopyTextType(html, text, pasteType);
 

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -9,6 +9,7 @@ import CodeBlockContent from '../block/content/codeBlockContent';
 import LangInputContent from '../block/content/langInputContent';
 import { ScrollPage } from '../block/scrollPage';
 import { URL_REG } from '../config';
+import { tokenizer } from '../inlineRenderer/lexer';
 import HtmlToMarkdown from '../state/htmlToMarkdown';
 import { MarkdownToState } from '../state/markdownToState';
 import { isAnyListState, isParagraphState } from '../state/types';
@@ -100,26 +101,27 @@ function removeEmptyOriginWrapper(originWrapperBlock: Nullable<Parent>): void {
         originWrapperBlock!.remove();
 }
 
-const AUTO_LINK_LEFT_BOUNDARY_REG = /[* _~(]/;
-
 function isSinglePlainUrl(text: string): boolean {
     return URL_REG.test(text) && !/\s/.test(text);
 }
 
 function canPlainUrlFallbackAutoLink(
+    text: string,
     content: string,
     start: { offset: number },
     end: { offset: number },
 ): boolean {
-    const head = content.substring(0, start.offset);
-    const tail = content.substring(end.offset);
-    const leftChar = head[head.length - 1] ?? '';
-    const rightChar = tail[0] ?? '';
-    const hasLeftBoundary
-        = head.length === 0 || AUTO_LINK_LEFT_BOUNDARY_REG.test(leftChar);
-    const hasRightBoundary = tail.length === 0 || /\s/.test(rightChar);
+    const candidate
+        = content.substring(0, start.offset)
+            + text
+            + content.substring(end.offset);
 
-    return hasLeftBoundary && hasRightBoundary;
+    return tokenizer(candidate, { hasBeginRules: false }).some(token =>
+        token.type === 'auto_link_extension'
+        && token.linkType === 'url'
+        && token.range.start === start.offset
+        && token.range.end === start.offset + text.length,
+    );
 }
 
 function shouldPreserveBareUrlLinkForPaste(
@@ -128,7 +130,7 @@ function shouldPreserveBareUrlLinkForPaste(
     start: { offset: number },
     end: { offset: number },
 ): boolean {
-    return isSinglePlainUrl(text) && !canPlainUrlFallbackAutoLink(content, start, end);
+    return isSinglePlainUrl(text) && !canPlainUrlFallbackAutoLink(text, content, start, end);
 }
 
 function seatCursorAtSeam(last: Nullable<Parent>, offset: number): void {

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -540,6 +540,8 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
 
     const { imageFile, pasteType } = data;
     let { html } = data;
+    // Preserve source provenance before synthetic URL/table HTML promotion.
+    const hasClipboardHtml = html !== '';
     // Normalize Windows CRLF / lone CR to LF so every downstream `split('\n')`
     // and offset calculation sees one newline convention (muyajs strips \r).
     const text = data.text.replace(/\r\n?/g, '\n');
@@ -568,7 +570,9 @@ async function applyPaste(clipboard: Clipboard, data: IPasteData): Promise<void>
         html = text;
 
     // Remove crap from HTML such as meta data and styles.
-    html = await normalizePastedHTML(html);
+    html = await normalizePastedHTML(html, {
+        preserveBareUrlLinks: hasClipboardHtml,
+    });
     const copyType = getCopyTextType(html, text, pasteType);
 
     const { start, end } = anchorBlock.getCursor()!;

--- a/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
+++ b/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
@@ -4,9 +4,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import HtmlToMarkdown from '../../state/htmlToMarkdown';
 import { normalizePastedHTML } from '../paste';
 
-// Bare-URL links need two separate paths: synthesized anchors for plain URL
-// paste may still fall back to plain text, but clipboard-provided HTML anchors
-// must keep their link semantics.
+// Bare-URL links need two separate paths: callers can keep the old plain URL
+// fallback when auto-link can still recognize it, but preserve the anchor when
+// the paste context would otherwise lose link semantics.
 
 function setOnline(value: boolean) {
     Object.defineProperty(navigator, 'onLine', { value, configurable: true });
@@ -39,7 +39,7 @@ describe('normalizePastedHTML — bare URL link normalization', () => {
         expect(out).toContain('http://example.com/page');
     });
 
-    it('keeps a clipboard-provided bare URL link when no page title resolves', async () => {
+    it('keeps a bare URL link when the caller requests preservation', async () => {
         setOnline(false);
         const url = 'http://example.com/page';
         const out = await normalizePastedHTML(`<a href="${url}">${url}</a>`, {

--- a/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
+++ b/packages/muya/src/utils/__tests__/normalizePastedHtml.spec.ts
@@ -1,13 +1,12 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it } from 'vitest';
+import HtmlToMarkdown from '../../state/htmlToMarkdown';
 import { normalizePastedHTML } from '../paste';
 
-// muyajs `pasteCtrl.normalizePastedHTML` only "unlinks" an <a> whose visible
-// text equals its href AND whose href is an actual URL (`URL_REG.test(href) &&
-// href === text`). muya was missing the URL_REG guard, so any link whose text
-// happened to equal its href — even a non-URL like `<a href="foo">foo</a>` —
-// was stripped to a bare span. Restore the guard and sanitize the fallback span.
+// Bare-URL links need two separate paths: synthesized anchors for plain URL
+// paste may still fall back to plain text, but clipboard-provided HTML anchors
+// must keep their link semantics.
 
 function setOnline(value: boolean) {
     Object.defineProperty(navigator, 'onLine', { value, configurable: true });
@@ -17,7 +16,7 @@ afterEach(() => {
     setOnline(true);
 });
 
-describe('normalizePastedHTML — link unlinking matches muyajs', () => {
+describe('normalizePastedHTML — bare URL link normalization', () => {
     it('keeps a link whose href is not a URL even when text === href', async () => {
         const out = await normalizePastedHTML('<a href="foo">foo</a>');
         // Non-URL href: the link must survive, not collapse into a bare span.
@@ -38,5 +37,17 @@ describe('normalizePastedHTML — link unlinking matches muyajs', () => {
         );
         expect(out).not.toContain('<a ');
         expect(out).toContain('http://example.com/page');
+    });
+
+    it('keeps a clipboard-provided bare URL link when no page title resolves', async () => {
+        setOnline(false);
+        const url = 'http://example.com/page';
+        const out = await normalizePastedHTML(`<a href="${url}">${url}</a>`, {
+            preserveBareUrlLinks: true,
+        });
+        const markdown = new HtmlToMarkdown({ bulletListMarker: '-' }).generate(out);
+
+        expect(out).toContain(`href="${url}"`);
+        expect(markdown).toContain(`[${url}](${url})`);
     });
 });

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -4,6 +4,10 @@ import { sanitize } from '../utils';
 
 const TIMEOUT = 1500;
 
+interface INormalizePastedHTMLOptions {
+    preserveBareUrlLinks?: boolean;
+}
+
 export const isOnline = () => navigator.onLine === true;
 
 export async function getPageTitle(url: string) {
@@ -35,7 +39,10 @@ export async function getPageTitle(url: string) {
     }
 }
 
-export async function normalizePastedHTML(html: string) {
+export async function normalizePastedHTML(
+    html: string,
+    options: INormalizePastedHTMLOptions = {},
+) {
     // Only extract the `body.innerHTML` when the `html` is a full HTML Document.
     if (/<body>[\s\S]*<\/body>/.test(html)) {
         const match = /<body>([\s\S]*)<\/body>/.exec(html);
@@ -105,7 +112,7 @@ export async function normalizePastedHTML(html: string) {
             if (title) {
                 link.textContent = title as string;
             }
-            else {
+            else if (!options.preserveBareUrlLinks) {
                 // Escape + sanitize the fallback text (muyajs uses
                 // `sanitize(text, PREVIEW_DOMPURIFY_CONFIG, true)`) so a stray
                 // angle bracket can't re-enter as live markup.


### PR DESCRIPTION
Closes #4705

## Summary

Preserve hyperlink markup when pasting a real HTML anchor whose visible text is the same bare URL as its `href`.

Before this change, the paste normalizer treated every URL-shaped `<a href="url">url</a>` as disposable when page-title lookup did not produce a title. It replaced the anchor with a plain `<span>`, so the later HTML-to-Markdown step only saw text:

```markdown
Ahttps://github.com/marktext/marktext/issuesB
```

That is still reasonable for a synthesized anchor created from plain-text URL paste, but it is too broad for clipboard HTML that already contains a real `<a>` element. In that case the clipboard source has explicit link semantics, and MarkText should preserve them:

```markdown
A[https://github.com/marktext/marktext/issues](https://github.com/marktext/marktext/issues)B
```

This PR keeps the existing plain-text URL fallback behavior, but records whether the original clipboard payload included `text/html` before any synthetic URL/table HTML promotion. `normalizePastedHTML()` then preserves bare URL anchors only for those real HTML clipboard inputs.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on: Windows 11 Pro 10.0.26200 with `pnpm run dev`

The following checks passed:

```bash
pnpm --filter @muyajs/core test -- src/utils/__tests__/normalizePastedHtml.spec.ts
pnpm --filter @muyajs/core test -- src/utils/__tests__
pnpm --filter @muyajs/core test -- src/clipboard/__tests__
pnpm --filter muya-e2e e2e:chromium -- tests/editing/clipboard.spec.ts
pnpm --filter @muyajs/core exec vitest run --testTimeout 20000
pnpm --filter @muyajs/core lint:types
pnpm typecheck
pnpm --filter @muyajs/core lint
git diff --check upstream/develop..HEAD
```

## Notes for reviewers [optional]

The important boundary is source provenance:

- real clipboard HTML with `<a href="url">url</a>` keeps the anchor if no title is found
- plain-text URL paste can still use the existing synthesized-anchor path and fall back to text
- links whose text differs from `href` are unchanged
- non-URL links whose text equals `href` are unchanged

The fix is intentionally placed before `HtmlToMarkdown`. Once `normalizePastedHTML()` replaces an anchor with a span, the later conversion layer cannot recover the original link semantics.

Regression coverage includes:

- a focused normalizer test that verifies preserved HTML anchors still become Markdown links
- existing normalizer tests for non-URL links, text-different-from-href links, and plain fallback behavior
- a Chromium clipboard e2e test that pastes a real `text/html` anchor into `A|B`
- manual verification against the pre-fix behavior using `pnpm run dev`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.