### PR TITLE
fix: vertically center task list checkbox with item text

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -490,11 +490,23 @@ li.mu-task-list-item {
 li.mu-task-list-item > input[type='checkbox'],
 li.mu-task-list-item > span.mu-task-list-checkbox {
     position: absolute;
-    top: 0.3em;
-    inset-inline-start: -23px;
+
+    /* Center the 18px circle (drawn by ::before at top:-2px, so its center sits
+       7px below this box's top) on the first text line, whose vertical midpoint
+       is `0.5 * line-height * font-size`. The editor font is read from
+       `--mu-font-size` rather than `em` on purpose: on Chromium the checkbox is
+       a real <input>, which keeps the UA form-control font size and ignores
+       `font-size: inherit`, so `em` here would be frozen and the marker would
+       stop tracking the editor font. Custom properties still inherit into the
+       input, so this stays aligned at every font size. */
+    top: calc(var(--mu-line-height, 1.6) * 0.5 * var(--mu-font-size, 16px) - 7px);
 
     width: 12px;
     height: 12px;
+
+    /* Drop the UA <input> margin (3px top), which otherwise pushes the
+       absolutely-positioned marker below the computed `top`. */
+    margin: 0;
 
     transform-origin: center;
     cursor: pointer;
@@ -502,11 +514,7 @@ li.mu-task-list-item > span.mu-task-list-checkbox {
     transition: all 0.2s ease;
 
     appearance: none;
-}
-
-ul.mu-tight-list > li.mu-task-list-item > input[type='checkbox'],
-ul.mu-tight-list > li.mu-task-list-item > span.mu-task-list-checkbox {
-    top: 0.3em;
+    inset-inline-start: -23px;
 }
 
 li.mu-task-list-item > input.mu-checkbox-checked ~ *,


### PR DESCRIPTION
## Summary

Task list checkbox markers were not vertically aligned with their item text, and the gap grew as the editor font size increased.

Root cause — two issues, both specific to the `<input type="checkbox">` the marker renders as on Chromium:

1. **The `em`-based offset never tracked the editor font.** Form controls don't inherit `font-size` (and the `<input>` ignores `font-size: inherit`), so any `em` on the checkbox resolves against the UA control font (~13.3px) and stays constant — while the text line grows with the editor font. Both the original `top: 0.3em` and a first attempt using `0.5em` were therefore frozen and drifted.
2. **The UA `<input>` `margin: 3px`** shifted the absolutely-positioned marker down.

## Fix

- Compute `top` from the custom property `--mu-font-size` (which *does* inherit into form controls) and `--mu-line-height`, instead of `em`:
  ```css
  top: calc(var(--mu-line-height, 1.6) * 0.5 * var(--mu-font-size, 16px) - 7px);
  ```
- Zero the UA `<input>` margin.
- Drop the now-redundant `mu-tight-list` override that repeated the old value.

## Verification

Measured `circleCenter − textCenter` against the real stylesheet with a live `<input>`, across font sizes and line heights:

| font-size | lh 1.4 | lh 1.6 |
|---|---|---|
| 16px | +0.2px | +0.8px |
| 24px | +0.8px | +0.2px |
| 32px | +0.9px | +0.1px |
| 40px | +0.5px | +0.5px |

The old `em` approach drifted to ~−18px at 40px. Also confirmed live in the running desktop app via CDP that `--mu-font-size` propagates into the `<input>` (editor→li→p→input) while `em`/`inherit` stayed frozen at the UA size.

`stylelint` on `blockSyntax.css`: fewer problems than before (the change also resolves a pre-existing property-order warning in this rule).

Fixes #4748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
