### PR TITLE
fix(muya): preserve code fence length on serialize

### DIFF
--- a/packages/muya/src/state/__tests__/codeFenceLength.spec.ts
+++ b/packages/muya/src/state/__tests__/codeFenceLength.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
+import ExportMarkdown from '../stateToMarkdown';
+
+// #1841 — a fenced code block whose info-string fence is longer than 3
+// backticks (needed when the block's content itself contains a ``` line) was
+// always re-serialized with exactly 3 backticks, so the first ``` inside the
+// content prematurely closed the block and the saved markdown was corrupt.
+
+function gen(markdown: string): Parameters<ExportMarkdown['generate']>[0] {
+    return new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(markdown) as unknown as Parameters<ExportMarkdown['generate']>[0];
+}
+
+function openingFence(md: string): string {
+    return md.split('\n')[0];
+}
+
+describe('code fence length (#1841)', () => {
+    it('keeps a fence long enough to wrap content that contains ```', () => {
+        // A 4-backtick fence wrapping a body that contains a 3-backtick line.
+        const input = '````\n```\nfoo\n```\n````\n';
+
+        const md = new ExportMarkdown().generate(gen(input));
+
+        // The opening fence must be at least 4 backticks, otherwise the inner
+        // ``` closes the block and the markdown is broken.
+        expect(openingFence(md)).toMatch(/^`{4,}$/);
+
+        // Re-parsing must still yield a single code block whose body keeps the
+        // inner ``` — i.e. the round trip did not corrupt the document.
+        const reparsed = gen(md) as Array<{ name: string; text?: string }>;
+        const codeBlocks = reparsed.filter(b => b.name === 'code-block');
+        expect(codeBlocks).toHaveLength(1);
+        expect(codeBlocks[0].text).toContain('```');
+    });
+
+    it('round-trips a long-fenced block byte-stably', () => {
+        const input = '````js\n```\nconst a = 1\n```\n````\n';
+        const once = new ExportMarkdown().generate(gen(input));
+        const twice = new ExportMarkdown().generate(gen(once));
+        expect(twice).toBe(once);
+    });
+
+    it('still uses a plain 3-backtick fence for ordinary blocks', () => {
+        const input = '```js\nconst a = 1\n```\n';
+        const md = new ExportMarkdown().generate(gen(input));
+        expect(openingFence(md)).toBe('```js');
+    });
+});

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -281,12 +281,13 @@ export class MarkdownToState {
             }
 
             case 'code': {
-                const { codeBlockStyle, text, lang: infoString = '' } = token;
+                const { codeBlockStyle, text, lang: infoString = '', raw = '' } = token;
                 // marked >=17 appends a trailing newline to indented code text
                 // (fenced text has none); strip it so indented blocks round-trip.
                 const codeText = codeBlockStyle === 'indented' ? text.replace(/\n$/, '') : text;
+                const fenceLength = /^ {0,3}([`~]{3,})/.exec(raw)?.[1].length;
                 parentList[0].push(
-                    this._buildCodeState(codeText, infoString, codeBlockStyle, trimUnnecessaryCodeBlockEmptyLines),
+                    this._buildCodeState(codeText, infoString, codeBlockStyle, trimUnnecessaryCodeBlockEmptyLines, fenceLength),
                 );
                 break;
             }
@@ -412,6 +413,7 @@ export class MarkdownToState {
         infoString: string,
         codeBlockStyle: 'indented' | undefined,
         trimUnnecessaryCodeBlockEmptyLines: boolean,
+        fenceLength?: number,
     ): TState {
         // GH#697, markedjs#1387 — strip everything past the first
         // whitespace; `\S*` matches the empty string so this is
@@ -452,6 +454,7 @@ export class MarkdownToState {
             meta: {
                 type: isFenced ? 'fenced' : 'indented',
                 lang,
+                ...(isFenced && fenceLength && fenceLength > 3 ? { fenceLength } : {}),
             },
             text: value,
         };

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -356,11 +356,12 @@ export default class ExportMarkdown {
         const { type, lang } = meta;
 
         if (type === 'fenced') {
-            result.push(`${indent}${lang ? `\`\`\`${lang}\n` : '```\n'}`);
+            const fence = '`'.repeat(this._codeFenceLength(text, meta.fenceLength));
+            result.push(`${indent}${lang ? `${fence}${lang}\n` : `${fence}\n`}`);
             textList.forEach((text) => {
                 result.push(`${indent}${text}\n`);
             });
-            result.push(`${indent}\`\`\`\n`);
+            result.push(`${indent}${fence}\n`);
         }
         else {
             textList.forEach((text) => {
@@ -369,6 +370,20 @@ export default class ExportMarkdown {
         }
 
         return result.join('');
+    }
+
+    // The opening fence must be longer than any all-backtick line in the body
+    // (else that line closes the block early), at least as long as the original
+    // fence, and never shorter than the markdown minimum of 3.
+    private _codeFenceLength(text: string, stored?: number): number {
+        let longestInterior = 0;
+        for (const line of text.split('\n')) {
+            const trimmed = line.trim();
+            if (/^`+$/.test(trimmed))
+                longestInterior = Math.max(longestInterior, trimmed.length);
+        }
+
+        return Math.max(3, stored ?? 3, longestInterior + 1);
     }
 
     private _serializeHtmlBlock(state: IHtmlBlockState, indent: string) {

--- a/packages/muya/src/state/types.ts
+++ b/packages/muya/src/state/types.ts
@@ -30,6 +30,7 @@ export interface ICodeBlockState {
     meta: {
         type: string; // "indented" | "fenced";
         lang: string;
+        fenceLength?: number;
     };
     text: string;
 }


### PR DESCRIPTION
## Summary

A fenced code block written with **more than three backticks** — which is required when the block's own content contains a ``` line — was always re-serialized (`getMarkdown` / source-mode toggle) with exactly three backticks. The inner ``` then closed the block early and the saved markdown was corrupt.

Root cause: `ICodeBlockState.meta` had no fence-length field, `markdownToState` never captured it, and `stateToMarkdown._serializeCodeBlock` hard-coded ` ``` `.

Fix:
- capture the opening fence length on parse from the token's raw text, stored in `meta.fenceLength` **only when it exceeds the default 3** (ordinary blocks keep their existing state shape)
- serialize a fence of `max(3, stored, longestAllBacktickLineInBody + 1)`, so the output is both faithful to the original length and always long enough to be valid

## Verification

Unit test `src/state/__tests__/codeFenceLength.spec.ts`, RED→GREEN:
- a 4-backtick block wrapping a ``` line keeps a ≥4 fence and round-trips without corruption
- byte-stable round trip
- ordinary 3-backtick blocks are unchanged

Full state suite + CommonMark/GFM conformance lock unaffected (2 unrelated `parityExportHtml` failures are a pre-existing worktree `?inline`-CSS fs-deny, fail on clean develop too, pass in CI).

Fixes #1841