### PR TITLE
fix(muya): let Enter replace a selection when the format toolbar is shown (#3196)

### DIFF
--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -252,6 +252,28 @@ function makeFakeEvent(): Event {
     } as unknown as Event;
 }
 
+// #3196 — the inline format toolbar pops up on any text selection. It must be a
+// passive (non-capturing) float, otherwise the UI keydown gate swallows Enter
+// while it is shown and a selection can no longer be replaced with a line break.
+describe('inline format toolbar is a passive float (#3196)', () => {
+    it('does not capture content keydown, so Enter passes through the UI gate', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = new InlineFormatToolbar(muya);
+
+        expect(toolbar.capturesContentKeydown).toBe(false);
+
+        // Simulate the toolbar being the only shown float (as it is whenever
+        // text is selected) and assert the gate lets Enter through.
+        muya.ui.shownFloat.add(toolbar as unknown as Parameters<typeof muya.ui.shownFloat.add>[0]);
+        const event = { key: 'Enter', preventDefault: vi.fn() } as unknown as KeyboardEvent;
+
+        expect(muya.ui.handleContentKeydown(event)).toBe(false);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+
+        toolbar.destroy();
+    });
+});
+
 describe('format picker collapses after link creation', () => {
     it('selecting the link button runs content.format(\'link\') and hides the picker', () => {
         const muya = bootMuya('abc\n');

--- a/packages/muya/src/ui/__tests__/uiHandleContentKeydown.spec.ts
+++ b/packages/muya/src/ui/__tests__/uiHandleContentKeydown.spec.ts
@@ -38,12 +38,14 @@ describe('ui.handleContentKeydown', () => {
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('skips block handling but does not preventDefault for a non-capturing float', () => {
+    it('lets the block handle the key (and does not preventDefault) for a non-capturing float (#3196)', () => {
+        // A passive float (e.g. the inline format toolbar shown on selection)
+        // must not block Enter/Tab/arrows from reaching the block handler.
         const ui = makeUi();
         ui.shownFloat.add(fakeFloat(false));
         const event = keyEvent('Enter');
 
-        expect(ui.handleContentKeydown(event)).toBe(true);
+        expect(ui.handleContentKeydown(event)).toBe(false);
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 

--- a/packages/muya/src/ui/inlineFormatToolbar/index.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/index.ts
@@ -56,7 +56,9 @@ const NON_EDITING_KEYS = new Set([
  */
 export class InlineFormatToolbar extends BaseFloat {
     static pluginName = 'formatPicker';
-    public override capturesContentKeydown = true;
+    // Passive float: must not capture nav keys, or Enter over a selection is
+    // swallowed while it's shown (#3196).
+    public override capturesContentKeydown = false;
 
     /** Previous virtual node for patching */
     private _oldVNode: VNode | null = null;

--- a/packages/muya/src/ui/ui.ts
+++ b/packages/muya/src/ui/ui.ts
@@ -48,13 +48,18 @@ export class Ui {
             return false;
         }
 
+        // Block the content handler only when a shown float actually captures
+        // the key; a passive float (e.g. the format toolbar) must let it through
+        // so Enter/Tab/arrows over a selection still work (#3196).
+        let captured = false;
         for (const tool of this.shownFloat) {
             if (tool.capturesContentKeydown) {
                 event.preventDefault();
+                captured = true;
                 break;
             }
         }
 
-        return true;
+        return captured;
     }
 }


### PR DESCRIPTION
Fixes #3196

### Problem

Selecting some text and pressing **Enter** did nothing — the selection was neither deleted nor replaced with a line break (it works in every other editor).

### Root cause

Selecting text pops the `InlineFormatToolbar`. It declared `capturesContentKeydown = true`, and `Ui.handleContentKeydown` returned `true` (which makes the block's `keydownHandler` bail out early) for **any** shown float whenever the key was a content-nav key (`Enter`/`Tab`/arrows). So with the toolbar up, `Enter` never reached the block's `enterHandler` that deletes the selection and splits the paragraph.

Reproduced in a real browser: select text → toolbar visible → press Enter → the markdown was unchanged.

### Fix

Two coordinated changes:
- `Ui.handleContentKeydown` now blocks the block handler **only when a shown float actually captures the key** (a navigated menu/picker), instead of blocking whenever any float is open.
- The `InlineFormatToolbar` is a passive toolbar — it never navigates with Enter/Tab/arrows — so it opts out with `capturesContentKeydown = false`.

Navigated menus (slash quick-insert, emoji selector, table/code-block pickers, etc.) keep `capturesContentKeydown = true` and are unaffected — their Enter-to-select still works.

### Tests

- `uiHandleContentKeydown.spec.ts`: a non-capturing float no longer blocks the key (returns `false`).
- `formatToggle.spec.ts`: a real `InlineFormatToolbar` reports `capturesContentKeydown === false`, and the real `Ui.handleContentKeydown` lets Enter through when only the toolbar is shown.

Full muya unit suite (1303), CommonMark/GFM conformance (1347), lint, typecheck pass. The inline + ui + blocks e2e suites (78, incl. *"slash quick-insert menu → pressing Enter converts the paragraph"*) confirm navigated-menu Enter is unregressed. The end-to-end "select + Enter replaces" path was verified manually in a real browser; it isn't added as an e2e because the toolbar's async render races the synthetic keydown (a pre-existing selection-timing flake unrelated to this gate change).