### PR TITLE
fix(muya): remove the inner format when un-toggling a nested inline run (#2063)

### DIFF
--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -140,6 +140,36 @@ describe('format.format() toggle-off with the caret inside the formatted run', (
     });
 });
 
+// #2063 — toggling the INNER format off a nested run (e.g. removing italic from
+// bold-italic `***foo***`). `clearFormat` splices the inner token's children up
+// into the ancestor wrapper's `children` array, but the ancestor's cached `raw`
+// goes stale; the serializer must rebuild the wrapper from its children, not
+// trust that raw, or the toggle is a silent no-op.
+describe('format.format() toggle-off the inner format of a nested run (#2063)', () => {
+    it('em inside strong: selecting `foo` in `***foo***` un-italics to `**foo**`', () => {
+        // Raw offsets: `bar ***foo*** bar` → `foo` spans 7..10 (inside both the
+        // strong 4..13 and the em 6..11 token ranges).
+        const content = selectInFirstBlock(bootMuya('bar ***foo*** bar\n'), 7, 10);
+        content.format('em');
+        expect(content.text).toBe('bar **foo** bar');
+    });
+
+    it('the un-italic also drops the inner markers from the serialized markdown', async () => {
+        const muya = bootMuya('bar ***foo*** bar\n');
+        selectInFirstBlock(muya, 7, 10).format('em');
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown().trim()).toBe('bar **foo** bar');
+        });
+    });
+
+    it('strong inside del: selecting `b` in `~~a **b** a~~` un-bolds to `~~a b a~~`', () => {
+        // `~~a **b** a~~`: the strong `**b**` raw spans 5..10, text `b` at 7..8.
+        const content = selectInFirstBlock(bootMuya('~~a **b** a~~\n'), 7, 8);
+        content.format('strong');
+        expect(content.text).toBe('~~a b a~~');
+    });
+});
+
 describe('format.format() apply-ON over a non-collapsed selection', () => {
     it('strong: selecting `abc` and applying wraps it in `**…**`', async () => {
         const muya = bootMuya('abc\n');

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1610,7 +1610,7 @@ class Format extends Content {
             start.offset += start.delta;
             end.offset += end.delta;
 
-            this.text = generator(tokens);
+            this.text = generator(tokens, true);
         }
         else if (currentFormats.length) {
             for (const token of currentFormats)
@@ -1618,7 +1618,7 @@ class Format extends Content {
 
             start.offset += start.delta;
             end.offset += end.delta;
-            this.text = generator(tokens);
+            this.text = generator(tokens, true);
         }
         else {
             if (currentNeighbors.length) {
@@ -1628,7 +1628,7 @@ class Format extends Content {
 
             start.offset += start.delta;
             end.offset += end.delta;
-            this.text = generator(tokens);
+            this.text = generator(tokens, true);
 
             this._addFormat(type, { start, end });
 

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -900,11 +900,33 @@ export function tokenizer(src: string, {
 
 // transform `tokens` to text ignore the range of token
 // the opposite of tokenizer
-export function generator(tokens: Token[]) {
+// Rebuild a marker-wrapped token from its children instead of its stale cached
+// `raw` (#2063). Link/image keep their stored raw.
+function rebuildWrapperToken(token: Token): string {
+    switch (token.type) {
+        case 'strong':
+        case 'em':
+        case 'del':
+            return token.marker + generator(token.children, true) + token.marker;
+
+        case 'html_tag':
+            if (token.openTag != null && token.closeTag != null && token.children != null)
+                return token.openTag + generator(token.children, true) + token.closeTag;
+
+            return token.raw;
+
+        default:
+            return token.raw;
+    }
+}
+
+// `rebuildWrappers` is opt-in: only `format()` mutates a wrapper's children;
+// `backspaceHandler` trims a marker off `raw` and needs it echoed verbatim.
+export function generator(tokens: Token[], rebuildWrappers = false) {
     let result = '';
 
     for (const token of tokens)
-        result += token.raw;
+        result += rebuildWrappers ? rebuildWrapperToken(token) : token.raw;
 
     return result;
 }


### PR DESCRIPTION
Fixes #2063

### Problem

Selecting `foo` in bold-italic `bar ***foo*** bar` and pressing the italic button (to leave just bold) did nothing — the markdown stayed `***foo***`. The same no-op affected any nested inline format (e.g. un-bolding `**b**` inside `~~ … ~~`).

### Root cause

`clearFormat` removes a format by splicing the token's children up into its parent array. For a nested run, the inner token (`em`) lives in the wrapper's (`strong`) `children` array, so the splice mutates `strong.children` — but `strong.raw` is left untouched. `generator`, which serializes the edited token list back to text, only summed each token's cached `raw`, so it emitted the stale `***foo***` and the toggle had no effect.

Reproduced against the real engine (boot Muya on `bar ***foo*** bar`, select `foo`, call `format('em')`, read back `content.text` / `getMarkdown()`).

### Fix

Add an opt-in `rebuildWrappers` mode to `generator` that reconstructs a marker-wrapped token (`strong`/`em`/`del`/`html_tag`) from its children — `marker + inner + marker` — instead of trusting the cached `raw`. The three `format()` serialization points pass it; `backspaceHandler`, which deliberately trims a single marker char off `token.raw` (muya#113), keeps the default raw-verbatim behavior. For an unmodified token the rebuild reproduces the original raw exactly, so there is no serialization drift. URL-bearing tokens (link/image) keep their stored raw.

### Tests

Added three regression tests to `formatToggle.spec.ts` driving the real `format()` toggle-off over nested runs (em-in-strong, strong-in-del), asserting both the live block text and the serialized markdown. Full muya unit suite (1305), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass — including the `formatBackspace` marker-trim tests that pin the raw-verbatim path.