### PR TITLE
fix(muya): reset search state when the document is replaced (#1932)

### DIFF
--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -499,6 +499,7 @@ export class Editor {
 
         this.scrollPage!.updateState(state);
         this.history.clear();
+        this.searchModule.reset();
 
         if (autoFocus)
             this.focus();

--- a/packages/muya/src/search/__tests__/searchResetOnSetContent.spec.ts
+++ b/packages/muya/src/search/__tests__/searchResetOnSetContent.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// #1932 — switching tabs replaces the document via `Editor.setContent`, which
+// rebuilds the block tree. The Search module kept its old `matches` (now
+// pointing at detached blocks) and its old match count/value, so the search bar
+// still showed the previous tab's results and "Find Next" operated on orphaned
+// blocks. setContent must reset the search state.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('search resets when the document content is replaced (#1932)', () => {
+    it('clears stale matches/index/value on setContent', () => {
+        const muya = bootMuya('foo foo foo\n');
+        const search = muya.editor.searchModule;
+        search.search('foo');
+        expect(search.matches.length).toBe(3);
+        expect(search.value).toBe('foo');
+
+        muya.editor.setContent('bar baz\n');
+
+        expect(search.matches).toEqual([]);
+        expect(search.index).toBe(-1);
+        expect(search.value).toBe('');
+    });
+
+    it('find next after a tab switch is a no-op (no stale matches to act on)', () => {
+        const muya = bootMuya('foo foo\n');
+        const search = muya.editor.searchModule;
+        search.search('foo');
+        expect(search.matches.length).toBe(2);
+
+        muya.editor.setContent('unrelated content\n');
+
+        expect(() => search.find('next')).not.toThrow();
+        expect(search.matches).toEqual([]);
+        expect(search.index).toBe(-1);
+    });
+
+    it('a fresh search after setContent finds matches in the new document', () => {
+        const muya = bootMuya('foo\n');
+        const search = muya.editor.searchModule;
+        search.search('foo');
+
+        muya.editor.setContent('foo foo\n');
+        search.search('foo');
+
+        expect(search.matches.length).toBe(2);
+        expect(search.matches.every(m => m.block.parent !== null)).toBe(true);
+    });
+});

--- a/packages/muya/src/search/index.ts
+++ b/packages/muya/src/search/index.ts
@@ -21,6 +21,14 @@ export class Search {
 
     constructor(private _muya: Muya) {}
 
+    // Drop match state when the document is replaced (e.g. a tab switch), so
+    // stale matches don't reference the previous document's blocks (#1932).
+    reset() {
+        this._value = '';
+        this.matches = [];
+        this.index = -1;
+    }
+
     private _updateMatches(isClear = false) {
         const { matches, index } = this;
         let i;


### PR DESCRIPTION
Fixes #1932

### Problem

With two tabs open: search in tab 1, switch to tab 2, press **Find Next** → the search bar still showed tab 1's match count, and on the old engine an exception was thrown (`Cannot read property 'parent' of null`).

### Root cause

Switching tabs replaces the document through `Editor.setContent`, which rebuilds the block tree (`scrollPage.updateState`) and clears history — but never touched the `Search` module. Its `matches`/`index`/`value` still referenced detached blocks from the previous tab, so the count was stale and `find()` operated on orphaned blocks.

Reproduced against the real engine: boot, `search('foo')` (3 matches), `setContent(newDoc)`, then observe `matches` still held the 3 stale entries.

### Fix

Add `Search.reset()` (clears `value`/`matches`/`index`) and call it from `setContent` after the tree is rebuilt. A subsequent search re-scans the new document as normal.

### Tests

Added `searchResetOnSetContent.spec.ts` driving the real `Editor`: search populates matches, `setContent` clears them, **Find Next** is then a safe no-op, and a fresh search finds matches in the new document. Full muya unit suite (1305), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass.