### PR TITLE
fix(desktop): route undo/redo to CodeMirror in source code mode

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1044,12 +1044,20 @@ const replaceMisspelling = (payload: unknown) => {
 }
 
 const handleUndo = () => {
+  if (sourceCode.value) {
+    return
+  }
+
   if (editor.value) {
     editor.value.undo()
   }
 }
 
 const handleRedo = () => {
+  if (sourceCode.value) {
+    return
+  }
+
   if (editor.value) {
     editor.value.redo()
   }

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
@@ -205,6 +205,26 @@ const handleSelectAll = () => {
   }
 }
 
+const handleUndo = () => {
+  if (!sourceCode.value) {
+    return
+  }
+
+  if (editor.value) {
+    editor.value.execCommand('undo')
+  }
+}
+
+const handleRedo = () => {
+  if (!sourceCode.value) {
+    return
+  }
+
+  if (editor.value) {
+    editor.value.execCommand('redo')
+  }
+}
+
 interface ImageActionPayload {
   id: string
   result: string
@@ -340,6 +360,8 @@ onMounted(() => {
   bus.on('invalidate-image-cache', handleInvalidateImageCache)
   bus.on('file-changed', handleFileChange)
   bus.on('selectAll', handleSelectAll)
+  bus.on('undo', handleUndo)
+  bus.on('redo', handleRedo)
   bus.on('image-action', handleImageAction)
   bus.on('scroll-to-header', handleScrollToHeader)
 
@@ -378,6 +400,8 @@ onBeforeUnmount(() => {
   bus.off('invalidate-image-cache', handleInvalidateImageCache)
   bus.off('file-changed', handleFileChange)
   bus.off('selectAll', handleSelectAll)
+  bus.off('undo', handleUndo)
+  bus.off('redo', handleRedo)
   bus.off('image-action', handleImageAction)
   bus.off('scroll-to-header', handleScrollToHeader)
 

--- a/packages/desktop/test/e2e/issue-781-source-undo.spec.ts
+++ b/packages/desktop/test/e2e/issue-781-source-undo.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test'
+import type { Page } from 'playwright'
+import {
+  launchWithMarkdown,
+  waitForMenuReady,
+  enterSourceMode,
+  sendIpcToRenderer
+} from './helpers'
+
+// Issue #781 — Undo/redo while in Source Code mode must act on the CodeMirror
+// editor, not the hidden WYSIWYG (muya) engine. The Edit › Undo menu item and
+// Cmd/Ctrl+Z both route through `mt::editor-edit-action` → bus `undo`. Before the
+// fix only editor.vue subscribed and called muya.undo() (invisible in source
+// mode), so undo did nothing. sourceCode.vue now also subscribes and runs
+// CodeMirror's `undo`/`redo` command, and editor.vue's handler bails out while
+// source mode is active.
+
+const cmValue = (page: Page): Promise<string> =>
+  page.evaluate(() => {
+    const cm = (
+      document.querySelector('.source-code .CodeMirror') as Element & {
+        CodeMirror: { getValue(): string }
+      }
+    ).CodeMirror
+    return cm.getValue()
+  })
+
+const typeInCm = (page: Page, text: string): Promise<void> =>
+  page.evaluate((t) => {
+    const cm = (
+      document.querySelector('.source-code .CodeMirror') as Element & {
+        CodeMirror: {
+          focus(): void
+          setCursor(p: { line: number; ch: number }): void
+          replaceSelection(text: string): void
+        }
+      }
+    ).CodeMirror
+    cm.focus()
+    cm.setCursor({ line: 0, ch: 'saved baseline'.length })
+    cm.replaceSelection(t)
+  }, text)
+
+const undo = (app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> =>
+  sendIpcToRenderer(app, 'mt::editor-edit-action', 'undo')
+const redo = (app: Parameters<typeof sendIpcToRenderer>[0]): Promise<void> =>
+  sendIpcToRenderer(app, 'mt::editor-edit-action', 'redo')
+
+test.describe('Issue #781 — undo/redo in source code mode', () => {
+  test('undo reverts a source-mode edit; redo re-applies it', async() => {
+    const { app, page } = await launchWithMarkdown('saved baseline\n')
+    await waitForMenuReady(app)
+
+    await enterSourceMode(page, app)
+    const baseline = await cmValue(page)
+
+    // A single CodeMirror edit (one undo step).
+    await typeInCm(page, ' SRCKEY')
+    expect(await cmValue(page)).toContain('saved baseline SRCKEY')
+
+    // Undo through the same IPC the Edit › Undo menu uses — must hit CodeMirror.
+    await undo(app)
+    await expect.poll(() => cmValue(page)).toBe(baseline)
+
+    // Redo restores the edit.
+    await redo(app)
+    await expect.poll(() => cmValue(page)).toContain('saved baseline SRCKEY')
+
+    await app.close()
+  })
+})


### PR DESCRIPTION
## Summary

Undo/redo did nothing while in Source Code mode.

The Edit › Undo/Redo menu items and Cmd/Ctrl+Z dispatch through `mt::editor-edit-action` → bus `undo`/`redo`. Only `editor.vue` subscribed, and it called the muya (WYSIWYG) engine's `undo()`/`redo()` — invisible while source code mode is active and the muya editor is hidden — so undo appeared to do nothing.

`sourceCode.vue` now subscribes to the same bus events and runs CodeMirror's `undo`/`redo` command, mirroring the existing `selectAll` routing. `editor.vue`'s handlers bail out while `sourceCode` is active, so the hidden engine's history is left untouched.

## Verification

Added an e2e test (`test/e2e/issue-781-source-undo.spec.ts`) that, in source mode, types into the live CodeMirror instance, triggers undo through the same IPC the menu uses, and asserts the edit reverts (and redo re-applies it). Confirmed RED→GREEN against the built app:

- **without the fix**: undo never reverts the CodeMirror value → test fails
- **with the fix**: undo reverts, redo re-applies → test passes

Lint + typecheck clean.

Fixes #781