### PR TITLE
fix(renderer): keep the key bindings hover row readable on dark themes

### DIFF
--- a/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/keybindings/index.vue
@@ -335,11 +335,12 @@ const dumpKeyboardInformation = (): void => {
 .pref-keybindings .el-table__fixed::before {
   background: var(--tableBorderColor);
 }
-.pref-keybindings .el-table__body tr.hover-row.current-row > td,
-.pref-keybindings .el-table__body tr.hover-row.el-table__row--striped.current-row > td,
-.pref-keybindings .el-table__body tr.hover-row.el-table__row--striped > td,
-.pref-keybindings .el-table__body tr.hover-row > td {
-  background: var(--selectionColor);
+/* Element Plus paints the hovered row via --el-table-row-hover-bg-color, which
+   defaults to the light --el-fill-color-light — a near-white bar that hides the
+   theme-coloured text on dark themes. Point it at the theme's own selection
+   colour so hovered rows stay readable on every theme (follow-up to #3937). */
+.pref-keybindings .el-table {
+  --el-table-row-hover-bg-color: var(--selectionColor);
 }
 .pref-keybindings .el-table .el-table__cell {
   padding: 2px 0;


### PR DESCRIPTION
Follow-up to #3937. After that fix made the key bindings list text use the theme colour, @Jocs spotted that the **hovered** row becomes unreadable on dark themes (the row turns into a near-white bar).

### Cause
The list is an Element Plus `el-table`, which paints the hovered row with `--el-table-row-hover-bg-color`. That defaults to `--el-fill-color-light` (a light grey), so on dark themes the hovered row is a near-white bar and the theme-coloured text on it disappears. The component's previous `tr.hover-row > td { background: var(--selectionColor) }` rule didn't take effect because Element Plus drives the hover colour through that variable, not that selector.

### Fix
Set `--el-table-row-hover-bg-color: var(--selectionColor)` on the key bindings table, so the hovered row uses the theme's own selection colour and stays readable on every theme (light and dark).

CSS-only, scoped to `.pref-keybindings`. `pnpm run lint`, `pnpm run typecheck`, and the unit suite pass.
