### PR TITLE
fix(muya): stop punctuation after a link wrapping to its own line (#2258, #3025)

### DIFF
--- a/packages/muya/e2e/tests/inline/link-punctuation-wrap.spec.ts
+++ b/packages/muya/e2e/tests/inline/link-punctuation-wrap.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '../fixtures/muya';
+
+// #2258 / #3025 — punctuation right after a link wraps to its own line. With the
+// caret outside a link its `](url)` markers render as zero-size `.mu-hide
+// .mu-remove` spans. As `inline-block` (atomic) boxes they introduce soft-wrap
+// opportunities between the link and the following text, so a trailing period
+// can break onto its own line. This drives the REAL stylesheet rule: a hidden
+// marker sandwiched between a word and a period, in a container just wide enough
+// for the word, must not push the period to a new line.
+
+test.describe('punctuation after a link does not wrap (#2258/#3025)', () => {
+    test('a zero-size hidden marker introduces no wrap opportunity before a period', async ({ page }) => {
+        await page.goto('http://localhost:5174/');
+
+        const sameLine = await page.evaluate(() => {
+            const host = document.createElement('div');
+            host.style.cssText = 'position:absolute;top:0;left:0;font-size:16px;line-height:1.5;white-space:normal;';
+            host.innerHTML
+                = '<span id="w">aaaa</span>'
+                + '<span class="mu-hide mu-remove">](http://example.com)</span>'
+                + '<span id="d">.</span>';
+            document.body.appendChild(host);
+
+            const w = document.getElementById('w')!;
+            // Just wide enough for the word — the period is the only overflow
+            // candidate, so it wraps iff a break opportunity exists before it.
+            host.style.width = `${Math.ceil(w.getBoundingClientRect().width) + 2}px`;
+
+            const wTop = Math.round(w.getBoundingClientRect().top);
+            const dTop = Math.round(document.getElementById('d')!.getBoundingClientRect().top);
+            host.remove();
+            return dTop <= wTop;
+        });
+
+        expect(sameLine).toBe(true);
+    });
+});

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -14,6 +14,21 @@
     vertical-align: middle;
 }
 
+/* Hide syntax markers as zero-size `inline` text, not `inline-block` — atomic
+   boxes create a wrap opportunity that breaks punctuation after a link onto its
+   own line (#2258 / #3025). `nowrap` stops the hidden URL's `/`,`.` from
+   wrapping. Scoped to `.mu-remove` so math/ruby/emoji previews keep inline-block. */
+.mu-hide.mu-remove,
+.mu-hide.mu-remove .mu-highlight,
+.mu-hide.mu-remove .mu-selection {
+    display: inline;
+    width: auto;
+    height: auto;
+
+    font-size: 0;
+    white-space: nowrap;
+}
+
 /* link and auto-link and reference link */
 a.mu-inline-rule,
 span.mu-inline-rule.mu-link {


### PR DESCRIPTION
Fixes #2258
Fixes #3025

### Problem

A period (or other punctuation) immediately following a hyperlink could wrap to its own line, separated from the link — e.g. `[link](url)` at a line end pushed the trailing `.` down by itself.

### Root cause

With the caret outside a link, its `](url)` portion renders as zero-size `.mu-hide.mu-remove` spans. Those spans are `display: inline-block` (atomic inline boxes), and CSS introduces a soft-wrap opportunity before/after every atomic inline box — so the layout engine is allowed to break between the link and the following punctuation. Isolated in a real browser: a zero-size `inline-block` marker sandwiched between a word and a period lets the period wrap; the same marker as plain `inline` text does not.

### Fix

Render the hidden inline-syntax markers as plain `inline` text instead of `inline-block`:

```css
.mu-hide.mu-remove,
.mu-hide.mu-remove .mu-highlight,
.mu-hide.mu-remove .mu-selection {
    display: inline;
    width: auto;
    height: auto;
    font-size: 0;       /* keep them invisible */
    white-space: nowrap; /* the hidden URL's own `/` `.` must not break either */
}
```

Scoped to `.mu-remove` (the pure syntax markers: link brackets/URL, emphasis `**`, code, footnote, headings, sup/sub, `$$`, backlash) so the preview-bearing `.mu-hide` variants — math/ruby/emoji, which rely on `inline-block` + `width/height: auto` for their rendered previews — are untouched.

### Tests

Added `e2e/tests/inline/link-punctuation-wrap.spec.ts`, which drives the **real stylesheet rule**: a `.mu-hide.mu-remove` marker between a word and a period, in a container just wide enough for the word, must not push the period to a new line (deterministic, font-robust via a measured width). Verified the markers stay zero-width (still hidden). Full muya unit suite (1302), CommonMark/GFM conformance (1347), the inline + editing + ui e2e suites (81, incl. marker-toggle and selection), ESLint, stylelint (this file), and typecheck all pass.