### PR TITLE
fix(desktop): persist export dialog options across sessions

### DIFF
--- a/packages/desktop/src/renderer/src/components/exportSettings/index.vue
+++ b/packages/desktop/src/renderer/src/components/exportSettings/index.vue
@@ -288,8 +288,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, type Ref } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, type Ref } from 'vue'
 import bus from '../../bus'
+import { loadExportSettings, saveExportSettings } from './persistence'
 import Bool from '@/prefComponents/common/bool/index.vue'
 import CurSelect from '@/prefComponents/common/select/index.vue'
 import FontTextBox from '@/prefComponents/common/fontTextBox/index.vue'
@@ -338,7 +339,57 @@ const headerFooterFontSize = ref(12)
 const tocTitle = ref('')
 const tocIncludeTopHeading = ref(true)
 
+// #2287 — persist the chosen export options across sessions. Every option ref
+// is registered here; changes are saved to localStorage and restored on mount.
+const persistableSettings: Record<string, Ref<unknown>> = {
+  htmlTitle,
+  pageSize,
+  pageSizeWidth,
+  pageSizeHeight,
+  isLandscape,
+  pageMarginTop,
+  pageMarginRight,
+  pageMarginBottom,
+  pageMarginLeft,
+  fontSettingsOverwrite,
+  fontFamily,
+  fontSize,
+  lineHeight,
+  autoNumberingHeadings,
+  showFrontMatter,
+  theme,
+  headerType,
+  headerTextLeft,
+  headerTextCenter,
+  headerTextRight,
+  footerType,
+  footerTextLeft,
+  footerTextCenter,
+  footerTextRight,
+  headerFooterCustomize,
+  headerFooterStyled,
+  headerFooterFontSize,
+  tocTitle,
+  tocIncludeTopHeading
+}
+
+const restoreExportSettings = () => {
+  const saved = loadExportSettings()
+  for (const [key, settingRef] of Object.entries(persistableSettings)) {
+    if (key in saved) settingRef.value = saved[key]
+  }
+}
+
+watch(Object.values(persistableSettings), () => {
+  saveExportSettings(
+    Object.fromEntries(
+      Object.entries(persistableSettings).map(([key, settingRef]) => [key, settingRef.value])
+    )
+  )
+})
+
 onMounted(() => {
+  restoreExportSettings()
   bus.on('showExportDialog', showDialog)
   bus.on('language-changed', updateTranslations)
 })

--- a/packages/desktop/src/renderer/src/components/exportSettings/persistence.ts
+++ b/packages/desktop/src/renderer/src/components/exportSettings/persistence.ts
@@ -1,0 +1,27 @@
+// Persists the export dialog's options across sessions (#2287). The dialog's
+// options were component-local refs with hardcoded defaults, so every restart
+// (and every dialog open) reset them. We store the chosen values in
+// localStorage — the same renderer-side persistence the sidebar width uses —
+// and restore them when the dialog opens.
+
+export const EXPORT_SETTINGS_STORAGE_KEY = 'export-settings'
+
+export function loadExportSettings(): Record<string, unknown> {
+  try {
+    const raw = localStorage.getItem(EXPORT_SETTINGS_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function saveExportSettings(settings: Record<string, unknown>): void {
+  try {
+    localStorage.setItem(EXPORT_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // Storage can be unavailable (private mode / quota); persisting export
+    // options is best-effort and must never break the export flow.
+  }
+}

--- a/packages/desktop/test/unit/specs/export-settings-persist.spec.ts
+++ b/packages/desktop/test/unit/specs/export-settings-persist.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  EXPORT_SETTINGS_STORAGE_KEY,
+  loadExportSettings,
+  saveExportSettings
+} from '@/components/exportSettings/persistence'
+
+// #2287 — export options (font, margins, page size, theme, …) reset to default
+// on every restart because the dialog never persisted them. These pin the
+// persistence layer: a save→load round-trip survives, missing/corrupt storage
+// falls back to {} (so the component keeps its defaults) and never throws.
+
+describe('#2287 — export settings persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips saved settings through localStorage', () => {
+    saveExportSettings({ pageSize: 'A3', fontSize: 18, pageMarginTop: 30, theme: 'liber' })
+    expect(loadExportSettings()).toEqual({ pageSize: 'A3', fontSize: 18, pageMarginTop: 30, theme: 'liber' })
+  })
+
+  it('returns an empty object when nothing was saved', () => {
+    expect(loadExportSettings()).toEqual({})
+  })
+
+  it('returns an empty object (no throw) when stored JSON is corrupt', () => {
+    localStorage.setItem(EXPORT_SETTINGS_STORAGE_KEY, '{not json')
+    expect(() => loadExportSettings()).not.toThrow()
+    expect(loadExportSettings()).toEqual({})
+  })
+
+  it('persists under a stable, namespaced key', () => {
+    saveExportSettings({ fontSize: 12 })
+    expect(localStorage.getItem(EXPORT_SETTINGS_STORAGE_KEY)).toContain('fontSize')
+  })
+})


### PR DESCRIPTION
## Summary

Export options (page size, margins, landscape, font family/size/line-height, theme, header/footer, TOC title, …) reset to defaults on every restart — there was no way to keep a preferred export setup.

Root cause: in `components/exportSettings/index.vue` every option is a component-local `ref(<default>)`; `onMounted`/`showDialog` never loaded persisted values and changes were never saved.

## Fix

Add a small `persistence.ts` helper (load/save the settings object to `localStorage`, the same renderer-side store the sidebar width uses — `store/layout.ts`). Register every option ref in one map; a `watch` saves on any change and `onMounted` restores the saved values. Best-effort: storage failures never break export, corrupt JSON falls back to defaults.

## Reproduction & root cause

Confirmed in code that the options are bare refs with no load/save path. The persistence layer is unit-tested (`export-settings-persist.spec.ts`): save→load round-trip, empty storage → `{}` (defaults kept), corrupt JSON → `{}` without throwing, namespaced key. The dialog restores through this layer on mount; cross-restart persistence relies on `localStorage` (Electron persists it, exactly like the working sidebar-width setting).

Full desktop unit suite (685) passes.

Fixes #2287