### PR TITLE
fix(muya): scroll wide math blocks instead of clipping

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -733,6 +733,12 @@ figure.mu-math-block .mu-math-preview .katex-display {
     overflow: auto hidden;
 }
 
+figure.mu-math-block .mu-math-preview .katex-display::-webkit-scrollbar {
+    display: block;
+    width: 3px;
+    height: 6px;
+}
+
 /* to prevent plantuml img overflow */
 figure.mu-diagram-block .mu-diagram-preview img {
     max-width: 100%;

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -729,6 +729,8 @@ figure.mu-diagram-block .mu-diagram-preview {
 figure.mu-math-block .mu-math-preview .katex-display {
     margin: 0;
     padding: 1em 0;
+
+    overflow: auto hidden;
 }
 
 /* to prevent plantuml img overflow */


### PR DESCRIPTION
## Summary

Wide KaTeX math blocks overflowed past the block and got clipped with no way to read the rest of the formula.

KaTeX renders display math as fixed-width, `white-space: nowrap` HTML and cannot wrap (upstream KaTeX [#327](https://github.com/KaTeX/KaTeX/issues/327) / [#1023](https://github.com/KaTeX/KaTeX/issues/1023)). In KaTeX 0.17 `.katex-display` carries no `overflow` of its own, and muya's `.mu-math-preview .katex-display` rule set only `margin`/`padding`, leaving `overflow: visible`. A formula wider than the editor therefore spilled out of the block and was clipped by the ancestor `overflow: hidden`.

The fix adds `overflow: auto hidden` to `.mu-math-preview .katex-display`, so wide formulas scroll horizontally within the block.

## Verification

Real-browser measurement (system Chrome) of a display formula wider than a 600px editor box:

| | `.katex-display` overflow-x | content overflows box | scrollable | formula spills past block |
|---|---|---|---|---|
| before | `visible` | yes (641 > 520px) | no | yes |
| after | `auto` | yes (641 > 520px) | yes | no (becomes a scroll region) |

Stylelint clean for the changed rule.

Fixes #1022