### PR TITLE
fix(muya): refresh math/diagram preview on undo

### DIFF
--- a/packages/muya/src/block/content/codeBlockContent/__tests__/previewUpdateOnRender.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/previewUpdateOnRender.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #1632 — re-rendering a math/diagram/html block via update() (the path taken
+// by undo/redo: editor.applyTextEdit -> sd.update()) must refresh the rendered
+// preview, not only the source text. inputHandler/backspaceHandler called
+// _updatePreviewIfHave explicitly, but update() did not, so undoing an edit to
+// a math block left a stale formula in the preview.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('math block preview refresh on update() (#1632)', () => {
+    it('update() re-renders the preview after the text changes', () => {
+        const muya = bootMuya('$$\nalpha\n$$\n');
+        const preview = muya.domNode.querySelector<HTMLElement>('.mu-math-preview')!;
+        expect(preview).not.toBeNull();
+
+        // The math content block (editable source inside the math container).
+        const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as {
+            text: string;
+            update: () => void;
+        };
+
+        // Simulate what undo does: mutate the text and re-render via update()
+        // WITHOUT going through inputHandler/backspaceHandler.
+        content.text = 'omega';
+        content.update();
+
+        // The preview must reflect the new formula, not the stale one.
+        expect(preview.textContent).toContain('omega');
+        expect(preview.textContent).not.toContain('alpha');
+    });
+});

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -114,8 +114,14 @@ class CodeBlockContent extends Content {
             : codeContainer!.parent;
     }
 
+    // The text the preview was last rendered from. Seeded with the initial
+    // text so the create-pass update() does not re-trigger a render that races
+    // the preview's own one-shot render on append (async for diagrams).
+    private _lastPreviewText: string;
+
     constructor(muya: Muya, state: CodeContentState) {
         super(muya, state.text);
+        this._lastPreviewText = state.text;
         if (hasStateMeta(state))
             this._initialLang = state.meta.lang;
         else
@@ -134,6 +140,17 @@ class CodeBlockContent extends Content {
 
     // Some block has a preview container, like math, diagram, html, should update the preview if the text changed.
     private _updatePreviewIfHave(text: string) {
+        // update() runs during the initial create pass before this block is
+        // attached, when outContainer cannot resolve its parent chain.
+        if (!this._codeContainer)
+            return;
+        // Only re-render when the text actually changed. update() is called on
+        // every render pass; without this guard a diagram's create-pass render
+        // and update()'s render race (DiagramPreview.update is async), leaving
+        // the SVG unmounted.
+        if (text === this._lastPreviewText)
+            return;
+        this._lastPreviewText = text;
         if (this.outContainer?.attachments?.length)
             (this.outContainer?.attachments?.head as HTMLPreview).update(text);
     }
@@ -166,6 +183,9 @@ class CodeBlockContent extends Content {
         }
 
         this._updateLineNumbers(text);
+        // Re-render the math/diagram/html preview too; undo/redo reaches this
+        // block only through update(), not inputHandler (#1632).
+        this._updatePreviewIfHave(text);
     }
 
     private _lastLineCount = -1;


### PR DESCRIPTION
## Summary

Undoing (or redoing) an edit inside a math / diagram / html block left a **stale rendered preview** — the source text reverted but the rendered formula/diagram did not.

Root cause: the preview was refreshed only from `inputHandler` / `backspaceHandler` (`_updatePreviewIfHave`). Undo/redo reach the block through `editor.applyTextEdit → CodeBlockContent.update()`, which re-rendered the source code and line numbers but never the preview.

Fix: call `_updatePreviewIfHave` from `update()` as well. Guarded against the initial create pass, where the block is not yet attached and `outContainer` cannot resolve its parent chain (without the guard, every plain code block crashes on first render).

## Verification

Unit test `previewUpdateOnRender.spec.ts`, RED→GREEN: mutate a math block's text and call `update()` directly (as undo does) → preview reflects the new formula (was stale before). Full muya unit suite (189 files / 1347 tests) + lint + typecheck pass.

Fixes #1632