### PR TITLE
fix: scroll the active tab into view on tab switch (#3958)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/tabs.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/tabs.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { useLayoutStore } from '@/store/layout'
 import { storeToRefs } from 'pinia'
@@ -89,6 +89,25 @@ const removeFileInTab = (file: IFileState) => {
 // Original methods
 const newFile = () => {
   editorStore.NEW_UNTITLED_TAB({})
+}
+
+// Keep the active tab visible when the selection changes by something other
+// than a direct click on a visible tab (keyboard cycle, switch-by-index, open
+// from the sidebar): the strip has `overflow: hidden` and only scrolls on the
+// wheel, so an off-screen tab would otherwise stay hidden (#3958).
+const scrollActiveTabIntoView = () => {
+  const container = tabContainer.value
+  if (!container) return
+  const activeTab = container.querySelector<HTMLElement>('li.active')
+  if (!activeTab) return
+
+  const containerRect = container.getBoundingClientRect()
+  const tabRect = activeTab.getBoundingClientRect()
+  if (tabRect.left < containerRect.left) {
+    container.scrollLeft -= containerRect.left - tabRect.left
+  } else if (tabRect.right > containerRect.right) {
+    container.scrollLeft += tabRect.right - containerRect.right
+  }
 }
 
 const handleTabScroll = (event: WheelEvent) => {
@@ -156,6 +175,13 @@ const handleContextMenu = (event: MouseEvent, tab: IFileState) => {
     showContextMenu(event, tab)
   }
 }
+
+watch(
+  () => currentFile.value?.id,
+  () => {
+    nextTick(scrollActiveTabIntoView)
+  }
+)
 
 onMounted(() => {
   bus.on('TABS::close-this', closeTab)

--- a/packages/desktop/test/e2e/tabs.spec.ts
+++ b/packages/desktop/test/e2e/tabs.spec.ts
@@ -299,6 +299,71 @@ test.describe('Tab management', () => {
     }
   })
 
+  // Issue #3958 — switching to a tab that has overflowed off the right edge of
+  // the tab bar must scroll it back into the visible viewport. Before the fix
+  // the active tab is highlighted but invisible (the strip never scrolls), so
+  // the user can't see which tab they're on. Runs in its own app because it
+  // opens many tabs to force horizontal overflow.
+  test('Switching to an overflowed tab scrolls it into view', async() => {
+    const launch = await launchWithMarkdown('# overflow base\n')
+    const sApp = launch.app
+    const sPage = launch.page
+    try {
+      // Open enough untitled tabs to overflow the tab strip horizontally,
+      // regardless of the test window width.
+      const TAB_COUNT = 25
+      for (let i = 0; i < TAB_COUNT; i++) {
+        const before = await sPage.locator(tabSelector).count()
+        await sendIpcToRenderer(sApp, 'mt::new-untitled-tab', true, `overflow body ${i}\n`)
+        await sPage.waitForFunction(
+          ({ selector, prev }) => document.querySelectorAll(selector).length > prev,
+          { selector: tabSelector, prev: before },
+          { timeout: 5000 }
+        )
+      }
+
+      // The strip must genuinely overflow, otherwise the assertions below are
+      // vacuously true.
+      await expect
+        .poll(
+          () =>
+            sPage.evaluate(() => {
+              const c = document.querySelector('.scrollable-tabs') as HTMLElement | null
+              return !!c && c.scrollWidth > c.clientWidth + 4
+            }),
+          { timeout: 5000 }
+        )
+        .toBe(true)
+
+      // The active tab's box must sit fully inside the scroll viewport.
+      const activeTabVisible = () =>
+        sPage.evaluate(() => {
+          const container = document.querySelector('.scrollable-tabs')
+          const tab = document.querySelector('.tabs-container > li.active')
+          if (!container || !tab) return false
+          const c = container.getBoundingClientRect()
+          const t = tab.getBoundingClientRect()
+          return t.width > 0 && t.left >= c.left - 1 && t.right <= c.right + 1
+        })
+
+      // Far-left tab: must be brought into view.
+      await sendIpcToRenderer(sApp, 'mt::switch-tab-by-index', 0)
+      await expect.poll(activeTabVisible, { timeout: 5000 }).toBe(true)
+
+      // Far-right (last) tab: at scrollLeft 0 it is off the right edge — the
+      // regression. Switching to it must scroll the strip so it's visible.
+      const ids = await readTabIds(sPage)
+      await sendIpcToRenderer(sApp, 'mt::switch-tab-by-index', ids.length - 1)
+      await expect.poll(activeTabVisible, { timeout: 5000 }).toBe(true)
+
+      // Back to the first tab: must scroll left again.
+      await sendIpcToRenderer(sApp, 'mt::switch-tab-by-index', 0)
+      await expect.poll(activeTabVisible, { timeout: 5000 }).toBe(true)
+    } finally {
+      await sApp.close()
+    }
+  })
+
   // Item 267 — the tab context-menu "close others / close saved / close all"
   // survivor sets. Driven through the live `editor` store actions (the bus
   // events delegate verbatim to these; the native context menu / mitt bus are


### PR DESCRIPTION
## Summary

Fixes #3958. When switching to a tab that has scrolled off the edge of the tab strip (keyboard cycle, switch-by-index, or selecting from the sidebar), the tab received the `active` highlight but the strip never scrolled, leaving the active tab invisible behind the others.

## Root cause

The tab strip in `editorWithTabs/tabs.vue` lives in `.scrollable-tabs`, which has `overflow: hidden`. The only code that moved its `scrollLeft` was the mouse-wheel handler. Every tab-switch path (`UPDATE_CURRENT_FILE`, `CYCLE_TABS`, `SWITCH_TAB_BY_INDEX`) only updated `currentFile` state — nothing scrolled the newly-active tab into the viewport, and there was no watcher to do so.

## Fix

Watch the active file id and, on the next tick, scroll the active tab back into the visible viewport. Uses `getBoundingClientRect` (robust regardless of `offsetParent`) and scrolls only the minimum amount needed to reveal the tab.

## Testing

- New e2e test in `tabs.spec.ts`: opens 25 tabs to force horizontal overflow, switches to the far-right (off-screen) tab, and asserts its box sits inside the scroll viewport. **Fails before the fix, passes after.**
- Full `tabs.spec.ts`: 8/8 pass (no regression).
- `pnpm run lint`: 0 errors. `pnpm run typecheck`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)