### PR TITLE
fix(muya): require a word boundary before an emoji shortcode

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/emojiWordBoundary.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/emojiWordBoundary.spec.ts
@@ -1,0 +1,32 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+// #1677 — the emoji rule (/^(:)([a-z_\d+-]+)\1/) matched the colons inside a
+// timestamp range like "12:00-14:00", so ":00-14:" was tokenized as an
+// (invalid) emoji and rendered with the red mu-warn styling. An emoji opener
+// must sit at a word boundary: a ":" glued to a preceding letter/digit is not
+// the start of an emoji shortcode.
+
+function emojiTokens(src: string) {
+    return tokenizer(src).filter(t => t.type === 'emoji');
+}
+
+describe('emoji detection — word boundary (#1677)', () => {
+    it('does not treat the colons in a timestamp range as an emoji', () => {
+        expect(emojiTokens('12:00-14:00')).toHaveLength(0);
+    });
+
+    it('does not treat a colon glued to a word as an emoji', () => {
+        expect(emojiTokens('hello:smile:')).toHaveLength(0);
+    });
+
+    it('still recognises an emoji at the start of the text', () => {
+        expect(emojiTokens(':smile:').length).toBeGreaterThan(0);
+    });
+
+    it('still recognises an emoji after whitespace', () => {
+        expect(emojiTokens('lunch :100: today').length).toBeGreaterThan(0);
+    });
+});

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -196,11 +196,17 @@ function tryChunks(state: ILexState): boolean {
     for (const rule of chunks) {
         const to = state.inlineRules[rule].exec(state.src);
         if (to && isLengthEven(to[3])) {
-            if (
-                rule === 'emoji'
-                && !lowerPriority(state.src, to[0].length, validateRules)
-            ) {
-                return false;
+            if (rule === 'emoji') {
+                // An emoji opener must sit at a word boundary: a ":" glued to a
+                // preceding letter/digit (e.g. the colons in "12:00-14:00") is
+                // not the start of a shortcode (#1677).
+                const prevChar = state.originSrc[state.pos - 1];
+                if (
+                    (prevChar && /\w/.test(prevChar))
+                    || !lowerPriority(state.src, to[0].length, validateRules)
+                ) {
+                    return false;
+                }
             }
             pushPending(state);
             const range = {


### PR DESCRIPTION
## Summary

A timestamp range such as `12:00-14:00` was partly rendered in red: the emoji rule `/^(:)([a-z_\d+-]+)\1/` matched the inner `:00-14:` as an emoji shortcode, which then failed validation and got the `mu-warn` (red) styling (#1677).

Fix: an emoji opener must sit at a word boundary. When the `:` is glued to a preceding letter or digit (as in a timestamp), it is no longer treated as the start of a shortcode. Emoji at the start of the text, after whitespace, or after punctuation are unaffected, and valid numeric emoji like `:100:` still work.

## Verification

Unit test `emojiWordBoundary.spec.ts`, RED→GREEN:
- `12:00-14:00` → no emoji token (was tokenized as `:00-14:`)
- `hello:smile:` → no emoji token (glued to a word)
- `:smile:` (start) and `lunch :100: today` (after space) → still emoji

Full muya unit suite (1350 tests) + CommonMark/GFM conformance lock pass; lint + typecheck clean.

Fixes #1677