### PR TITLE
fix(desktop): keep sidebar width + tree collapse state across icon toggle

### DIFF
--- a/packages/desktop/src/renderer/src/components/sideBar/index.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/index.vue
@@ -116,8 +116,12 @@ onMounted(() => {
 
 const handleLeftIconClick = (name: string): void => {
   if (rightColumn.value === name) {
+    // Capture the expanded width BEFORE collapsing: once rightColumn is '',
+    // finalSideBarWidth evaluates to the 45px icon strip and would overwrite
+    // the user's real width with the clamped 220px minimum (#2421).
+    const widthToPersist = finalSideBarWidth.value
     layoutStore.SET_LAYOUT({ rightColumn: '' })
-    layoutStore.CHANGE_SIDE_BAR_WIDTH(finalSideBarWidth.value)
+    layoutStore.CHANGE_SIDE_BAR_WIDTH(widthToPersist)
   } else {
     const needDispatch = rightColumn.value === ''
     layoutStore.SET_LAYOUT({ rightColumn: name })

--- a/packages/desktop/src/renderer/src/components/sideBar/tree.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/tree.vue
@@ -176,8 +176,15 @@ const props = defineProps<{
 }>()
 
 const depth = 0
-const showDirectories = ref(true)
-const showOpenedFiles = ref(true)
+// Persist the section collapse state (#2421). The tree is rendered under a
+// v-if and is destroyed when the sidebar collapses to its icon strip, so local
+// refs reset to expanded on re-open. Back them with localStorage (like the
+// sidebar width) so the state survives a re-mount and app restart.
+const SHOW_DIRECTORIES_KEY = 'side-bar-show-directories'
+const SHOW_OPENED_FILES_KEY = 'side-bar-show-opened-files'
+const readSectionExpanded = (key: string): boolean => localStorage.getItem(key) !== 'false'
+const showDirectories = ref(readSectionExpanded(SHOW_DIRECTORIES_KEY))
+const showOpenedFiles = ref(readSectionExpanded(SHOW_OPENED_FILES_KEY))
 const createName = ref('')
 const input = ref<HTMLInputElement | null>(null)
 
@@ -219,10 +226,12 @@ const handleRootContextMenu = (event: MouseEvent): void => {
 
 const toggleOpenedFiles = (): void => {
   showOpenedFiles.value = !showOpenedFiles.value
+  localStorage.setItem(SHOW_OPENED_FILES_KEY, String(showOpenedFiles.value))
 }
 
 const toggleDirectories = (): void => {
   showDirectories.value = !showDirectories.value
+  localStorage.setItem(SHOW_DIRECTORIES_KEY, String(showDirectories.value))
 }
 
 // From createFileOrDirectoryMixins

--- a/packages/desktop/test/e2e/issue-2421-sidebar-state.spec.ts
+++ b/packages/desktop/test/e2e/issue-2421-sidebar-state.spec.ts
@@ -73,4 +73,30 @@ test.describe('#2421 sidebar state survives icon toggle', () => {
     expect(Math.abs(reExpanded - widened)).toBeLessThanOrEqual(3)
   })
 
+  test('a collapsed tree section stays collapsed after toggling the sidebar', async() => {
+    const arrow = page.locator('.side-bar .opened-files > .title .icon-arrow').first()
+    await expect(arrow).toBeVisible()
+
+    // Collapse the "Opened files" section.
+    await arrow.click()
+    await page.waitForFunction(() => {
+      const a = document.querySelector('.side-bar .opened-files .icon-arrow')
+      return !!(a && a.classList.contains('fold'))
+    }, null, { timeout: 5000 })
+
+    // Toggle the whole sidebar off and back on via its icon.
+    await filesIcon(page).click()
+    await page.waitForTimeout(250)
+    await filesIcon(page).click()
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.side-bar .opened-files') as HTMLElement | null
+      return !!(el && el.offsetParent !== null)
+    }, null, { timeout: 5000 })
+
+    const stillCollapsed = await page.evaluate(() => {
+      const a = document.querySelector('.side-bar .opened-files .icon-arrow')
+      return !!(a && a.classList.contains('fold'))
+    })
+    expect(stillCollapsed).toBe(true)
+  })
 })

--- a/packages/desktop/test/e2e/issue-2421-sidebar-state.spec.ts
+++ b/packages/desktop/test/e2e/issue-2421-sidebar-state.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown } from './helpers'
+
+// #2421 — toggling the sidebar via its left-column icons must not lose state.
+// Two bugs: (1) collapsing to the icon strip persisted the clamped 220px width
+// instead of the real width, so re-expanding shrank the sidebar; (2) the tree's
+// collapsed sections (Opened files / Directories) are local refs under a v-if,
+// so collapsing the sidebar destroyed the tree and reset them on re-expand.
+// These drive the real built app.
+
+const filesIcon = (page: Page) =>
+  page.locator('.side-bar .left-column > ul').first().locator('li').nth(0)
+
+const sideBarWidth = (page: Page) =>
+  page.evaluate(() => {
+    const el = document.querySelector('.side-bar') as HTMLElement | null
+    return el ? Math.round(el.getBoundingClientRect().width) : 0
+  })
+
+test.describe('#2421 sidebar state survives icon toggle', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\n## A\n\n## B\n')
+    app = launched.app
+    page = launched.page
+    // The files panel is the default right column; make sure it is open + wide.
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.side-bar') as HTMLElement | null
+      return !!(el && el.offsetParent !== null && el.getBoundingClientRect().width > 220)
+    }, null, { timeout: 5000 })
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('collapsing then re-expanding preserves a widened sidebar width', async() => {
+    // Widen the sidebar past the 220px minimum by dragging the drag-bar, so a
+    // width loss on collapse is observable (the default already sits at 220).
+    const dragBar = page.locator('.side-bar .drag-bar')
+    const box = await dragBar.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + 80)
+    await page.mouse.down()
+    await page.mouse.move(box!.x + box!.width / 2 + 120, box!.y + 80, { steps: 8 })
+    await page.mouse.up()
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.side-bar') as HTMLElement | null
+      return !!el && el.getBoundingClientRect().width >= 300
+    }, null, { timeout: 5000 })
+
+    const widened = await sideBarWidth(page)
+    expect(widened).toBeGreaterThanOrEqual(300)
+
+    await filesIcon(page).click() // collapse to icon strip
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.side-bar') as HTMLElement | null
+      return !!el && el.getBoundingClientRect().width <= 50
+    }, null, { timeout: 5000 })
+
+    await filesIcon(page).click() // re-expand
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.side-bar') as HTMLElement | null
+      return !!el && el.getBoundingClientRect().width > 50
+    }, null, { timeout: 5000 })
+
+    const reExpanded = await sideBarWidth(page)
+    // The widened width must survive the collapse round-trip (it was reset to
+    // the clamped 220px before the fix).
+    expect(Math.abs(reExpanded - widened)).toBeLessThanOrEqual(3)
+  })
+
+})


### PR DESCRIPTION
## Summary

Toggling the sidebar via its left-column icons lost UI state (#2421). Two distinct bugs, one atomic commit each:

1. **Width reset** — collapsing the sidebar to its icon strip by clicking the active icon overwrote the persisted width with the clamped 220px minimum. `handleLeftIconClick` read `finalSideBarWidth` *after* setting `rightColumn=''`, when that computed already returns the 45px icon-strip width → `CHANGE_SIDE_BAR_WIDTH(45)` clamps to 220. Re-expanding then restored 220, shrinking a widened sidebar. **Fix:** capture the expanded width before collapsing.
2. **Collapse state reset** — the "Opened files" / "Directories" section collapse lived in local refs in `tree.vue`, which is rendered under `v-if` and destroyed when the sidebar collapses, so the sections reset to expanded on re-open (Ctrl+J uses `v-show`, so it didn't). **Fix:** back the state with `localStorage` (same convention as the sidebar width), so it survives the re-mount and app restart (also requested in the issue comments).

## Reproduction & verification (real app)

Added `issue-2421-sidebar-state.spec.ts`, a Playwright/Electron e2e against the **built app**. Both tests were RED on the current code and GREEN after the fixes:
- drag-widen → collapse via icon → re-expand: width was reset by ~120px (340→220), now preserved within 3px.
- collapse the "Opened files" section → toggle the sidebar off/on: section reset to expanded, now stays collapsed.

The existing `layout-toggles.spec.ts` (4 tests, incl. the editor-fills-width-after-collapse case) still passes; lint + `vue-tsc` clean.

Fixes #2421