### PR TITLE
fix(desktop): remove doubled Edit-menu separator on Windows/Linux

### DIFF
--- a/packages/desktop/src/main/menu/templates/edit.ts
+++ b/packages/desktop/src/main/menu/templates/edit.ts
@@ -159,7 +159,10 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
         }
       },
       {
-        type: 'separator'
+        // Screenshot is macOS-only; hide its trailing separator too so
+        // Windows/Linux don't show a doubled divider here (#2997).
+        type: 'separator',
+        visible: isOsx
       },
       {
         // TODO: Remove this menu entry and add it to the command palette (#1408).

--- a/packages/desktop/test/unit/specs/edit-menu-separator.spec.ts
+++ b/packages/desktop/test/unit/specs/edit-menu-separator.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The Edit menu's screenshot entry is macOS-only (`visible: isOsx`). On
+// Windows/Linux it was hidden but its surrounding separators stayed, leaving
+// two adjacent separators (a doubled divider) between "Find in Folder" and
+// "Line Ending" (#2997). Build the template per-platform and assert no two
+// visible separators are adjacent.
+
+vi.mock('electron', () => ({}))
+vi.mock('main_renderer/menu/actions/edit', () => ({}))
+vi.mock('main_renderer/i18n', () => ({ t: (key: string) => key }))
+vi.mock('main_renderer/commands', () => ({
+  COMMANDS: new Proxy({}, { get: () => 'cmd' })
+}))
+
+const keybindings = { getAccelerator: () => undefined } as never
+
+interface Item { type?: string, visible?: boolean, id?: string }
+
+async function buildEditSubmenu(isOsx: boolean): Promise<Item[]> {
+  vi.resetModules()
+  vi.doMock('main_renderer/config', () => ({ isOsx }))
+  const mod = await import('main_renderer/menu/templates/edit')
+  return (mod.default(keybindings).submenu as Item[])
+}
+
+const hasAdjacentVisibleSeparators = (items: Item[]): boolean => {
+  const visible = items.filter(i => i.visible !== false)
+  return visible.some((item, i) =>
+    item.type === 'separator' && visible[i + 1]?.type === 'separator'
+  )
+}
+
+describe('Edit menu separators (#2997)', () => {
+  it('has no doubled separator on Windows/Linux', async() => {
+    const submenu = await buildEditSubmenu(false)
+    expect(submenu.find(i => i.id === 'screenshot')?.visible).toBe(false)
+    expect(hasAdjacentVisibleSeparators(submenu)).toBe(false)
+  })
+
+  it('keeps the screenshot entry and its separators on macOS', async() => {
+    const submenu = await buildEditSubmenu(true)
+    expect(submenu.find(i => i.id === 'screenshot')?.visible).toBe(true)
+    expect(hasAdjacentVisibleSeparators(submenu)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

On Windows and Linux the Edit menu showed two adjacent separators (a doubled divider) between "Find in Folder" and "Line Ending". The screenshot entry between those separators is macOS-only (`visible: isOsx`); when hidden, its leading and trailing separators became adjacent.

## Fix

Gate the separator that follows the screenshot entry with `visible: isOsx`, so it is hidden alongside the entry it belongs to. macOS is unchanged (screenshot stays in its own group); Windows/Linux collapse to a single separator.

## Test

`packages/desktop/test/unit/specs/edit-menu-separator.spec.ts` builds the Edit submenu per-platform and asserts no two visible separators are adjacent, with the screenshot entry hidden on non-macOS and shown on macOS.

Fixes #2997

🤖 Generated with [Claude Code](https://claude.com/claude-code)