### PR TITLE
fix(muya): keep a nested sublist when forward-deleting an empty list item (#1845)

### DIFF
--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -11,6 +11,7 @@ import type { IImageInfo } from '../../utils/image';
 import type AtxHeading from '../commonMark/atxHeading';
 import type BulletList from '../commonMark/bulletList';
 import type SetextHeading from '../commonMark/setextHeading';
+import type Parent from './parent';
 import type TreeNode from './treeNode';
 import Content from '../../block/base/content';
 import { ScrollPage } from '../../block/scrollPage';
@@ -1482,9 +1483,32 @@ class Format extends Content {
 
         event.preventDefault();
 
-        const paragraphBlock = nextBlock.parent;
-        let needRemovedBlock = paragraphBlock;
+        const paragraphBlock = nextBlock.parent!;
 
+        this.text = text + nextBlock.text;
+        this.setCursor(start.offset, end.offset, true);
+
+        // When the merge crosses a list-item boundary, blocks that followed the
+        // next paragraph inside its item (e.g. a nested sublist) must travel up
+        // with the merged text. Left behind they become the sole child of the
+        // now-empty item and serialize with a doubled bullet (#1845).
+        const paragraph = this.parent;
+        if (paragraph && paragraphBlock.parent !== paragraph.parent) {
+            const trailing: TreeNode[] = [];
+            let sibling = paragraphBlock.next;
+            while (sibling) {
+                trailing.push(sibling);
+                sibling = sibling.next;
+            }
+
+            let anchor: Parent = paragraph;
+            for (const block of trailing) {
+                block.insertInto(paragraph.parent!, anchor.next as Nullable<Parent>);
+                anchor = block as Parent;
+            }
+        }
+
+        let needRemovedBlock: Nullable<Parent> = paragraphBlock;
         while (
             needRemovedBlock
             && needRemovedBlock.isOnlyChild()
@@ -1492,9 +1516,6 @@ class Format extends Content {
         ) {
             needRemovedBlock = needRemovedBlock.parent;
         }
-
-        this.text = text + nextBlock.text;
-        this.setCursor(start.offset, end.offset, true);
         needRemovedBlock!.remove();
     }
 

--- a/packages/muya/src/block/content/paragraphContent/__tests__/deleteMerge.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/deleteMerge.spec.ts
@@ -121,6 +121,52 @@ describe('forward Delete at end-of-paragraph — merge with next block', () => {
     });
 });
 
+// #1845 — forward-Delete at the end of an empty list item must pull the next
+// item's WHOLE content up, not just its paragraph. The next item held a nested
+// sublist (`- D`) as a sibling of its paragraph; merging only the paragraph and
+// removing it stranded that sublist as the item's sole child, which serializes
+// with a doubled bullet (`* - D`).
+describe('forward Delete merging a list item that owns a nested sublist (#1845)', () => {
+    function emptyFirstItemThenDelete(muya: Muya): void {
+        const first = contentByText(muya, 'a');
+        first.text = '';
+        deleteAtEnd(muya, first);
+    }
+
+    it('does not strand the nested sublist with a doubled bullet', async () => {
+        const muya = bootMuya('* a\n\n* C\n  \n  - D\n');
+
+        emptyFirstItemThenDelete(muya);
+
+        await flush();
+        const markdown = muya.getMarkdown();
+        expect(markdown).not.toMatch(/\*\s+-\s+D/);
+        expect(markdown).toContain('  - D');
+    });
+
+    it('moves the merged text and sublist into the first item and drops the empty one', async () => {
+        const muya = bootMuya('* a\n\n* C\n  \n  - D\n');
+
+        emptyFirstItemThenDelete(muya);
+
+        await flush();
+        const state = muya.getState();
+        expect(state.length).toBe(1);
+        const list = state[0] as { name: string; children: unknown[] };
+        expect(list.name).toBe('bullet-list');
+        expect(list.children.length).toBe(1);
+        const item = list.children[0] as { name: string; children: unknown[] };
+        expect(item.name).toBe('list-item');
+        expect(item.children[0]).toMatchObject({ name: 'paragraph', text: 'C' });
+        expect(item.children[1]).toMatchObject({ name: 'bullet-list' });
+        const sublist = item.children[1] as { children: Array<{ children: unknown[] }> };
+        expect(sublist.children[0].children[0]).toMatchObject({
+            name: 'paragraph',
+            text: 'D',
+        });
+    });
+});
+
 describe('forward Delete at end of a code block — no merge', () => {
     it('leaves the state unchanged (codeBlockContent has no merging deleteHandler)', async () => {
         const muya = bootMuya('```js\nx\n```\n');


### PR DESCRIPTION
Fixes #1845

### Problem

Pressing <kbd>Delete</kbd> (forward-delete) at the end of an empty list item, where the next item owns a nested sublist, produced a doubled bullet:

```
* C

* - D
```

instead of the expected

```
* C

  - D
```

### Root cause

`Format.deleteHandler` merges the next paragraph's text into the current content and then removes the next paragraph. The removal walks up only through *only-child* ancestors. When the next item's paragraph has a following sibling (a nested sublist), the walk stops at the paragraph, so just the paragraph is removed — leaving the sublist as the item's sole child. On serialization a list item that begins directly with a sublist renders with a second bullet (`* - D`).

Reproduced against the real engine (boot Muya, empty the first item, route a `Delete` through `deleteHandler`, read back `getMarkdown()`/`getState()`).

### Fix

When the merge crosses a list-item boundary, relocate the merged paragraph's trailing siblings (the sublist) into the target item right after the merged paragraph, *before* removing the source paragraph. The source item is then empty and is removed whole by the existing only-child walk-up. Flat same-container merges (plain paragraph + paragraph) are untouched.

### Tests

Added two regression tests to `deleteMerge.spec.ts` driving the real handler: the output no longer contains a doubled bullet, and the merged text + sublist land in the surviving item. Full muya unit suite (1302), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass.