### PR TITLE
fix(muya): open paragraph front menu for multi-block selections

### DIFF
--- a/packages/muyajs/lib/contentState/clickCtrl.js
+++ b/packages/muyajs/lib/contentState/clickCtrl.js
@@ -61,8 +61,10 @@ const clickCtrl = (ContentState) => {
         const endOutBlock = this.findOutMostBlock(endBlock)
         hasSameParent = startOutBlock === endOutBlock
       }
-      // show the muya-front-menu only when the cursor in the same paragraph
-      if (target.closest('.ag-front-icon-button') && hasSameParent) {
+      // Open the front menu for the block the icon belongs to. It must also be
+      // available for multi-block selections (e.g. "turn into list" wraps every
+      // selected paragraph), so it is no longer gated by `hasSameParent`.
+      if (target.closest('.ag-front-icon-button')) {
         const currentBlock = this.findOutMostBlock(startBlock)
         const frontIcon = target.closest('.ag-front-icon-button')
         const rect = frontIcon.getBoundingClientRect()


### PR DESCRIPTION
## Problem

When you select multiple blocks (e.g. several paragraphs) and click the **¶ front-menu button** on the left of a block, nothing happens — the menu never opens.

The handler in `packages/muyajs/lib/contentState/clickCtrl.js` only opens the menu when `hasSameParent` is true, i.e. the selection start and end share the same outermost block:

```js
// show the muya-front-menu only when the cursor in the same paragraph
if (target.closest('.ag-front-icon-button') && hasSameParent) {
```

A normal multi-paragraph selection has different outermost blocks, so `hasSameParent === false` and the click is silently ignored.

This is more than a minor annoyance: `handleListMenu` **already** supports multi-block selections — its `getCommonParent()` branch wraps every selected sibling block into a single `ol`/`ul`/task list, and `isAllowedTransformation` explicitly permits list/blockquote transforms on multiline selections. The front menu was the only thing preventing users from reaching that code path, so "select N paragraphs → Turn Into → Ordered List" was impossible via the front handle.

## Fix

Remove the `hasSameParent` guard on the front-icon branch so the menu opens regardless of how many blocks are selected. The menu's actions already have the appropriate behavior:

- **Turn Into → Ordered / Bullet / Task List**, **Blockquote**: apply to all selected blocks (existing multi-block logic).
- **Turn Into → Heading / Table**: still rejected by `isAllowedTransformation` for multiline selections (unchanged).
- **Delete / Duplicate**: keep their existing single-block guards and no-op on multi-block selections (unchanged).

`hasSameParent` is still used by the adjacent `.ag-copy-header-link` branch, so it is left in place.

## Testing

Manually verified on a local 0.19.0 build (macOS): select several paragraphs, click the ¶ button, choose **Turn Into → Ordered List** → all selected lines become a single numbered list. Single-block behavior is unchanged.