### PR TITLE
fix(muya): skip empty sibling containers in caret navigation (#4644 follow-up)

### DIFF
--- a/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
+++ b/packages/muya/src/block/base/__tests__/arrowNavigation.spec.ts
@@ -309,6 +309,65 @@ describe('content arrowHandler — trailing-paragraph creation at document end',
     });
 });
 
+// #4644: an empty list item with no content descendant (e.g. left behind after
+// its only paragraph is removed during editing) sitting between two items used
+// to make previous/nextContentInContext return null, so ArrowUp/ArrowDown could
+// not cross it and the caret got stuck. Navigation must skip the empty container
+// and reach the content beyond it. `*  ` (a bullet marker with no text) parses to
+// exactly such a childless list item.
+function allContentTexts(muya: Muya): string[] {
+    const texts: string[] = [];
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content'))
+            texts.push(block.text ?? '');
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    return texts;
+}
+
+describe('content arrowHandler — skips empty sibling containers (#4644)', () => {
+    it('arrowUp at offset 0 skips an empty list item and lands at the END of the item above', async () => {
+        const muya = bootMuya('* A\n*  \n* B\n');
+        // Precondition: the middle item holds NO content block, so a passing
+        // caret assertion below can only mean the empty item was skipped.
+        expect(allContentTexts(muya)).toEqual(['A', 'B']);
+
+        const b = contentByText(muya, 'B');
+        const event = arrowAt(muya, b, 'ArrowUp', 0);
+        await flush();
+
+        const a = contentByText(muya, 'A');
+        const cursor = a.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe('A'.length);
+        expect(cursor!.end.offset).toBe('A'.length);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('arrowDown at end of an item skips an empty list item and lands at offset 0 of the item below', async () => {
+        const muya = bootMuya('* A\n*  \n* B\n');
+        expect(allContentTexts(muya)).toEqual(['A', 'B']);
+
+        const a = contentByText(muya, 'A');
+        const event = arrowAt(muya, a, 'ArrowDown', 'A'.length);
+        await flush();
+
+        const b = contentByText(muya, 'B');
+        const cursor = b.getCursor();
+        expect(cursor).not.toBeNull();
+        expect(cursor!.start.offset).toBe(0);
+        expect(cursor!.end.offset).toBe(0);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+});
+
 // marktext #3568: in RTL mode the physical Left/Right arrows are visually
 // mirrored, so the cross-block boundary keys must swap. Offset 0 is the visual
 // RIGHT end of an RTL line (ArrowRight should go to the previous block); offset

--- a/packages/muya/src/block/base/treeNode.ts
+++ b/packages/muya/src/block/base/treeNode.ts
@@ -119,14 +119,25 @@ class TreeNode implements ILinkedNode {
             return null;
 
         const { parent } = this;
-        if (parent.prev) {
-            return parent.prev.isParent()
-                ? parent.prev.lastContentInDescendant()
-                : parent.prev; // language input
+
+        // Walk previous siblings, skipping empty containers (e.g. a list item
+        // whose only paragraph was removed) that hold no content descendant.
+        // Otherwise such a sibling yields null and the caret gets stuck when
+        // navigating up/left across it (#4644).
+        let sibling = parent.prev;
+        while (sibling) {
+            if (sibling.isParent()) {
+                const content = sibling.lastContentInDescendant();
+                if (content)
+                    return content;
+            }
+            else {
+                return sibling; // language input
+            }
+            sibling = sibling.prev;
         }
-        else {
-            return parent.previousContentInContext();
-        }
+
+        return parent.previousContentInContext();
     }
 
     // Get next content block in block tree.
@@ -139,10 +150,22 @@ class TreeNode implements ILinkedNode {
         if (this.blockName === 'language-input')
             return parent.lastContentInDescendant();
 
-        if (parent.next)
-            return parent.next.firstContentInDescendant();
-        else
-            return parent.nextContentInContext();
+        // Walk next siblings, skipping empty containers with no content
+        // descendant so the caret can cross them instead of getting stuck (#4644).
+        let sibling = parent.next;
+        while (sibling) {
+            if (sibling.isParent()) {
+                const content = sibling.firstContentInDescendant();
+                if (content)
+                    return content;
+            }
+            else {
+                return sibling; // language input
+            }
+            sibling = sibling.next;
+        }
+
+        return parent.nextContentInContext();
     }
 
     /**


### PR DESCRIPTION
Follow-up to #4660, which closed #4644.

#4660 fixed the **editing** path that produced a childless list item (Enter on the empty first paragraph of a loose list item). But a childless list item can also come straight from **Markdown**, which #4660 doesn't touch — so the original symptom still reproduces:

```js
muya.setContent('* A\n*  \n* B')   // the middle item parses to a list-item with 0 children
```

With the caret in "B", ArrowUp no longer moves up to "A" (and ArrowDown from "A" can't reach "B"). The cause is exactly the one #4660's commit message names: `previousContentInContext` / `nextContentInContext` return `null` when the adjacent sibling is an empty container with no content descendant.

### Fix
Make the two navigation helpers walk the previous/next siblings and **skip empty containers**, falling through to the parent only when no sibling holds content. Symmetric for both directions, so navigation is robust regardless of how the empty container arises.

### Tests
Adds ArrowUp/ArrowDown regression tests in `arrowNavigation.spec.ts` (a list with an empty middle item via `setContent('* A\n*  \n* B')`); both fail without this change. Full muya suite (unit + conformance), typecheck, lint, circular-dep, and build all pass locally.

Context: I left a heads-up on the issue first — https://github.com/marktext/marktext/issues/4644#issuecomment-4798628739
