### PR TITLE
fix(desktop): resolve Homebrew/standard bin dirs for GUI launches

### DIFF
--- a/packages/desktop/src/main/app/env.ts
+++ b/packages/desktop/src/main/app/env.ts
@@ -1,17 +1,7 @@
-import path from 'path'
 import AppPaths, { ensureAppDirectoriesSync } from './paths'
+import { patchEnvPath } from './envPath'
 
 let envId = 0
-
-const patchEnvPath = (): void => {
-  if (process.platform === 'darwin') {
-    const currentPath = process.env.PATH ?? ''
-    process.env.PATH =
-      currentPath +
-      (currentPath.endsWith(path.delimiter) ? '' : path.delimiter) +
-      '/Library/TeX/texbin'
-  }
-}
 
 export interface AppEnvironmentOptions {
   userDataPath?: string

--- a/packages/desktop/src/main/app/envPath.ts
+++ b/packages/desktop/src/main/app/envPath.ts
@@ -1,0 +1,21 @@
+import path from 'path'
+
+// GUI-launched apps on macOS/Linux don't inherit the user's login-shell PATH,
+// so Homebrew (/opt/homebrew/bin, /usr/local/bin) and standard bin dirs are
+// absent and CLI tools like pandoc can't be found (#2751). These mirror the
+// picgo uploader's PATH handling (ipc/uploader.ts).
+const EXTRA_PATH_DIRS: Record<string, string[]> = {
+  darwin: ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', '/Library/TeX/texbin'],
+  linux: ['/usr/local/bin', '/usr/bin', '/bin']
+}
+
+export const patchEnvPath = (): void => {
+  const extras = EXTRA_PATH_DIRS[process.platform]
+  if (!extras) return
+
+  const current = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean)
+  for (const dir of extras) {
+    if (!current.includes(dir)) current.push(dir)
+  }
+  process.env.PATH = current.join(path.delimiter)
+}

--- a/packages/desktop/test/unit/specs/patch-env-path.spec.ts
+++ b/packages/desktop/test/unit/specs/patch-env-path.spec.ts
@@ -1,0 +1,51 @@
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { patchEnvPath } from 'main_renderer/app/envPath'
+
+const origPlatform = process.platform
+const origPath = process.env.PATH
+
+const setPlatform = (value: string): void => {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
+
+afterEach(() => {
+  setPlatform(origPlatform)
+  process.env.PATH = origPath
+})
+
+describe('patchEnvPath (#2751)', () => {
+  it('adds Homebrew and standard bin dirs on darwin when missing', () => {
+    setPlatform('darwin')
+    process.env.PATH = '/usr/bin'
+    patchEnvPath()
+    const dirs = (process.env.PATH ?? '').split(path.delimiter)
+    expect(dirs).toContain('/opt/homebrew/bin')
+    expect(dirs).toContain('/usr/local/bin')
+    expect(dirs).toContain('/Library/TeX/texbin')
+  })
+
+  it('adds standard bin dirs on linux', () => {
+    setPlatform('linux')
+    process.env.PATH = '/snap/bin'
+    patchEnvPath()
+    expect((process.env.PATH ?? '').split(path.delimiter)).toContain('/usr/local/bin')
+  })
+
+  it('does not duplicate an entry that is already present', () => {
+    setPlatform('darwin')
+    process.env.PATH = ['/opt/homebrew/bin', '/usr/bin'].join(path.delimiter)
+    patchEnvPath()
+    const homebrew = (process.env.PATH ?? '')
+      .split(path.delimiter)
+      .filter(d => d === '/opt/homebrew/bin')
+    expect(homebrew).toHaveLength(1)
+  })
+
+  it('leaves PATH untouched on win32', () => {
+    setPlatform('win32')
+    process.env.PATH = 'C:\\Windows'
+    patchEnvPath()
+    expect(process.env.PATH).toBe('C:\\Windows')
+  })
+})


### PR DESCRIPTION
## Problem

Importing/exporting via pandoc (and other CLI tools) fails with a "pandoc not found" error when MarkText is launched from Finder/GUI, even though pandoc is installed via Homebrew. GUI-launched apps on macOS/Linux don't inherit the user's login-shell `PATH`, so `/opt/homebrew/bin` (Apple-Silicon Homebrew, the reporter's pandoc location), `/usr/local/bin`, etc. are absent from `process.env.PATH`. `pandoc.exists()` uses `command-exists` which resolves against `PATH`, so detection fails.

`patchEnvPath()` only appended `/Library/TeX/texbin` on darwin and did nothing on linux.

## Fix

Extract the PATH logic into an electron-free `envPath` module and have it merge the Homebrew + standard bin dirs on darwin/linux — the same set the picgo uploader already uses (`ipc/uploader.ts`). Existing entries are de-duplicated and win32 is left untouched.

## Test

`packages/desktop/test/unit/specs/patch-env-path.spec.ts`: darwin adds Homebrew/`texbin`, linux adds standard dirs, no duplication, win32 unchanged.

Fixes #2751

🤖 Generated with [Claude Code](https://claude.com/claude-code)