### PR TITLE
fix(desktop): make the source-mode selection visible on dark themes

### DIFF
--- a/packages/desktop/src/renderer/src/codeMirror/index.css
+++ b/packages/desktop/src/renderer/src/codeMirror/index.css
@@ -7,3 +7,11 @@
 .CodeMirror-line > span > span::selection {
   background: rgb(178, 215, 254);
 }
+/* #2372 — make the source-mode selection use the same visible colour as the
+   WYSIWYG editor. The bundled railscasts theme paints the selection at #272935,
+   almost identical to its #2b2b2b background, so it was invisible on dark
+   themes. The higher specificity (+ !important) beats both railscasts' own
+   !important rule and the one-dark theme. */
+.source-code .CodeMirror div.CodeMirror-selected {
+  background: var(--selection-color, rgb(45 170 219 / 30%)) !important;
+}

--- a/packages/desktop/test/e2e/issue-2372-source-selection-color.spec.ts
+++ b/packages/desktop/test/e2e/issue-2372-source-selection-color.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, clickMenuById, enterSourceMode } from './helpers'
+
+// #2372 — in source-code mode the dark themes (railscasts) rendered the
+// selection at #272935, almost identical to the #2b2b2b editor background, so a
+// selection was effectively invisible. The selection should use the same
+// visible colour as the WYSIWYG editor (--selection-color). Drives the real
+// built app: switch to the "dark" theme, enter source mode, select all, and
+// read the rendered selection background.
+
+test.describe('#2372 source-mode selection colour', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('# Selection\n\nalpha bravo charlie\n\ndelta echo foxtrot\n')
+    app = launched.app
+    page = launched.page
+    await clickMenuById(app, 'dark') // a railscasts dark theme
+    await page.waitForFunction(() => document.body.classList.contains('dark'), null, { timeout: 5000 })
+    await enterSourceMode(page, app)
+    await page.waitForFunction(() => !!document.querySelector('.source-code .CodeMirror.cm-s-railscasts'), null, {
+      timeout: 5000
+    })
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('selection background is the visible editor selection colour, not near-background', async() => {
+    // Select all via the real CodeMirror instance so it renders .CodeMirror-selected.
+    await page.evaluate(() => {
+      const cm = (document.querySelector('.source-code .CodeMirror') as Element & { CodeMirror?: { focus: () => void; execCommand: (c: string) => void } }).CodeMirror
+      cm!.focus()
+      cm!.execCommand('selectAll')
+    })
+    await page.waitForSelector('.source-code .CodeMirror-selected', { state: 'attached', timeout: 5000 })
+
+    const { selBg, selectionColor } = await page.evaluate(() => {
+      const sel = document.querySelector('.source-code .CodeMirror-selected') as HTMLElement
+      // Resolve --selection-color (what the WYSIWYG editor uses) to its computed
+      // rgb form so we can compare against the rendered selection background.
+      const probe = document.createElement('div')
+      probe.style.background = 'var(--selection-color)'
+      document.body.appendChild(probe)
+      const selectionColor = getComputedStyle(probe).backgroundColor
+      probe.remove()
+      return { selBg: getComputedStyle(sel).backgroundColor, selectionColor }
+    })
+
+    // Source-mode selection now matches the editor's --selection-color
+    // (consistent with WYSIWYG mode), and is no longer the near-invisible
+    // railscasts colour rgb(39, 41, 53) (#272935).
+    expect(selBg).toBe(selectionColor)
+    expect(selBg).not.toBe('rgb(39, 41, 53)')
+  })
+})


### PR DESCRIPTION
## Summary

In source-code mode the text selection was nearly invisible on dark themes. Dark themes use the bundled CodeMirror `railscasts` theme, whose `.CodeMirror-selected { background: #272935 !important }` is almost identical to its `#2b2b2b` editor background — so you couldn't see what you'd selected (the issue shows it on Dark / Material Dark).

## Fix

Override the CodeMirror selection background to the editor's `--selection-color` — the same variable the WYSIWYG editor uses — so the source-mode selection is both **visible** and **consistent with regular mode** across all themes. The override uses a higher specificity (`.source-code .CodeMirror div.CodeMirror-selected`) + `!important` to beat railscasts' own `!important` rule and the one-dark theme.

## Reproduction & verification (real app)

`issue-2372-source-selection-color.spec.ts` drives the built app: switch to the `dark` (railscasts) theme, enter source mode, select all, and read the rendered `.CodeMirror-selected` background.
- **RED** (before): `rgb(39, 41, 53)` (#272935) — indistinguishable from the background.
- **GREEN** (after): equals the resolved `--selection-color` (the theme's selection colour, the same one WYSIWYG mode uses), and is no longer the near-invisible value.

Existing theme + view-mode e2e specs still pass.

Fixes #2372