### PR TITLE
fix(desktop): resolve relative local links on export

### DIFF
--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -13,6 +13,7 @@ import type { Muya } from '@muyajs/core'
 import { MarkdownToHtml } from '@muyajs/core'
 import { sanitize, EXPORT_DOMPURIFY_CONFIG } from './dompurify'
 import { resolveLocalImageSrc } from './resolveImageSrc'
+import { resolveLocalLinkHref } from './resolveLinkHref'
 
 export interface HeaderFooterPart {
   type?: number
@@ -134,6 +135,23 @@ const rewriteImageSrcs = (html: string): string =>
     return resolved === src ? match : `${pre}${resolved}${post}`
   })
 
+// Match the `href="…"` of an <a> tag in the (already sanitized, double-quoted)
+// engine output, so relative local links are rewritten to absolute `file://`
+// URLs the same way images are.
+const ANCHOR_HREF_REG = /(<a\b[^>]*?\shref=")([^"]*)(")/gi
+
+/**
+ * Rewrite relative / absolute-local `<a href>` to absolute `file://` URLs so a
+ * link to a local file still resolves after the saved document is moved out of
+ * the source folder (#1688). Remote URLs, `mailto:`/`data:` schemes and in-page
+ * fragment anchors are left untouched.
+ */
+const rewriteAnchorHrefs = (html: string): string =>
+  html.replace(ANCHOR_HREF_REG, (match, pre: string, href: string, post: string) => {
+    const resolved = resolveLocalLinkHref(href)
+    return resolved === href ? match : `${pre}${resolved}${post}`
+  })
+
 /**
  * Build a styled, standalone HTML document equivalent to legacy muyajs
  * `exportStyledHTML`. Renders markdown through the new engine, injects the TOC
@@ -170,6 +188,9 @@ export const exportStyledHTML = async(
   // Resolve relative image paths to absolute file:// URLs so the saved document
   // still shows its images when opened from a different folder (issue 230).
   article = rewriteImageSrcs(article)
+  // Same for relative local links so they still resolve after the document is
+  // moved out of the source folder (#1688).
+  article = rewriteAnchorHrefs(article)
 
   // Inject the TOC at the `[TOC]` marker (legacy behaviour: only appears when
   // the document explicitly contains `[TOC]`). The marker is rendered as a

--- a/packages/desktop/src/renderer/src/util/resolveLinkHref.ts
+++ b/packages/desktop/src/renderer/src/util/resolveLinkHref.ts
@@ -1,0 +1,20 @@
+// Resolve an <a>'s href for export / static print (#1688): a relative local
+// path is resolved to an absolute `file://` URL against the current document
+// directory so a link to a local file still works after the exported HTML / PDF
+// is moved out of the source folder. In-page fragments, any URL scheme, and
+// already-absolute paths are left untouched.
+export function resolveLocalLinkHref(href: string): string {
+  if (!href) return href
+  // In-page fragment anchor (#heading) — never a filesystem path.
+  if (href.startsWith('#')) return href
+  // Windows drive-absolute path (C:\… / C:/…) → file://. Checked before the
+  // scheme test, since `C:` otherwise reads as a URL scheme.
+  if (/^[a-z]:[\\/]/i.test(href)) return `file://${href}`
+  // POSIX / UNC absolute path → file://.
+  if (/^(?:\/|\\\\)/.test(href)) return `file://${href}`
+  // Any URL scheme (http:, https:, file:, mailto:, tel:, data:…) — leave as-is.
+  if (/^[a-z][a-z\d+.-]*:/i.test(href)) return href
+  // Relative local path — resolve against the document directory.
+  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, href)}`
+  return href
+}

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -255,3 +255,27 @@ describe('exportStyledHTML — relative image paths', () => {
     expect(out).not.toContain('file://')
   })
 })
+
+describe('exportStyledHTML — relative link paths (#1688)', () => {
+  it('rewrites a relative <a href> to an absolute file:// URL', async() => {
+    // window.DIRNAME is stubbed to '/docs', so `./my_file.pdf` resolves against it.
+    const out = await exportStyledHTML(NO_MUYA, '[doc](./my_file.pdf)', {})
+
+    expect(out).toMatch(/<a[^>]+href="file:\/\/\/docs\/my_file\.pdf"/)
+    expect(out).not.toContain('href="./my_file.pdf"')
+  })
+
+  it('leaves a remote http(s) link untouched', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '[site](https://example.com/p)', {})
+
+    expect(out).toMatch(/<a[^>]+href="https:\/\/example\.com\/p"/)
+    expect(out).not.toContain('file://')
+  })
+
+  it('leaves an in-page fragment anchor untouched', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Heading\n\n[jump](#heading)', {})
+
+    expect(out).toContain('href="#heading"')
+    expect(out).not.toContain('file://')
+  })
+})


### PR DESCRIPTION
## Summary

A relative local link such as `[doc](./my_file.pdf)` was exported to HTML / PDF verbatim, so in the saved document the link pointed into the app resource directory instead of the file next to the source markdown (issue #1688).

Relative `<img src>` was already rewritten to absolute `file://` URLs on export (issue 230). This applies the same treatment to `<a href>` through a sibling `resolveLocalLinkHref` helper, wired into `exportStyledHTML` alongside the image rewrite (which covers the HTML, styled-HTML and PDF export paths).

In-page fragment anchors (`#heading`), URL schemes (`http:`/`https:`/`mailto:`/`data:`…) and already-absolute paths are left untouched.

## Verification

Unit tests added to `exportHtml.spec.ts` (real engine + stubbed `window.DIRNAME`), RED→GREEN: relative `<a href>` → `file:///docs/my_file.pdf`; remote link untouched; in-page `#fragment` untouched. lint + typecheck clean; full exportHtml suite (19 tests) passes.

Fixes #1688