### PR TITLE
fix(muya): preserve current-line indent on Enter in code fences

### DIFF
--- a/packages/muya/src/block/content/codeBlockContent/__tests__/enterBackspaceHandler.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/enterBackspaceHandler.spec.ts
@@ -157,6 +157,23 @@ describe('codeBlockContent.enterHandler — plain Enter inserts newline + indent
         expect(event.preventDefault).toHaveBeenCalledTimes(1);
     });
 
+    it('inherits the CURRENT line indent when Enter is pressed on a later line, not line 0', () => {
+        const muya = bootMuya('```js\nfoo\n```\n');
+        const content = codeContent(muya);
+        // Two lines: line 0 has no indent, line 1 is indented 4 spaces.
+        content.text = 'def foo():\n    bar()';
+        muya.editor.activeContentBlock = content;
+        const offset = content.text.length; // caret at end of the indented 2nd line
+        content.setCursor(offset, offset, true);
+
+        content.enterHandler(keyEvent({ key: 'Enter' }));
+
+        // The new line must inherit line 1's 4-space indent, not line 0's empty indent.
+        expect(content.text).toBe('def foo():\n    bar()\n    ');
+        const cursor = content.getCursor()!;
+        expect(cursor.start.offset).toBe(offset + 1 + 4);
+    });
+
     it('adds an extra tabSize block when the caret sits inside an auto-indent pair', () => {
         const muya = bootMuya('```js\nfoo\n```\n');
         const content = codeContent(muya);

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -22,8 +22,12 @@ function checkAutoIndent(text: string, offset: number) {
     return /^(?:\{\}|\[\]|\(\)|><)$/.test(pairStr);
 }
 
-function getIndentSpace(text: string) {
-    const match = /^(\s*)\S/.exec(text);
+function getIndentSpace(text: string, offset: number) {
+    const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1)
+        lineEnd = text.length;
+    const match = /^(\s*)\S/.exec(text.slice(lineStart, lineEnd));
 
     return match ? match[1] : '';
 }
@@ -281,7 +285,7 @@ class CodeBlockContent extends Content {
         const { start } = this.getCursor()!;
         const { text } = this;
         const autoIndent = checkAutoIndent(text, start.offset);
-        const indent = getIndentSpace(text);
+        const indent = getIndentSpace(text, start.offset);
 
         this.text
             = `${text.substring(0, start.offset)


### PR DESCRIPTION
## Summary

Inside a fenced code block, pressing <kbd>Enter</kbd> on any line other than the first dropped that line's indentation — the new line was inserted with line 0's indent instead of the current line's.

Root cause: `getIndentSpace()` in `codeBlockContent/index.ts` ran `/^(\s*)\S/` against the **entire** code-block text, which is anchored to position 0, so it only ever captured the first line's leading whitespace. `enterHandler` also called it without the cursor offset.

Fix: scope the indent match to the cursor's own line (`text.lastIndexOf('\n', offset - 1) + 1` … next newline) and pass `start.offset` from `enterHandler`.

## Test

Added a RED→GREEN case in `enterBackspaceHandler.spec.ts`: Enter at the end of an indented second line now inherits that line's 4-space indent (previously inherited line 0's empty indent). The pre-existing single-line and auto-indent-pair cases still pass, as do the full unit suite (1355) and the CommonMark/GFM conformance lock (1347).

Fixes #2158