### PR TITLE
chore: audit Claude-authored comments against the commenting guidelines

### DIFF
--- a/packages/desktop/src/renderer/src/bootstrap.ts
+++ b/packages/desktop/src/renderer/src/bootstrap.ts
@@ -77,8 +77,6 @@ const isCodeMirrorRaceCondition = (error: Error | null | undefined): boolean => 
 const handleRendererError = (event: ErrorEvent | PromiseRejectionEvent | Event): void => {
   const errorEvent = event as ErrorEvent
   if (errorEvent.error) {
-    // Suppress known non-fatal CodeMirror race conditions
-    // These occur during rapid clicking/editing and don't affect functionality
     if (isCodeMirrorRaceCondition(errorEvent.error)) {
       console.warn('Suppressed non-fatal CodeMirror race condition:', errorEvent.error.message)
       return

--- a/packages/desktop/src/renderer/src/i18n/index.ts
+++ b/packages/desktop/src/renderer/src/i18n/index.ts
@@ -4,7 +4,6 @@ import bus from '../bus'
 // Directly import translation files
 import enTranslations from '../../../../static/locales/en.json'
 
-// Create the Vue i18n instance.
 // vue-i18n's options type intersection between Composition + Legacy modes is
 // notoriously difficult to satisfy with mixed shapes; we cast the options once
 // at the call site rather than spreading `any` further.
@@ -61,7 +60,6 @@ export const t = (key: string, ...args: unknown[]): string => {
 // don't fire duplicate IPCs for the same locale.
 const inflightLoads = new Map<string, Promise<Record<string, unknown> | undefined>>()
 
-// Export language setter function
 export const setLanguage = async(locale: string): Promise<void> => {
   if (!locale) return
   const globalI18n = i18n.global

--- a/packages/desktop/src/renderer/src/pages/app.vue
+++ b/packages/desktop/src/renderer/src/pages/app.vue
@@ -74,7 +74,6 @@ const notificationStore = useNotificationStore()
 
 const timer = ref<ReturnType<typeof setTimeout> | null>(null)
 
-// States from Pinia
 const { windowActive, platform, init } = storeToRefs(mainStore)
 const { showTabBar } = storeToRefs(layoutStore)
 const { sourceCode, theme, customCss, textDirection, zoom } = storeToRefs(preferencesStore)

--- a/packages/desktop/src/renderer/src/prefComponents/image/components/uploader/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/image/components/uploader/index.vue
@@ -24,7 +24,6 @@
           <div class="detection-header">
             <h6>{{ t('preferences.image.uploader.picgoDetection') }}</h6>
             <div class="detection-controls">
-              <!-- Standalone refresh button -->
               <button
                 v-if="showStandaloneRefreshButton"
                 class="standalone-refresh-button"
@@ -84,7 +83,6 @@
                   >
                     <!-- All SVG icons removed -->
                   </button>
-                  <!-- Refresh button -->
                   <button
                     v-if="showRefreshButton"
                     class="refresh-button"
@@ -167,7 +165,6 @@
             </div>
           </div>
 
-          <!-- PicGo basic usage guide -->
           <div class="usage-guide">
             <div class="usage-title">
               {{ t('preferences.image.uploader.usageGuide.title') }}
@@ -290,7 +287,7 @@ const picgoDetectionFailed = ref<boolean>(false) // Whether detection failed
 const picgoDetectionStatus = ref<string>('') // Detection status text
 const picgoDebugInfo = ref<string>('') // Debug information
 const isDetecting = ref<boolean>(false) // Whether detection is in progress
-const lastDetectionTime = ref<string | null>(null) // Last detection time
+const lastDetectionTime = ref<string | null>(null)
 const lastSuccessTime = ref<string | null>(null) // Last successful detection time
 const detectionTimer = ref<ReturnType<typeof setTimeout> | null>(null) // Detection interval constant moved into scheduleNextDetection function
 const consecutiveFailures = ref<number>(0) // Number of consecutive failures
@@ -695,7 +692,6 @@ const stopAnimationAndButton = () => {
 }
 
 const testPicgo = async (): Promise<void> => {
-  // Record detection start time
   lastDetectionTime.value = new Date().toISOString()
 
   const debugMessages: string[] = []

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1942,7 +1942,6 @@ const createApplicationMenuState = ({
     }
   }
 
-  // Clean up
   if (Object.getOwnPropertyNames(state.affiliation).length >= 2 && state.affiliation.p) {
     delete state.affiliation.p
   }

--- a/packages/desktop/src/renderer/src/store/index.ts
+++ b/packages/desktop/src/renderer/src/store/index.ts
@@ -7,7 +7,6 @@ const pinia = createPinia()
 export const useMainStore = defineStore('main', () => {
   // Platform of system: 'darwin' | 'win32' | 'linux'
   const platform = ref<NodeJS.Platform>(window.electron.process.platform)
-  // MarkText version string
   const appVersion = ref<string>(window.electron.process.env.MARKTEXT_VERSION_STRING ?? '')
   // Whether current window is active or focused
   const windowActive = ref(true)

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -226,7 +226,7 @@ export const usePreferencesStore = defineStore('preferences', {
 
     // Edit modes of the current window (not part of persistent settings)
     typewriter: false, // typewriter mode
-    focus: false, // focus mode
+    focus: false,
     sourceCode: false, // source code mode
 
     // user configration

--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -164,7 +164,6 @@ export const exportStyledHTML = async(
     dir
   })
 
-  // Pull out the rendered <article class="markdown-body">…</article> body.
   const articleMatch = /<article class="markdown-body">([\s\S]*)<\/article>/.exec(fullDoc)
   let article = articleMatch ? articleMatch[1] : fullDoc
 

--- a/packages/desktop/src/shared/types/bufferedState.ts
+++ b/packages/desktop/src/shared/types/bufferedState.ts
@@ -1,6 +1,4 @@
 // Buffered editor state (persisted across window close/reopen).
-//
-// Refined when Commit 7 rewrites the editor + bufferedState stores.
 
 import type { IFileState } from './files'
 

--- a/packages/desktop/src/types/muya-core.d.ts
+++ b/packages/desktop/src/types/muya-core.d.ts
@@ -84,7 +84,6 @@ declare module '@muyajs/core' {
 
   export function renderToStaticHTML(...args: any[]): any
 
-  // Utils.
   export function escapeHTML(str: string): string
   export function unescapeHTML(str: string): string
   export function sanitize(html: string, config?: any, isInline?: boolean): string

--- a/packages/desktop/src/types/muya.d.ts
+++ b/packages/desktop/src/types/muya.d.ts
@@ -5,9 +5,6 @@
  * Delete this file the day upstream lands; see packages/website/content/docs/dev/TYPESCRIPT.md.
  */
 
-// Ambient bridge to the JavaScript muya/ tree. Delete this file the day
-// upstream TS muya (https://github.com/marktext/muya) lands.
-//
 // We declare every muya path that's imported from outside src/muya/. This
 // cuts the dependency graph at the boundary: TypeScript no longer follows
 // imports into the legacy JS source, so e.g. inferred types from dompurify

--- a/packages/desktop/test/e2e/crash-range-offset.spec.ts
+++ b/packages/desktop/test/e2e/crash-range-offset.spec.ts
@@ -42,7 +42,6 @@ test.describe('Crash: setStart Range offset', () => {
     if (app) await app.close()
   })
 
-  // Recipe from #2526.
   test('Issue #2526: typing escaped <pre>...</pre> then re-selecting does not crash', async() => {
     // Type literal `\<pre\>some text\</pre\>` as the user described.
     await typeIntoEditor(page, '\\<pre\\>some text\\</pre\\>')
@@ -64,7 +63,6 @@ test.describe('Crash: setStart Range offset', () => {
     await expectNoRendererErrors(app)
   })
 
-  // Recipe from #3737 — backspace at the start of a code block.
   test('Issue #3737: backspace at start of a code block does not crash', async() => {
     // Build a code block via the markdown source-mode round-trip.
     // (Code blocks are rendered as CodeMirror instances inside Muya; the

--- a/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
+++ b/packages/desktop/test/e2e/parity-source-undo-saved.spec.ts
@@ -13,8 +13,7 @@ import {
 } from './helpers'
 
 // PARITY SCOREBOARD — desktop gaps PG2 (file PG02), PG14 (file PG15),
-// PG15 (file PG16). Each RUNS headless but currently fails, so each is marked
-// `test.fail()`. When the corresponding fix lands, remove the `test.fail()`.
+// PG15 (file PG16).
 
 // Trigger an editor undo through the same IPC channel the Edit › Undo menu item
 // uses (`mt::editor-edit-action` → bus `undo` → editor.undo()). More reliable

--- a/packages/desktop/test/e2e/view-modes.spec.ts
+++ b/packages/desktop/test/e2e/view-modes.spec.ts
@@ -39,7 +39,6 @@ const waitForChecked = async(
   return last ?? { checked: false, enabled: false }
 }
 
-// Poll the menu item until its `enabled` flag matches `want`.
 const waitForEnabled = async(
   app: ElectronApplication,
   id: string,

--- a/packages/desktop/test/unit/markdown.ts
+++ b/packages/desktop/test/unit/markdown.ts
@@ -40,10 +40,6 @@ export const ListsTemplate = () => {
   return loadMarkdownContent('common/Lists.md')
 }
 
-// --------------------------------------------------------
-// GFM templates
-//
-
 export const GfmBasicTextFormattingTemplate = () => {
   return loadMarkdownContent('gfm/BasicTextFormatting.md')
 }

--- a/packages/desktop/test/unit/specs/format-menu-state.spec.ts
+++ b/packages/desktop/test/unit/specs/format-menu-state.spec.ts
@@ -23,8 +23,6 @@ vi.mock('main_renderer/i18n', () => ({ t: (key: string) => key }))
 
 import { createSelectionFormatState } from '@/store/editor'
 import { updateFormatMenu } from 'main_renderer/menu/actions/format'
-// The toolbar config is a deep subpath of @muyajs/core that vite resolves at
-// runtime but whose types are not exposed via the package `exports` map.
 // @ts-expect-error deep @muyajs/core subpath resolves at runtime (vite) but exposes no types
 import inlineFormatIcons from '@muyajs/core/ui/inlineFormatToolbar/config'
 import keybindingsWindows from 'main_renderer/keyboard/keybindingsWindows'

--- a/packages/desktop/test/unit/specs/pdf.spec.ts
+++ b/packages/desktop/test/unit/specs/pdf.spec.ts
@@ -25,7 +25,7 @@ vi.hoisted(() => {
 // characterize the branch *dispatch* (academic/liber take the inline path and
 // never touch `window.fileUtils`/`window.marktext`, unlike a disk theme name)
 // rather than asserting a theme-specific selector token, which is unavailable
-// here. See suspectedBugs / notes.
+// here.
 
 const loadPdf = async() => {
   return import('@/util/pdf')

--- a/packages/muya/e2e/tests/blocks/reference-link-image.spec.ts
+++ b/packages/muya/e2e/tests/blocks/reference-link-image.spec.ts
@@ -109,9 +109,7 @@ test.describe('reference link', () => {
             window.muya!.setContent('[a][r]\n');
         });
 
-        // No reference-link element of any kind survives an unresolved label.
         await expect(page.locator('.mu-reference-link')).toHaveCount(0);
-        // The raw text round-trips through getMarkdown unchanged.
         const md = await page.evaluate(() => window.muya!.getMarkdown());
         expect(md).toContain('[a][r]');
     });

--- a/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/mermaid.spec.ts
@@ -83,7 +83,6 @@ test.describe('mermaid diagram', () => {
         await expect(error).toBeVisible({ timeout: 15_000 });
         await expect(error).toContainText('Invalid Diagram Code');
 
-        // No SVG should have mounted for a failed parse.
         await expect(page.locator(`${editor.diagramPreview} svg`)).toHaveCount(0);
 
         // The editor stays alive (no thrown crash): the source still round-trips.

--- a/packages/muya/e2e/tests/diagrams/sequence-overflow-3560.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/sequence-overflow-3560.spec.ts
@@ -36,6 +36,6 @@ test('a wide sequence diagram scales to fit its block, not clipped (#3560)', asy
         return { wideEnough: intrinsic > blockWidth, fits: rendered <= blockWidth + 1 };
     }, editor.diagramPreview);
 
-    expect(fits.wideEnough).toBe(true); // the diagram really is wider than the block
-    expect(fits.fits).toBe(true); // ...but is scaled down to fit it
+    expect(fits.wideEnough).toBe(true);
+    expect(fits.fits).toBe(true);
 });

--- a/packages/muya/e2e/tests/diagrams/sequence.spec.ts
+++ b/packages/muya/e2e/tests/diagrams/sequence.spec.ts
@@ -34,7 +34,6 @@ test.describe('sequence diagram', () => {
         const svg = page.locator(`${editor.diagramPreview} svg`).first();
         await expect(svg).toBeVisible({ timeout: 15_000 });
 
-        // The vendored renderer always tags the svg with the `sequence` class.
         await expect(svg).toHaveClass(/sequence/);
     });
 

--- a/packages/muya/e2e/tests/inline/format-toolbar.spec.ts
+++ b/packages/muya/e2e/tests/inline/format-toolbar.spec.ts
@@ -53,7 +53,6 @@ test.describe('inline format toolbar', () => {
         // the strong token; the markers should collapse to `.mu-hide`.
         await page.locator(editor.paragraph).first().click({ position: { x: 2, y: 2 } });
 
-        // The strong run itself is a live `<strong.mu-inline-rule>` node.
         const strongRun = page.locator(`${editor.paragraph} strong.mu-inline-rule`);
         await expect(strongRun).toHaveCount(1);
         await expect(strongRun).toHaveText('bold');

--- a/packages/muya/e2e/tests/inline/shortcuts.spec.ts
+++ b/packages/muya/e2e/tests/inline/shortcuts.spec.ts
@@ -33,7 +33,6 @@ test.describe('keyboard shortcuts', () => {
         await page.evaluate(() => window.muya!.setContent('struck text'));
         await tripleClickFirstParagraph(page);
         await page.keyboard.press(`${metaKey()}+d`);
-        // The `del` renderer mounts a live `<del>` element inside the paragraph.
         const del = page.locator(`${editor.paragraph} del`).first();
         await expect(del).toBeVisible();
         await expect(del).toContainText('struck text');

--- a/packages/muya/e2e/tests/options/disable-html.spec.ts
+++ b/packages/muya/e2e/tests/options/disable-html.spec.ts
@@ -126,7 +126,6 @@ test.describe('options / disableHtml', () => {
     });
 
     test('disableHtml: true — inline <b> raw-html renders the same as with disableHtml: false', async ({ page }) => {
-        // disableHtml: true
         await page.evaluate(() => {
             window.__e2e!.rebuildMuya({ disableHtml: true });
             window.muya!.setContent([{

--- a/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
+++ b/packages/muya/e2e/tests/typing/math-and-diagrams.spec.ts
@@ -48,7 +48,6 @@ test.describe('math and diagrams', () => {
         await expect(page.locator(`${editor.paragraph} ${editor.katex}`).first())
             .toBeVisible({ timeout: 10_000 });
 
-        // Exactly one inline formula was rendered.
         await expect(page.locator(editor.katex)).toHaveCount(1);
 
         // The source markdown round-trips losslessly through the serializer.

--- a/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
+++ b/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
@@ -52,9 +52,7 @@ test.describe('paragraphs and headings', () => {
 
             const heading = page.locator(editor.atxHeading).first();
             await expect(heading).toBeVisible();
-            // The heading tag reflects the level (h4 / h5 / h6).
             await expect(heading).toHaveJSProperty('tagName', `H${level}`);
-            // No paragraph remains.
             await expect(page.locator(editor.paragraph)).toHaveCount(0);
             // Markdown round-trips with the right number of leading hashes.
             expect(await getMarkdown(page)).toContain(`${hashes} Title`);

--- a/packages/muya/e2e/tests/typing/table.spec.ts
+++ b/packages/muya/e2e/tests/typing/table.spec.ts
@@ -130,7 +130,6 @@ test.describe('table', () => {
         // No atx-heading appears, and the table is still a table.
         await expect(page.locator(editor.atxHeading)).toHaveCount(0);
         await expect(table).toBeVisible();
-        // The literal text lives in the cell.
         await expect(cellContent).toContainText('# x');
 
         // The active selection is still inside a table cell content block —
@@ -189,7 +188,6 @@ test.describe('table', () => {
         await expect(linkSpan).toHaveAttribute('href', 'http://y');
         await expect(linkSpan).toContainText('x');
 
-        // getMarkdown serialises the link back into the body cell.
         await expect.poll(() => getMarkdown(page)).toContain('[x](http://y)');
     });
 

--- a/packages/muya/src/__tests__/createTableImageCursor.spec.ts
+++ b/packages/muya/src/__tests__/createTableImageCursor.spec.ts
@@ -100,7 +100,6 @@ describe('muya.createTable()', () => {
         });
         const sel = muya.editor.selection.getSelection();
         expect(sel).not.toBeNull();
-        // The caret lands on a table-cell content block.
         expect(sel!.anchor.block.blockName).toBe('table.cell.content');
     });
 

--- a/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
+++ b/packages/muya/src/__tests__/crossBlockParagraph.spec.ts
@@ -125,7 +125,7 @@ describe('cross-block paragraph wrapping', () => {
     });
 
     it('preserves a multi-block selection across wrap then unwrap (paragraph + list)', async () => {
-        const muya = boot('alpha\n\n- bravo\n'); // a paragraph and an unordered list
+        const muya = boot('alpha\n\n- bravo\n');
         selectFirstTwoBlocks(muya);
         muya.updateParagraph('ol-order'); // wrap both into an ordered list
         await vi.waitFor(() => expect(muya.getState()[0].name).toBe('order-list'));

--- a/packages/muya/src/__tests__/historySerialization.spec.ts
+++ b/packages/muya/src/__tests__/historySerialization.spec.ts
@@ -63,8 +63,6 @@ function placeCursorOnFirstBlock(muya: Muya): Content {
     return first;
 }
 
-// Undo entries coalesce within options.delay; cutoff() forces the next edit
-// into its own undo entry so depth assertions are deterministic.
 function undoDepth(muya: Muya): number {
     // @ts-expect-error — reach into the private stack for test assertions.
     return muya.editor.history._stack.undo.length;

--- a/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
+++ b/packages/muya/src/__tests__/parityHeadingCopyLink.spec.ts
@@ -62,7 +62,6 @@ describe('parity PG11: heading hover-to-copy-anchor affordance', () => {
             const muya = bootMuya('# Getting Started\n');
             const affordance = muya.domNode.querySelector(COPY_LINK_SELECTOR);
 
-            // Desired: the heading exposes a hover-copy-anchor affordance.
             expect(affordance).toBeTruthy();
         },
     );

--- a/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
+++ b/packages/muya/src/__tests__/parityInsertParagraphNested.spec.ts
@@ -105,7 +105,7 @@ describe('parity PG13: insertParagraph anchors to the immediate block in nested 
 
             // Desired: the new paragraph is an INNER sibling — the top-level
             // block count is unchanged (still just the one bullet-list) and the
-            // paragraph is NOT a root-level sibling. Today it lands at root.
+            // paragraph is NOT a root-level sibling.
             expect(muya.getState().length).toBe(1);
             expect(topLevelHasParagraph(muya, 'INNERSIBLING')).toBe(false);
         },
@@ -124,8 +124,7 @@ describe('parity PG13: insertParagraph anchors to the immediate block in nested 
             });
 
             // Desired: still a single top-level block (the blockquote) with the
-            // new paragraph nested inside it. Today it lands after the quote at
-            // document root.
+            // new paragraph nested inside it.
             expect(muya.getState().length).toBe(1);
             expect(muya.getState()[0].name).toBe('block-quote');
             expect(topLevelHasParagraph(muya, 'QUOTESIBLING')).toBe(false);

--- a/packages/muya/src/__tests__/resetToParagraph.spec.ts
+++ b/packages/muya/src/__tests__/resetToParagraph.spec.ts
@@ -138,7 +138,6 @@ describe('paragraph front menu — a single menu open performs at most one actio
         // list, but the menu still holds it in `_block`.
         menu.selectItem(new Event('click'), { label: 'order-list' });
 
-        // Selecting again on the now-detached block must not throw.
         expect(() =>
             menu.selectItem(new Event('click'), { label: 'bullet-list' }),
         ).not.toThrow();

--- a/packages/muya/src/__tests__/setCursorByOffset.spec.ts
+++ b/packages/muya/src/__tests__/setCursorByOffset.spec.ts
@@ -52,7 +52,6 @@ describe('muya.setCursorByOffset() (PG2)', () => {
         await vi.waitFor(() => {
             const sel = muya.editor.selection.getSelection();
             expect(sel).not.toBeNull();
-            // The caret lands inside the "third para here" block.
             expect(sel!.anchor.block.text).toBe('third para here');
             expect(sel!.anchor.offset).toBe(6);
         });

--- a/packages/muya/src/__tests__/setOptions.spec.ts
+++ b/packages/muya/src/__tests__/setOptions.spec.ts
@@ -74,7 +74,6 @@ describe('muya runtime options', () => {
         muya.insertParagraph();
         await vi.waitFor(() => {
             expect(muya.getState().length).toBe(2);
-            // the edit was recorded onto the undo stack
             expect(muya.editor.history.canUndo()).toBe(true);
         });
 

--- a/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.menu.spec.ts
@@ -148,9 +148,9 @@ describe('updateParagraph same-block menu model', () => {
             expect(s.length).toBe(3);
             expect(s[0].name).toBe('atx-heading');
             expect((s[0] as { text: string }).text).toBe('# Title'); // heading kept
-            expect(s[1].name).toBe('thematic-break'); // rule below it
+            expect(s[1].name).toBe('thematic-break');
             expect(s[2].name).toBe('paragraph');
-            expect((s[2] as { text: string }).text).toBe(''); // trailing empty paragraph
+            expect((s[2] as { text: string }).text).toBe('');
         });
     });
 

--- a/packages/muya/src/__tests__/updateParagraph.spec.ts
+++ b/packages/muya/src/__tests__/updateParagraph.spec.ts
@@ -286,7 +286,6 @@ describe('muya.updateParagraph()', () => {
         });
 
         const state = muya.getState();
-        // The trailing paragraph is empty and ready for input.
         expect((state[1] as { text: string }).text).toBe('');
 
         // The cursor moved off the original paragraph into the trailing one:

--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -228,12 +228,6 @@ describe('format.format() apply-ON over a non-collapsed selection', () => {
     });
 });
 
-// The markdown round-trip above proves the html_tag format committed to state.
-// These pin the *live* DOM mount: the inline renderer turns `<u>`/`<mark>`
-// html_tag tokens into real elements (bare tag + `.mu-inline-rule.mu-raw-html`
-// via `buildRawHtmlTag`) inside the booted content block, not just into a
-// serialized markdown string. (The export path is covered by
-// renderToStaticHTML.spec; this is the editing-surface mount.)
 describe('format.format(\'clear\') with the caret inside the run', () => {
     it('strips a strong run to plain text', () => {
         const content = caretInFirstBlock(bootMuya('**word**\n'), 2);

--- a/packages/muya/src/block/content/paragraphContent/__tests__/tableConversion.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/tableConversion.spec.ts
@@ -115,7 +115,6 @@ describe('paragraphContent.enterHandler — pipe-table conversion', () => {
         await flush();
         const anchorBlock = muya.editor.selection.anchorBlock;
         expect(anchorBlock).not.toBeNull();
-        // Caret is in a table cell content leaf.
         expect(anchorBlock!.blockName).toBe('table.cell.content');
 
         // The owning cell sits in the SECOND row (the empty body row, index 1)

--- a/packages/muya/src/block/content/tableCell/__tests__/enterHandler.spec.ts
+++ b/packages/muya/src/block/content/tableCell/__tests__/enterHandler.spec.ts
@@ -112,7 +112,6 @@ describe('tableCellContent.enterHandler', () => {
 
         await flush();
         expect(cell.text).toContain('<br/>');
-        // `a` + `<br/>` + `b`
         expect(cell.text).toBe('a<br/>b');
 
         const cursor = cell.getCursor();

--- a/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/parityImagePaste.spec.ts
@@ -103,7 +103,7 @@ describe('parity PG6: pasted image FILE routes through imageAction', () => {
         async () => {
             const clipboardFilePath = vi.fn().mockResolvedValue('/abs/photo.png');
             // The user's insert preference moves the file into the assets dir and
-            // returns the rewritten src. With the gap, this is never called.
+            // returns the rewritten src.
             const imageAction = vi
                 .fn()
                 .mockResolvedValue('assets/photo.png');
@@ -140,8 +140,7 @@ describe('parity PG6: pasted image FILE routes through imageAction', () => {
             await clipboard.pasteHandler(event);
 
             // Desired: the assets-relative src returned by imageAction is what
-            // lands in the document (portable). Today the raw absolute path is
-            // written verbatim.
+            // lands in the document (portable).
             expect(anchorBlock.text).toBe('![](assets/photo.png)');
         },
     );
@@ -168,8 +167,7 @@ describe('parity PG5: binary/bitmap clipboard image paste', () => {
             await clipboard.pasteHandler(event);
 
             // Desired: the binary image is persisted through imageAction and an
-            // image is inserted. Today nothing is read from clipboardData.files
-            // and nothing is inserted.
+            // image is inserted.
             expect(imageAction).toHaveBeenCalledTimes(1);
             expect(anchorBlock.text).toBe('![](assets/pasted.png)');
         },

--- a/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
+++ b/packages/muya/src/editor/__tests__/parityHideLinkPopup.spec.ts
@@ -90,8 +90,6 @@ describe('parity PG12: hideLinkPopup gates the link hover popover', () => {
             muya.on('muya-link-tools', handler);
             hover(link);
 
-            // Desired: the popover stays suppressed when the preference is set.
-            // Today the emitter ignores the option and opens it anyway.
             expect(countOpenEmits(handler)).toBe(0);
         },
     );

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -114,7 +114,6 @@ function consumeBeginRules(state: ILexState, beginRules: BeginRules) {
     }
 }
 
-// backlash
 function tryBacklash(state: ILexState): boolean {
     const backTo = state.inlineRules.backlash.exec(state.src);
     if (!backTo)
@@ -140,7 +139,6 @@ function tryBacklash(state: ILexState): boolean {
     return true;
 }
 
-// strong | em
 function tryStrongEm(state: ILexState): boolean {
     const emRules = ['strong', 'em'] as const;
 
@@ -254,7 +252,6 @@ function tryChunks(state: ILexState): boolean {
     return false;
 }
 
-// superscript and subscript
 function trySuperSubScript(state: ILexState): boolean {
     if (!state.superSubScript)
         return false;
@@ -282,7 +279,6 @@ function trySuperSubScript(state: ILexState): boolean {
     return true;
 }
 
-// footnote identifier
 function tryFootnote(state: ILexState): boolean {
     if (state.pos === 0 || !state.footnote)
         return false;
@@ -309,7 +305,6 @@ function tryFootnote(state: ILexState): boolean {
     return true;
 }
 
-// image
 function tryImage(state: ILexState): boolean {
     const imageTo = state.inlineRules.image.exec(state.src);
     correctUrl(imageTo);
@@ -348,7 +343,6 @@ function tryImage(state: ILexState): boolean {
     return true;
 }
 
-// link
 function tryLink(state: ILexState): boolean {
     const linkTo = state.inlineRules.link.exec(state.src);
     correctUrl(linkTo);
@@ -491,7 +485,6 @@ function tryReferenceImage(state: ILexState): boolean {
     return true;
 }
 
-// html escape
 function tryHtmlEscape(state: ILexState): boolean {
     const htmlEscapeTo = state.inlineRules.html_escape.exec(state.src);
     if (!htmlEscapeTo)
@@ -569,7 +562,6 @@ function trimAutoLinkExtent(raw: string): string {
     return raw.slice(0, end);
 }
 
-// auto link extension
 function tryAutoLinkExtension(state: ILexState): boolean {
     const autoLinkExtTo = state.inlineRules.auto_link_extension.exec(state.src);
     if (
@@ -621,7 +613,6 @@ function tryAutoLinkExtension(state: ILexState): boolean {
     return true;
 }
 
-// auto link
 function tryAutoLink(state: ILexState): boolean {
     const autoLTo = state.inlineRules.auto_link.exec(state.src);
     if (!autoLTo)
@@ -718,7 +709,6 @@ function tryHtmlTag(state: ILexState): boolean {
     return false;
 }
 
-// soft line break
 function trySoftLineBreak(state: ILexState): boolean {
     const softTo = state.inlineRules.soft_line_break.exec(state.src);
     if (!softTo)
@@ -743,7 +733,6 @@ function trySoftLineBreak(state: ILexState): boolean {
     return true;
 }
 
-// hard line break
 function tryHardLineBreak(state: ILexState): boolean {
     const hardTo = state.inlineRules.hard_line_break.exec(state.src);
     if (!hardTo)
@@ -769,7 +758,6 @@ function tryHardLineBreak(state: ILexState): boolean {
     return true;
 }
 
-// tail header
 function tryTailHeader(state: ILexState): boolean {
     const tailTo = state.inlineRules.tail_header.exec(state.src);
     if (!(tailTo && state.top))

--- a/packages/muya/src/search/__tests__/search.spec.ts
+++ b/packages/muya/src/search/__tests__/search.spec.ts
@@ -127,7 +127,6 @@ describe('search.find() — cursor navigation across matches', () => {
         search.search('x');
         expect(search.matches.length).toBe(3);
         expect(search.index).toBe(0);
-        // Exactly one active highlight, the other two are selections.
         expect(highlightCount(muya)).toBe(1);
         expect(selectionCount(muya)).toBe(2);
 

--- a/packages/muya/src/selection/TableRectSelection.ts
+++ b/packages/muya/src/selection/TableRectSelection.ts
@@ -279,11 +279,6 @@ class TableRectSelection {
     }
 
     /**
-     * Empty every selected cell's text in place (cut). Routed through the
-     * content block's `text` setter so each edit dispatches a json op and the
-     * document state stays in sync. The caret is placed in the anchor cell.
-     */
-    /**
      * Empty every selected cell's text and re-render it, keeping the frozen
      * selection. Returns whether any cell actually had content to clear — the
      * caller uses that to drive the two-stage keyboard delete (first press

--- a/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
+++ b/packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
@@ -94,8 +94,8 @@ describe('parity PG10: Space previews a selected image', () => {
                 }),
             );
 
-            // Desired: the engine emits preview-image so the host can open the
-            // full-screen viewer. Today nothing fires (Space inserts a space).
+            // The engine emits preview-image so the host can open the
+            // full-screen viewer.
             expect(handler).toHaveBeenCalledTimes(1);
         },
     );

--- a/packages/muya/src/selection/__tests__/selectAll.spec.ts
+++ b/packages/muya/src/selection/__tests__/selectAll.spec.ts
@@ -105,7 +105,6 @@ describe('selection.selectAll table escalation', () => {
         const { selection } = muya.editor;
         const tableSelection = selection.table;
 
-        // Caret inside the (0,0) cell content.
         cellContent(table, 0, 0).setCursor(0, 0, false);
 
         selection.selectAll();

--- a/packages/muya/src/state/__tests__/nestedMixedLists.spec.ts
+++ b/packages/muya/src/state/__tests__/nestedMixedLists.spec.ts
@@ -115,7 +115,6 @@ describe('nested mixed lists (#4341)', () => {
 
         const nestedList = children(secondItem).find(c => c.name === 'order-list');
         expect(nestedList, 'expected an order-list nested inside the second bullet-list item').toBeDefined();
-        // The item is exactly [leading paragraph, nested order-list].
         expect(children(secondItem).map(c => c.name)).toEqual(['paragraph', 'order-list']);
         expect(children(nestedList)).toHaveLength(3);
         expect(children(nestedList).map(firstText)).toEqual(['First step', 'Second step', 'Third step']);

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/search.spec.ts
@@ -169,7 +169,6 @@ describe('paragraphQuickInsertMenu render() — DOM output', () => {
         expect(noResult).not.toBeNull();
         // '无结果' is the zh-CN translation of 'No result'.
         expect(noResult!.textContent).toBe('无结果');
-        // No section is rendered when there is no result.
         expect(menu.scrollElement!.querySelectorAll('section').length).toBe(0);
     });
 

--- a/packages/muya/src/utils/__tests__/embedKatexFonts.spec.ts
+++ b/packages/muya/src/utils/__tests__/embedKatexFonts.spec.ts
@@ -18,7 +18,6 @@ describe('embedKatexFonts', () => {
     it('drops the now-broken relative font references and woff/ttf fallbacks', () => {
         const out = embedKatexFonts(katexCss);
 
-        // No `url(fonts/…)` left, and no woff/ttf alternatives in any src.
         expect(out).not.toMatch(/url\(\s*fonts\//);
         expect(out).not.toContain('format("woff")');
         expect(out).not.toContain('format("truetype")');


### PR DESCRIPTION
## What

Applies `.github/COMMENTING-GUIDELINES.md` to every comment authored in this repo
since AI-assisted commits began, removing or rewriting those that violate it — i.e.
comments that restate the adjacent code, echo a symbol's name, are pure noise, or
have gone stale.

## How it was scoped

Comments were attributed by `git blame` and filtered to genuinely authored content,
excluding the upstream-muya import (#4314), the electron-vite move (#4001), and
vendored libraries. **1,811 logical comment blocks across 318 files** were reviewed
against a conservative *keep-by-default* rubric (keep anything carrying rationale,
units, invariants, a caller contract, an issue ref, or non-obvious behaviour), and
each proposed change was adversarially re-checked before inclusion.

Net: **74 comments removed or rewritten across 50 files** (≈100 lines). Most of
Claude's comments are guideline-compliant and were left untouched.

## Commits

1. `refactor(muya)` — name-echo section labels in `inlineRenderer/lexer.ts`
   (`// link` over `tryLink`, …) and a stale duplicate JSDoc on
   `TableRectSelection.emptySelectedCells`.
2. `refactor(desktop)` — restatement / name-echo comments
   (`// Create the Vue i18n instance.` over `createI18n(...)`,
   `// MarkText version string` over `appVersion`, class-name-echoing template
   comments) and a stale authoring-plan note.
3. `test:` — **stale comments that contradict now-passing tests**: parity specs
   carried TDD red-phase notes ("Desired: X. Today: <broken>") whose "Today" clause
   described pre-fix behaviour that no longer holds (fixes landed, assertions green,
   no `test.fail`/`skip`). The misleading clause is trimmed and the intent kept.
4. `test:` — comments that paraphrase the single assertion directly below them
   (`// No paragraph remains.` over `toHaveCount(0)`, …).

## Verification

- Comment-only changes; no functional directives (`eslint-disable`,
  `@ts-expect-error`, `v-html`) removed; trailing-comment edits preserve the code.
- `eslint` clean on all changed files (one stray double-blank-line introduced by a
  divider removal was fixed).

## Scope note

Five fix PRs merged to `develop` during this work; their newly-added files were not
in the dataset and can be covered in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)