### PR TITLE
fix(muya): don't highlight LaTeX `\%` as a comment

### DIFF
--- a/packages/muya/src/utils/prism/__tests__/latexEscapedPercent.spec.ts
+++ b/packages/muya/src/utils/prism/__tests__/latexEscapedPercent.spec.ts
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+import { beforeAll, describe, expect, it } from 'vitest';
+import prism, { loadLanguage, patchLatexEscapedPercent } from '../index';
+
+function hasCommentToken(code: string): boolean {
+    const tokens = prism.tokenize(code, prism.languages.latex);
+    return tokens.some(
+        t => typeof t === 'object' && (t as { type?: string }).type === 'comment',
+    );
+}
+
+describe('latex escaped percent highlighting (#3037)', () => {
+    beforeAll(async () => {
+        await loadLanguage('latex');
+        patchLatexEscapedPercent(prism);
+    });
+
+    it('does not treat `\\%` as the start of a comment', () => {
+        expect(hasCommentToken('1\\%+2\\%=3\\%')).toBe(false);
+    });
+
+    it('still treats a bare `%` as a comment', () => {
+        expect(hasCommentToken('100% done')).toBe(true);
+    });
+
+    it('still treats a line-leading `%` as a comment', () => {
+        expect(hasCommentToken('%a real comment')).toBe(true);
+    });
+});

--- a/packages/muya/src/utils/prism/index.ts
+++ b/packages/muya/src/utils/prism/index.ts
@@ -50,8 +50,19 @@ function search(text: string) {
     return fuse.search(text).map(i => i.item).slice(0, 5);
 }
 
+// In LaTeX `\%` is an escaped literal percent, not a line comment, but
+// prismjs's default latex `comment` token (`/%.*/`) swallows everything after
+// it. Require the `%` to not follow a backslash so `\%` highlights as a normal
+// control sequence (#3037). tex/context alias the same grammar object, so this
+// one override covers all three.
+export function patchLatexEscapedPercent(prismInstance: typeof Prism) {
+    const latex = prismInstance.languages.latex as { comment?: unknown } | undefined;
+    if (latex?.comment)
+        latex.comment = { pattern: /(^|[^\\])%.*/, lookbehind: true };
+}
+
 // pre load latex and yaml and html for `math block` \ `front matter` and `html block`
-loadLanguage('latex');
+loadLanguage('latex').then(() => patchLatexEscapedPercent(prism));
 loadLanguage('yaml');
 
 export { walkTokens } from './walkToken';


### PR DESCRIPTION
## Problem

In a LaTeX math/code block, an escaped percent `\%` (a literal percent sign) was highlighted as the start of a line comment, greying out the rest of the line. prismjs's latex `comment` token is `/%.*/`, which matches any `%` regardless of a preceding backslash.

## Fix

Override the latex `comment` pattern to `/(^|[^\\])%.*/` with `lookbehind`, so a `%` only starts a comment when it is at line start or not preceded by a backslash. `\%` then falls through and highlights as a control sequence. The `tex`/`context` aliases reference the same grammar object, so the single override covers all three. Applied right after the grammar is loaded (`patchLatexEscapedPercent`).

## Test

`packages/muya/src/utils/prism/__tests__/latexEscapedPercent.spec.ts`: `\%` produces no comment token, while a bare `%` and a line-leading `%` still do.

Fixes #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)