### PR TITLE
fix(desktop): scroll the view up when the caret moves above the viewport (#3329)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1912,6 +1912,10 @@ onMounted(() => {
         // editableHeight is the lowest cursor position(till to top) that editor allowed.
         const editableHeight = container.clientHeight - 100
         animatedScrollTo(container, container.scrollTop + (y - editableHeight), 0)
+      } else if (y < 100) {
+        // Symmetric to #628: scroll up when the cursor rises above the top edge
+        // (e.g. Arrow-Up), otherwise the caret leaves the viewport (#3329).
+        animatedScrollTo(container, container.scrollTop + (y - 100), 0)
       }
     }
 

--- a/packages/desktop/test/e2e/scroll-up-arrow.spec.ts
+++ b/packages/desktop/test/e2e/scroll-up-arrow.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { focusEditor, launchWithMarkdown } from './helpers'
+
+// #3329 — moving the caret DOWN auto-scrolls the view (the #628 handler), but
+// moving it UP did not, so the caret slid above the viewport. The fix adds the
+// symmetric upward scroll.
+test.describe('Arrow-up scrolls the document (#3329)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const md = `${Array.from({ length: 120 }, (_, i) => `Paragraph ${i + 1}`).join('\n\n')}\n`
+    const launched = await launchWithMarkdown(md)
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  const scrollTop = () =>
+    page.evaluate(() => (document.querySelector('.editor-component') as HTMLElement)?.scrollTop ?? -1)
+
+  const pressMany = async(key: string, times: number) => {
+    for (let i = 0; i < times; i++) {
+      await page.keyboard.press(key)
+      await page.waitForTimeout(6)
+    }
+    await page.waitForTimeout(120)
+  }
+
+  test('moving the caret up brings the view back up', async() => {
+    // Caret to the bottom — the #628 handler scrolls the view down.
+    await pressMany('ArrowDown', 80)
+    const bottom = await scrollTop()
+    expect(bottom).toBeGreaterThan(200)
+
+    // Caret back up — the view must follow it upward.
+    await pressMany('ArrowUp', 80)
+    const top = await scrollTop()
+    expect(top).toBeLessThan(bottom - 200)
+  })
+})


### PR DESCRIPTION
Fixes #3329

### Problem

Moving the caret **down** scrolls the document so the caret stays visible, but moving it **up** (Arrow-Up) did not — the caret slid above the viewport while the text stayed put.

### Root cause

The `selection-change` handler in `editorWithTabs/editor.vue` only handled the *bottom* edge (the #628 fix): when the caret is within 100px of the bottom (`container.clientHeight - y < 100`) it scrolls down. There was no symmetric branch for the top edge, so arrow keys (handled by the engine, which sets the caret programmatically and does **not** trigger the browser's native scroll-into-view) never scrolled the container upward.

Reproduced in the real built app (e2e): with a tall document, moving the caret to the bottom scrolls the view down, but moving it back up leaves `scrollTop` unchanged — the caret leaves the viewport.

### Fix

Add the symmetric upward scroll: when the caret rises within 100px of the top edge (`y < 100`), scroll the container up so it stays visible — mirroring the existing down-scroll. It's an `else if`, so the two edges never fight, and it clamps to `scrollTop: 0` at the document top.

### Tests

Added `test/e2e/scroll-up-arrow.spec.ts` (real Electron app): in a 120-paragraph doc, pressing Arrow-Down scrolls the view down (already worked), and pressing Arrow-Up brings it back up. **Confirmed RED on the pre-fix build** (the up case leaves the view at the bottom) → GREEN after the fix, deterministic across 3 repeats. ESLint + `vue-tsc` typecheck pass.