### PR TITLE
fix: #4749 handle malformed percent-encoded local links

### DIFF
--- a/packages/desktop/src/main/menu/actions/file.ts
+++ b/packages/desktop/src/main/menu/actions/file.ts
@@ -23,6 +23,7 @@ import { getPath, getRecommendTitleFromMarkdownString } from '../../utils'
 import pandoc from '../../utils/pandoc'
 import { t } from '../../i18n'
 import type { UnsavedFile } from '@shared/types/files'
+import { normalizeFormatLinkPath } from './formatLinkPath'
 
 type Win = BrowserWindow | null | undefined
 
@@ -607,14 +608,8 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }: FormatLinkPayload) =>
     return
   }
 
-  let pathname = urlCandidate
-  if (dirname && !path.isAbsolute(urlCandidate)) {
-    pathname = path.join(dirname, urlCandidate)
-  }
-
+  const pathname = normalizeFormatLinkPath(urlCandidate, dirname)
   if (pathname) {
-    // decodeURIComponent() CommonMark #503, allow percent encoded path names to open files. https://github.com/marktext/marktext/issues/57
-    pathname = path.normalize(decodeURIComponent(pathname))
     if (isMarkdownFile(pathname)) {
       const innerWin = BrowserWindow.fromWebContents(e.sender)
       if (innerWin) {

--- a/packages/desktop/src/main/menu/actions/formatLinkPath.ts
+++ b/packages/desktop/src/main/menu/actions/formatLinkPath.ts
@@ -1,0 +1,20 @@
+import path from 'path'
+
+export const normalizeFormatLinkPath = (urlCandidate: string, dirname?: string): string => {
+  let pathname = urlCandidate
+  if (dirname && !path.isAbsolute(urlCandidate)) {
+    pathname = path.join(dirname, urlCandidate)
+  }
+
+  // Keep CommonMark percent-decoding for filenames such as `bad%20name.md`.
+  try {
+    pathname = decodeURIComponent(pathname)
+  } catch (err) {
+    if (!(err instanceof URIError)) {
+      throw err
+    }
+    // '%' is valid in filenames, so keep malformed escapes as literal path text.
+  }
+
+  return path.normalize(pathname)
+}

--- a/packages/desktop/test/unit/specs/format-link-path.spec.ts
+++ b/packages/desktop/test/unit/specs/format-link-path.spec.ts
@@ -1,0 +1,30 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+import { normalizeFormatLinkPath } from 'main_renderer/menu/actions/formatLinkPath'
+
+describe('normalizeFormatLinkPath', () => {
+  const dirname = path.join(path.sep, 'docs')
+
+  it('decodes valid percent-encoded local link paths', () => {
+    expect(normalizeFormatLinkPath('bad%20name.md', dirname)).toBe(
+      path.join(dirname, 'bad name.md')
+    )
+  })
+
+  it('does not throw for malformed percent escapes', () => {
+    expect(normalizeFormatLinkPath('bad%zz.md', dirname)).toBe(path.join(dirname, 'bad%zz.md'))
+    expect(normalizeFormatLinkPath('%.md', dirname)).toBe(path.join(dirname, '%.md'))
+    expect(normalizeFormatLinkPath('%E0%A4%A.md', dirname)).toBe(
+      path.join(dirname, '%E0%A4%A.md')
+    )
+  })
+
+  it('normalizes absolute paths without joining dirname', () => {
+    const absolutePath = path.join(path.sep, 'tmp', 'bad%20name.md')
+
+    expect(normalizeFormatLinkPath(absolutePath, dirname)).toBe(
+      path.join(path.sep, 'tmp', 'bad name.md')
+    )
+  })
+})


### PR DESCRIPTION
Closes #4749.

## Summary

This PR moves local format-link path normalization into a small helper and handles `URIError` from `decodeURIComponent()`. Valid CommonMark percent-encoded local paths such as `bad%20name.md` still decode, while malformed percent escapes such as `bad%zz.md`, `%.md`, and invalid UTF-8 escape sequences are kept as literal path text instead of throwing from the main-process IPC handler.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [ ] Manually tested on: not run; this is covered by focused path-normalization unit tests

Verification:

- `corepack pnpm exec vitest run test/unit/specs/format-link-path.spec.ts`
- `corepack pnpm --filter marktext typecheck`
- `corepack pnpm exec vitest run --testTimeout=20000`

Note: `corepack pnpm test` still fails locally in existing `pdf.spec.ts` tests under the default 5s timeout. The same full Vitest suite passes with `--testTimeout=20000` (`38` files, `684` tests).

## Notes for reviewers [optional]

No UI screenshot is included because the visible behavior is avoiding a main-process exception for malformed local link paths. The regression tests cover valid percent-decoding and malformed percent escape inputs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
