### PR TITLE
fix(desktop): paint the launch window in the active theme's background (#3957)

### DIFF
--- a/packages/desktop/src/common/theme.ts
+++ b/packages/desktop/src/common/theme.ts
@@ -31,3 +31,59 @@ export const isDarkThemeId = (theme: unknown): theme is string => {
     typeof theme === 'string' && (railscastsThemes.includes(theme) || oneDarkThemes.includes(theme))
   )
 }
+
+// Each built-in theme's editor background colour, kept in sync with the
+// `--editorBgColor` of the matching renderer theme (renderer/src/assets/themes/
+// *.theme.css; the default light theme lives in styles/index.css and is handled
+// by the white fallback below). The main process paints a freshly-created window
+// with this colour before the renderer loads, so a dark theme no longer flashes
+// white on launch (#3957).
+const themeBackgroundColors: ReadonlyMap<string, string> = new Map([
+  ['ayu-dark', '#0a0e14'],
+  ['ayu-light', '#fafafa'],
+  ['ayu-mirage', '#1f2430'],
+  ['catppuccin-latte', '#eff1f5'],
+  ['catppuccin-mocha', '#1e1e2e'],
+  ['cyberdream', '#16181a'],
+  ['dark', '#282828'],
+  ['dracula', '#282a36'],
+  ['everforest-dark', '#2d353b'],
+  ['everforest-light', '#fdf6e3'],
+  ['graphite', '#f7f7f7'],
+  ['gruvbox-dark', '#282828'],
+  ['gruvbox-light', '#fbf1c7'],
+  ['horizon-dark', '#1c1e26'],
+  ['kanagawa', '#1f1f28'],
+  ['material-dark', '#34393f'],
+  ['monokai-pro', '#2d2a2e'],
+  ['nightfox', '#192330'],
+  ['nord', '#2e3440'],
+  ['one-dark', '#282c34'],
+  ['oxocarbon-dark', '#161616'],
+  ['palenight', '#292d3e'],
+  ['rose-pine', '#191724'],
+  ['rose-pine-dawn', '#faf4ed'],
+  ['rose-pine-moon', '#232136'],
+  ['solarized-dark', '#002b36'],
+  ['solarized-light', '#fdf6e3'],
+  ['synthwave-84', '#262335'],
+  ['tokyo-night', '#1a1b26'],
+  ['tokyo-night-light', '#d5d6db'],
+  ['tokyo-night-storm', '#24283b'],
+  ['ulysses', '#f3f3f3']
+])
+
+const DARK_FALLBACK_BACKGROUND = '#282828'
+const LIGHT_FALLBACK_BACKGROUND = '#ffffff'
+
+/**
+ * Background colour to paint a freshly-created window before the renderer
+ * loads, so the window matches the active theme instead of flashing white
+ * (#3957). Falls back by dark/light classification for any theme without an
+ * explicit colour (e.g. the default light theme or a future/custom theme).
+ */
+export const getThemeBackgroundColor = (theme: string | undefined): string => {
+  const exact = typeof theme === 'string' ? themeBackgroundColors.get(theme) : undefined
+  if (exact) return exact
+  return isDarkThemeId(theme) ? DARK_FALLBACK_BACKGROUND : LIGHT_FALLBACK_BACKGROUND
+}

--- a/packages/desktop/src/main/windows/base.ts
+++ b/packages/desktop/src/main/windows/base.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import type { BrowserWindow } from 'electron'
 import { TypedEmitter } from '@shared/types/typedEmitter'
 import type Accessor from '../app/accessor'
+import { getThemeBackgroundColor } from '../../common/theme'
 
 /**
  * A MarkText window.
@@ -149,24 +150,11 @@ class BaseWindow extends TypedEmitter<BaseWindowEvents> {
   }
 
   protected _getPreferredBackgroundColor(theme: string | undefined): string {
-    // Hardcode the theme background color and show the window direct for the fastet window ready time.
-    // Later with custom themes we need the background color (e.g. from meta information) and wait
-    // that the window is loaded and then pass theme data to the renderer.
-    switch (theme) {
-      case 'dark':
-        return '#282828'
-      case 'material-dark':
-        return '#34393f'
-      case 'ulysses':
-        return '#f3f3f3'
-      case 'graphite':
-        return '#f7f7f7'
-      case 'one-dark':
-        return '#282c34'
-      case 'light':
-      default:
-        return '#ffffff'
-    }
+    // Paint the window with the active theme's background and show it directly,
+    // for the fastest window-ready time. Previously only a handful of themes
+    // were mapped and every other (dark) theme fell back to white, flashing
+    // white on launch (#3957); the full per-theme map lives in common/theme.
+    return getThemeBackgroundColor(theme)
   }
 }
 

--- a/packages/desktop/test/unit/specs/theme-background-color.spec.ts
+++ b/packages/desktop/test/unit/specs/theme-background-color.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { getThemeBackgroundColor, railscastsThemes, oneDarkThemes } from 'common/theme'
+
+// #3957: a dark theme used to flash white on launch because the main process
+// only mapped a handful of themes to a background colour and every other theme
+// fell back to white. `getThemeBackgroundColor` now covers every built-in theme
+// and classifies unknown ones, so no dark theme is painted white.
+describe('theme launch background colour (#3957)', () => {
+  it('never returns white for a dark theme (no white flash on launch)', () => {
+    for (const theme of [...railscastsThemes, ...oneDarkThemes]) {
+      expect(getThemeBackgroundColor(theme).toLowerCase()).not.toBe('#ffffff')
+    }
+  })
+
+  it('maps representative dark themes to their own editor background', () => {
+    expect(getThemeBackgroundColor('dracula')).toBe('#282a36')
+    expect(getThemeBackgroundColor('nord')).toBe('#2e3440')
+    expect(getThemeBackgroundColor('tokyo-night')).toBe('#1a1b26')
+    expect(getThemeBackgroundColor('dark')).toBe('#282828')
+    expect(getThemeBackgroundColor('one-dark')).toBe('#282c34')
+  })
+
+  it('uses the explicit background for built-in light themes', () => {
+    expect(getThemeBackgroundColor('ulysses')).toBe('#f3f3f3')
+    expect(getThemeBackgroundColor('tokyo-night-light')).toBe('#d5d6db')
+  })
+
+  it('falls back to white for the default light theme and unknown themes', () => {
+    for (const theme of ['light', undefined, 'no-such-theme']) {
+      expect(getThemeBackgroundColor(theme as string | undefined)).toBe('#ffffff')
+    }
+  })
+})


### PR DESCRIPTION
Fixes #3957.

### Problem
A freshly-created window's `backgroundColor` was chosen by a `switch` in `BaseWindow._getPreferredBackgroundColor` that only handled six themes (`dark`, `material-dark`, `ulysses`, `graphite`, `one-dark`, `light`). Every other theme fell through to `#ffffff` — including dark themes like `dracula`, `nord`, `tokyo-night`, `catppuccin-mocha`, `gruvbox-dark`, etc. Because the editor window is shown immediately (`show: true`), those themes paint **white** for the moment before the renderer loads → the white flash on launch.

(The renderer itself doesn't flash: it injects the theme stylesheet in a `nextTick` microtask, which runs before the first paint, so the only white came from the window background.)

### Fix
Move the lookup into `common/theme` as `getThemeBackgroundColor`, backed by a per-theme map covering **every built-in theme**, with each value taken from that theme's real `--editorBgColor`. Unknown/future themes fall back by the existing `isDarkThemeId` classification (dark → dark, else white) instead of always white. `BaseWindow._getPreferredBackgroundColor` now delegates to it.

e.g. `dracula` → `#282a36`, `nord` → `#2e3440` (both were `#ffffff` before).

### Tests
Adds `theme-background-color.spec.ts`, which asserts no dark theme resolves to white and that representative themes map to their editor background. Full unit suite, typecheck, and lint pass.
