### PR TITLE
fix(muya): convert $$ to a math block in place inside a list item

### DIFF
--- a/packages/muya/src/block/content/paragraphContent/__tests__/listMathEnterConvert.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/listMathEnterConvert.spec.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #2276 — inside a list item, typing `$$` then Enter should convert the item's
+// paragraph into a math block IN PLACE (like a code fence already does), not
+// split the item and leave behind an extra empty list entry. The enterHandler
+// early-converts code fences even inside a list, but `$$` fell through to the
+// list-split path, producing the math input AND an unwanted next list item.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function keyEvent(over: Partial<KeyboardEvent> = {}): KeyboardEvent {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        key: 'Enter',
+        shiftKey: false,
+        ...over,
+    } as unknown as KeyboardEvent;
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+// Drive `$$` + Enter on the list item's paragraph content and return the
+// resulting top-level document state (the order-list).
+async function enterDollarsInList(token: string): Promise<{ listChildren: number; itemBlockNames: string[] }> {
+    const muya = bootMuya('1. x\n');
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Content;
+    content.text = token;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(token.length, token.length, true);
+
+    content.enterHandler(keyEvent({ key: 'Enter' }));
+    await flush();
+
+    const state = muya.getState() as Array<{ name: string; children?: Array<{ name: string; children?: Array<{ name: string }> }> }>;
+    const list = state[0];
+    const items = list.children ?? [];
+    return {
+        listChildren: items.length,
+        itemBlockNames: (items[0]?.children ?? []).map(c => c.name),
+    };
+}
+
+describe('#2276 — `$$`/code-fence + Enter inside a list converts in place, no extra item', () => {
+    it('`$$` converts the list item to a math block without adding a new list item', async () => {
+        const { listChildren, itemBlockNames } = await enterDollarsInList('$$');
+        expect(listChildren).toBe(1); // no unwanted second list item
+        expect(itemBlockNames).toContain('math-block');
+    });
+
+    it('a code fence ```` ``` ```` converts in place without adding a new list item', async () => {
+        const { listChildren, itemBlockNames } = await enterDollarsInList('```js');
+        expect(listChildren).toBe(1);
+        expect(itemBlockNames).toContain('code-block');
+    });
+
+    it('a table `|a|b|` converts in place without adding a new list item', async () => {
+        const { listChildren, itemBlockNames } = await enterDollarsInList('|a|b|');
+        expect(listChildren).toBe(1);
+        expect(itemBlockNames).toContain('table');
+    });
+
+    it('an HTML block `<div>` converts in place without adding a new list item', async () => {
+        const { listChildren, itemBlockNames } = await enterDollarsInList('<div>');
+        expect(listChildren).toBe(1);
+        expect(itemBlockNames).toContain('html-block');
+    });
+});

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -41,6 +41,39 @@ const debug = logger('paragraph:content');
 
 const HTML_BLOCK_REG = /^<([a-z\d-]+)(?=\s|>)[^<>]*>$/i;
 const CODE_BLOCK_REG = /(^ {0,3}`{3,})([^` ]*)/;
+const MATH_BLOCK_REG = /^\$\$/;
+// eslint-disable-next-line regexp/no-super-linear-backtracking
+const TABLE_BLOCK_REG = /^\|.*?(\\*)\|.*?(\\*)\|/;
+
+type BlockConversion
+    = | { kind: 'math' }
+        | { kind: 'code'; lang: string }
+        | { kind: 'table' }
+        | { kind: 'html'; tagName: string };
+
+// Single source of truth for "what block, if any, does this paragraph text
+// convert into on Enter". Shared by the enterHandler guard (to decide whether
+// to convert in place) and `_enterConvert` (to perform it), so the match rules
+// can never drift between the two.
+function matchBlockConversion(text: string): BlockConversion | null {
+    if (MATH_BLOCK_REG.test(text))
+        return { kind: 'math' };
+
+    const codeBlockToken = text.match(CODE_BLOCK_REG);
+    if (codeBlockToken)
+        return { kind: 'code', lang: codeBlockToken[2] };
+
+    const tableMatch = TABLE_BLOCK_REG.exec(text);
+    if (tableMatch && isLengthEven(tableMatch[1]) && isLengthEven(tableMatch[2]))
+        return { kind: 'table' };
+
+    const htmlMatch = HTML_BLOCK_REG.exec(text);
+    const tagName = htmlMatch && htmlMatch[1] && HTML_TAGS.find(t => t === htmlMatch[1]);
+    if (tagName && VOID_HTML_TAGS.every(tag => tag !== tagName))
+        return { kind: 'html', tagName };
+
+    return null;
+}
 
 const BOTH_SIDES_FORMATS = [
     'strong',
@@ -224,117 +257,113 @@ class ParagraphContent extends Format {
         event.preventDefault();
         event.stopPropagation();
 
-        // eslint-disable-next-line regexp/no-super-linear-backtracking
-        const TABLE_BLOCK_REG = /^\|.*?(\\*)\|.*?(\\*)\|/;
-        const MATH_BLOCK_REG = /^\$\$/;
-        const { text } = this;
-        const codeBlockToken = text.match(CODE_BLOCK_REG);
-        const tableMatch = TABLE_BLOCK_REG.exec(text);
-        const htmlMatch = HTML_BLOCK_REG.exec(text);
-        const mathMath = MATH_BLOCK_REG.exec(text);
-        const tagName
-            = htmlMatch && htmlMatch[1] && HTML_TAGS.find(t => t === htmlMatch[1]);
-
-        if (mathMath) {
-            const state = {
-                name: 'math-block',
-                text: '',
-                meta: {
-                    mathStyle: '',
-                },
-            };
-            const mathBlock = ScrollPage.loadBlock('math-block').create(
-                this.muya,
-                state,
-            );
-            this.parent!.replaceWith(mathBlock);
-            mathBlock.firstContentInDescendant().setCursor(0, 0);
-        }
-        else if (codeBlockToken) {
-            const lang = codeBlockToken[2];
-            // Diagram fences (```mermaid etc.) become diagram blocks, mirroring
-            // the file-load path in markdownToState; everything else is a fenced
-            // code block.
-            const diagramMatch = /^(?:mermaid|vega-lite|plantuml|flowchart|sequence)$/.exec(lang);
-            if (diagramMatch) {
-                const type = lang as IDiagramMeta['type'];
-                const state = {
-                    name: 'diagram',
-                    text: '',
-                    meta: {
-                        type,
-                        lang: type === 'vega-lite' ? 'json' : 'yaml',
-                    },
-                };
-                const diagramBlock = ScrollPage.loadBlock(state.name).create(
-                    this.muya,
-                    state,
-                );
-
-                this.parent!.replaceWith(diagramBlock);
-
-                diagramBlock.firstContentInDescendant().setCursor(0, 0, true);
-            }
-            else {
-                const state = {
-                    name: 'code-block',
-                    meta: {
-                        lang,
-                        type: 'fenced',
-                    },
-                    text: '',
-                };
-                const codeBlock = ScrollPage.loadBlock(state.name).create(
-                    this.muya,
-                    state,
-                );
-
-                this.parent!.replaceWith(codeBlock);
-
-                codeBlock.lastContentInDescendant().setCursor(0, 0);
-            }
-        }
-        else if (
-            tableMatch
-            && isLengthEven(tableMatch[1])
-            && isLengthEven(tableMatch[2])
-        ) {
-            const tableHeader = parseTableHeader(this.text);
-            // Table extends the base `create` shape with a static
-            // `createWithHeader(muya, header)` factory; the registry-level
-            // IConstructor doesn't surface it. Cast to a structural view that
-            // names only the static slot we read.
-            const tableCtor = ScrollPage.loadBlock('table') as {
-                createWithHeader?: (muya: Muya, header: string[]) => Parent;
-            };
-            const tableBlock = tableCtor.createWithHeader!(this.muya, tableHeader);
-
-            this.parent!.replaceWith(tableBlock);
-
-            // Set cursor at the first cell of second row. The runtime chain
-            // is: table → table-body (Parent.firstChild) → row (find(1)) →
-            // first cell content (firstContentInDescendant). Asserted as
-            // Parent at each container hop since createWithHeader guarantees
-            // a populated structure.
-            const tableBody = tableBlock.firstChild as Parent;
-            const secondRow = tableBody.find(1) as Parent;
-            secondRow.firstContentInDescendant()?.setCursor(0, 0, true);
-        }
-        else if (tagName && VOID_HTML_TAGS.every(tag => tag !== tagName)) {
-            const state = {
-                name: 'html-block',
-                text: `<${tagName}>\n\n</${tagName}>`,
-            };
-            const htmlBlock = ScrollPage.loadBlock('html-block').create(
-                this.muya,
-                state,
-            );
-            this.parent!.replaceWith(htmlBlock);
-            const offset = tagName.length + 3;
-            htmlBlock.firstContentInDescendant().setCursor(offset, offset);
-        }
-        else {
+        const match = matchBlockConversion(this.text);
+        if (!match)
             return super.enterHandler(event);
+
+        switch (match.kind) {
+            case 'math': {
+                const state = {
+                    name: 'math-block',
+                    text: '',
+                    meta: {
+                        mathStyle: '',
+                    },
+                };
+                const mathBlock = ScrollPage.loadBlock('math-block').create(
+                    this.muya,
+                    state,
+                );
+                this.parent!.replaceWith(mathBlock);
+                mathBlock.firstContentInDescendant().setCursor(0, 0);
+                break;
+            }
+
+            case 'code': {
+                const { lang } = match;
+                // Diagram fences (```mermaid etc.) become diagram blocks,
+                // mirroring the file-load path in markdownToState; everything
+                // else is a fenced code block.
+                const diagramMatch = /^(?:mermaid|vega-lite|plantuml|flowchart|sequence)$/.exec(lang);
+                if (diagramMatch) {
+                    const type = lang as IDiagramMeta['type'];
+                    const state = {
+                        name: 'diagram',
+                        text: '',
+                        meta: {
+                            type,
+                            lang: type === 'vega-lite' ? 'json' : 'yaml',
+                        },
+                    };
+                    const diagramBlock = ScrollPage.loadBlock(state.name).create(
+                        this.muya,
+                        state,
+                    );
+
+                    this.parent!.replaceWith(diagramBlock);
+
+                    diagramBlock.firstContentInDescendant().setCursor(0, 0, true);
+                }
+                else {
+                    const state = {
+                        name: 'code-block',
+                        meta: {
+                            lang,
+                            type: 'fenced',
+                        },
+                        text: '',
+                    };
+                    const codeBlock = ScrollPage.loadBlock(state.name).create(
+                        this.muya,
+                        state,
+                    );
+
+                    this.parent!.replaceWith(codeBlock);
+
+                    codeBlock.lastContentInDescendant().setCursor(0, 0);
+                }
+                break;
+            }
+
+            case 'table': {
+                const tableHeader = parseTableHeader(this.text);
+                // Table extends the base `create` shape with a static
+                // `createWithHeader(muya, header)` factory; the registry-level
+                // IConstructor doesn't surface it. Cast to a structural view
+                // that names only the static slot we read.
+                const tableCtor = ScrollPage.loadBlock('table') as {
+                    createWithHeader?: (muya: Muya, header: string[]) => Parent;
+                };
+                const tableBlock = tableCtor.createWithHeader!(this.muya, tableHeader);
+
+                this.parent!.replaceWith(tableBlock);
+
+                // Set cursor at the first cell of second row. The runtime chain
+                // is: table → table-body (Parent.firstChild) → row (find(1)) →
+                // first cell content (firstContentInDescendant). Asserted as
+                // Parent at each container hop since createWithHeader guarantees
+                // a populated structure.
+                const tableBody = tableBlock.firstChild as Parent;
+                const secondRow = tableBody.find(1) as Parent;
+                secondRow.firstContentInDescendant()?.setCursor(0, 0, true);
+                break;
+            }
+
+            case 'html': {
+                const { tagName } = match;
+                const state = {
+                    name: 'html-block',
+                    text: `<${tagName}>\n\n</${tagName}>`,
+                };
+                const htmlBlock = ScrollPage.loadBlock('html-block').create(
+                    this.muya,
+                    state,
+                );
+                this.parent!.replaceWith(htmlBlock);
+                const offset = tagName.length + 3;
+                htmlBlock.firstContentInDescendant().setCursor(offset, offset);
+                break;
+            }
         }
     }
 
@@ -524,10 +553,13 @@ class ParagraphContent extends Format {
         if (event.shiftKey)
             return this.shiftEnterHandler(event);
 
-        // A code fence (```` ```lang ````) always converts the paragraph in
-        // place, even inside a block-quote or list item — the resulting
-        // code-block stays nested in its container (matches muyajs).
-        if (CODE_BLOCK_REG.test(this.text))
+        // Any paragraph that would convert to a block (code fence, math block,
+        // table, HTML block) converts in place, even inside a block-quote or
+        // list item — the resulting block stays nested in its container
+        // (matches muyajs). Otherwise typing the block syntax in a list would
+        // split the item and strand an empty list entry (#2276, plus table /
+        // HTML block).
+        if (matchBlockConversion(this.text))
             return this._enterConvert(event);
 
         const type = this._paragraphParentType();


### PR DESCRIPTION
## Summary

Inside a numbered/bullet list item, typing `$$` then <kbd>Enter</kbd> created the math input **and** an unwanted extra list entry (`2.`). Steps from the issue: type `1.`, space, `$$`, Enter → expected the item to hold a math block; actual added a new empty list item too.

Root cause: `paragraphContent`'s `enterHandler` early-converts a **code fence** in place even inside a list (so `_enterConvert` runs and the resulting block stays nested), but math `$$` was not in that guard — it fell through to `_enterInListItem`, which splits the item and inserts a new list item.

## Reproduction

Booted the real engine, put `$$` in a single-item list, drove the real `enterHandler`, and inspected the resulting document state: the order-list had **2** children (the unwanted entry). A code fence in the same setup already produced 1 child — confirming only math was missing from the guard.

## Fix

Hoist `MATH_BLOCK_REG` (`/^\$\$/`) to module scope and add it to the early-convert guard alongside `CODE_BLOCK_REG`, so `$$`+Enter converts the list item's paragraph into a math block in place — no extra entry.

## Test

`listMathEnterConvert.spec.ts` (RED→GREEN): `$$`+Enter in a single-item list yields exactly 1 list item containing a `math-block`; the code-fence case (already correct) is pinned alongside. Full unit suite (1356) + CommonMark/GFM conformance lock (1347) pass.

Fixes #2276