### PR TITLE
fix(muya): escape parentheses in inserted image paths (#3060)

### DIFF
--- a/packages/muya/src/__tests__/imageInsertEscape.spec.ts
+++ b/packages/muya/src/__tests__/imageInsertEscape.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import type Format from '../block/base/format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { tokenizer } from '../inlineRenderer/lexer';
+import { Muya } from '../muya';
+
+// #3060 — an image whose file path contains a parenthesis must escape it, or the
+// unbalanced `)` terminates the markdown image destination early (CommonMark:
+// the destination ends at the first unbalanced `)`), truncating the path and
+// spilling the tail into plain text. `insertImage` already percent-encodes
+// spaces and `#`; parentheses belong to the same class.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function insertImageAtStart(muya: Muya, src: string): Format {
+    const block = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = block as never;
+    block.setCursor(0, 0, true);
+    muya.insertImage({ src });
+    return block;
+}
+
+// Re-parse the block's markdown and return the single image token's destination,
+// decoded back to a real path. A truncated `)` would split the image so either
+// no image token is produced or its src stops short.
+function roundTripImageSrc(text: string): string {
+    const tokens = tokenizer(text, { options: {} as never });
+    const image = tokens.find(t => t.type === 'image');
+    if (!image)
+        throw new Error(`no image token parsed from ${JSON.stringify(text)}`);
+    return decodeURIComponent((image as { src: string }).src);
+}
+
+describe('insertImage escapes parentheses in the path (#3060)', () => {
+    it('an unbalanced `)` in the path round-trips instead of truncating', () => {
+        const muya = bootMuya('\n');
+        const block = insertImageAtStart(muya, '/home/user/My Photos)/photo.png');
+        expect(roundTripImageSrc(block.text)).toBe('/home/user/My Photos)/photo.png');
+    });
+
+    it('a `)` followed by a `(` round-trips', () => {
+        const muya = bootMuya('\n');
+        const block = insertImageAtStart(muya, '/a)b(c.png');
+        expect(roundTripImageSrc(block.text)).toBe('/a)b(c.png');
+    });
+
+    it('still encodes spaces and keeps balanced parens loadable', () => {
+        const muya = bootMuya('\n');
+        const block = insertImageAtStart(muya, '/a (b)/c.png');
+        expect(roundTripImageSrc(block.text)).toBe('/a (b)/c.png');
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -27,7 +27,7 @@ import Selection, { getCursorReference } from '../../selection';
 import { getTextContent } from '../../selection/dom';
 import { isListItemState } from '../../state/types';
 import { conflict, isHTMLElement, isMouseEvent } from '../../utils';
-import { correctImageSrc, getImageInfo } from '../../utils/image';
+import { correctImageSrc, encodeImageSrc, getImageInfo } from '../../utils/image';
 import logger from '../../utils/logger';
 
 interface IOffset {
@@ -371,11 +371,8 @@ class Format extends Content {
                 imageText += alt;
 
             imageText += '](';
-            if (src) {
-                imageText += src
-                    .replace(/ /g, encodeURI(' '))
-                    .replace(/#/g, encodeURIComponent('#'));
-            }
+            if (src)
+                imageText += encodeImageSrc(src);
 
             if (title)
                 imageText += ` "${title}"`;

--- a/packages/muya/src/clipboard/pasteImage.ts
+++ b/packages/muya/src/clipboard/pasteImage.ts
@@ -5,7 +5,7 @@ import type Clipboard from './index';
 import { CLASS_NAMES } from '../config';
 import { SelectionType } from '../selection/types';
 import { getUniqueId } from '../utils';
-import { getImageInfo } from '../utils/image';
+import { encodeImageSrc, getImageInfo } from '../utils/image';
 import { readFileAsDataURL, resolveClipboardImagePath } from '../utils/paste';
 
 /**
@@ -15,7 +15,7 @@ import { readFileAsDataURL, resolveClipboardImagePath } from '../utils/paste';
  * Inline images in muya are plain markdown text (`![](src)`) on a content
  * block; rendering turns the token into an image. We replace any
  * collapsed/expanded range and place the cursor after it. The src is
- * escaped the same way as {@link Format.replaceImage} so spaces and `#`
+ * escaped via {@link encodeImageSrc} so spaces, `#`, and parentheses
  * survive in the path.
  */
 function insertImageText(anchorBlock: Content, src: string, alt = ''): string {
@@ -25,9 +25,7 @@ function insertImageText(anchorBlock: Content, src: string, alt = ''): string {
 
     const { start, end } = cursor;
     const { text: content } = anchorBlock;
-    const escapedSrc = src
-        .replace(/ /g, encodeURI(' '))
-        .replace(/#/g, encodeURIComponent('#'));
+    const escapedSrc = encodeImageSrc(src);
     const imageText = `![${alt}](${escapedSrc})`;
 
     anchorBlock.text
@@ -55,9 +53,7 @@ function replacePlaceholderImage(
     if (index === -1)
         return;
 
-    const escapedSrc = src
-        .replace(/ /g, encodeURI(' '))
-        .replace(/#/g, encodeURIComponent('#'));
+    const escapedSrc = encodeImageSrc(src);
     const imageText = `![](${escapedSrc})`;
 
     anchorBlock.text
@@ -187,9 +183,7 @@ function spliceImageText(
     src: string,
     alt = '',
 ): string {
-    const escapedSrc = src
-        .replace(/ /g, encodeURI(' '))
-        .replace(/#/g, encodeURIComponent('#'));
+    const escapedSrc = encodeImageSrc(src);
     const imageText = `![${alt}](${escapedSrc})`;
 
     block.text

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -31,6 +31,7 @@ import {
 import { isAnyListState, isAtxHeadingState, isCodeBlockState } from './state/types';
 import { Ui } from './ui/ui';
 import { deepClone } from './utils';
+import { encodeImageSrc } from './utils/image';
 import './assets/styles/blockSyntax.css';
 import './assets/styles/index.css';
 import './assets/styles/inlineSyntax.css';
@@ -994,7 +995,7 @@ export class Muya {
         else if (DATA_URL_REG.test(src))
             imgUrl = src;
         else
-            imgUrl = src.replace(/ /g, encodeURI(' ')).replace(/#/g, encodeURIComponent('#'));
+            imgUrl = encodeImageSrc(src);
 
         const { start, end } = cursor;
         const { text } = block;

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -177,6 +177,17 @@ export async function checkImageContentType(url: string) {
     }
 }
 
+// Percent-encode the chars that break a markdown image destination — an
+// unbalanced `)` truncates the path (#3060). `encodeURIComponent` leaves `(`/`)`
+// untouched, so encode them explicitly.
+export function encodeImageSrc(src: string): string {
+    return src
+        .replace(/ /g, encodeURI(' '))
+        .replace(/#/g, encodeURIComponent('#'))
+        .replace(/\(/g, '%28')
+        .replace(/\)/g, '%29');
+}
+
 export function correctImageSrc(src: string) {
     if (src) {
     // Fix ASCII and UNC paths on Windows (#1997).


### PR DESCRIPTION
Fixes #3060

### Problem

Inserting an image whose file path contains a parenthesis corrupted the path. A markdown image destination ends at the first unbalanced `)` (CommonMark), so a path like `/home/user/My Photos)/photo.png` serialized to:

```
![photo](/home/user/My%20Photos)/photo.png)
```

The destination was cut at the first `)` (→ `/home/user/My%20Photos`), and `/photo.png)` spilled out as plain text — the image broke.

### Root cause

The five image-insert sites (`muya.insertImage`, `Format.replaceImage`, and three in `clipboard/pasteImage.ts`) each percent-encoded only spaces and `#`, leaving parentheses raw. `correctUrl` (the parser) then correctly truncated the destination at the first unbalanced `)`.

Reproduced against the real engine (boot Muya, `insertImage({ src })` with a `)` in the path, re-tokenize the result and check the image destination round-trips).

### Fix

Extract a shared `encodeImageSrc` helper that percent-encodes spaces, `#`, **and** `(`/`)`, and route all five sites through it (removing the duplicated `.replace` chains). Note `encodeURIComponent` leaves parentheses untouched — they are in its unreserved set — so the parens are encoded explicitly as `%28`/`%29`. The encoded path is decoded again when the image loads (same as the existing `%20` space handling), so the file still resolves. Balanced parens already round-tripped and continue to; full URLs / data URLs keep their existing branches.

### Tests

Added `imageInsertEscape.spec.ts` driving the real `insertImage` over an unbalanced `)`, a `)`-then-`(`, and a balanced-paren-with-space path, asserting each round-trips through the tokenizer to the original path. Full muya unit suite (1305), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass.