### PR TITLE
fix(muya): move preview toolbar to the block's top-right

### DIFF
--- a/packages/muya/src/ui/previewToolBar/index.ts
+++ b/packages/muya/src/ui/previewToolBar/index.ts
@@ -12,7 +12,7 @@ import ICONS from './config';
 import './index.css';
 
 const defaultOptions = {
-    placement: 'left-start' as const,
+    placement: 'right-start' as const,
     offsetOptions: {
         mainAxis: -95,
         crossAxis: 5,


### PR DESCRIPTION
## Summary

The HTML/math block preview toolbar (edit / delete) was anchored at the **top-left corner inside the block** (`placement: 'left-start'` + `mainAxis: -95`), so it overlapped the rendered content.

This mirrors it to the **top-right corner** (`placement: 'right-start'`, same `-95` inset). HTML/math block content is typically left-aligned, so the top-right corner is usually empty and the toolbar no longer obscures content. Vertical position is unchanged; the diff is a single string literal.

| Before | After |
|---|---|
| `[✎][🗑]ontent…` (toolbar over top-left content) | `…content     [✎][🗑]` (toolbar at empty top-right) |

Verified the floating-ui geometry with fixed reference rects: the toolbar now sits 5px inset from the block's right edge (mirror of the previous 5px-from-left), and `flip()` does not push it back into the content.

Closes #4733

## Test plan

- [x] `tsc --noEmit` (muya) — passes
- [x] `eslint` on the changed file — passes
