### PR TITLE
fix(muya): leave Tab to the IME during composition

### DIFF
--- a/packages/muya/src/block/base/__tests__/imeTabComposition.spec.ts
+++ b/packages/muya/src/block/base/__tests__/imeTabComposition.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+// #1250 — pressing Tab while an IME composition is active (e.g. cycling
+// Japanese candidates) must reach the IME, not run the editor's tabHandler.
+// keydownHandler already guards Enter and the arrow keys with `!isComposed`;
+// Tab was missing the same guard and inserted indentation mid-composition.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function pressTab(content: Format): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    content.keydownHandler(event);
+    return event;
+}
+
+describe('tab during IME composition (#1250)', () => {
+    it('does not run tabHandler while composing — Tab is left to the IME', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+        content.composeHandler(new Event('compositionstart'));
+        const tabHandler = vi.spyOn(content, 'tabHandler');
+
+        const event = pressTab(content);
+
+        expect(tabHandler).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+        expect(content.text).toBe('hello');
+    });
+
+    it('runs tabHandler normally when not composing', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 5);
+        const tabHandler = vi.spyOn(content, 'tabHandler');
+
+        pressTab(content);
+
+        expect(tabHandler).toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -746,7 +746,9 @@ class Content extends TreeNode {
                 break;
 
             case EVENT_KEYS.Tab:
-                this.tabHandler(event);
+                if (!this.isComposed)
+                    this.tabHandler(event);
+
                 break;
             default:
                 break;


### PR DESCRIPTION
## Summary

Pressing **Tab** to cycle IME candidates (e.g. Japanese input) inserted editor indentation instead of reaching the IME.

`keydownHandler` (content.ts) guards **Enter** and the **arrow keys** with `!this.isComposed`, but the **Tab** case had no such guard. During an active composition session (`isComposed === true`), Tab still ran `tabHandler`, which calls `event.preventDefault()` unconditionally and inserts indentation — so the IME never saw the keystroke. Added the same `!isComposed` guard to the Tab case.

## Verification

Unit test `src/block/base/__tests__/imeTabComposition.spec.ts`, proven RED→GREEN:
- composing → `tabHandler` is **not** called, no `preventDefault`, text unchanged
- not composing → `tabHandler` runs as before

141 related keydown/tab/arrow/autopair specs still pass; conformance lock unchanged.

Fixes #1250