### PR TITLE
fix(desktop): prefer UTF-8 when a file is valid UTF-8 instead of trusting ced (#3151)

### DIFF
--- a/packages/desktop/src/main/filesystem/encoding.ts
+++ b/packages/desktop/src/main/filesystem/encoding.ts
@@ -33,6 +33,22 @@ const checkSequence = (buffer: Buffer, sequence: number[]): boolean => {
   return sequence.every((v, i) => v === buffer[i])
 }
 
+// `ced` occasionally misdetects a valid UTF-8 file as a legacy double-byte
+// encoding (notably GBK), mojibaking multi-byte text — e.g. Greek µ/κ/α become
+// CJK 碌/魏/伪 (#3151). A NUL byte signals binary / BOM-less UTF-16, not a UTF-8
+// text file.
+const isLikelyUtf8 = (buffer: Buffer): boolean => {
+  if (buffer.includes(0)) {
+    return false
+  }
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(buffer)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /**
  * Guess the encoding from the buffer.
  */
@@ -49,6 +65,11 @@ export const guessEncoding = (buffer: Buffer, autoGuessEncoding: boolean): Encod
 
   // Auto guess encoding, otherwise use UTF-8.
   if (autoGuessEncoding) {
+    // A file that is already valid UTF-8 must be decoded as UTF-8, regardless
+    // of what `ced` heuristically guesses (#3151).
+    if (isLikelyUtf8(buffer)) {
+      return { encoding: 'utf8', isBom }
+    }
     encoding = ced(buffer)
     if (CED_ICONV_ENCODINGS[encoding]) {
       encoding = CED_ICONV_ENCODINGS[encoding]

--- a/packages/desktop/test/unit/specs/encoding.spec.ts
+++ b/packages/desktop/test/unit/specs/encoding.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// `ced` (compact_enc_det) occasionally misdetects a valid UTF-8 file as a legacy
+// double-byte encoding, mojibaking multi-byte text — e.g. Greek µ/κ/α become CJK
+// 碌/魏/伪 (#3151). Simulate that by forcing `ced` to always answer GBK; the fix
+// must override it whenever the bytes are valid UTF-8.
+vi.mock('ced', () => ({ default: vi.fn(() => 'GB') }))
+
+const { guessEncoding } = await import('main_renderer/filesystem/encoding')
+
+describe('guessEncoding — prefer UTF-8 over a ced misdetection (#3151)', () => {
+  it('returns utf8 for a valid UTF-8 buffer even when ced guesses GBK', () => {
+    const buffer = Buffer.from('# Notes\n\nµ = 0.5, κ, α — Greek letters.\n', 'utf8')
+    expect(guessEncoding(buffer, true).encoding).toBe('utf8')
+  })
+
+  it('still falls back to ced for a genuinely non-UTF-8 buffer', () => {
+    // `0xC2` is a UTF-8 lead byte; the following space is not a continuation
+    // byte, so the buffer is not valid UTF-8 and ced's guess stands.
+    const buffer = Buffer.from([0x68, 0x69, 0xc2, 0x20, 0x6f, 0x6b])
+    expect(guessEncoding(buffer, true).encoding).toBe('gb2312')
+  })
+
+  it('does not force utf8 for a buffer containing NUL (binary / BOM-less UTF-16)', () => {
+    const buffer = Buffer.from([0x68, 0x00, 0x65, 0x00, 0x6c, 0x00])
+    expect(guessEncoding(buffer, true).encoding).not.toBe('utf8')
+  })
+
+  it('honours a UTF-8 BOM and never reaches ced', () => {
+    const buffer = Buffer.from([0xef, 0xbb, 0xbf, 0x68, 0x69])
+    const result = guessEncoding(buffer, true)
+    expect(result.encoding).toBe('utf8')
+    expect(result.isBom).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #3151

### Problem

Some UTF-8 files open with multi-byte characters corrupted into CJK — the reporter's Greek letters render as Chinese:

- `µ` → `碌`  (UTF-8 `C2 B5` decoded as GBK)
- `κ` → `魏`  (`CE BA`)
- `α` → `伪`  (`CE B1`)

It's intermittent ("not in every file") and the file is fine in other editors, which pointed at encoding **detection**.

### Root cause

`loadMarkdownFile` calls `guessEncoding`, which runs the buffer through `ced` (Google's `compact_enc_det`). `ced` is a statistical detector and occasionally misdetects a valid UTF-8 file as a legacy double-byte encoding (GBK here). `iconv.decode(buffer, 'gb2312')` then reinterprets the UTF-8 multi-byte sequences as CJK characters → mojibake.

### Fix

Before consulting `ced`, short-circuit to `utf8` whenever the buffer **is valid UTF-8 and contains no NUL byte** (a NUL signals binary / BOM-less UTF-16). A file that is already valid UTF-8 must be decoded as UTF-8; `ced` is only needed for genuinely non-UTF-8 files. This is the standard "prefer UTF-8" heuristic and is safe — a non-UTF-8 file that is *coincidentally* valid UTF-8 throughout is vanishingly rare for real text, and single-byte/GBK/Shift-JIS content is almost always invalid UTF-8 so it still flows to `ced`.

### Tests

`test/unit/specs/encoding.spec.ts`, with `ced` mocked to always answer GBK (simulating the documented misdetection):
- a valid UTF-8 Greek buffer → `utf8` (the fix; **fails without it**, returning `gb2312`);
- a genuinely invalid-UTF-8 buffer → still falls back to `ced` (`gb2312`);
- a buffer with NUL → not forced to `utf8`;
- a UTF-8 BOM → `utf8` without reaching `ced`.

Lint + typecheck pass.

### Verification note

`ced` is robust enough that I could **not** reproduce its specific misdetection locally without the reporter's exact file (every valid-UTF-8 Greek/Cyrillic/Arabic sample I tried was correctly detected as UTF-8). The fix targets the root cause directly and the test simulates the misdetection via a `ced` mock; if you have a file that reproduced the original bug, it's the ideal real-world confirmation.