### PR TITLE
fix(muya): decode HTML entities in fetched page titles when pasting a URL (#2525)

### DIFF
--- a/packages/muya/src/utils/__tests__/getPageTitle.spec.ts
+++ b/packages/muya/src/utils/__tests__/getPageTitle.spec.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Regression for marktext commit 141d25d8 (#1344).

--- a/packages/muya/src/utils/__tests__/pasteUrlTitleEntities.spec.ts
+++ b/packages/muya/src/utils/__tests__/pasteUrlTitleEntities.spec.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPageTitle, normalizePastedHTML } from '../paste';
+
+// #2525 — copying a bare URL from a browser pastes a markdown link whose anchor
+// text is the page `<title>`. The title is fetched as raw HTML, so entities such
+// as `&ndash;` / `&uuml;` must be decoded before they become the link text;
+// otherwise the literal `&ndash;` shows up in the document.
+function mockFetchReturningTitle(titleInnerHtml: string) {
+    const body = `<!doctype html><html><head><title>${titleInnerHtml}</title></head><body>x</body></html>`;
+    return vi.fn(async () => ({
+        status: 200,
+        headers: {
+            get: (h: string) => (h.toLowerCase() === 'content-type' ? 'text/html; charset=utf-8' : null),
+        },
+        text: async () => body,
+    }));
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('getPageTitle decodes HTML entities (#2525)', () => {
+    it('decodes named entities in the fetched page title', async () => {
+        vi.stubGlobal(
+            'fetch',
+            mockFetchReturningTitle('On Statistical Data Compression &ndash; Digitale Bibliothek Th&uuml;ringen'),
+        );
+
+        const title = await getPageTitle('https://www.db-thueringen.de/receive/dbt_mods_00027239');
+
+        expect(title).toBe('On Statistical Data Compression – Digitale Bibliothek Thüringen');
+    });
+
+    it('a pasted bare URL becomes a link whose anchor text has decoded entities', async () => {
+        vi.stubGlobal('fetch', mockFetchReturningTitle('Foo &ndash; B&uuml;cher'));
+
+        const out = await normalizePastedHTML(
+            '<a href="https://www.db-thueringen.de/x">https://www.db-thueringen.de/x</a>',
+        );
+
+        expect(out).toContain('Foo – Bücher');
+        expect(out).not.toContain('ndash');
+    });
+});

--- a/packages/muya/src/utils/paste.ts
+++ b/packages/muya/src/utils/paste.ts
@@ -45,13 +45,13 @@ export async function getPageTitle(url: string) {
         if (res.status !== 200 || !contentType || !/text\/html/i.test(contentType))
             return '';
 
-        // The response is HTML — read it as text and pluck `<title>`.
-        // Reading it as `res.json()` would always throw and make the helper
-        // silently return ''.
+        // Parse inertly and read `<title>` textContent, which decodes HTML
+        // entities so they don't leak into the pasted link text (#2525).
         const body = await res.text();
-        const match = body.match(/<title>([\s\S]*?)<\/title>/i);
+        const doc = new DOMParser().parseFromString(body, 'text/html');
+        const title = doc.querySelector('title')?.textContent?.trim();
 
-        return match && match[1] ? match[1].trim() : '';
+        return title || '';
     }
     catch {
         return '';


### PR DESCRIPTION
Fixes #2525

### Problem

Copying a URL from a browser and pasting it produced a link whose anchor text contained raw HTML entities:

```
[On Statistical Data Compression &ndash; Digitale Bibliothek Th&uuml;ringen](https://www.db-thueringen.de/receive/dbt_mods_00027239)
```

instead of the decoded `On Statistical Data Compression – Digitale Bibliothek Thüringen`.

### Root cause

When a bare URL is pasted, `normalizePastedHTML` fetches the page and `getPageTitle` extracts the `<title>` with a raw regex (`body.match(/<title>([\s\S]*?)<\/title>/i)`). The captured text still holds HTML entities, and it is then assigned to `link.textContent`, so `&ndash;` / `&uuml;` appear verbatim.

Reproduced against the real helper by feeding it the page's actual entity-laden `<title>` (fetch is the only thing mocked; the extraction/decoding path runs for real).

### Fix

Parse the fetched body with `DOMParser` (inert — scripts don't run and resources aren't loaded) and read the `<title>` element's `textContent`, which decodes the entities. The existing `getPageTitle` spec ran under the node env; it now declares `@vitest-environment jsdom` since the helper legitimately needs the DOM (its sibling `normalizePastedHTML` already manipulates `document`).

### Tests

Added `pasteUrlTitleEntities.spec.ts`: a unit test that `getPageTitle` decodes named entities, and an integration test that a pasted bare URL yields a link whose anchor text is decoded. Full muya unit suite (1304), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass.