### PR TITLE
fix(renderer): hide muya float tools in source-code mode

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -2028,6 +2028,11 @@ onBeforeUnmount(() => {
   top: 0;
   left: 0;
   overflow: hidden;
+  /* `z-index: -1` only hides the editor visually; `document.elementsFromPoint`
+     ignores stacking, so muya's mousemove-driven float tools (front button/menu,
+     table drag/column toolbars, preview toolbar) still re-trigger over the source
+     editor. Drop the subtree from hit-testing too so they cannot (#4731). */
+  pointer-events: none;
 }
 
 .editor-component {


### PR DESCRIPTION
Closes #4731

## Summary

In source-code mode the WYSIWYG (muya) editor is only sent behind the source editor via `z-index: -1` (`.editor-wrapper.source`) — it stays in the DOM and remains hit-testable. Four muya float tools listen on a document-level `mousemove` and locate the hovered block with `document.elementsFromPoint(...)`, which returns elements **regardless of z-index**. So moving the mouse over the source editor found the muya block sitting underneath and re-showed muya's floating UI on top of CodeMirror:

- paragraph **front button** (and the front menu it opens)
- **table drag bar**
- **table column toolbar**
- **preview toolbar** (math / diagram blocks)

The legacy `hideAllFloatTools()` call on entering source mode still hides already-open floats; the gap was that they could be **re-triggered** by hovering — a regression of #1101.

The fix adds `pointer-events: none` to `.editor-wrapper.source`, removing the hidden editor subtree from hit-testing. `document.elementsFromPoint` then no longer returns the muya blocks, so none of the float tools can re-trigger. CodeMirror is a **sibling** of `.editor-wrapper` (not a descendant), so it stays fully interactive.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New unit/e2e test added — the bug is `document.elementsFromPoint` hit-testing behavior, which the happy-dom unit suite cannot reproduce, and the desktop e2e requires a full Electron build. A deterministic regression test belongs in `test/e2e/view-modes.spec.ts` (assert `elementsFromPoint` over the editor returns no muya block in source mode) when run against a build.
- [x] Verified in real Chromium (the engine Electron uses) with a faithful replica of the exact source-mode DOM hierarchy + CSS rule:
  - **Before:** `elementsFromPoint` over the editor returns the muya block (the leak) even though it sits behind CodeMirror in the hit-test stack.
  - **After (`pointer-events: none`):** the muya block is excluded, while CodeMirror is still returned (i.e. remains interactive).
- [x] Tested on: macOS

## Notes for reviewers

- That `elementsFromPoint` ignores `z-index` but honors `pointer-events: none` / `visibility: hidden` / `display: none` was confirmed empirically in Chromium.
- `pointer-events: none` is the most surgical of those options — it changes neither layout, paint, nor the editor's scroll/focus state, only its hit-testability, and it fixes all four float tools at the container level rather than patching each plugin individually.
