### PR TITLE
fix(muya): split on Enter over a cross-block selection (#2443)

### DIFF
--- a/packages/muya/e2e/tests/editing/cross-block-enter.spec.ts
+++ b/packages/muya/e2e/tests/editing/cross-block-enter.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { loadMarkdown } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #2443 — pressing Enter while a selection spans two blocks. The cross-block
+// keydown handler only `preventDefault()`ed Backspace/Delete, so the browser's
+// native Enter ran on top of the model edit and split/`<br>`-corrupted the
+// contenteditable. Enter should behave like the same-block case: delete the
+// selection and split at the caret into a new paragraph.
+
+async function selectAcrossParagraphs(
+    page: import('@playwright/test').Page,
+    startOffset: number,
+    endOffset: number,
+): Promise<void> {
+    await page.evaluate(({ startOffset, endOffset }) => {
+        const paras = document.querySelectorAll('.mu-paragraph');
+        const firstText = (el: Element): Text => {
+            const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            return walker.nextNode() as Text;
+        };
+        const n1 = firstText(paras[0]);
+        const n2 = firstText(paras[1]);
+        const range = document.createRange();
+        range.setStart(n1, startOffset);
+        range.setEnd(n2, endOffset);
+        const sel = window.getSelection()!;
+        sel.removeAllRanges();
+        sel.addRange(range);
+        document.dispatchEvent(new Event('selectionchange'));
+    }, { startOffset, endOffset });
+}
+
+test.describe('cross-block selection + Enter (#2443)', () => {
+    test('replaces the selection with a paragraph break, not native DOM corruption', async ({ page }) => {
+        await loadMarkdown(page, 'Hello world\n\nFoo bar\n');
+        await page.locator(editor.paragraph).first().click();
+
+        // Select "world\n\nFoo": from after "Hello " (p1 offset 6) to after
+        // "Foo" (p2 offset 3).
+        await selectAcrossParagraphs(page, 6, 3);
+        await page.keyboard.press('Enter');
+
+        expect(await getMarkdown(page)).toBe('Hello \n\n bar\n');
+    });
+});

--- a/packages/muya/src/clipboard/index.ts
+++ b/packages/muya/src/clipboard/index.ts
@@ -1,5 +1,6 @@
 import type { Muya } from '../muya';
 import type { IClipboardPayload } from './copyData';
+import Format from '../block/base/format';
 import { isClipboardEvent, isKeyboardEvent } from '../utils';
 import { getClipboardData, writeClipboardData } from './copyData';
 import { cutSelection, deleteTableSelection } from './cut';
@@ -80,6 +81,17 @@ class Clipboard {
 
             if (!shouldCrossBlockCut(key, metaKey, event.ctrlKey))
                 return;
+
+            // Enter over a cross-block selection: suppress the corrupting native
+            // Enter and mirror the same-block path — delete then split (#2443).
+            if (key === 'Enter') {
+                event.preventDefault();
+                this.cutHandler();
+                const block = this.muya.editor.activeContentBlock;
+                if (!event.shiftKey && block instanceof Format)
+                    block.enterHandler(event);
+                return;
+            }
 
             if (key === 'Backspace' || key === 'Delete')
                 event.preventDefault();


### PR DESCRIPTION
Fixes #2443

### Problem

Selecting text that spans two blocks and pressing **Enter** deselected everything and left the editor in a state where you couldn't type (and on the old engine the page jumped to the bottom). The selection was deleted but no new paragraph was created, and the browser's native Enter mutated the contenteditable underneath the model.

### Root cause

Cross-block keydowns are handled by a document-level listener in `clipboard/index.ts`. It only called `event.preventDefault()` for `Backspace`/`Delete`. For `Enter` it ran `cutHandler()` (which deletes the cross-block selection and collapses the caret) but did **not** suppress the native Enter, so the browser also ran its own paragraph-split/`<br>` insertion on top of the model edit — corruption, and no clean new paragraph.

Reproduced in a real browser (Playwright): select across two paragraphs, press Enter → markdown was `Hello  bar` (selection deleted, no split) with a corrupted DOM, instead of a paragraph break.

### Fix

Handle `Enter` explicitly in the cross-block path: `preventDefault()`, delete the selection via `cutHandler()`, then split at the collapsed caret through the active block's `enterHandler` — exactly mirroring the same-block selection+Enter behaviour (which already deletes the selection and splits). A `Shift+Enter` is left as a plain deletion (no soft break) rather than corrupting.

### Tests

Added `e2e/tests/editing/cross-block-enter.spec.ts` (real browser): selecting `world\n\nFoo` across two paragraphs and pressing Enter now yields `Hello \n\n bar\n`. Full muya unit suite (1305), the editing e2e suite (36), CommonMark/GFM conformance (1347), lint, typecheck, and circular-dep checks all pass.