### PR TITLE
fix(desktop): ignore content-identical file-change events

### DIFF
--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1658,6 +1658,14 @@ export const useEditorStore = defineStore('editor', {
             }
             case 'add':
             case 'change': {
+              // Only the file's metadata changed on disk (e.g. a git checkout
+              // that left the content byte-identical) — there is nothing to
+              // reload and no reason to warn the user (#1861).
+              const newMarkdown = (change as unknown as FileChangePayload).data?.markdown
+              if (typeof newMarkdown === 'string' && newMarkdown === tab.markdown) {
+                break
+              }
+
               const { autoSave } = preferencesStore
               if (autoSave) {
                 if (autoSaveTimers.has(id)) {

--- a/packages/desktop/test/e2e/issue-1861-filechange.spec.ts
+++ b/packages/desktop/test/e2e/issue-1861-filechange.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+import fs from 'fs'
+import { launchWithMarkdown, waitForMenuReady } from './helpers'
+
+// #1861 — rewriting the open file on disk with byte-identical content (e.g. a
+// git checkout that left it unchanged) fires a watcher 'change', but must NOT
+// mark the tab unsaved or show the "file changed on disk" banner. A genuinely
+// different on-disk content must still warn.
+//
+// This drives the REAL watcher: it writes the actual file and lets the
+// main-process chokidar watcher -> loadMarkdownFile -> renderer handler run,
+// rather than hand-crafting the IPC payload (which would tautologically match).
+
+const isDirty = (page: Page) =>
+  page.evaluate(() => !!document.querySelector('.editor-tabs li.unsaved'))
+
+// macOS uses polling + awaitWriteFinish (stabilityThreshold 1000ms), so a disk
+// write surfaces ~1–2s later.
+const WATCH_SETTLE = 2500
+
+test.describe('Issue #1861 — content-identical file change', () => {
+  test('an identical on-disk rewrite stays clean; a real change warns', async() => {
+    const { app, page, filePath } = await launchWithMarkdown('hello\nworld\n')
+    await waitForMenuReady(app)
+    await page.waitForTimeout(500)
+    expect(await isDirty(page)).toBe(false)
+
+    // Identical bytes — the watcher fires, but the tab must stay clean.
+    fs.writeFileSync(filePath, 'hello\nworld\n', 'utf-8')
+    await page.waitForTimeout(WATCH_SETTLE)
+    expect(await isDirty(page)).toBe(false)
+
+    // A genuine content change still marks the tab unsaved.
+    fs.writeFileSync(filePath, 'hello\nworld\nchanged\n', 'utf-8')
+    await expect.poll(() => isDirty(page), { timeout: 8000 }).toBe(true)
+
+    await app.close()
+  })
+})

--- a/packages/desktop/test/unit/specs/file-change-content-check.spec.ts
+++ b/packages/desktop/test/unit/specs/file-change-content-check.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      fileUtils?: { isSamePathSync: (a: string, b: string) => boolean }
+      electron?: { ipcRenderer: { send: (...a: unknown[]) => void; on: Mock } }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.fileUtils ??= { isSamePathSync: (a, b) => a === b }
+  w.window.electron ??= { ipcRenderer: { send: () => {}, on: vi.fn() } }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+vi.mock('@/store/bufferedState', () => ({ debouncedSendBufferedState: vi.fn() }))
+
+import { useEditorStore } from '@/store/editor'
+
+// #1861: a watcher 'change' event fires even when only the file's mtime changed
+// (e.g. a git checkout that left the content byte-identical). The handler then
+// marked the tab unsaved and showed a "file changed on disk" prompt for a
+// no-op change. Skip the handling when the new on-disk content equals the
+// tab's current content.
+describe('useEditorStore LISTEN_FOR_FILE_CHANGE — content-identical change (#1861)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    ;(window.electron.ipcRenderer.on as Mock).mockReset()
+  })
+
+  const makeSavedTab = (store: ReturnType<typeof useEditorStore>) => {
+    const tab = { id: 'tab-1', filename: 'a.md', pathname: '/x/a.md', markdown: 'hello', isSaved: true }
+    store.tabs = [tab] as unknown as typeof store.tabs
+    store.tabIdToIndex = { 'tab-1': 0 }
+    return tab
+  }
+
+  const captureHandler = () => {
+    const onMock = window.electron.ipcRenderer.on as Mock
+    const call = onMock.mock.calls.find((c) => c[0] === 'mt::update-file')!
+    return call[1] as (e: unknown, payload: unknown) => void
+  }
+
+  const fire = (handler: ReturnType<typeof captureHandler>, markdown: string) =>
+    handler(null, { type: 'change', change: { pathname: '/x/a.md', data: { markdown } } })
+
+  it('ignores a change whose content matches the tab (mtime-only change)', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+    const notifySpy = vi.spyOn(store, 'pushTabNotification').mockImplementation(() => {})
+    store.LISTEN_FOR_FILE_CHANGE()
+
+    fire(captureHandler(), 'hello')
+
+    expect(notifySpy).not.toHaveBeenCalled()
+    expect(tab.isSaved).toBe(true)
+  })
+
+  it('still warns when the on-disk content actually changed', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+    const notifySpy = vi.spyOn(store, 'pushTabNotification').mockImplementation(() => {})
+    store.LISTEN_FOR_FILE_CHANGE()
+
+    fire(captureHandler(), 'hello world')
+
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    expect(tab.isSaved).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

A file watcher `change` event fires whenever a file's mtime changes — even when the content is byte-identical (e.g. a `git checkout` that switches to a branch where the file is unchanged). MarkText then marked the tab unsaved and popped a spurious "file changed on disk" prompt for a no-op change (#1861).

Fix: in the `change`/`add` handler, skip the work when the new on-disk content equals the tab's current content.

## Verification

Editor-store unit test (`file-change-content-check.spec.ts`), RED→GREEN — drives the real `mt::update-file` handler:
- content identical → no prompt, tab stays saved
- content actually changed → prompt shown, tab marked unsaved (unchanged behavior)

lint + typecheck clean.

Fixes #1861