### PR TITLE
fix(muya): make autolinks and bare URLs followable on Cmd/Ctrl-click

### DIFF
--- a/packages/muya/src/editor/__tests__/clickableAutolink.spec.ts
+++ b/packages/muya/src/editor/__tests__/clickableAutolink.spec.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import type { Muya as MuyaType } from '../../muya';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// #2165 — "make it easy to follow a link". CommonMark autolinks
+// (`<https://x.com>`) and GFM bare-URL autolinks (`https://x.com`) render as
+// `a.mu-auto-link` / `a.mu-auto-link-extension`, but those classes were absent
+// from linkMouseEvents' LINK_SELECTOR and the renderers never set `data-raw`,
+// so `getLinkInfo` returned null and a Cmd/Ctrl-click never emitted
+// `format-click` — the link could not be followed. These boot a real engine,
+// render each autolink variant, and assert a modifier-click asks the host to
+// open it.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): MuyaType {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+interface IFormatClick { formatType: string; data: { href: string | null; raw: string } }
+
+function captureFormatClick(muya: MuyaType): IFormatClick[] {
+    const emits: IFormatClick[] = [];
+    muya.eventCenter.subscribe('format-click', (payload: IFormatClick) => emits.push(payload));
+    return emits;
+}
+
+function modifierClick(el: Element) {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }));
+}
+
+describe('#2165 — autolinks are followable via Cmd/Ctrl-click', () => {
+    it('renders a.mu-auto-link with data-raw + href for a CommonMark autolink `<https://example.com>`', () => {
+        const muya = bootMuya('<https://example.com>\n');
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link');
+        expect(anchor).not.toBeNull();
+        expect(anchor!.dataset.raw).toBeTruthy();
+        expect(anchor!.getAttribute('href')).toContain('https://example.com');
+    });
+
+    it('a Ctrl-click on a CommonMark autolink emits format-click with the href', () => {
+        const muya = bootMuya('<https://example.com>\n');
+        const emits = captureFormatClick(muya);
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link')!;
+
+        modifierClick(anchor);
+
+        expect(emits).toHaveLength(1);
+        expect(emits[0].formatType).toBe('link');
+        expect(emits[0].data.href).toContain('https://example.com');
+    });
+
+    it('renders a.mu-auto-link-extension for a bare GFM URL `https://example.com` and follows it', () => {
+        const muya = bootMuya('see https://example.com here\n');
+        const emits = captureFormatClick(muya);
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link-extension');
+        expect(anchor).not.toBeNull();
+        expect(anchor!.dataset.raw).toBeTruthy();
+
+        modifierClick(anchor!);
+
+        expect(emits).toHaveLength(1);
+        expect(emits[0].data.href).toContain('https://example.com');
+    });
+
+    it('a plain (non-modifier) click on an autolink does NOT emit format-click', () => {
+        const muya = bootMuya('<https://example.com>\n');
+        const emits = captureFormatClick(muya);
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link')!;
+
+        anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(emits).toHaveLength(0);
+    });
+
+    it('hovering an autolink does NOT open the edit/unlink popover (follow-only)', () => {
+        const muya = bootMuya('<https://example.com>\n');
+        const popoverEmits: unknown[] = [];
+        muya.eventCenter.subscribe('muya-link-tools', (p: { reference: unknown }) => {
+            if (p.reference)
+                popoverEmits.push(p);
+        });
+        const anchor = muya.domNode.querySelector<HTMLAnchorElement>('a.mu-auto-link')!;
+
+        anchor.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+        expect(popoverEmits).toHaveLength(0);
+    });
+});

--- a/packages/muya/src/editor/linkMouseEvents.ts
+++ b/packages/muya/src/editor/linkMouseEvents.ts
@@ -40,6 +40,8 @@ const LINK_SELECTOR = [
     `span.${CLASS_NAMES.MU_LINK}`,
     `a.${CLASS_NAMES.MU_REFERENCE_LINK}`,
     `a.${CLASS_NAMES.MU_RAW_HTML}`,
+    `a.${CLASS_NAMES.MU_AUTO_LINK}`,
+    `a.${CLASS_NAMES.MU_AUTO_LINK_EXTENSION}`,
 ].join(', ');
 
 // Click suppression covers all real anchor variants whether or not they
@@ -62,6 +64,16 @@ function isModifierClick(event: Event): boolean {
 }
 
 function isPopoverTarget(wrapper: HTMLElement): boolean {
+    // Auto-detected links are follow-only (Cmd/Ctrl-click). The edit/unlink
+    // popover doesn't apply — there is no `[text](url)` source to rewrite, and
+    // the URL re-autolinks on the next render anyway.
+    if (
+        wrapper.classList.contains(CLASS_NAMES.MU_AUTO_LINK)
+        || wrapper.classList.contains(CLASS_NAMES.MU_AUTO_LINK_EXTENSION)
+    ) {
+        return false;
+    }
+
     // HTML `<a>` is always a popover target — no source markers to hide.
     if (wrapper.classList.contains(CLASS_NAMES.MU_RAW_HTML))
         return true;

--- a/packages/muya/src/inlineRenderer/renderer/autoLink.ts
+++ b/packages/muya/src/inlineRenderer/renderer/autoLink.ts
@@ -42,6 +42,11 @@ export default function autoLink(
                     href: sanitizeHyperlink(hyperlink),
                     target: '_blank',
                 },
+                dataset: {
+                    start: String(start),
+                    end: String(end),
+                    raw: token.raw,
+                },
             },
             content,
         ),

--- a/packages/muya/src/inlineRenderer/renderer/autoLinkExtension.ts
+++ b/packages/muya/src/inlineRenderer/renderer/autoLinkExtension.ts
@@ -30,6 +30,11 @@ export default function autoLinkExtension(
                     href: sanitizeHyperlink(hyperlink),
                     target: '_blank',
                 },
+                dataset: {
+                    start: String(start),
+                    end: String(end),
+                    raw: token.raw,
+                },
             },
             content,
         ),


### PR DESCRIPTION
## Summary

CommonMark autolinks (`<https://example.com>`) and GFM bare-URL autolinks (`https://example.com`) rendered as anchors but could **not be followed** — Cmd/Ctrl-clicking them did nothing, while regular `[text](url)` links opened.

Root cause (two gaps):
1. `linkMouseEvents.ts`'s `LINK_SELECTOR` only listed `span.mu-link`, `a.mu-reference-link`, `a.mu-raw-html` — not `a.mu-auto-link` / `a.mu-auto-link-extension`, so `findLinkWrapper()` returned null for autolinks.
2. The `autoLink.ts` / `autoLinkExtension.ts` renderers never set `data-raw`, so even with the selector fixed `getLinkInfo()` would return null and abort.

## Fix

- Set `data-{start,end,raw}` on both autolink `<a>` vnodes (mirroring `link.ts`).
- Add the two autolink classes to `LINK_SELECTOR`.
- Keep autolinks **follow-only**: `isPopoverTarget()` returns false for them, so the edit/unlink hover popover doesn't appear (there's no `[](…)` source to rewrite, and the URL re-autolinks on the next render). The existing modifier-click → `format-click` contract the desktop shell already consumes is unchanged.

## Test

New `clickableAutolink.spec.ts` boots a real engine and drives the actual click path (renderer → DOM → `attachLinkMouseHandlers` → event):
- `<https://example.com>` renders `a.mu-auto-link` with `data-raw` + href; Ctrl-click emits `format-click` with the href.
- bare `https://example.com` renders `a.mu-auto-link-extension`; Ctrl-click follows it.
- a plain (non-modifier) click does not emit.
- hovering an autolink does not open the edit/unlink popover.

Full unit suite (1359) and the CommonMark/GFM conformance lock (1347) pass; existing link hover/click tests (43) unaffected.

Fixes #2165