### PR TITLE
fix(desktop): default save dialogs to the active file's directory

### DIFF
--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -505,7 +505,7 @@ export const useEditorStore = defineStore('editor', {
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
-      const defaultPath = getRootFolderFromState(projectStore)
+      const defaultPath = getDialogDefaultPath(projectStore)
       if (id) {
         window.electron.ipcRenderer.send(
           'mt::response-file-save',
@@ -534,7 +534,7 @@ export const useEditorStore = defineStore('editor', {
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
-      const defaultPath = getRootFolderFromState(projectStore)
+      const defaultPath = getDialogDefaultPath(projectStore)
 
       if (id) {
         window.electron.ipcRenderer.send(
@@ -651,7 +651,7 @@ export const useEditorStore = defineStore('editor', {
                   pathname,
                   markdown,
                   options,
-                  defaultPath: getRootFolderFromState(projectStore)
+                  defaultPath: getDialogDefaultPath(projectStore)
                 }
               })
 
@@ -687,7 +687,7 @@ export const useEditorStore = defineStore('editor', {
             pathname,
             markdown,
             options,
-            defaultPath: getRootFolderFromState(projectStore)
+            defaultPath: getDialogDefaultPath(projectStore)
           }
         })
 
@@ -708,7 +708,7 @@ export const useEditorStore = defineStore('editor', {
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
-      const defaultPath = getRootFolderFromState(projectStore)
+      const defaultPath = getDialogDefaultPath(projectStore)
       if (!id) return
       if (!pathname) {
         // if current file is a newly created file, just save it!
@@ -750,7 +750,7 @@ export const useEditorStore = defineStore('editor', {
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
-      const defaultPath = getRootFolderFromState(projectStore)
+      const defaultPath = getDialogDefaultPath(projectStore)
       if (!id) return
       if (!pathname) {
         // if current file is a newly created file, just save it!
@@ -1474,7 +1474,7 @@ export const useEditorStore = defineStore('editor', {
 
         const tab = this.tabs.find((t) => t.id === id)
         if (tab && !tab.isSaved) {
-          const defaultPath = getRootFolderFromState(projectStore)
+          const defaultPath = getDialogDefaultPath(projectStore)
           window.electron.ipcRenderer.send(
             'mt::response-file-save',
             id,
@@ -1778,6 +1778,13 @@ const getRootFolderFromState = (projectStore: ProjectStoreLike): string => {
     return openedFolder.pathname ?? ''
   }
   return ''
+}
+
+// Default directory for save/move/rename dialogs: the opened project folder,
+// or — when none is open — the directory of the file currently being edited
+// (#2156). Main falls back to the Documents folder only when both are empty.
+const getDialogDefaultPath = (projectStore: ProjectStoreLike): string => {
+  return getRootFolderFromState(projectStore) || (window.DIRNAME ?? '')
 }
 
 /**

--- a/packages/desktop/test/unit/specs/save-dialog-default-dir.spec.ts
+++ b/packages/desktop/test/unit/specs/save-dialog-default-dir.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// #2156 — Save/Save As should default the dialog to the directory of the file
+// the user is editing, not the OS Documents folder, when no project folder is
+// open in the sidebar. The save dialog's `defaultPath` is derived in the
+// renderer and sent to the main process; it previously only ever resolved to
+// the opened project folder (or '' → Documents in main).
+//
+// `@/store/editor` transitively imports `@/config`, which reads
+// `window.path.sep` at module load, and reaches `window.electron.ipcRenderer`
+// at runtime. Stub those surfaces before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: { clipboard: { writeText: (s: string) => void }; ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void } }
+      DIRNAME?: string
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p.replace(/\/[^/]*$/, '') }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+import { defaultFileState } from '@/store/help'
+import type { IFileState } from '@shared/types/files'
+
+describe('#2156 — save dialog default path falls back to the active file directory', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    window.electron.ipcRenderer.send = vi.fn()
+  })
+
+  function lastSaveAsDefaultPath(): unknown {
+    const calls = (window.electron.ipcRenderer.send as ReturnType<typeof vi.fn>).mock.calls
+    const call = calls.find((c) => c[0] === 'mt::response-file-save-as')
+    expect(call).toBeTruthy()
+    if (!call) return undefined
+    return call[call.length - 1]
+  }
+
+  it('uses window.DIRNAME (the active file dir) when no project folder is open', () => {
+    window.DIRNAME = '/home/me/notes'
+    const store = useEditorStore()
+    store.currentFile = { ...defaultFileState, id: 'tab-1', pathname: '' } as IFileState
+
+    store.FILE_SAVE_AS()
+
+    expect(lastSaveAsDefaultPath()).toBe('/home/me/notes')
+  })
+
+  it('still resolves to an empty default when neither a project folder nor an active dir exist', () => {
+    window.DIRNAME = ''
+    const store = useEditorStore()
+    store.currentFile = { ...defaultFileState, id: 'tab-2', pathname: '' } as IFileState
+
+    store.FILE_SAVE_AS()
+
+    expect(lastSaveAsDefaultPath()).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Save / Save As / Move / Rename dialogs always defaulted to the OS **Documents** folder unless a project folder was open in the sidebar — they ignored the directory of the file the user was actually editing.

Root cause: the renderer derived the dialog `defaultPath` solely from `getRootFolderFromState(projectStore)` (the sidebar project folder, or `''`), and the main process falls back to `getPath('documents')` on an empty string. The active file's directory (already tracked in `window.DIRNAME`) was never consulted.

## Fix

Add a `getDialogDefaultPath(projectStore)` helper that falls back to `window.DIRNAME` when no project folder is open, and route all seven save/move/rename dialog sites through it. `getRootFolderFromState` keeps its project-folder-only semantics.

## Test

`save-dialog-default-dir.spec.ts` boots the real editor store and drives `FILE_SAVE_AS`, asserting the IPC payload's `defaultPath` is now the active file's directory (`window.DIRNAME`) when no project folder is open, and `''` when neither exists. Full desktop unit suite (683) passes.

## Scope

This covers the **save** half of #2156. The **open**-dialog half (defaulting File ▸ Open to the active file's directory) needs the main process to learn the focused window's directory — a per-window IPC/state change whose native `showOpenDialog` default path can't be asserted in automated tests and needs manual dev-app verification. Left as a follow-up; this PR therefore uses `Refs` rather than `Fixes`.

Refs #2156