### PR TITLE
fix(muya): re-sync the live tree from json state when an undo/redo apply throws

### DIFF
--- a/packages/muya/e2e/tests/stability/unwrap-undo-empty-4716.spec.ts
+++ b/packages/muya/e2e/tests/stability/unwrap-undo-empty-4716.spec.ts
@@ -1,0 +1,79 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+// #4716: undoing a list unwrap (or any op) must never leave ScrollPage empty.
+// `updateContents` dispatches to the json state first, then rebuilds the live
+// tree incrementally via pick/drop. If a block throws while being rebuilt
+// (KaTeX/diagram/etc.), the tree was left half-applied — `pick` removed blocks
+// `drop` never re-inserted — so the document looked correct (json state is
+// right) but the live ScrollPage was empty, and the next blank-area click
+// crashed the renderer in `ScrollPage._clickHandler`.
+
+function liveTree(page: Page) {
+    return page.evaluate(() => {
+        const sp = (window.muya as any).editor.scrollPage;
+        return {
+            len: sp.children.length,
+            tail: sp.children.tail?.blockName ?? null,
+            dom: sp.domNode.childElementCount,
+            md: window.muya!.getMarkdown(),
+        };
+    });
+}
+
+test('undo that fails to rebuild a block re-syncs from state and never empties the editor', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', err => pageErrors.push(err.message));
+
+    await page.evaluate(() => window.muya!.setContent([
+        { name: 'bullet-list', meta: { loose: true, marker: '-' }, children: [
+            { name: 'list-item', children: [{ name: 'paragraph', text: 'foo' }] },
+            { name: 'list-item', children: [{ name: 'paragraph', text: 'bar' }] },
+        ] },
+    ] as never));
+
+    // Unwrap the list (what the front menu's highlighted list item does).
+    await page.evaluate(() => {
+        const sp = (window.muya as any).editor.scrollPage;
+        sp.firstChild.firstContentInDescendant().setCursor(0, 0, true);
+        window.muya!.resetToParagraph(sp.firstChild);
+        (window.muya as any).editor.jsonState.flush();
+    });
+    expect((await liveTree(page)).md).not.toContain('- ');
+
+    // Make the bullet-list throw ONCE while the undo's drop phase rebuilds it,
+    // then undo. The incremental apply fails after pick emptied the tree.
+    await page.evaluate(() => {
+        const SP = (window.muya as any).editor.scrollPage.constructor;
+        const real = SP.loadBlock.bind(SP);
+        let thrown = false;
+        SP.loadBlock = (name: string) => {
+            if (name === 'bullet-list' && !thrown) {
+                thrown = true;
+                throw new Error('simulated block build failure');
+            }
+            return real(name);
+        };
+        try {
+            window.muya!.undo();
+            (window.muya as any).editor.jsonState.flush();
+        }
+        finally {
+            SP.loadBlock = real;
+        }
+    });
+
+    const afterUndo = await liveTree(page);
+    expect(afterUndo.md).toContain('- foo');
+    expect(afterUndo.tail, 'ScrollPage must not be left empty').not.toBeNull();
+    expect(afterUndo.len).toBe(afterUndo.dom);
+
+    // The reported crash trigger: click the editor's blank area.
+    const edBox = await page.locator(editor.root).boundingBox();
+    if (edBox)
+        await page.mouse.click(edBox.x + edBox.width / 2, edBox.y + edBox.height - 4);
+    await page.waitForTimeout(50);
+
+    expect(pageErrors, `renderer errors: ${pageErrors.join(' | ')}`).toEqual([]);
+});

--- a/packages/muya/src/editor/__tests__/updateContentsResync.spec.ts
+++ b/packages/muya/src/editor/__tests__/updateContentsResync.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ScrollPage } from '../../block/scrollPage';
+import { Muya } from '../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function spState(muya: Muya) {
+    const sp = muya.editor.scrollPage as unknown as {
+        children: { length: number; tail: unknown };
+        domNode: HTMLElement;
+    };
+    return { len: sp.children.length, tail: sp.children.tail, dom: sp.domNode.childElementCount };
+}
+
+describe('updateContents keeps the live tree in sync with jsonState when block construction throws', () => {
+    it('does not leave the ScrollPage empty if a block fails to build during an undo apply', () => {
+        const muya = bootMuya('- foo\n\n- bar\n');
+        const list = (muya.editor.scrollPage as unknown as { firstChild: { firstContentInDescendant: () => { setCursor: (a: number, b: number, c: boolean) => void } } }).firstChild;
+        list.firstContentInDescendant().setCursor(0, 0, true);
+
+        // Unwrap the list -> two paragraphs, recorded as one undo entry.
+        muya.resetToParagraph(list as never);
+        muya.editor.jsonState.flush();
+        expect(muya.getMarkdown()).not.toContain('- ');
+
+        // Simulate a block whose construction throws while the undo's `drop`
+        // phase rebuilds the live tree (KaTeX/diagram/etc. can throw on
+        // create). The undo re-inserts the bullet-list, so make THAT throw.
+        const realLoadBlock = ScrollPage.loadBlock.bind(ScrollPage);
+        let thrown = false;
+        const spy = (name: string) => {
+            if (name === 'bullet-list' && !thrown) {
+                thrown = true;
+                throw new Error('simulated block build failure');
+            }
+            return realLoadBlock(name);
+        }
+        ;(ScrollPage as unknown as { loadBlock: (n: string) => unknown }).loadBlock = spy as never;
+
+        try {
+            muya.undo();
+        }
+        catch {
+            // The apply may throw; the engine must still leave a consistent tree.
+        }
+        finally {
+            ;(ScrollPage as unknown as { loadBlock: unknown }).loadBlock = realLoadBlock;
+        }
+
+        // jsonState was updated first, so the markdown is the restored list.
+        expect(muya.getMarkdown()).toContain('- foo');
+        // The live tree MUST match it — never left empty/half-applied.
+        const s = spState(muya);
+        expect(s.tail, 'ScrollPage must not be left empty after a failed undo apply').not.toBeNull();
+        expect(s.len).toBe(s.dom);
+        expect(s.len).toBeGreaterThan(0);
+    });
+});

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -407,11 +407,21 @@ export class Editor {
         if (operations === null)
             return;
 
-        const snapshot = pick(this.scrollPage as BlockNode, operations);
+        try {
+            const snapshot = pick(this.scrollPage as BlockNode, operations);
 
-        drop(snapshot, operations, muya);
+            drop(snapshot, operations, muya);
 
-        this._restoreSelection(selection);
+            this._restoreSelection(selection);
+        }
+        catch (error) {
+            // The incremental walk left the live tree half-applied (pick removed
+            // blocks drop never re-inserted). The json state is authoritative and
+            // already up to date — rebuild from it instead of leaving an empty doc.
+            debug.error(`updateContents incremental apply failed; rebuilding from state: ${String(error)}`);
+            this.scrollPage!.updateState(this.jsonState.getState());
+            this._restoreSelection(selection, true);
+        }
     }
 
     private _restoreSelection(selection: Nullable<IHistorySelection>, treeRebuilt = false) {


### PR DESCRIPTION
## Summary

Fixes #4716.

### Root cause

`Editor.updateContents` (the undo/redo + live apply path) dispatches an op to the **authoritative json state first**, then rebuilds the live block tree incrementally via the `pick`/`drop` walker. That walker is **not atomic**:

1. `pick` removes the blocks the op deletes.
2. `drop` re-creates the blocks the op inserts.

If any block throws while being rebuilt in step 2 (e.g. a KaTeX / diagram / code block whose `create` or render fails), `drop` aborts **after** `pick` already emptied the tree — leaving the live `ScrollPage` half-applied, often with **no children at all**.

Because the json state was updated first, `getMarkdown()` still returns the correct document, which masks the desync. But the live tree is empty, so the next click on the editor's blank area dereferences `this.lastChild` (null) in `ScrollPage._clickHandler` and crashes the renderer:

```
TypeError: Cannot read properties of null (reading 'lastContentInDescendant')
    at ScrollPage._clickHandler
```

The list-unwrap + undo sequence in the report is one way to trigger an undo whose `drop` re-creates a structural block; if that rebuild throws, the document is left empty.

### Fix

An empty `ScrollPage` is never a valid state. Wrap the incremental apply in `try/catch`; on failure, rebuild the live tree wholesale from the authoritative json state (the same safe path `rebuildContents` / `setContent` use), so the document can never be left half-applied or empty. This complements #4685, which released the undo/redo guard on exception but did not prevent the half-applied tree.

## Tests

- **Unit** — `packages/muya/src/editor/__tests__/updateContentsResync.spec.ts`: forces a one-time block build failure during an undo apply and asserts the live tree is rebuilt from json state (non-empty, DOM in sync) rather than left empty. Fails before the fix (ScrollPage empty), passes after.
- **E2E** — `packages/muya/e2e/tests/stability/unwrap-undo-empty-4716.spec.ts`: drives the unwrap → failing-undo → blank-area click sequence in real Chromium and asserts no renderer error and a non-empty editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
