### PR TITLE
fix(i18n): degrade malformed translations to raw text instead of crashing (#4046)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@intlify/core-base": "^11.4.6",
     "@element-plus/icons-vue": "^2.3.2",
     "@hfelix/electron-localshortcut": "^4.0.1",
     "@marktext/file-icons": "^1.0.6",

--- a/packages/desktop/src/renderer/src/i18n/index.ts
+++ b/packages/desktop/src/renderer/src/i18n/index.ts
@@ -1,8 +1,27 @@
 import { createI18n } from 'vue-i18n'
+import { compile, type MessageCompiler } from '@intlify/core-base'
 import bus from '../bus'
-
 // Directly import translation files
 import enTranslations from '../../../../static/locales/en.json'
+
+// vue-i18n compiles each translation lazily on first use, and its compiler
+// throws a SyntaxError on any value it can't parse — e.g. a literal `{{x}}`
+// (nested placeholder) or stray linked-message syntax. A single malformed
+// translation then crashed the renderer; during HTML/PDF export this surfaced
+// as an "Unexpected renderer process error" even though the export itself
+// succeeded (issue #4046). Reuse vue-i18n's own compiler so well-formed
+// messages keep their `{name}` interpolation, plurals and linked references,
+// and fall back to the raw text when compilation fails.
+const safeMessageCompiler: MessageCompiler = (message, context) => {
+  try {
+    return compile(message, context)
+  } catch (err) {
+    if (typeof message === 'string') {
+      return () => message
+    }
+    throw err
+  }
+}
 
 // vue-i18n's options type intersection between Composition + Legacy modes is
 // notoriously difficult to satisfy with mixed shapes; we cast the options once
@@ -18,17 +37,8 @@ const i18n = createI18n({
   },
   // Disable plural parsing
   pluralRules: {},
-  // Custom message compiler to handle '|' characters
-  messageCompiler: {
-    compile: (message: unknown) => {
-      // If the message contains '|', return the raw string without plural parsing
-      if (typeof message === 'string' && message.includes('|')) {
-        return () => message
-      }
-      // For other messages, use the default compiler
-      return null
-    }
-  }
+  // Degrade malformed translations to raw text instead of crashing the renderer.
+  messageCompiler: safeMessageCompiler
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any)
 

--- a/packages/desktop/test/unit/specs/i18n.spec.ts
+++ b/packages/desktop/test/unit/specs/i18n.spec.ts
@@ -46,3 +46,46 @@ describe('renderer i18n language loading', () => {
     expect(win.i18nUtils!.loadTranslations).toHaveBeenCalledWith('zh-CN')
   })
 })
+
+// Issue #4046: exporting HTML/PDF surfaced an "Unexpected renderer process
+// error" — a vue-i18n message-compiler SyntaxError (code 9,
+// NOT_ALLOW_NEST_PLACEHOLDER) thrown while lazily compiling a translation whose
+// value contained a nested placeholder (e.g. literal `{{type}}`). A single
+// malformed translation must degrade to raw text, never crash the renderer.
+describe('renderer i18n malformed-message resilience (issue #4046)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    win.i18nUtils = { loadTranslations: vi.fn() }
+  })
+
+  afterEach(() => {
+    delete win.i18nUtils
+  })
+
+  interface TestComposer {
+    setLocaleMessage: (locale: string, message: Record<string, unknown>) => void
+    locale: { value: string }
+    t: (key: string, named?: Record<string, unknown>) => string
+  }
+
+  it('does not throw when a registered message contains a nested placeholder', async() => {
+    const { i18n } = await import('../../../src/renderer/src/i18n')
+    const composer = i18n.global as unknown as TestComposer
+
+    composer.setLocaleMessage('xx', { export: { failed: 'Failed {{type}} export' } })
+    composer.locale.value = 'xx'
+
+    expect(() => composer.t('export.failed', { type: 'PDF' })).not.toThrow()
+    expect(composer.t('export.failed', { type: 'PDF' })).toBe('Failed {{type}} export')
+  })
+
+  it('still interpolates well-formed messages', async() => {
+    const { i18n } = await import('../../../src/renderer/src/i18n')
+    const composer = i18n.global as unknown as TestComposer
+
+    composer.setLocaleMessage('xx', { greeting: 'Hello {name}' })
+    composer.locale.value = 'xx'
+
+    expect(composer.t('greeting', { name: 'World' })).toBe('Hello World')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@hfelix/electron-localshortcut':
         specifier: ^4.0.1
         version: 4.0.1
+      '@intlify/core-base':
+        specifier: ^11.4.6
+        version: 11.4.6
       '@marktext/file-icons':
         specifier: ^1.0.6
         version: 1.0.6


### PR DESCRIPTION
## Summary

Fixes #4046 — exporting HTML/PDF could surface an *"Unexpected renderer process error"* even though the export itself completed and produced valid files.

The error originates in vue-i18n's message compiler:

```
SyntaxError: 9
    at createCompileError ...
    at readTokenInPlaceholder ...
    at parseMessage ...
    at baseCompile ...
```

`SyntaxError: 9` is `NOT_ALLOW_NEST_PLACEHOLDER`. vue-i18n compiles each translation **lazily on first use**; the export flow resolves a batch of `editor.export.*` / `exportSettings.*` / `store.editor.export*` keys for the first time. If the active locale's value for one of them contains a nested placeholder (a literal `{{x}}`, or a `{` inside a `{…}`), that first compile throws and crashes the renderer — while the export, which runs independently, still succeeds. This matches the report exactly (error dialog + well-formed output).

## Root cause

The existing guard in `i18n/index.ts` used the **object form** `messageCompiler: { compile }`. vue-i18n 11 expects `messageCompiler` to be a **function** and silently ignores the object form, so:

- the intended `|` handling never took effect (the default compiler still plural-split), and
- the `{{…}}` crash was **not** prevented — the app behaved like the default compiler, which throws.

## Fix

Replace it with the correct **function form** that reuses vue-i18n's own compiler (`compile` from `@intlify/core-base`) wrapped in `try/catch`:

- well-formed messages keep `{name}` interpolation, plurals and linked references (compiled by the real compiler);
- a message that fails to compile degrades to its **raw text** instead of throwing — a single bad translation can never crash the renderer again.

Because the old object form was already ignored, behavior is **byte-identical for every valid message**; only malformed messages change from *throw* to *raw text*. `@intlify/core-base` is promoted to a direct dependency (pinned to vue-i18n's version).

## Reproduction & tests (TDD)

Added regression tests in `test/unit/specs/i18n.spec.ts`:

- a registered message containing `{{type}}` no longer throws and renders as raw text (this **failed** before the fix with `Message compilation error: Not allowed nest placeholder`);
- a well-formed `Hello {name}` message still interpolates.

## Verification

- Full unit suite: **668 passed (33 files)**, no regressions.
- `typecheck` ✅ · `lint` ✅ (no new findings).
- Verified all 10 shipped locales compile cleanly under the new compiler (so no current message is affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)