### PR TITLE
fix(renderer): use the theme text colour for the key bindings list (#3937)

### DIFF
--- a/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
@@ -309,6 +309,15 @@ const dumpKeyboardInformation = (): void => {
 .pref-keybindings .el-table tr {
   background: var(--editorBgColor) !important;
 }
+/* Element Plus colours table text with its own --el-text-color-regular grey,
+   which the app never themes — so the list rendered as low-contrast grey on
+   every theme (≈2.3:1 on dark themes, well below WCAG AA). Use the theme's own
+   editor text colour so the bindings stay readable everywhere (#3937). */
+.pref-keybindings .el-table,
+.pref-keybindings .el-table th.el-table__cell,
+.pref-keybindings .el-table td.el-table__cell {
+  color: var(--editorColor);
+}
 .pref-keybindings .el-table th.el-table__cell.is-leaf,
 .pref-keybindings .el-table th,
 .pref-keybindings .el-table td {


### PR DESCRIPTION
Fixes #3937.

### Problem
The key bindings list in Preferences is an Element Plus `el-table`. Element Plus colours table cells with its own `--el-text-color-regular` (a fixed grey, `#606266`), and the app never themes that variable. So the list rendered in the same grey on **every** theme, ignoring the active theme's text colour.

On dark themes this drops the text contrast far below the WCAG AA minimum (4.5:1 for normal text), which is what the reporter described as "practically invisible":

| theme | now (EP grey) | with fix (`--editorColor`) |
|---|---|---|
| default (light) | 6.11 | 8.45 |
| dracula | **2.33 ✗** | 13.36 ✓ |
| one-dark | **2.29 ✗** | 5.65 ✓ |
| tokyo-night | **2.80 ✗** | 10.59 ✓ |

### Fix
Point the table cells (header + body) at the theme's own `--editorColor`, so the bindings inherit the editor text colour and stay readable on every theme. The action buttons keep their explicit `--themeColor`. CSS-only, scoped to `.pref-keybindings`.

### Verification
- WCAG contrast ratios above (light unchanged/improved; all dark themes now pass AA).
- `pnpm run lint` (0 errors) and `pnpm run typecheck` pass.
