### PR TITLE
fix(desktop): don't overwrite an existing file when creating from the sidebar

### DIFF
--- a/packages/desktop/src/renderer/src/store/project.ts
+++ b/packages/desktop/src/renderer/src/store/project.ts
@@ -269,7 +269,7 @@ export const useProjectStore = defineStore('project', () => {
     })
   }
 
-  function CREATE_FILE_DIRECTORY(name: string): void {
+  async function CREATE_FILE_DIRECTORY(name: string): Promise<void> {
     const cache = createCache.value as CreateCacheEntry
     const { dirname, type } = cache
 
@@ -278,6 +278,18 @@ export const useProjectStore = defineStore('project', () => {
     }
 
     const fullName = `${dirname}/${name}`
+
+    // Creating over an existing path would silently overwrite it (outputFile
+    // truncates). Refuse instead of destroying the existing file (#1946).
+    if (await window.fileUtils.pathExists(fullName)) {
+      createCache.value = {}
+      notice.notify({
+        title: 'Error in Side Bar',
+        type: 'error',
+        message: `A ${type} named "${name}" already exists in this folder.`
+      })
+      return
+    }
 
     create(fullName, type as FileCreateType)
       .then(() => {

--- a/packages/desktop/test/unit/specs/sidebar-create-conflict.spec.ts
+++ b/packages/desktop/test/unit/specs/sidebar-create-conflict.spec.ts
@@ -1,0 +1,65 @@
+import type * as FileSystemModule from '@/util/fileSystem'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `@/store/project` reaches window.path (via @/config) and window.fileUtils at
+// runtime. Stub the surfaces before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; normalize: (p: string) => string; basename: (p: string) => string; dirname: (p: string) => string }
+      fileUtils?: { hasMarkdownExtension: (n: string) => boolean; pathExists: (p: string) => Promise<boolean> }
+      electron?: { ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void } }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', normalize: (p) => p, basename: (p) => p, dirname: (p) => p }
+  w.window.fileUtils ??= {
+    hasMarkdownExtension: (n: string) => n.endsWith('.md'),
+    pathExists: () => Promise.resolve(false)
+  }
+  w.window.electron ??= { ipcRenderer: { send: () => {}, on: () => {} } }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+// Spy on the actual filesystem create so we can assert it never runs on a conflict.
+vi.mock('@/util/fileSystem', async(orig) => {
+  const actual = await orig<typeof FileSystemModule>()
+  return { ...actual, create: vi.fn(() => Promise.resolve()) }
+})
+
+import { useProjectStore } from '@/store/project'
+import { create } from '@/util/fileSystem'
+import notice from '@/services/notification'
+
+describe('CREATE_FILE_DIRECTORY — name conflict guard (#1946)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('does not create (overwrite) when a file with the same name exists; notifies instead', async() => {
+    window.fileUtils.pathExists = vi.fn(() => Promise.resolve(true))
+    const store = useProjectStore()
+    store.createCache = { dirname: '/docs', type: 'file' }
+
+    await store.CREATE_FILE_DIRECTORY('notes')
+
+    expect(create).not.toHaveBeenCalled()
+    expect(notice.notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates the file when there is no conflict', async() => {
+    window.fileUtils.pathExists = vi.fn(() => Promise.resolve(false))
+    const store = useProjectStore()
+    store.createCache = { dirname: '/docs', type: 'file' }
+
+    await store.CREATE_FILE_DIRECTORY('fresh')
+
+    expect(create).toHaveBeenCalledWith('/docs/fresh.md', 'file')
+    expect(notice.notify).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Creating a file/folder from the sidebar with the same name as an existing one silently **overwrote** it (data loss): `CREATE_FILE_DIRECTORY` → `create` → `outputFile`, which truncates the target, with no warning. Rename already guards against this conflict; create did not (#1946).

Fix: check `pathExists` before creating and, on a conflict, abort with a notice instead of overwriting.

## Verification

Pinia store unit test (`sidebar-create-conflict.spec.ts`), RED→GREEN:
- existing name → `create` is **not** called, a notice is shown
- no conflict → the file is created as before

Without the fix, `create` runs and overwrites the existing file. lint + typecheck clean.

Fixes #1946