### PR TITLE
fix(muya): exclude selection whitespace when applying inline format

### DIFF
--- a/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatToggle.spec.ts
@@ -228,6 +228,33 @@ describe('format.format() apply-ON over a non-collapsed selection', () => {
     });
 });
 
+// #2166 — double-clicking a word selects the word PLUS the trailing whitespace.
+// Wrapping that whitespace inside the markers (`**foo **`) is invalid emphasis
+// per CommonMark's flanking rules, so it renders as literal text. The markers
+// must hug the non-whitespace content, leaving the whitespace outside.
+describe('format.format() trims selection whitespace before wrapping (#2166)', () => {
+    it('strong: selecting `foo ` (with trailing space) wraps only `foo`', () => {
+        // `foo bar`: offsets 0..4 cover `foo ` including the trailing space.
+        const content = selectInFirstBlock(bootMuya('foo bar\n'), 0, 4);
+        content.format('strong');
+        expect(content.text).toBe('**foo** bar');
+    });
+
+    it('em: selecting ` bar` (with leading space) wraps only `bar`', () => {
+        // `foo bar`: offsets 3..7 cover ` bar` including the leading space.
+        const content = selectInFirstBlock(bootMuya('foo bar\n'), 3, 7);
+        content.format('em');
+        expect(content.text).toBe('foo *bar*');
+    });
+
+    it('strong: selecting `foo ` then ` bar` style both-side padding wraps only the words', () => {
+        // ` foo ` at offsets 0..5 of ` foo bar` → only `foo` gets wrapped.
+        const content = selectInFirstBlock(bootMuya(' foo bar\n'), 0, 5);
+        content.format('strong');
+        expect(content.text).toBe(' **foo** bar');
+    });
+});
+
 describe('format.format(\'clear\') with the caret inside the run', () => {
     it('strips a strong run to plain text', () => {
         const content = caretInFirstBlock(bootMuya('**word**\n'), 2);

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1648,6 +1648,15 @@ class Format extends Content {
             end.offset += end.delta;
             this.text = generator(tokens, true);
 
+            // Whitespace wrapped inside emphasis markers is invalid CommonMark
+            // (`**foo **` is not right-flanking, so it renders literally), so
+            // trim the selection to its non-whitespace span before wrapping.
+            const selected = this.text.substring(start.offset, end.offset);
+            if (selected.trim().length > 0) {
+                start.offset += selected.length - selected.trimStart().length;
+                end.offset -= selected.length - selected.trimEnd().length;
+            }
+
             this._addFormat(type, { start, end });
 
             if (type === 'image') {


### PR DESCRIPTION
## Summary

Double-clicking a word selects the word **plus its trailing whitespace**. Applying an inline format (bold/italic/strike/etc.) then wrapped that whitespace inside the markers — e.g. `**foo **` — which is invalid emphasis under CommonMark's left/right-flanking rules, so it rendered as literal `**foo **` instead of bold.

Root cause: `format()` passed the raw selection offsets straight to `_addFormat`, which wraps `text.substring(start, end)` with no whitespace handling.

Fix: in `format()`, trim leading/trailing whitespace off the selection (only when the selection isn't all whitespace) before `_addFormat`, so the markers hug the word and any whitespace stays outside.

## Test

Added RED→GREEN cases in `formatToggle.spec.ts`:
- `foo ` (trailing space) → `**foo** bar` (was `**foo **bar`)
- ` bar` (leading space) → `foo *bar*` (was `foo* bar*`)
- ` foo ` (both sides) → ` **foo** bar` (was `** foo **bar`)

Full unit suite (1357) and the CommonMark/GFM conformance lock (1347) pass; the existing no-whitespace apply/toggle cases are unaffected.

Fixes #2166