### PR TITLE
fix(muya): produce correct file:// URLs for UNC/WSL network paths

### DIFF
--- a/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
+++ b/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
@@ -6,6 +6,19 @@
 // the source folder.
 const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
 
+/**
+ * Convert a local filesystem path to a `file://` URL, handling UNC paths
+ * (\\server\share\... or //server/share/...) correctly as
+ * file://server/share/... instead of the invalid file:////server/share/...
+ */
+function pathToFileUrl(p: string): string {
+  const normalized = p.replace(/\\/g, '/')
+  // UNC paths: //server/share/... → file://server/share/...
+  if (normalized.startsWith('//')) return 'file:' + normalized
+  // Regular paths: /posix or C:/windows
+  return 'file://' + normalized
+}
+
 export function resolveLocalImageSrc(src: string): string {
   if (!src) return src
   // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
@@ -15,8 +28,8 @@ export function resolveLocalImageSrc(src: string): string {
   // server path `/api/image?id=…` must not become `file:///api/image…`.
   if (!IMAGE_EXT_REG.test(src)) return src
   // Absolute local image path (POSIX / UNC / Windows drive) → file://.
-  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
+  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return pathToFileUrl(src)
   // Relative local image path — resolve against the document directory.
-  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  if (window.DIRNAME) return pathToFileUrl(window.path.resolve(window.DIRNAME, src))
   return src
 }

--- a/packages/desktop/test/unit/specs/printService-image.spec.ts
+++ b/packages/desktop/test/unit/specs/printService-image.spec.ts
@@ -36,13 +36,13 @@ describe('resolveLocalImageSrc — branch coverage', () => {
     expect(resolveLocalImageSrc('/tmp/b.png')).toBe('file:///tmp/b.png')
   })
 
-  it('(b) Windows drive image path → file:// preserving backslashes', () => {
-    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:\\pics\\b.png')
+  it('(b) Windows drive image path → file:// with forward slashes', () => {
+    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:/pics/b.png')
   })
 
-  it('(c) UNC image path → file:// preserving the \\\\host prefix', () => {
+  it('(c) UNC image path → file:// authority form', () => {
     expect(resolveLocalImageSrc('\\\\host\\share\\c.png')).toBe(
-      'file://\\\\host\\share\\c.png'
+      'file://host/share/c.png'
     )
   })
 

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -153,21 +153,53 @@ describe('getImageSrc — Windows drive + UNC base directories (Phase G review)'
         });
     });
 
-    it('resolves against a UNC share base directory', () => {
+    it('resolves against a UNC share base directory (authority form)', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('a.png').src).toBe('file:////server/share/docs/a.png');
+            expect(getImageSrc('a.png').src).toBe('file://server/share/docs/a.png');
         });
     });
 
     it('normalises a backslash UNC base', () => {
         withDirname('\\\\server\\share', () => {
-            expect(getImageSrc('sub/a.png').src).toBe('file:////server/share/sub/a.png');
+            expect(getImageSrc('sub/a.png').src).toBe('file://server/share/sub/a.png');
         });
     });
 
     it('clamps `..` at the UNC share root', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('../../../a.png').src).toBe('file:////server/share/a.png');
+            expect(getImageSrc('../../../a.png').src).toBe('file://server/share/a.png');
+        });
+    });
+
+    it('resolves images on a WSL path base directory', () => {
+        withDirname('//wsl.localhost/Ubuntu-24.04/home/user/docs', () => {
+            expect(getImageSrc('img/photo.png').src).toBe(
+                'file://wsl.localhost/Ubuntu-24.04/home/user/docs/img/photo.png',
+            );
+        });
+    });
+
+    it('resolves an absolute UNC path with backslashes', () => {
+        withDirname('/home/user/docs', () => {
+            expect(getImageSrc('\\\\server\\share\\img\\pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
+        });
+    });
+
+    it('resolves an absolute forward-slash UNC path', () => {
+        withDirname('/home/user/docs', () => {
+            expect(getImageSrc('//server/share/img/pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
+        });
+    });
+
+    it('does not corrupt an already-correct file:// UNC URL', () => {
+        withDirname(undefined, () => {
+            expect(getImageSrc('file://server/share/img/pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
         });
     });
 });

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -77,10 +77,10 @@ function pathToFileUrl(p: string): string {
     const normalized = p.replace(/\\/g, '/');
     // UNC paths: `//server/share/...` → `file://server/share/...` (authority form).
     if (normalized.startsWith('//')) {
-        return 'file:' + normalized;
+        return `file:${normalized}`;
     }
     // Regular absolute paths: `/posix` or `C:/windows` → `file:///posix` or `file://C:/windows`.
-    return 'file://' + normalized;
+    return `file://${normalized}`;
 }
 
 export function getImageSrc(src: string) {
@@ -204,7 +204,7 @@ export function correctImageSrc(src: string) {
         }
         else if (isWin && /^\\\\[^?]/.test(src)) {
             // UNC path (\\server\share\...) → file://server/share/...
-            src = 'file://' + src.substring(2).replace(/\\/g, '/');
+            src = `file://${src.substring(2).replace(/\\/g, '/')}`;
         }
         else if (/^\/.+/.test(src)) {
             // Also adding file protocol on UNIX.

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -67,6 +67,22 @@ function resolveRelativePath(base: string, relative: string): string {
     return tail ? `${root}/${tail}` : root;
 }
 
+/**
+ * Convert a local filesystem path to a `file://` URL, handling UNC paths
+ * (e.g. `\\server\share\...` or `//server/share/...`) correctly as
+ * `file://server/share/...` instead of the invalid `file:////server/share/...`
+ * which Chromium cannot load.
+ */
+function pathToFileUrl(p: string): string {
+    const normalized = p.replace(/\\/g, '/');
+    // UNC paths: `//server/share/...` → `file://server/share/...` (authority form).
+    if (normalized.startsWith('//')) {
+        return 'file:' + normalized;
+    }
+    // Regular absolute paths: `/posix` or `C:/windows` → `file:///posix` or `file://C:/windows`.
+    return 'file://' + normalized;
+}
+
 export function getImageSrc(src: string) {
     const EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
     // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
@@ -95,13 +111,13 @@ export function getImageSrc(src: string) {
         else if (!isAbsoluteLocal && baseUrl) {
             return {
                 isUnknownType: false,
-                src: `file://${resolveRelativePath(baseUrl, src)}`,
+                src: pathToFileUrl(resolveRelativePath(baseUrl, src)),
             };
         }
         else {
             return {
                 isUnknownType: false,
-                src: `file://${src}`,
+                src: pathToFileUrl(src),
             };
         }
     }
@@ -179,12 +195,16 @@ export async function checkImageContentType(url: string) {
 
 export function correctImageSrc(src: string) {
     if (src) {
-    // Fix ASCII and UNC paths on Windows (#1997).
+        // Fix ASCII and UNC paths on Windows (#1997).
         if (isWin && /^(?:[a-z]:\\|[a-z]:\/).+/i.test(src)) {
             src = `file:///${src.replace(/\\/g, '/')}`;
         }
         else if (isWin && /^\\\\\?\\.+/.test(src)) {
             src = `file:///${src.substring(4).replace(/\\/g, '/')}`;
+        }
+        else if (isWin && /^\\\\[^?]/.test(src)) {
+            // UNC path (\\server\share\...) → file://server/share/...
+            src = 'file://' + src.substring(2).replace(/\\/g, '/');
         }
         else if (/^\/.+/.test(src)) {
             // Also adding file protocol on UNIX.


### PR DESCRIPTION
When a document is opened from a UNC path (e.g. \server\share\... or \wsl.localhost\Distro\...), getImageSrc() and resolveLocalImageSrc() produced invalid file:// URLs with 4 slashes (file:////server/share/...) that Chromium cannot load, causing 'Load image failed' errors.

Root cause: both muya's path resolver and the desktop's export/print resolver prepend 'file://' to UNC paths, producing the malformed URL 'file:////server/share/...' instead of the correct authority-based form 'file://server/share/...'.

Fix: add a pathToFileUrl() helper that detects UNC paths (starting with // after backslash normalisation) and produces the correct authority form. Applied consistently in:
- packages/muya/src/utils/image.ts: getImageSrc() and correctImageSrc()
- packages/desktop/src/renderer/src/util/resolveImageSrc.ts

Fixes #4577, #4563 (use case 1)

<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #4577

## Summary

Allows to render diagrams for files opened over network in windows.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
