### PR TITLE
fix(muya): stop the paragraph front-menu from acting on a stale block (#4686)

### DIFF
--- a/packages/muya/src/__tests__/resetToParagraph.spec.ts
+++ b/packages/muya/src/__tests__/resetToParagraph.spec.ts
@@ -188,3 +188,13 @@ describe('paragraph front menu — a single menu open performs at most one actio
         ).not.toThrow();
     });
 });
+
+describe('muya.resetToParagraph(block) — detached block (#4686)', () => {
+    it('is a no-op on a list already removed from the document', () => {
+        const muya = bootMuya('- one\n- two\n');
+        const list = firstOutmostBlock(muya);
+        list.remove(); // detach: parent -> null, children left intact
+
+        expect(() => muya.resetToParagraph(list)).not.toThrow();
+    });
+});

--- a/packages/muya/src/__tests__/resetToParagraph.spec.ts
+++ b/packages/muya/src/__tests__/resetToParagraph.spec.ts
@@ -97,3 +97,94 @@ describe('paragraph front menu — clicking the active list type unwraps the lis
         });
     });
 });
+
+// Regression for #4686: the front menu kept a reference to the block it was
+// opened on (`_block`) and hid itself on a deferred `setTimeout`, so a rapid
+// second click (a real double-click) ran a second action on the same target.
+// When the first action removed/replaced the block, the second dereferenced a
+// null `parent` deep in `_unwrapToParagraphs` and crashed the renderer with
+// "Cannot read properties of null (reading 'insertAfter')". The fix makes a
+// single menu open perform at most one action.
+describe('paragraph front menu — a single menu open performs at most one action (#4686)', () => {
+    it('a rapid second click runs no further action (double-click is single-shot)', async () => {
+        const muya = bootMuya('hello\n');
+        const para = firstOutmostBlock(muya);
+        expect(para.blockName).toBe('paragraph');
+
+        const menu = new ParagraphFrontMenu(muya, {});
+        (menu as unknown as { _block: Parent })._block = para;
+
+        // Double "duplicate": the first inserts one copy; the second click
+        // (before the menu's deferred hide) must be ignored, not insert a
+        // second copy.
+        menu.selectItem(new Event('click'), { label: 'duplicate' });
+        menu.selectItem(new Event('click'), { label: 'duplicate' });
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(2); // original + exactly one duplicate
+        });
+    });
+
+    it('ignores a second turn-into after the first action detached the block', async () => {
+        const muya = bootMuya('- one\n- two\n- three\n');
+        const list = firstOutmostBlock(muya);
+        expect(list.blockName).toBe('bullet-list');
+
+        const menu = new ParagraphFrontMenu(muya, {});
+        (menu as unknown as { _block: Parent })._block = list;
+
+        // Convert bullet -> order: `replaceWith` detaches the original bullet
+        // list, but the menu still holds it in `_block`.
+        menu.selectItem(new Event('click'), { label: 'order-list' });
+
+        // Selecting again on the now-detached block must not throw.
+        expect(() =>
+            menu.selectItem(new Event('click'), { label: 'bullet-list' }),
+        ).not.toThrow();
+
+        await vi.waitFor(() => {
+            const state = muya.getState();
+            expect(state.length).toBe(1);
+            expect(state[0].name).toBe('order-list');
+        });
+    });
+
+    it('toggling the active list type twice does not crash', () => {
+        const muya = bootMuya('- one\n- two\n');
+        const list = firstOutmostBlock(muya);
+
+        const menu = new ParagraphFrontMenu(muya, {});
+        (menu as unknown as { _block: Parent })._block = list;
+
+        // First toggle unwraps the list back to paragraphs (removes the list).
+        menu.selectItem(new Event('click'), { label: 'bullet-list' });
+
+        // The stale `_block` now points at the removed list; toggling again
+        // must be a no-op, not a crash.
+        expect(() =>
+            menu.selectItem(new Event('click'), { label: 'bullet-list' }),
+        ).not.toThrow();
+    });
+
+    // The deterministic real-world repro: an external command (the app menu bar)
+    // unwraps the list while the front menu stays open, detaching `_block`. The
+    // next front-menu click then targets the detached block. This must hold for
+    // EVERY item — Duplicate/New reparent via `block.parent!.insertAfter`, which
+    // the engine-level `_unwrapToParagraphs` guard does not cover.
+    it('ignores a Duplicate click after an external command unwrapped the open block', () => {
+        const muya = bootMuya('- one\n- two\n');
+        const list = firstOutmostBlock(muya);
+
+        const menu = new ParagraphFrontMenu(muya, {});
+        (menu as unknown as { _block: Parent })._block = list;
+
+        // Simulate the menu bar's "reset to paragraph": unwraps + removes the
+        // list, but leaves the front menu open with its now-detached `_block`.
+        muya.resetToParagraph(list);
+
+        expect(() =>
+            menu.selectItem(new Event('click'), { label: 'duplicate' }),
+        ).not.toThrow();
+    });
+});

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -1455,6 +1455,11 @@ export class Muya {
      * blocks it contains, preserving every item.
      */
     private _unwrapToParagraphs(block: Parent) {
+        // A detached block has no parent to reparent its children into (#4686).
+        const parent = block.parent;
+        if (!parent)
+            return;
+
         const state = block.getState();
         let inner: TState[] = [];
         if (isAnyListState(state))
@@ -1466,7 +1471,6 @@ export class Muya {
             return;
 
         const cursorText = (this.editor.activeContentBlock ?? this.editor.selection.anchorBlock)?.text;
-        const parent = block.parent!;
         let ref: Parent = block;
         let firstNew: Parent | null = null;
         for (const childState of inner) {

--- a/packages/muya/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/muya/src/ui/paragraphFrontMenu/index.ts
@@ -187,10 +187,17 @@ export class ParagraphFrontMenu extends BaseFloat {
         event.preventDefault();
         event.stopPropagation();
 
-        if (!this._block)
+        // A single menu open performs at most one action: consume the target
+        // synchronously, then bail unless it is still in the document. This
+        // covers both a rapid second click (a real double-click before the
+        // deferred hide()) and an external command — e.g. the app menu bar —
+        // that unwrapped the block while this menu stayed open. Every action
+        // below assumes `block.parent` (#4686).
+        const block = this._block;
+        this._block = null;
+        if (!block?.parent)
             return;
 
-        const { _block: block } = this;
         const oldState = block.getState();
 
         const cursorBlock = /duplicate|new|delete/.test(label)


### PR DESCRIPTION
### Summary

Fixes #4686 — the paragraph front-menu could crash the renderer:

```
TypeError: Cannot read properties of null (reading 'insertAfter')
    at Muya._unwrapToParagraphs
    at Muya.resetToParagraph
    at ParagraphFrontMenu._turnIntoList
    at ParagraphFrontMenu._turnIntoBlock
    at ParagraphFrontMenu.selectItem
```

### Root cause

`ParagraphFrontMenu` stores the block it was opened on in `_block`, hides itself on a deferred `setTimeout`, and never checks the block is still in the document before acting. When the block is removed/replaced, `getState()` still reports a list (`remove()` nulls `parent` but keeps `children`/`meta`), so `selectItem` proceeds and dereferences a null `parent` in `_unwrapToParagraphs`.

Two real interactions trigger it:

1. **Deterministic (no timing):** open the front menu on a list, then use the **application menu bar** (Paragraph → reset to paragraph, or toggle the list) to unwrap it. The native menu never closes the float, so `_block` is now detached; the next front-menu click crashes.
2. **Double-click:** a fast second click runs a second action before the deferred `hide()` (window is sub-frame, so it needs a fast/synthetic double-click).

Besides the turn-into crash above, Duplicate/New would also reparent via `block.parent!.insertAfter` on the detached block.

### Fix

- **`selectItem` consumes `_block` synchronously and bails unless it is still attached.** A single menu open now performs at most one action, on a live block — covering turn-into, duplicate, new, and delete, for both triggers.
- **Defense in depth:** `_unwrapToParagraphs` replaces its `block.parent!` assertion with a null guard, so the public `resetToParagraph` is a safe no-op on a detached block.

### Tests

`packages/muya/src/__tests__/resetToParagraph.spec.ts` (each reproduced the bug before the fix):

- ignores a click after an external command unwrapped the open menu's block (Duplicate);
- a rapid second click runs no further action (double "Duplicate" yields one copy);
- a second turn-into after the first detached the block is ignored;
- toggling the active list type twice does not crash;
- `muya.resetToParagraph(block)` on a removed block is a no-op.

Both triggers were also reproduced in real Chromium (Playwright) against the pre-fix engine and verified clean after the fix.

### Verification

- `pnpm -C packages/muya test` — 178 files / 1290 tests pass
- `pnpm -C packages/muya lint:types` — clean · `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
