### PR TITLE
fix: remove ~1s sidebar delay for newly created files (#3955)

### DIFF
--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -228,11 +228,19 @@ class Watcher {
 
       depth: type === 'file' ? (isOsx ? 1 : 0) : undefined,
 
-      // Please see GH#1043
-      awaitWriteFinish: {
-        stabilityThreshold: WATCHER_STABILITY_THRESHOLD,
-        pollInterval: WATCHER_STABILITY_POLL_INTERVAL
-      },
+      // Defer events until writes settle only for the file watcher, which
+      // reloads file CONTENT on change and would otherwise read a partial file
+      // (GH#1043). The directory watcher just lists nodes and re-sorts by mtime,
+      // so deferring its `add` events only made new files appear in the sidebar
+      // ~1s late (GH#3955).
+      ...(type === 'file'
+        ? {
+          awaitWriteFinish: {
+            stabilityThreshold: WATCHER_STABILITY_THRESHOLD,
+            pollInterval: WATCHER_STABILITY_POLL_INTERVAL
+          }
+        }
+        : {}),
 
       usePolling
       // chokidar's `ignored` callback signature varies between versions; this options

--- a/packages/desktop/test/unit/specs/watcher-await-write-finish.spec.ts
+++ b/packages/desktop/test/unit/specs/watcher-await-write-finish.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// #3955: newly created files appeared in the sidebar ~1s late because the
+// directory watcher inherited chokidar's `awaitWriteFinish` (stabilityThreshold
+// 1000ms), which defers `add`/`change` events until the file size settles. That
+// protection (GH#1043) only matters for the file watcher, which reloads file
+// CONTENT on change; the directory watcher just lists nodes and re-sorts by
+// mtime. These tests pin that only the file watcher defers events.
+
+const watchMock = vi.fn()
+
+function fakeWatcher(): Record<string, ReturnType<typeof vi.fn>> {
+  const w: Record<string, ReturnType<typeof vi.fn>> = {}
+  w.on = vi.fn(() => w)
+  w.close = vi.fn()
+  w.add = vi.fn()
+  w.unwatch = vi.fn()
+  return w
+}
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: (...args: unknown[]) => {
+      watchMock(...args)
+      return fakeWatcher()
+    }
+  }
+}))
+
+// Importing the watcher pulls in the markdown loader, whose encoding detection
+// uses the native `ced` addon. Its bindings are built for Electron's ABI, not
+// the plain-Node test runner, so stub it to keep this spec import-only.
+vi.mock('ced', () => ({ default: () => 'UTF-8' }))
+
+import Watcher, {
+  WATCHER_STABILITY_THRESHOLD,
+  WATCHER_STABILITY_POLL_INTERVAL
+} from 'main_renderer/filesystem/watcher'
+
+function optionsForLastWatch(): Record<string, unknown> {
+  const calls = watchMock.mock.calls
+  return calls[calls.length - 1][1] as Record<string, unknown>
+}
+
+describe('watcher awaitWriteFinish (#3955)', () => {
+  let watcher: Watcher
+  const win = { id: 1, webContents: { send: vi.fn() } }
+
+  beforeEach(() => {
+    watchMock.mockClear()
+    const preferences = { getItem: vi.fn(() => false) }
+    watcher = new Watcher(preferences as never)
+  })
+
+  it('does not defer directory-tree events with awaitWriteFinish', () => {
+    watcher.watch(win as never, '/project', 'dir')
+    expect(optionsForLastWatch().awaitWriteFinish).toBeFalsy()
+  })
+
+  it('keeps awaitWriteFinish for the file watcher (GH#1043)', () => {
+    watcher.watch(win as never, '/project/note.md', 'file')
+    expect(optionsForLastWatch().awaitWriteFinish).toEqual({
+      stabilityThreshold: WATCHER_STABILITY_THRESHOLD,
+      pollInterval: WATCHER_STABILITY_POLL_INTERVAL
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #3955.

Newly created files appeared in the sidebar file tree ~1 second late. The cause is in the main-process file watcher (`packages/desktop/src/main/filesystem/watcher.ts`): both watcher types were configured with chokidar's `awaitWriteFinish` (`stabilityThreshold: 1000ms`), which holds back every `add`/`change` event until the file size stays stable for 1s.

That deferral exists for #1043 — when an external editor (e.g. VS Code) saves a file MarkText has **open**, the watcher could otherwise reload partial/empty content. But it only matters for the **file** watcher, which reloads file *content* on change. The **directory** watcher (the sidebar project tree) just lists nodes and re-sorts by `mtimeMs`; the content it loads on `add` is consumed only for MarkText's *own* freshly-created (empty) file. So `awaitWriteFinish` gave the directory watcher no real protection while delaying every new file's appearance by ~1s.

## Fix

Apply `awaitWriteFinish` only to the `'file'` watcher. The `'dir'` watcher now emits `add` immediately, so:

- newly created files appear in the sidebar without delay, and
- the **New File** command opens instantly instead of after ~1s.

The #1043 protection for open files is unchanged.

## Testing

- New regression test `test/unit/specs/watcher-await-write-finish.spec.ts` spies on `chokidar.watch` and asserts the directory watcher does **not** receive `awaitWriteFinish` while the file watcher keeps it (`stabilityThreshold` / `pollInterval`). It fails before the fix and passes after — deterministic, no wall-clock timing.
- `vue-tsc --noEmit` clean; ESLint clean on the changed files.
- Full desktop unit suite passes (the two unrelated `pdf`/`exportHtml` failures are a pre-existing local worktree `vite fs.allow` artifact on a `github-markdown-css ?inline` import, reproducible with this change reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)