### PR TITLE
fix(desktop): add a context menu to the sidebar root folder

### DIFF
--- a/packages/desktop/src/renderer/src/components/sideBar/tree.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/tree.vue
@@ -65,7 +65,10 @@
       v-if="projectTree"
       class="project-tree"
     >
-      <div class="title">
+      <div
+        class="title"
+        @contextmenu.prevent="handleRootContextMenu"
+      >
         <el-icon
           class="icon-arrow"
           :class="{ fold: !showDirectories }"
@@ -155,6 +158,7 @@ import Folder from './treeFolder.vue'
 import File from './treeFile.vue'
 import OpenedFile from './treeOpenedTab.vue'
 import bus from '../../bus'
+import { showContextMenu } from '../../contextMenu/sideBar'
 import { useI18n } from 'vue-i18n'
 import { ArrowRight } from '@element-plus/icons-vue'
 import type { TreeNode, TabDescriptor } from './types'
@@ -183,6 +187,7 @@ const preferencesStore = usePreferencesStore()
 
 // Computed properties
 const { createCache } = storeToRefs(projectStore)
+const { clipboard } = storeToRefs(projectStore)
 const { openedFilesInSidebar } = storeToRefs(preferencesStore)
 
 // The createCache state is `{ dirname, type }` while an input is shown, and
@@ -205,6 +210,11 @@ const saveAll = (isClose: boolean): void => {
 const createFile = (): void => {
   projectStore.CHANGE_ACTIVE_ITEM(props.projectTree)
   bus.emit('SIDEBAR::new', 'file')
+}
+
+const handleRootContextMenu = (event: MouseEvent): void => {
+  projectStore.CHANGE_ACTIVE_ITEM(props.projectTree)
+  showContextMenu(event, !!clipboard.value)
 }
 
 const toggleOpenedFiles = (): void => {


### PR DESCRIPTION
## Summary

Right-clicking the **root project folder** title in the sidebar did nothing, so there was no way to create a file or directory at the project root. The only workaround was right-clicking a file that already lived directly at the root (which set the active item so New File/New Directory resolved to the root dir).

Sub-folders already wire `contextmenu` → set active item → open the sidebar context menu (`treeFolder.vue`). This applies the same pattern to the root folder title: on right-click it sets the active item to the project tree and opens the context menu.

## Verification

- lint + typecheck + `build:unpack` clean (the change is a 1:1 mirror of the proven per-subfolder handler).
- Behavioral check is manual in the running app (the menu is a native Electron context menu; there is no e2e harness to open a project folder and the popup can't be asserted in Playwright): right-click the root folder → context menu appears → New File / New Directory create at the project root.

Fixes #1239