### PR TITLE
Fix/project over network fs

### DIFF
--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -507,7 +507,7 @@ class Watcher {
     const id = getUniqueId()
     let disposed = false
 
-    const handler = async (): Promise<void> => {
+    const handler = async(): Promise<void> => {
       if (disposed) return
 
       const isMarkdown = hasMarkdownExtension(watchPath)
@@ -576,7 +576,7 @@ class Watcher {
     let known = new Map<string, 'file' | 'dir'>()
     let disposed = false
 
-    const handler = async (): Promise<void> => {
+    const handler = async(): Promise<void> => {
       if (disposed) return
 
       const current = new Map<string, 'file' | 'dir'>()

--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs, { type Dirent } from 'fs'
 import fsPromises from 'fs/promises'
 import log from 'electron-log'
 import chokidar, { type FSWatcher } from 'chokidar'
@@ -6,7 +7,7 @@ import { exists } from 'common/filesystem'
 import { hasMarkdownExtension, checkPathExcludePattern } from 'common/filesystem/paths'
 import { getUniqueId } from '../utils'
 import { loadMarkdownFile } from '../filesystem/markdown'
-import { isLinux, isOsx } from '../config'
+import { isLinux, isOsx, isWindows } from '../config'
 import type { BrowserWindow } from 'electron'
 import type { LineEnding } from '@shared/types/files'
 import type Preference from '../preferences'
@@ -15,6 +16,22 @@ import type Preference from '../preferences'
 
 export const WATCHER_STABILITY_THRESHOLD = 1000
 export const WATCHER_STABILITY_POLL_INTERVAL = 150
+
+/**
+ * How often (in ms) to poll the directory tree when using the UNC fallback.
+ *
+ * chokidar / fs.watch cannot watch Windows UNC paths (\\server\share, \\wsl.localhost\…)
+ * because virtual filesystems such as WSL2's 9P protocol do not support
+ * ReadDirectoryChangesW or inotify.  The same limitation applies to SSHFS mounts,
+ * network drives, and Docker-mounted volumes that use FUSE or VirtioFS.
+ *
+ * Other projects that have hit this:
+ *   - VS Code  ships its own FileWatcher with a polling fallback for UNC paths.
+ *   - Cypress  forces CHOKIDAR_USEPOLLING=1 for WSL.
+ *   - Angular  recommends polling or moving sources out of the 9P mount.
+ *   - Vite     exposes server.watch.usePolling for the same reason.
+ */
+const UNC_POLL_INTERVAL = 3000
 
 const EVENT_NAME = {
   dir: 'mt::update-object-tree' as const,
@@ -32,7 +49,7 @@ interface IgnoreEntry {
 
 interface WatcherEntry {
   win: BrowserWindow
-  watcher: FSWatcher
+  watcher: FSWatcher | { close: () => void }
   pathname: string
   type: WatchType
   close: () => void
@@ -195,9 +212,37 @@ class Watcher {
   }
 
   watch(win: BrowserWindow, watchPath: string, type: WatchType = 'dir'): () => void {
-    const usePolling = isOsx ? true : this._preferences.getItem<boolean>('watcherUsePolling')
+    // Windows UNC paths (\\server\share, \\wsl.localhost\…) cannot be watched by
+    // chokidar/fs.watch because virtual filesystems (WSL2 9P, SSHFS, network drives)
+    // do not support ReadDirectoryChangesW or inotify.  We fall back to a manual
+    // readdir-based poll loop — see UNC_POLL_INTERVAL for details.
+    const needsPolling = isWindows && (() => {
+      try {
+        fs.realpathSync.native(watchPath)
+        return false
+      } catch {
+        return true
+      }
+    })()
+    if (needsPolling) {
+      if (type === 'file') {
+        return this._watchUncFile(win, watchPath)
+      }
+      return this._startUncPolling(win, watchPath, type)
+    }
 
+    const usePolling = isOsx ? true : this._preferences.getItem<boolean>('watcherUsePolling')
+    return this._startWatcher(win, watchPath, type, usePolling)
+  }
+
+  private _startWatcher(
+    win: BrowserWindow,
+    watchPath: string,
+    type: WatchType,
+    usePolling: boolean
+  ): () => void {
     const id = getUniqueId()
+    const { _preferences } = this
 
     const watcher = chokidar.watch(watchPath, {
       ignored: (pathname: string, fileInfo?: { isDirectory: () => boolean }) => {
@@ -212,7 +257,7 @@ class Watcher {
         if (
           checkPathExcludePattern(
             pathname,
-            this._preferences.getItem<readonly string[]>('treePathExcludePatterns')
+            _preferences.getItem<readonly string[]>('treePathExcludePatterns')
           )
         ) {
           return true
@@ -229,10 +274,14 @@ class Watcher {
       depth: type === 'file' ? (isOsx ? 1 : 0) : undefined,
 
       // Please see GH#1043
-      awaitWriteFinish: {
+      // Only wait for write stability on single-file watches; for directory
+      // watches it delays the `ready` event unnecessarily and can hang on
+      // slow / virtual filesystems (SSHFS, WSL 9P) where fs.stat never
+      // stabilises.
+      awaitWriteFinish: type === 'file' ? {
         stabilityThreshold: WATCHER_STABILITY_THRESHOLD,
         pollInterval: WATCHER_STABILITY_POLL_INTERVAL
-      },
+      } : undefined,
 
       usePolling
       // chokidar's `ignored` callback signature varies between versions; this options
@@ -333,6 +382,8 @@ class Watcher {
       })
 
     const closeFn = (): void => {
+      // Guard: exit early if the entry was already replaced by a fallback restart
+      if (!this.watchers[id]) return
       disposed = true
       if (this.watchers[id]) {
         delete this.watchers[id]
@@ -352,7 +403,279 @@ class Watcher {
       close: closeFn
     }
 
+    // Fallback: when native file watching silently fails (e.g., SSHFS on Windows,
+    // SMB/CIFS network shares, or remote filesystems that don't support
+    // ReadDirectoryChangesW), switch to polling. Chokidar's initial scan won't
+    // emit any events if the underlying platform doesn't support native watching.
+    if (type === 'dir' && !usePolling) {
+      this._addFallbackDetection(win, watchPath, type, id, watcher)
+    }
+
     return closeFn
+  }
+
+  /**
+   * Detect when chokidar's native watching fails to emit initial events for a
+   * non-empty directory, and restart the watcher with polling enabled.
+   *
+   * This handles SSHFS/WinFsp, SMB/CIFS network shares, and other filesystems
+   * that don't support the native filesystem notification API on Windows.
+   */
+  private _addFallbackDetection(
+    win: BrowserWindow,
+    watchPath: string,
+    type: WatchType,
+    id: string,
+    watcher: FSWatcher
+  ): void {
+    let initialEventCount = 0
+    let fallbackTriggered = false
+
+    const onAnyEvent = (): void => { initialEventCount++ }
+
+    watcher.on('add', onAnyEvent)
+    watcher.on('addDir', onAnyEvent)
+
+    const attemptFallback = async(force = false): Promise<void> => {
+      if (fallbackTriggered) return
+      if (!force && initialEventCount > 0) return
+
+      const entry = this.watchers[id]
+      if (!entry || entry.watcher !== watcher) return
+
+      fallbackTriggered = true
+
+      try {
+        const entries = await fsPromises.readdir(watchPath, { withFileTypes: true })
+        const hasWatchableContent = entries.some(e =>
+          e.isDirectory() || hasMarkdownExtension(e.name)
+        )
+        if (!hasWatchableContent) return
+
+        log.warn(
+          `[Watcher] No initial events for non-empty directory "${watchPath}". ` +
+          'Native file watching may not be supported on this filesystem. ' +
+          'Restarting watcher with polling.'
+        )
+
+        watcher.close()
+        delete this.watchers[id]
+
+        this._startUncPolling(win, watchPath, type)
+      } catch (err) {
+        log.error(`[Watcher] Failed to read directory "${watchPath}":`, err)
+      }
+    }
+
+    // Listen on 'ready' — without awaitWriteFinish blocking the scan this
+    // fires sub-second even on slow filesystems, so no safety timeout needed.
+    watcher.on('ready', () => attemptFallback(false))
+
+    // On Windows, chokidar's native watcher may emit UNKNOWN errors on FUSE
+    // mounts (SSHFS/WinFsp, WSL 9P) — fall back to polling regardless of
+    // whether an initial addDir event was already emitted.
+    watcher.on('error', (error: unknown) => {
+      if (isWindows && (error as NodeJS.ErrnoException)?.code === 'UNKNOWN') {
+        attemptFallback(true)
+      }
+    })
+  }
+
+  /**
+   * Polling-based file-tree scanner for Windows UNC paths / FUSE mounts.
+   *
+   * chokidar relies on fs.watch / ReadDirectoryChangesW under the hood, which
+   * does not work on virtual filesystems such as WSL2's 9P server, SSHFS mounts,
+   * or mapped network drives (see Node.js#37960, chokidar#1206, chokidar#1376).
+   *
+   * This method bypasses chokidar entirely: it runs a recursive readdir scan on
+   * every tick and emits add / addDir / unlink / unlinkDir events to the renderer
+   * in the same format that chokidar would use.  The renderer's tree controller
+   * treats them identically, so the rest of the UI is unaffected.
+   *
+   * The same strategy (manual polling for UNC / virtual FS roots) is used by
+   * VS Code, Cypress, Angular CLI, and Vite — none of which can rely on the
+   * OS-native watcher across those mount boundaries.
+   */
+  private _watchUncFile(win: BrowserWindow, watchPath: string): () => void {
+    log.info('[Watcher] Starting UNC file polling for:', watchPath)
+
+    const id = getUniqueId()
+    let disposed = false
+
+    const handler = async (): Promise<void> => {
+      if (disposed) return
+
+      const isMarkdown = hasMarkdownExtension(watchPath)
+      if (isMarkdown) {
+        const { _preferences } = this
+        const eol = _preferences.getPreferredEol() as LineEnding
+        const {
+          autoGuessEncoding = true,
+          trimTrailingNewline = 2,
+          autoNormalizeLineEndings = false
+        } = _preferences.getAll()
+
+        // Simulate the same work chokidar would do on a "change" event.
+        try {
+          const [data, stats] = await Promise.all([
+            loadMarkdownFile(watchPath, eol, autoGuessEncoding, trimTrailingNewline, autoNormalizeLineEndings),
+            fsPromises.stat(watchPath)
+          ])
+          win.webContents.send('mt::update-file', {
+            type: 'change',
+            change: { pathname: watchPath, data, mtimeMs: stats.mtimeMs }
+          })
+        } catch {
+          // File may have been removed — send unlink.
+          win.webContents.send('mt::update-file', {
+            type: 'unlink',
+            change: { pathname: watchPath }
+          })
+        }
+      }
+    }
+
+    // Periodically stat the file — same as chokidar's polling path would do.
+    fs.watchFile(watchPath, { interval: UNC_POLL_INTERVAL }, () => {
+      handler().catch(err => log.error('[Watcher] UNC file poll error:', err))
+    })
+
+    const closeFn = (): void => {
+      disposed = true
+      fs.unwatchFile(watchPath)
+      if (this.watchers[id]) {
+        delete this.watchers[id]
+      }
+    }
+
+    this.watchers[id] = {
+      win,
+      watcher: { close: closeFn },
+      pathname: watchPath,
+      type: 'file',
+      close: closeFn
+    }
+
+    return closeFn
+  }
+
+  private _startUncPolling(
+    win: BrowserWindow,
+    watchPath: string,
+    type: WatchType
+  ): () => void {
+    log.info('[Watcher] Starting UNC polling fallback for:', watchPath)
+
+    const id = getUniqueId()
+    // Map of known pathname → 'file' | 'dir' — used for change detection.
+    let known = new Map<string, 'file' | 'dir'>()
+    let disposed = false
+
+    const handler = async (): Promise<void> => {
+      if (disposed) return
+
+      const current = new Map<string, 'file' | 'dir'>()
+      await this._scanUncDirectory(watchPath, current)
+
+      // Emit additions.
+      const { _preferences } = this
+      const eol = _preferences.getPreferredEol() as LineEnding
+      const {
+        autoGuessEncoding = true,
+        trimTrailingNewline = 2,
+        autoNormalizeLineEndings = false
+      } = _preferences.getAll()
+
+      for (const [p, kind] of current) {
+        if (known.has(p)) continue
+        if (kind === 'dir') {
+          addDir(win, p, type)
+        } else {
+          await add(win, p, type, eol, autoGuessEncoding, trimTrailingNewline, autoNormalizeLineEndings)
+        }
+      }
+
+      // Emit removals.
+      for (const [p, kind] of known) {
+        if (current.has(p)) continue
+        if (kind === 'dir') {
+          unlinkDir(win, p, type)
+        } else {
+          unlink(win, p, type)
+        }
+      }
+
+      known = current
+    }
+
+    // Initial population (fire-and-forget).
+    handler().catch(err => log.error('[Watcher] UNC polling handler error:', err))
+
+    const intervalId = setInterval(() => {
+      handler().catch(err => log.error('[Watcher] UNC polling handler error:', err))
+    }, UNC_POLL_INTERVAL)
+
+    const closeFn = (): void => {
+      disposed = true
+      clearInterval(intervalId)
+      if (this.watchers[id]) {
+        delete this.watchers[id]
+      }
+    }
+
+    this.watchers[id] = {
+      win,
+      watcher: { close: closeFn },
+      pathname: watchPath,
+      type,
+      close: closeFn
+    }
+
+    return closeFn
+  }
+
+  /**
+   * Recursively walk `dirPath` with readdir ({ withFileTypes: true }) and
+   * populate `results` with every markdown file and sub-directory found.
+   *
+   * Directories whose name would be ignored by the chokidar `ignored` callback
+   * (node_modules, .asar) are skipped during the walk rather than filtered out
+   * later.
+   */
+  private async _scanUncDirectory(
+    dirPath: string,
+    results: Map<string, 'file' | 'dir'>
+  ): Promise<void> {
+    let entries: Dirent[]
+    try {
+      entries = await fsPromises.readdir(dirPath, { withFileTypes: true })
+    } catch (err) {
+      log.error('[Watcher] UNC scan — cannot read directory:', dirPath, err)
+      return
+    }
+
+    for (const entry of entries) {
+      // Skip ignored entries in the same way chokidar's `ignored` callback does.
+      if (entry.name === 'node_modules' || entry.name.endsWith('.asar')) {
+        continue
+      }
+
+      const fullPath = path.join(dirPath, entry.name)
+
+      // On WSL2's 9P virtual filesystem the Dirent type flags returned by
+      // readdir({ withFileTypes: true }) can be unreliable — isDirectory()
+      // may incorrectly return true for regular files (microsoft/WSL#13105).
+      // We therefore use the file extension as the primary signal:
+      //   - markdown extension  → always a file, regardless of Dirent
+      //   - no markdown extension → only recurse if Dirent says directory
+      if (hasMarkdownExtension(entry.name)) {
+        results.set(fullPath, 'file')
+      } else if (entry.isDirectory()) {
+        results.set(fullPath, 'dir')
+        await this._scanUncDirectory(fullPath, results)
+      }
+    }
   }
 
   unwatch(win: BrowserWindow, watchPath: string, type: WatchType = 'dir'): void {
@@ -367,7 +690,7 @@ class Watcher {
   }
 
   unwatchByWindowId(windowId: number): void {
-    const watchers: FSWatcher[] = []
+    const watchers: (FSWatcher | { close: () => void })[] = []
     const watchIds: string[] = []
     for (const id of Object.keys(this.watchers)) {
       const w = this.watchers[id]

--- a/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
+++ b/packages/desktop/src/renderer/src/util/resolveImageSrc.ts
@@ -6,6 +6,19 @@
 // the source folder.
 const IMAGE_EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i
 
+/**
+ * Convert a local filesystem path to a `file://` URL, handling UNC paths
+ * (\\server\share\... or //server/share/...) correctly as
+ * file://server/share/... instead of the invalid file:////server/share/...
+ */
+function pathToFileUrl(p: string): string {
+  const normalized = p.replace(/\\/g, '/')
+  // UNC paths: //server/share/... → file://server/share/...
+  if (normalized.startsWith('//')) return 'file:' + normalized
+  // Regular paths: /posix or C:/windows
+  return 'file://' + normalized
+}
+
 export function resolveLocalImageSrc(src: string): string {
   if (!src) return src
   // Already a URL or data: URI — leave as-is (avoids `file://file://…`).
@@ -15,8 +28,8 @@ export function resolveLocalImageSrc(src: string): string {
   // server path `/api/image?id=…` must not become `file:///api/image…`.
   if (!IMAGE_EXT_REG.test(src)) return src
   // Absolute local image path (POSIX / UNC / Windows drive) → file://.
-  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return `file://${src}`
+  if (/^(?:\/|\\\\|[a-zA-Z]:[\\/])/.test(src)) return pathToFileUrl(src)
   // Relative local image path — resolve against the document directory.
-  if (window.DIRNAME) return `file://${window.path.resolve(window.DIRNAME, src)}`
+  if (window.DIRNAME) return pathToFileUrl(window.path.resolve(window.DIRNAME, src))
   return src
 }

--- a/packages/desktop/test/unit/specs/printService-image.spec.ts
+++ b/packages/desktop/test/unit/specs/printService-image.spec.ts
@@ -36,13 +36,13 @@ describe('resolveLocalImageSrc — branch coverage', () => {
     expect(resolveLocalImageSrc('/tmp/b.png')).toBe('file:///tmp/b.png')
   })
 
-  it('(b) Windows drive image path → file:// preserving backslashes', () => {
-    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:\\pics\\b.png')
+  it('(b) Windows drive image path → file:// with forward slashes', () => {
+    expect(resolveLocalImageSrc('C:\\pics\\b.png')).toBe('file://C:/pics/b.png')
   })
 
-  it('(c) UNC image path → file:// preserving the \\\\host prefix', () => {
+  it('(c) UNC image path → file:// authority form', () => {
     expect(resolveLocalImageSrc('\\\\host\\share\\c.png')).toBe(
-      'file://\\\\host\\share\\c.png'
+      'file://host/share/c.png'
     )
   })
 

--- a/packages/desktop/test/unit/specs/watcher.spec.ts
+++ b/packages/desktop/test/unit/specs/watcher.spec.ts
@@ -70,6 +70,12 @@ vi.mock('common/filesystem', () => ({
   exists: vi.fn()
 }))
 
+// Prevent `ced` native bindings from being loaded during the dynamic import
+// of watcher.ts (which transitively imports loadMarkdownFile → ... → ced).
+// In CI, ced is compiled for Electron's Node.js ABI and fails to load under
+// the system Node.js that vitest uses.
+vi.mock('ced', () => ({ default: {} }))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/desktop/test/unit/specs/watcher.spec.ts
+++ b/packages/desktop/test/unit/specs/watcher.spec.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { EventEmitter } from 'events'
+
+// ---------------------------------------------------------------------------
+// Mock setup
+// ---------------------------------------------------------------------------
+
+interface MockWatcher {
+  on: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  unwatch: ReturnType<typeof vi.fn>
+  add: ReturnType<typeof vi.fn>
+  emitter: EventEmitter
+}
+
+function createMockWatcher(): MockWatcher {
+  const emitter = new EventEmitter()
+  return {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      emitter.on(event, handler)
+      return emitter
+    }),
+    close: vi.fn(),
+    unwatch: vi.fn(),
+    add: vi.fn(),
+    emitter
+  }
+}
+
+const watchers: MockWatcher[] = []
+const chokidarWatchMock = vi.fn(() => {
+  const w = createMockWatcher()
+  watchers.push(w)
+  return w
+})
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: (...args: Parameters<typeof chokidarWatchMock>) => chokidarWatchMock(...args)
+  }
+}))
+
+vi.mock('electron-log', () => ({
+  default: {
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const defaultStat = {
+  birthtime: new Date('2024-01-01'),
+  mtimeMs: 1704067200000,
+  mtime: new Date('2024-01-01'),
+  isFile: () => true,
+  isDirectory: () => false,
+  isSymbolicLink: () => false
+}
+
+const mockReaddir = vi.fn()
+const mockStat = vi.fn().mockResolvedValue(defaultStat)
+
+vi.mock('fs/promises', () => ({
+  default: {
+    readdir: (...args: unknown[]) => mockReaddir(...args),
+    stat: (...args: unknown[]) => mockStat(...args)
+  }
+}))
+
+vi.mock('common/filesystem', () => ({
+  exists: vi.fn()
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockPreference {
+  getItem: Mock
+  getPreferredEol: Mock
+  getAll: Mock
+  setItems?: Mock
+}
+
+function createMockPreferences(
+  overrides?: Partial<{ watcherUsePolling: boolean }>
+): MockPreference {
+  const polling = overrides?.watcherUsePolling ?? false
+  return {
+    getItem: vi.fn((key: string) => {
+      if (key === 'watcherUsePolling') return polling
+      if (key === 'treePathExcludePatterns') return []
+      return undefined
+    }),
+    getPreferredEol: vi.fn(() => 'lf'),
+    getAll: vi.fn(() => ({
+      autoGuessEncoding: true,
+      trimTrailingNewline: 2,
+      autoNormalizeLineEndings: false
+    }))
+  }
+}
+
+function createMockBrowserWindow(): Record<string, unknown> {
+  return {
+    id: 1,
+    webContents: {
+      send: vi.fn()
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  watchers.length = 0
+  chokidarWatchMock.mockClear()
+  mockReaddir.mockReset()
+  mockStat.mockReset()
+  mockStat.mockResolvedValue(defaultStat)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Watcher fallback detection', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function loadWatcher(): Promise<{ default: new (pref: any) => { watch: (...args: any[]) => () => void; unwatch: (...args: any[]) => void } }> {
+    return await import('../../../src/main/filesystem/watcher')
+  }
+
+  it('does not trigger fallback when events are received before ready', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    watcher.watch(win as never, '/some/dir', 'dir')
+    const mockW = watchers[0]
+
+    // Simulate chokidar finding content
+    mockW.emitter.emit('addDir', '/some/dir/sub')
+    mockW.emitter.emit('add', '/some/dir/file.md')
+    expect(mockW.on).toHaveBeenCalledWith('ready', expect.any(Function))
+
+    // Emit ready — fallback should NOT trigger since we had events
+    mockW.emitter.emit('ready')
+
+    await Promise.resolve()
+
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+    expect(mockW.close).not.toHaveBeenCalled()
+  })
+
+  it('triggers fallback when no events on non-empty directory', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([
+      { name: 'doc.md', isDirectory: () => false },
+      { name: 'notes.md', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/sshfs/dir', 'dir')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    // _addFallbackDetection calls readdir, then _startUncPolling also calls readdir via _scanUncDirectory
+    expect(mockReaddir).toHaveBeenCalledWith('/sshfs/dir', { withFileTypes: true })
+    expect(mockW.close).toHaveBeenCalled()
+    // The fallback uses _startUncPolling (no chokidar), so only one chokidar instance
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT trigger fallback when directory is empty', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([])
+
+    watcher.watch(win as never, '/empty/dir', 'dir')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    expect(mockReaddir).toHaveBeenCalledWith('/empty/dir', { withFileTypes: true })
+    expect(mockW.close).not.toHaveBeenCalled()
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT trigger fallback when directory has only non-markdown files', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    // .jpg is not a markdown extension in MarkText
+    mockReaddir.mockResolvedValue([
+      { name: 'photo.jpg', isDirectory: () => false },
+      { name: 'archive.zip', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/nonmd/dir', 'dir')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    expect(mockReaddir).toHaveBeenCalled()
+    expect(mockW.close).not.toHaveBeenCalled()
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not trigger fallback for file watches', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([
+      { name: 'doc.md', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/file.md', 'file')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+    expect(mockW.close).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger fallback when usePolling preference is true', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences({ watcherUsePolling: true })
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([
+      { name: 'doc.md', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/polling/dir', 'dir')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    // With usePolling: true, fallback detection is not added
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+    expect(mockW.close).not.toHaveBeenCalled()
+  })
+
+  it('fallback is idempotent (double ready does not double-fallback)', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([
+      { name: 'doc.md', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/idempotent/dir', 'dir')
+    const mockW = watchers[0]
+
+    mockW.emitter.emit('ready')
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    // Should have triggered fallback only once (native = 1, fallback uses _startUncPolling)
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+    expect(mockW.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not trigger fallback when watcher was already closed externally', async() => {
+    const { default: WatcherClass } = await loadWatcher()
+    const prefs = createMockPreferences()
+    const win = createMockBrowserWindow()
+    const watcher = new WatcherClass(prefs as never)
+
+    mockReaddir.mockResolvedValue([
+      { name: 'doc.md', isDirectory: () => false }
+    ])
+
+    watcher.watch(win as never, '/transient/dir', 'dir')
+    const mockW = watchers[0]
+
+    // Close via unwatch (simulating user closing the folder)
+    watcher.unwatch(win as never, '/transient/dir', 'dir')
+
+    mockW.emitter.emit('ready')
+    await vi.runAllTimersAsync()
+    await Promise.resolve()
+
+    // Fallback should NOT trigger because the entry was removed
+    expect(mockReaddir).not.toHaveBeenCalled()
+    expect(chokidarWatchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -153,21 +153,53 @@ describe('getImageSrc — Windows drive + UNC base directories (Phase G review)'
         });
     });
 
-    it('resolves against a UNC share base directory', () => {
+    it('resolves against a UNC share base directory (authority form)', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('a.png').src).toBe('file:////server/share/docs/a.png');
+            expect(getImageSrc('a.png').src).toBe('file://server/share/docs/a.png');
         });
     });
 
     it('normalises a backslash UNC base', () => {
         withDirname('\\\\server\\share', () => {
-            expect(getImageSrc('sub/a.png').src).toBe('file:////server/share/sub/a.png');
+            expect(getImageSrc('sub/a.png').src).toBe('file://server/share/sub/a.png');
         });
     });
 
     it('clamps `..` at the UNC share root', () => {
         withDirname('//server/share/docs', () => {
-            expect(getImageSrc('../../../a.png').src).toBe('file:////server/share/a.png');
+            expect(getImageSrc('../../../a.png').src).toBe('file://server/share/a.png');
+        });
+    });
+
+    it('resolves images on a WSL path base directory', () => {
+        withDirname('//wsl.localhost/Ubuntu-24.04/home/user/docs', () => {
+            expect(getImageSrc('img/photo.png').src).toBe(
+                'file://wsl.localhost/Ubuntu-24.04/home/user/docs/img/photo.png',
+            );
+        });
+    });
+
+    it('resolves an absolute UNC path with backslashes', () => {
+        withDirname('/home/user/docs', () => {
+            expect(getImageSrc('\\\\server\\share\\img\\pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
+        });
+    });
+
+    it('resolves an absolute forward-slash UNC path', () => {
+        withDirname('/home/user/docs', () => {
+            expect(getImageSrc('//server/share/img/pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
+        });
+    });
+
+    it('does not corrupt an already-correct file:// UNC URL', () => {
+        withDirname(undefined, () => {
+            expect(getImageSrc('file://server/share/img/pic.png').src).toBe(
+                'file://server/share/img/pic.png',
+            );
         });
     });
 });

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -77,10 +77,10 @@ function pathToFileUrl(p: string): string {
     const normalized = p.replace(/\\/g, '/');
     // UNC paths: `//server/share/...` → `file://server/share/...` (authority form).
     if (normalized.startsWith('//')) {
-        return 'file:' + normalized;
+        return `file:${normalized}`;
     }
     // Regular absolute paths: `/posix` or `C:/windows` → `file:///posix` or `file://C:/windows`.
-    return 'file://' + normalized;
+    return `file://${normalized}`;
 }
 
 export function getImageSrc(src: string) {
@@ -204,7 +204,7 @@ export function correctImageSrc(src: string) {
         }
         else if (isWin && /^\\\\[^?]/.test(src)) {
             // UNC path (\\server\share\...) → file://server/share/...
-            src = 'file://' + src.substring(2).replace(/\\/g, '/');
+            src = `file://${src.substring(2).replace(/\\/g, '/')}`;
         }
         else if (/^\/.+/.test(src)) {
             // Also adding file protocol on UNIX.

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -67,6 +67,22 @@ function resolveRelativePath(base: string, relative: string): string {
     return tail ? `${root}/${tail}` : root;
 }
 
+/**
+ * Convert a local filesystem path to a `file://` URL, handling UNC paths
+ * (e.g. `\\server\share\...` or `//server/share/...`) correctly as
+ * `file://server/share/...` instead of the invalid `file:////server/share/...`
+ * which Chromium cannot load.
+ */
+function pathToFileUrl(p: string): string {
+    const normalized = p.replace(/\\/g, '/');
+    // UNC paths: `//server/share/...` → `file://server/share/...` (authority form).
+    if (normalized.startsWith('//')) {
+        return 'file:' + normalized;
+    }
+    // Regular absolute paths: `/posix` or `C:/windows` → `file:///posix` or `file://C:/windows`.
+    return 'file://' + normalized;
+}
+
 export function getImageSrc(src: string) {
     const EXT_REG = /\.(?:jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
     // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
@@ -95,13 +111,13 @@ export function getImageSrc(src: string) {
         else if (!isAbsoluteLocal && baseUrl) {
             return {
                 isUnknownType: false,
-                src: `file://${resolveRelativePath(baseUrl, src)}`,
+                src: pathToFileUrl(resolveRelativePath(baseUrl, src)),
             };
         }
         else {
             return {
                 isUnknownType: false,
-                src: `file://${src}`,
+                src: pathToFileUrl(src),
             };
         }
     }
@@ -179,12 +195,16 @@ export async function checkImageContentType(url: string) {
 
 export function correctImageSrc(src: string) {
     if (src) {
-    // Fix ASCII and UNC paths on Windows (#1997).
+        // Fix ASCII and UNC paths on Windows (#1997).
         if (isWin && /^(?:[a-z]:\\|[a-z]:\/).+/i.test(src)) {
             src = `file:///${src.replace(/\\/g, '/')}`;
         }
         else if (isWin && /^\\\\\?\\.+/.test(src)) {
             src = `file:///${src.substring(4).replace(/\\/g, '/')}`;
+        }
+        else if (isWin && /^\\\\[^?]/.test(src)) {
+            // UNC path (\\server\share\...) → file://server/share/...
+            src = 'file://' + src.substring(2).replace(/\\/g, '/');
         }
         else if (/^\/.+/.test(src)) {
             // Also adding file protocol on UNIX.


### PR DESCRIPTION
<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Based of [PR 4788](https://github.com/marktext/marktext/pull/4788)

Closes #4599 #4477 #4563 (usecase 1 & 2)


## Summary

Fix file watching and image URL resolution on Windows network shares (UNC paths),
WSL, SSHFS, and other FUSE-based filesystem mounts where native file watching is
not supported and `file://` URLs were malformed.


## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows 11

## Notes for reviewers [optional]

chokidar / `fs.watch` cannot watch Windows UNC paths or virtual filesystems
such as WSL2's 9P protocol, SSHFS mounts, network drives, and Docker-mounted
volumes because they do not support `ReadDirectoryChangesW` or `inotify`.

**Fix:** When `fs.realpathSync.native()` fails (indicating a non-native
filesystem), the watcher falls back to a manual `readdir`-based poll loop
(interval: 3s) instead of crashing or silently missing changes.

This is not ideal, but at least it works.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
