### PR TITLE
fix(muya): surface the KaTeX parse error for invalid math

### DIFF
--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -220,10 +220,23 @@ div .mu-math-error,
     font-size: 14px;
     font-family: monospace;
     font-style: italic;
+}
 
-    /* Keep the KaTeX parse-error message on one line instead of wrapping
-       across the narrow inline-math popup. */
+/* Inline math shows a short error label: keep it on one line in the narrow
+   popup, and let it overflow VISIBLE rather than be clipped — the default
+   `overflow: auto` on .mu-math-render both clips the label and takes the
+   inline-block's baseline from its bottom edge, lifting it off the text. */
+.mu-math > .mu-math-render.mu-math-error {
+    overflow: visible;
+
     white-space: nowrap;
+}
+
+/* Block math shows the full KaTeX parse-error message, which can be long; wrap
+   it within the block instead of overflowing horizontally (#2220). */
+.mu-math-preview .mu-math-error {
+    white-space: normal;
+    overflow-wrap: break-word;
 }
 
 .mu-math > .mu-math-render .katex-display {
@@ -264,14 +277,6 @@ div .mu-math-error,
     box-shadow: none;
 
     user-select: auto;
-}
-
-/* A parse-error message is short and never needs scrolling, but `overflow: auto`
-   makes the inline-block take its baseline from its bottom edge, pushing it a few
-   px above the surrounding text. `visible` keeps it on the baseline. (A long
-   valid formula keeps `overflow: auto` so it stays scrollable, not truncated.) */
-.mu-hide.mu-math > .mu-math-render.mu-math-error {
-    overflow: visible;
 }
 
 .mu-ruby:not(.mu-hide) > .mu-ruby-render,

--- a/packages/muya/src/block/extra/math/__tests__/mathErrorMessage.spec.ts
+++ b/packages/muya/src/block/extra/math/__tests__/mathErrorMessage.spec.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+
+import type { Muya as MuyaType } from '../../../../muya';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #2220 — "How to debug <Invalid Mathematical Formula>?". The live editor
+// caught KaTeX's parse error and replaced it with an opaque generic message,
+// so the user had no idea WHAT was wrong. Surface KaTeX's actual parse-error
+// reason: inline math keeps the compact baseline-aligned label but exposes the
+// message via the title (a long message inline would break the text baseline —
+// #4100 / inline-math-align); block math shows the message text directly.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): MuyaType {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('#2220 — invalid math surfaces the KaTeX parse error, not a generic message', () => {
+    it('inline math `$\\frac{1}{$` carries the parse reason in the .mu-math-error title (compact label kept)', () => {
+        const muya = bootMuya('$\\frac{1}{$\n');
+        const errorEl = muya.domNode.querySelector('.mu-math-error');
+        expect(errorEl).not.toBeNull();
+        // The visible label stays compact (baseline-safe); the reason is on the title.
+        expect(errorEl!.getAttribute('title') ?? '').toMatch(/parse error/i);
+        expect(errorEl!.textContent ?? '').toContain('Invalid Mathematical Formula');
+    });
+
+    it('block math `$$\\frac{1}{$$` shows the parse reason in .mu-math-error', () => {
+        const muya = bootMuya('$$\n\\frac{1}{\n$$\n');
+        const errorEl = muya.domNode.querySelector('.mu-math-error');
+        expect(errorEl).not.toBeNull();
+        expect(errorEl!.textContent ?? '').toMatch(/parse error/i);
+        expect(muya.domNode.textContent ?? '').not.toContain('Invalid Mathematical Formula');
+    });
+});

--- a/packages/muya/src/block/extra/math/mathPreview.ts
+++ b/packages/muya/src/block/extra/math/mathPreview.ts
@@ -3,6 +3,7 @@ import type { IMathBlockState, TState } from '../../../state/types';
 import katex from 'katex';
 import { fromEvent } from 'rxjs';
 import { CLASS_NAMES } from '../../../config';
+import { escapeHTML } from '../../../utils';
 import logger from '../../../utils/logger';
 import Parent from '../../base/parent';
 import 'katex/dist/contrib/mhchem.mjs';
@@ -70,10 +71,9 @@ class MathPreview extends Parent {
                 });
                 this.domNode!.innerHTML = html;
             }
-            catch {
-                this.domNode!.innerHTML = `<div class="${CLASS_NAMES.MU_MATH_ERROR}">&lt; ${i18n.t(
-                    'Invalid Mathematical Formula',
-                )} &gt;</div>`;
+            catch (err) {
+                const message = err instanceof Error ? err.message : i18n.t('Invalid Mathematical Formula');
+                this.domNode!.innerHTML = `<div class="${CLASS_NAMES.MU_MATH_ERROR}">${escapeHTML(message)}</div>`;
             }
         }
         else {

--- a/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
+++ b/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
@@ -48,6 +48,9 @@ export default function inlineMath(this: Renderer, {
     const key = `${math}_${type}`;
     let mathVnode = null;
     let previewSelector = `span.${CLASS_NAMES.MU_MATH_RENDER}`;
+    // Inline math errors stay compact to keep the surrounding text baseline
+    // (#4100, inline-math-align); surface the parse reason via the title.
+    let errorTitle = '';
     if (loadMathMap.has(key)) {
         mathVnode = loadMathMap.get(key);
     }
@@ -59,9 +62,10 @@ export default function inlineMath(this: Renderer, {
             mathVnode = htmlToVNode(html);
             loadMathMap.set(key, mathVnode);
         }
-        catch {
+        catch (err) {
             mathVnode = `<${i18n.t('Invalid Mathematical Formula')}>`;
             previewSelector += `.${CLASS_NAMES.MU_MATH_ERROR}`;
+            errorTitle = err instanceof Error ? err.message : '';
         }
     }
 
@@ -78,7 +82,9 @@ export default function inlineMath(this: Renderer, {
             h(
                 previewSelector,
                 {
-                    attrs: { contenteditable: 'false' },
+                    attrs: errorTitle
+                        ? { contenteditable: 'false', title: errorTitle }
+                        : { contenteditable: 'false' },
                     dataset: {
                         start: String(start + 1), // '$'.length
                         end: String(end - 1), // '$'.length


### PR DESCRIPTION
## Summary

When a math formula was invalid, the live editor showed a generic `< Invalid Mathematical Formula >` with no indication of *what* was wrong — the reporter asked how they were supposed to debug it. Both live render sites caught KaTeX's `ParseError` and discarded it.

## Fix

- **Block math** (`mathPreview.ts`): render the caught error's `message` in the existing `.mu-math-error` element (escaped).
- **Inline math** (`inlineMath.ts`): keep the compact generic label as visible content — a long message inline breaks the surrounding-text baseline (regression caught by the existing `inline-math-align` e2e; see also #4100 one-line rule) — and expose KaTeX's parse reason via the element `title` (hover).

## Test

`mathErrorMessage.spec.ts` boots a real engine with an invalid formula and asserts: inline → `.mu-math-error` `title` carries the parse reason while the visible label stays compact; block → `.mu-math-error` text contains the parse reason. Full unit suite (1356) + CommonMark/GFM conformance lock (1347) pass.

Fixes #2220