### PR TITLE
fix: handle UNC image paths and watchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ temp/
 logs/
 test-results/
 playwright-report/
+.playwright-mcp/
 *.min.json
 .claude/settings.local.json
 .claude/

--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -23,6 +23,9 @@ const EVENT_NAME = {
 
 type WatchType = 'dir' | 'file'
 
+export const isUncPath = (pathname: string): boolean =>
+  /^(?:\\\\|\/\/)[^\\/]+[\\/][^\\/]+/.test(pathname)
+
 interface IgnoreEntry {
   windowId: number
   pathname: string
@@ -195,7 +198,9 @@ class Watcher {
   }
 
   watch(win: BrowserWindow, watchPath: string, type: WatchType = 'dir'): () => void {
-    const usePolling = isOsx ? true : this._preferences.getItem<boolean>('watcherUsePolling')
+    const usePolling = isOsx || isUncPath(watchPath)
+      ? true
+      : this._preferences.getItem<boolean>('watcherUsePolling')
 
     const id = getUniqueId()
 

--- a/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
+++ b/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
@@ -6,6 +6,20 @@
 // the source folder.
 const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
 
+export function localPathToFileUrl(src: string): string {
+  const normalized = src.replace(/\\/g, '/')
+
+  if (/^\/\/[^/]+\/[^/]+/.test(normalized)) {
+    return `file://${normalized.slice(2)}`
+  }
+
+  if (/^[a-z]:\//i.test(normalized)) {
+    return `file:///${normalized}`
+  }
+
+  return `file://${normalized}`
+}
+
 export function resolveLocalImageSrc(src: string): string {
   if (!src) return src
   // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
@@ -15,8 +29,8 @@ export function resolveLocalImageSrc(src: string): string {
   // server path `/api/image?id=…` must not become `file:///api/image…`.
   if (!IMAGE_EXT_REG.test(src)) return src
   // Absolute local image path (POSIX / UNC / Windows drive) → file://.
-  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
+  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return localPathToFileUrl(src)
   // Relative local image path — resolve against the document directory.
-  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  if (window.DIRNAME) return localPathToFileUrl(window.path.join(window.DIRNAME, src))
   return src
 }

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -19,9 +19,9 @@ vi.hoisted(() => {
   w.window ??= {}
   w.window.path ??= {
     sep: '/',
-    join: (...parts: string[]) => parts.join('/'),
-    // Minimal POSIX-ish resolve good enough for relative image rewriting:
-    // `resolve('/docs', './a.png')` → `/docs/a.png`.
+    join: (...parts: string[]) =>
+      parts.join('/').replace(/\/\.\//g, '/').replace(/\/{3,}/g, '//'),
+    // Some transitive helpers still expect a minimal POSIX-ish `resolve`.
     resolve: (...parts: string[]) =>
       parts.join('/').replace(/\/\.\//g, '/').replace(/\/{2,}/g, '/')
   }

--- a/packages/desktop/test/unit/specs/printService-image.spec.ts
+++ b/packages/desktop/test/unit/specs/printService-image.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 
-// `resolveLocalImageSrc` reads `window.DIRNAME` + `window.path.resolve` for the
+// `resolveLocalImageSrc` reads `window.DIRNAME` + `window.path.join` for the
 // relative-resolve branch. Stub those preload surfaces before the hoisted
 // import runs (copied from exportHtml.spec.ts). The function is otherwise a
 // pure string transform — no Muya/engine needed.
@@ -18,7 +18,8 @@ vi.hoisted(() => {
   w.window ??= {}
   w.window.path ??= {
     sep: '/',
-    join: (...parts: string[]) => parts.join('/'),
+    join: (...parts: string[]) =>
+      parts.join('/').replace(/\/\.\//g, '/').replace(/\/{3,}/g, '//'),
     resolve: (...parts: string[]) =>
       parts.join('/').replace(/\/\.\//g, '/').replace(/\/{2,}/g, '/')
   }
@@ -36,13 +37,20 @@ describe('resolveLocalImageSrc — branch coverage', () => {
     expect(resolveLocalImageSrc('/tmp/b.png')).toBe('file:///tmp/b.png')
   })
 
-  it('(b) Windows drive image path → file:// preserving backslashes', () => {
-    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:\\pics\\b.png')
+  it('(b) Windows drive image path → file:// with forward slashes', () => {
+    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file:///C:/pics/b.png')
   })
 
-  it('(c) UNC image path → file:// preserving the \\\\host prefix', () => {
+  it('(c) UNC image path → host-based file:// URL', () => {
     expect(resolveLocalImageSrc('\\\\host\\share\\c.png')).toBe(
-      'file://\\\\host\\share\\c.png'
+      'file://host/share/c.png'
+    )
+  })
+
+  it('resolves relative images from WSL UNC document directories without losing the host', () => {
+    window.DIRNAME = '//wsl.localhost/Ubuntu-24.04/home/me/docs'
+    expect(resolveLocalImageSrc('./img/my_image.png')).toBe(
+      'file://wsl.localhost/Ubuntu-24.04/home/me/docs/img/my_image.png'
     )
   })
 

--- a/packages/desktop/test/unit/specs/watcher-await-write-finish.spec.ts
+++ b/packages/desktop/test/unit/specs/watcher-await-write-finish.spec.ts
@@ -34,7 +34,8 @@ vi.mock('ced', () => ({ default: () => 'UTF-8' }))
 
 import Watcher, {
   WATCHER_STABILITY_THRESHOLD,
-  WATCHER_STABILITY_POLL_INTERVAL
+  WATCHER_STABILITY_POLL_INTERVAL,
+  isUncPath
 } from 'main_renderer/filesystem/watcher'
 
 function optionsForLastWatch(): Record<string, unknown> {
@@ -63,5 +64,17 @@ describe('watcher awaitWriteFinish (#3955)', () => {
       stabilityThreshold: WATCHER_STABILITY_THRESHOLD,
       pollInterval: WATCHER_STABILITY_POLL_INTERVAL
     })
+  })
+
+  it('forces polling for UNC roots because fs.watch does not enumerate WSL shares reliably', () => {
+    watcher.watch(win as never, '\\\\wsl.localhost\\Ubuntu-24.04\\home\\me\\project', 'dir')
+    expect(optionsForLastWatch().usePolling).toBe(true)
+  })
+
+  it('detects both backslash and slash UNC paths', () => {
+    expect(isUncPath('\\\\server\\share\\project')).toBe(true)
+    expect(isUncPath('//server/share/project')).toBe(true)
+    expect(isUncPath('C:\\project')).toBe(false)
+    expect(isUncPath('/home/me/project')).toBe(false)
   })
 })

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -73,7 +73,7 @@ describe('getImageSrc — relative local image paths anchored to window.DIRNAME'
     it('resolves Windows-drive base dirs with forward slashes', () => {
         withDirname('C:\\Users\\me\\docs', () => {
             expect(getImageSrc('assets\\foo.png').src).toBe(
-                'file://C:/Users/me/docs/assets/foo.png',
+                'file:///C:/Users/me/docs/assets/foo.png',
             );
         });
     });
@@ -91,7 +91,7 @@ describe('getImageSrc — non-relative sources are left unchanged', () => {
 
     it('leaves an absolute Windows-drive path as a single `file://`', () => {
         withDirname(DIRNAME, () => {
-            expect(getImageSrc('C:/img/pic.png').src).toBe('file://C:/img/pic.png');
+            expect(getImageSrc('C:/img/pic.png').src).toBe('file:///C:/img/pic.png');
         });
     });
 
@@ -137,37 +137,53 @@ describe('getImageSrc — non-relative sources are left unchanged', () => {
 describe('getImageSrc — Windows drive + UNC base directories (Phase G review)', () => {
     it('preserves the drive when resolving `..`', () => {
         withDirname('C:/Users/me/docs', () => {
-            expect(getImageSrc('../img/a.png').src).toBe('file://C:/Users/me/img/a.png');
+            expect(getImageSrc('../img/a.png').src).toBe('file:///C:/Users/me/img/a.png');
         });
     });
 
     it('clamps `..` at the drive root so the drive is never lost', () => {
         withDirname('C:/docs', () => {
-            expect(getImageSrc('../../../a.png').src).toBe('file://C:/a.png');
+            expect(getImageSrc('../../../a.png').src).toBe('file:///C:/a.png');
         });
     });
 
     it('normalises a Windows-backslash base dir', () => {
         withDirname('C:\\docs', () => {
-            expect(getImageSrc('a.png').src).toBe('file://C:/docs/a.png');
+            expect(getImageSrc('a.png').src).toBe('file:///C:/docs/a.png');
         });
     });
 
     it('resolves against a UNC share base directory', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('a.png').src).toBe('file:////server/share/docs/a.png');
+            expect(getImageSrc('a.png').src).toBe('file://server/share/docs/a.png');
         });
     });
 
     it('normalises a backslash UNC base', () => {
         withDirname('\\\\server\\share', () => {
-            expect(getImageSrc('sub/a.png').src).toBe('file:////server/share/sub/a.png');
+            expect(getImageSrc('sub/a.png').src).toBe('file://server/share/sub/a.png');
         });
     });
 
     it('clamps `..` at the UNC share root', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('../../../a.png').src).toBe('file:////server/share/a.png');
+            expect(getImageSrc('../../../a.png').src).toBe('file://server/share/a.png');
+        });
+    });
+
+    it('keeps the UNC host when resolving relative images from WSL paths', () => {
+        withDirname('\\\\wsl.localhost\\Ubuntu-24.04\\home\\me\\docs', () => {
+            expect(getImageSrc('./img/my_image.png').src).toBe(
+                'file://wsl.localhost/Ubuntu-24.04/home/me/docs/img/my_image.png',
+            );
+        });
+    });
+
+    it('normalises an absolute UNC image path to a host-based file URL', () => {
+        withDirname(DIRNAME, () => {
+            expect(getImageSrc('\\\\server\\share\\img\\a.png').src).toBe(
+                'file://server/share/img/a.png',
+            );
         });
     });
 });

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -67,6 +67,18 @@ function resolveRelativePath(base: string, relative: string): string {
     return tail ? `${root}/${tail}` : root;
 }
 
+function localPathToFileUrl(src: string): string {
+    const normalized = src.replace(/\\/g, '/');
+
+    if (/^\/\/[^/]+\/[^/]+/.test(normalized))
+        return `file://${normalized.slice(2)}`;
+
+    if (/^[a-z]:\//i.test(normalized))
+        return `file:///${normalized}`;
+
+    return `file://${normalized}`;
+}
+
 export function getImageSrc(src: string) {
     const EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
     // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
@@ -95,13 +107,13 @@ export function getImageSrc(src: string) {
         else if (!isAbsoluteLocal && baseUrl) {
             return {
                 isUnknownType: false,
-                src: `file://${resolveRelativePath(baseUrl, src)}`,
+                src: localPathToFileUrl(resolveRelativePath(baseUrl, src)),
             };
         }
         else {
             return {
                 isUnknownType: false,
-                src: `file://${src}`,
+                src: localPathToFileUrl(src),
             };
         }
     }


### PR DESCRIPTION

Closes #4563

## Summary

Fix UNC path handling for local images and project-tree watching.

Relative images opened from UNC-backed documents could lose the UNC host during path resolution, producing invalid URLs such as `file:///wsl.localhost/...` instead of host-based file URLs such as `file://wsl.localhost/...`. This PR normalizes local image paths into valid `file://` URLs for UNC paths, Windows drive paths, and POSIX paths.

UNC roots also need polling for reliable directory watching. On WSL UNC paths, chokidar can fail to watch or enumerate files cleanly without polling, which can leave the project tree empty or produce watcher errors. This PR detects UNC roots and forces `usePolling: true` for those watchers.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added for UNC file URL normalization, WSL UNC relative image paths, and UNC watcher polling.
- [x] Manually tested on: Windows with a real WSL UNC path.

The following checks passed:

- `pnpm --filter @muyajs/core exec vitest run src/utils/__tests__/image.spec.ts`
- `pnpm --filter marktext exec vitest run test/unit/specs/printService-image.spec.ts test/unit/specs/exportHtml.spec.ts test/unit/specs/watcher-await-write-finish.spec.ts`
- `pnpm --filter @muyajs/core lint:types`
- `pnpm --filter marktext typecheck`
- `pnpm --filter @muyajs/core exec vitest run --testTimeout 30000`
- `git diff --check`

Manual WSL UNC verification:

- Created a real WSL-backed test folder at `\\wsl.localhost\HermesUbuntu\tmp\marktext-unc-real-test`.
- Placed `doc-relative.md` and `img/desktop-image.png` inside that WSL filesystem.
- Opened the markdown file through the Windows UNC path.
- Confirmed the relative image `![desktop image](img/desktop-image.png)` renders correctly.
- Confirmed opening the WSL UNC folder shows the project contents instead of an empty project.


Real SMB / Windows network share verification was not performed because no actual `\\server\share` environment was available. The same UNC-path fix is expected to address #4577  as well, and the ordinary UNC share case is covered by the same detection and file URL normalization logic with unit tests for both `\\server\share\...` and `//server/share/...` path forms. However, because #4577  was not verified against a real SMB share, this PR only closes #4563.

## Notes for reviewers [optional]

The core issue is not WSL-specific. WSL UNC paths and ordinary SMB share paths both use the same UNC shape:

```text
\\host\share\...
//host/share/...
```

The image fix preserves the `host/share` portion when resolving local image paths and converts local paths to valid file URLs:

```text
\\host\share\path  -> file://host/share/path
C:\path\file.png   -> file:///C:/path/file.png
/tmp/file.png      -> file:///tmp/file.png
```

For watcher behavior, UNC roots force polling because native watching on WSL UNC paths was unreliable during verification. A direct chokidar probe on the WSL UNC test folder showed non-polling watchers emitted `EISDIR` errors, while polling discovered the same files without watcher errors.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.