### PR TITLE
refactor(desktop): consume muya self-contained typography, remove shell style injection

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -260,6 +260,9 @@ const { projectTree } = storeToRefs(projectStore)
 
 // Component state
 const defaultFontFamily = DEFAULT_EDITOR_FONT_FAMILY
+const resolveEditorFont = (family: string): string =>
+  family ? `${family}, ${defaultFontFamily}` : defaultFontFamily
+const resolveCodeFont = (family: string): string => `${family}, ${DEFAULT_CODE_FONT_FAMILY}`
 const selectionChange = ref<unknown>(null)
 const editor = ref<MuyaInstance>(null)
 const isShowClose = ref(false)
@@ -557,9 +560,7 @@ watch(lineHeight, (value, oldValue) => {
 
 watch(editorFontFamily, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
-    editor.value.setOptions({
-      editorFontFamily: value ? `${value}, ${defaultFontFamily}` : defaultFontFamily
-    })
+    editor.value.setOptions({ editorFontFamily: resolveEditorFont(value) })
   }
 })
 
@@ -717,6 +718,12 @@ watch(autoCheck, (value, oldValue) => {
 watch(codeFontSize, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ codeFontSize: value })
+    // Source-mode CodeMirror is a separate surface muya doesn't own.
+    addCommonStyle({
+      codeFontSize: value,
+      codeFontFamily: codeFontFamily.value,
+      hideScrollbar: hideScrollbar.value
+    })
   }
 })
 
@@ -728,7 +735,13 @@ watch(codeBlockLineNumbers, (value, oldValue) => {
 
 watch(codeFontFamily, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
-    editor.value.setOptions({ codeFontFamily: `${value}, ${DEFAULT_CODE_FONT_FAMILY}` })
+    editor.value.setOptions({ codeFontFamily: resolveCodeFont(value) })
+    // Source-mode CodeMirror is a separate surface muya doesn't own.
+    addCommonStyle({
+      codeFontSize: codeFontSize.value,
+      codeFontFamily: value,
+      hideScrollbar: hideScrollbar.value
+    })
   }
 })
 
@@ -1688,11 +1701,9 @@ onMounted(() => {
     tabSize: tabSize.value,
     fontSize: fontSize.value,
     lineHeight: lineHeight.value,
-    editorFontFamily: editorFontFamily.value
-      ? `${editorFontFamily.value}, ${defaultFontFamily}`
-      : defaultFontFamily,
+    editorFontFamily: resolveEditorFont(editorFontFamily.value),
     codeFontSize: codeFontSize.value,
-    codeFontFamily: `${codeFontFamily.value}, ${DEFAULT_CODE_FONT_FAMILY}`,
+    codeFontFamily: resolveCodeFont(codeFontFamily.value),
     wrapCodeBlocks: wrapCodeBlocks.value,
     codeBlockLineNumbers: codeBlockLineNumbers.value,
     listIndentation: listIndentation.value,

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -573,7 +573,7 @@ watch(preferLooseListItem, (value, oldValue) => {
 
 watch(tabSize, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
-    editor.value.setTabSize(value)
+    editor.value.setOptions({ tabSize: value })
   }
 })
 

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -125,7 +125,7 @@ import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
 import { resolveTocHeadingElement } from '@/util/tocNavigation'
-import { addCommonStyle, setEditorWidth, setWrapCodeBlocks } from '@/util/theme'
+import { addCommonStyle, setEditorWidth } from '@/util/theme'
 import { usePreferencesStore } from '@/store/preferences'
 import { useEditorStore } from '@/store/editor'
 import { useProjectStore } from '@/store/project'
@@ -545,13 +545,21 @@ watch(focus, (value) => {
 
 watch(fontSize, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
-    editor.value.setFont({ fontSize: value })
+    editor.value.setOptions({ fontSize: value })
   }
 })
 
 watch(lineHeight, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
-    editor.value.setFont({ lineHeight: value })
+    editor.value.setOptions({ lineHeight: value })
+  }
+})
+
+watch(editorFontFamily, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({
+      editorFontFamily: value ? `${value}, ${defaultFontFamily}` : defaultFontFamily
+    })
   }
 })
 
@@ -653,8 +661,8 @@ watch(editorLineWidth, (value, oldValue) => {
 })
 
 watch(wrapCodeBlocks, (value, oldValue) => {
-  if (value !== oldValue) {
-    setWrapCodeBlocks(value)
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ wrapCodeBlocks: value })
   }
 })
 
@@ -707,12 +715,8 @@ watch(autoCheck, (value, oldValue) => {
 })
 
 watch(codeFontSize, (value, oldValue) => {
-  if (value !== oldValue) {
-    addCommonStyle({
-      codeFontSize: value,
-      codeFontFamily: codeFontFamily.value,
-      hideScrollbar: hideScrollbar.value
-    })
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ codeFontSize: value })
   }
 })
 
@@ -723,12 +727,8 @@ watch(codeBlockLineNumbers, (value, oldValue) => {
 })
 
 watch(codeFontFamily, (value, oldValue) => {
-  if (value !== oldValue) {
-    addCommonStyle({
-      codeFontSize: codeFontSize.value,
-      codeFontFamily: value,
-      hideScrollbar: hideScrollbar.value
-    })
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ codeFontFamily: `${value}, ${DEFAULT_CODE_FONT_FAMILY}` })
   }
 })
 
@@ -1916,7 +1916,6 @@ onMounted(() => {
 
   document.addEventListener('keyup', keyup)
 
-  setWrapCodeBlocks(wrapCodeBlocks.value)
   setEditorWidth(editorLineWidth.value)
 })
 

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -2,13 +2,6 @@
   <div
     class="editor-wrapper"
     :class="[{ typewriter: typewriter, focus: focus, source: sourceCode }]"
-    :style="{
-      lineHeight: lineHeight,
-      fontSize: `${fontSize}px`,
-      'font-family': editorFontFamily
-        ? `${editorFontFamily}, ${defaultFontFamily}`
-        : `${defaultFontFamily}`
-    }"
     :dir="textDirection"
   >
     <div
@@ -122,7 +115,7 @@ import { exportStyledHTML, type HeaderFooterPart } from '@/util/exportHtml'
 import { applyCursor, isIndexCursor } from '@/util/cursor'
 import EditorSearch from '../search/index.vue'
 import bus from '@/bus'
-import { DEFAULT_EDITOR_FONT_FAMILY } from '@/config'
+import { DEFAULT_EDITOR_FONT_FAMILY, DEFAULT_CODE_FONT_FAMILY } from '@/config'
 import notice from '@/services/notification'
 import Printer from '@/services/printService'
 import { SpellcheckerLanguageCommand } from '@/commands'
@@ -1695,6 +1688,12 @@ onMounted(() => {
     tabSize: tabSize.value,
     fontSize: fontSize.value,
     lineHeight: lineHeight.value,
+    editorFontFamily: editorFontFamily.value
+      ? `${editorFontFamily.value}, ${defaultFontFamily}`
+      : defaultFontFamily,
+    codeFontSize: codeFontSize.value,
+    codeFontFamily: `${codeFontFamily.value}, ${DEFAULT_CODE_FONT_FAMILY}`,
+    wrapCodeBlocks: wrapCodeBlocks.value,
     codeBlockLineNumbers: codeBlockLineNumbers.value,
     listIndentation: listIndentation.value,
     frontmatterType: frontmatterType.value,

--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -197,26 +197,6 @@ export const addThemeStyle = (theme: string): void => {
   }
 }
 
-export const setWrapCodeBlocks = (value: boolean): void => {
-  const CODE_WRAP_STYLE_ID = 'ag-code-wrap'
-  let result = ''
-  if (value) {
-    result =
-      '.mu-code-block .mu-code { display: block; white-space: pre-wrap; word-break: break-word; overflow: hidden; }'
-  } else {
-    result =
-      '.mu-code-block .mu-code { display: block; white-space: pre; word-break: break-word; overflow: auto; }'
-  }
-  let styleEle = document.querySelector(`#${CODE_WRAP_STYLE_ID}`) as HTMLStyleElement | null
-  if (!styleEle) {
-    styleEle = document.createElement('style')
-    styleEle.setAttribute('id', CODE_WRAP_STYLE_ID)
-    document.head.appendChild(styleEle)
-  }
-
-  styleEle.innerHTML = result
-}
-
 export const setEditorWidth = (value: string): void => {
   const EDITOR_WIDTH_STYLE_ID = 'editor-width'
   let result = ''
@@ -256,13 +236,7 @@ export const addCommonStyle = (options: CommonStyleOptions): void => {
   }
 
   sheet.innerHTML = `${scrollbarStyle}
-span code,
-td code,
-th code,
-code,
-code[class*="language-"],
-.CodeMirror,
-.mu-code-block {
+.CodeMirror {
 font-family: ${codeFontFamily}, ${DEFAULT_CODE_FONT_FAMILY};
 font-size: ${codeFontSize}px;
 }

--- a/packages/desktop/test/e2e/code-block-wrap.spec.ts
+++ b/packages/desktop/test/e2e/code-block-wrap.spec.ts
@@ -5,15 +5,11 @@ import { launchWithMarkdown } from './helpers'
 // Post-migration (muyajs -> @muyajs/core) coverage backfill for the
 // "Wrap Code Blocks" and "Code Block Line Numbers" editor preferences.
 //
-// The wrap preference is implemented as an injected <style id="ag-code-wrap">
-// (packages/desktop/src/renderer/src/util/theme.ts::setWrapCodeBlocks). Issue
-// #4421 changed the selector from the legacy DOM class to
-// `.mu-code-block .mu-code`. If that selector ever stops matching the rendered
-// @muyajs/core code DOM (`pre.mu-code-block > code.mu-code`), the style silently
-// no-ops — the computed white-space below would never flip. These tests prove
-// the selector still matches the live engine DOM and that the round-trip
-// (renderer -> main store -> broadcast -> Pinia watcher -> setWrapCodeBlocks /
-// muya.setOptions(forceRender)) takes effect live.
+// The wrap preference is implemented via muya.setOptions({ wrapCodeBlocks }),
+// which toggles a .mu-code-wrap class on the editor root. Muya's stylesheet
+// then applies `white-space: pre-wrap` to .mu-code-wrap .mu-code-block .mu-code.
+// These tests prove the round-trip (renderer -> main store -> broadcast ->
+// Pinia watcher -> muya.setOptions) takes effect live.
 //
 // The actual visual wrapping / horizontal scroll behaviour is not asserted here
 // (that remains manual); we assert the load-bearing computed style + class.
@@ -58,8 +54,8 @@ test.describe('Code block wrap + line-numbers preferences', () => {
 
   // Item 99: wrap preference toggles white-space on .mu-code-block .mu-code.
   test('wrapCodeBlocks toggles computed white-space on .mu-code-block .mu-code', async() => {
-    // Default preference is wrapCodeBlocks: false, so on boot setWrapCodeBlocks
-    // injects `white-space: pre`. Establish the baseline first.
+    // Default preference is wrapCodeBlocks: false, so the editor root has no
+    // .mu-code-wrap class and white-space is pre. Establish the baseline first.
     await expect.poll(() => readWhiteSpace(page), { timeout: 10000 }).toBe('pre')
 
     // Enable wrapping -> selector should resolve to `pre-wrap`.
@@ -113,7 +109,7 @@ test.describe('Code block wrap + line-numbers preferences', () => {
       { timeout: 10000 }
     )
 
-    // The newly-rendered .mu-code must still pick up the #ag-code-wrap style.
+    // The newly-rendered .mu-code must still pick up the muya wrap CSS.
     await expect.poll(() => readWhiteSpace(page), { timeout: 10000 }).toBe('pre-wrap')
 
     // Restore defaults so the suite leaves no global preference state behind.

--- a/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
@@ -9,7 +9,7 @@ vi.hoisted(() => {
   w.window.path ??= { sep: '/' }
 })
 
-import { addCommonStyle, setWrapCodeBlocks, setEditorWidth } from '@/util/theme'
+import { addCommonStyle, setEditorWidth } from '@/util/theme'
 import { COMMON_STYLE_ID, DEFAULT_CODE_FONT_FAMILY } from '@/config'
 
 const styleHtml = (id: string) =>
@@ -23,26 +23,28 @@ describe('theme.ts style injection helpers', () => {
     document.body.className = ''
   })
 
-  // Items 196, 210 — addCommonStyle injects code font onto the engine .mu-code-block.
+  // Items 196, 210 — addCommonStyle injects code font onto the source-mode .CodeMirror selector.
   describe('addCommonStyle', () => {
-    it('injects code font-family/size onto the .mu-code-block selector list', () => {
+    it('injects code font-family/size onto the .CodeMirror selector', () => {
       addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 24 })
 
       const css = styleHtml(COMMON_STYLE_ID)
-      // selector list targets the engine block class
-      expect(css).toContain('.mu-code-block')
+      // selector targets source-mode CodeMirror only (muya owns code-block font via --mu-code-* vars)
+      expect(css).toContain('.CodeMirror')
+      expect(css).not.toContain('.mu-code-block')
       // family is the requested font followed by the default fallback chain
       expect(css).toContain(`font-family: Courier New, ${DEFAULT_CODE_FONT_FAMILY};`)
       // size is the numeric value suffixed with px
       expect(css).toContain('font-size: 24px;')
     })
 
-    it('targets the engine .mu-code-block class (not a legacy ag-* class)', () => {
+    it('targets only .CodeMirror (no legacy ag-* or mu-code-block classes)', () => {
       addCommonStyle({ codeFontFamily: 'Courier New', codeFontSize: 14 })
 
       const css = styleHtml(COMMON_STYLE_ID)
-      expect(css).toContain('.mu-code-block')
+      expect(css).toContain('.CodeMirror')
       expect(css).not.toContain('.ag-code-block')
+      expect(css).not.toContain('.mu-code-block')
     })
 
     it('prepends the webkit scrollbar hide rule when hideScrollbar is true', () => {
@@ -68,41 +70,6 @@ describe('theme.ts style injection helpers', () => {
       expect(css).toContain('font-size: 18px;')
       expect(css).not.toContain('Courier New')
       expect(css).not.toContain('font-size: 14px;')
-    })
-  })
-
-  // Item 197 — setWrapCodeBlocks toggles pre-wrap vs pre on .mu-code-block .mu-code.
-  describe('setWrapCodeBlocks', () => {
-    const WRAP_STYLE_ID = 'ag-code-wrap'
-
-    it('uses white-space: pre-wrap and overflow: hidden when wrapping is enabled', () => {
-      setWrapCodeBlocks(true)
-
-      const css = styleHtml(WRAP_STYLE_ID)
-      expect(css).toContain('.mu-code-block .mu-code {')
-      expect(css).toContain('white-space: pre-wrap;')
-      expect(css).toContain('overflow: hidden;')
-    })
-
-    it('uses white-space: pre and overflow: auto when wrapping is disabled', () => {
-      setWrapCodeBlocks(false)
-
-      const css = styleHtml(WRAP_STYLE_ID)
-      expect(css).toContain('.mu-code-block .mu-code {')
-      expect(css).toContain('white-space: pre;')
-      expect(css).toContain('overflow: auto;')
-      // the disabled rule must not leak the wrapped values
-      expect(css).not.toContain('white-space: pre-wrap;')
-    })
-
-    it('replaces the rule in the same single style element when toggled true -> false', () => {
-      setWrapCodeBlocks(true)
-      setWrapCodeBlocks(false)
-
-      expect(styleCount(WRAP_STYLE_ID)).toBe(1)
-      const css = styleHtml(WRAP_STYLE_ID)
-      expect(css).toContain('white-space: pre;')
-      expect(css).not.toContain('white-space: pre-wrap;')
     })
   })
 


### PR DESCRIPTION
## Summary

Desktop side of the muya typography self-containment work. **Stacked on #4722** (muya engine changes) — review/merge that first.

Now that muya applies editor typography from options onto its own root, the desktop stops applying it via wrapper inline styles and global `<style>` injection into muya's DOM, and simply passes the values.

## What changed

- Pass `editorFontFamily` / `codeFontSize` / `codeFontFamily` / `wrapCodeBlocks` to muya at construction; remove the font inline-style from the `.editor-wrapper` element (the `:class` / `:dir` bindings stay).
- Route the editor-typography preference watchers (font size, line height, editor font, code font size/family, wrap, and tab size) through `muya.setOptions({...})`.
- Narrow `addCommonStyle` to style **source-mode CodeMirror (`.CodeMirror`) only** — muya now owns its own `.mu-code-block` font. Remove the now-dead `setWrapCodeBlocks` helper.

## Parity & scope

The desktop passes the **same computed values** it used before (same font-family fallback chains, same code px), so editor rendering is unchanged. The source-mode CodeMirror and the export/print path are unaffected (export goes through a separate `.markdown-body` path). Editor width, colour theme, and file-IO settings are out of scope and untouched.

UI chrome that previously inherited the editor font from the wrapper (e.g. the insert-table dialog title) now renders at a stable app-default size — reviewed as a benign improvement, not a regression.

## Tests

- desktop unit: **663/663** passing (`editor-theme-style.spec` updated to assert the narrowed `.CodeMirror` selector).
- `typecheck` + `lint`: 0 errors.
- Live in-app checks (font/wrap toggling, FOUC, export visual) to be confirmed on a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
