### PR TITLE
fix(muya): recolor sequence-diagram text/boxes for dark themes

### DIFF
--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -815,6 +815,20 @@ figure.mu-diagram-block .mu-diagram-preview svg path[stroke='#000000'] {
     stroke: var(--editor-color);
 }
 
+/* js-sequence-diagrams creates its <text> with no fill attribute and its
+   note/actor boxes with the 3-char `#fff`, so the attribute-keyed rules above
+   miss them and the labels/boxes stay black-on-white on dark themes (#3047).
+   Recolor the sequence SVG by element, scoped to `svg.sequence` so mermaid /
+   vega / flowchart (which set fills via attributes) are untouched. */
+figure.mu-diagram-block .mu-diagram-preview svg.sequence text {
+    fill: var(--editor-color);
+}
+
+figure.mu-diagram-block .mu-diagram-preview svg.sequence rect[fill='#fff'],
+figure.mu-diagram-block .mu-diagram-preview svg.sequence path[fill='#fff'] {
+    fill: var(--editor-bg-color);
+}
+
 figure.mu-active.mu-math-block > div.mu-math-preview,
 figure.mu-active.mu-diagram-block > div.mu-diagram-preview {
     position: absolute;


### PR DESCRIPTION
## Problem

Hand-drawn (and simple) sequence diagrams were hard to read on dark themes: the message text and the note/actor boxes stayed black-on-white while the rest of the editor was dark.

## Root cause

The dark-theme diagram recolor rules in `blockSyntax.css` key on explicit fill attributes (`svg text[fill='#000000']`, `svg rect[fill='#ffffff']`). js-sequence-diagrams' vendored renderer creates its `<text>` with **no** fill attribute (so it uses the SVG default black but never matches the rule) and its note/actor boxes with the 3-char `#fff` (which `[fill='#ffffff']` misses). The lines already recolor (they set `stroke='#000000'`), confirming only text/boxes fall through.

## Fix

Add two `svg.sequence`-scoped rules alongside the existing recolor block: text → `--editor-color`, `#fff` boxes → `--editor-bg-color`. Scoping to `svg.sequence` (the class js-sequence-diagrams adds to its SVG root) keeps mermaid/vega/flowchart — which set fills via attributes — untouched. The rules are theme-driven and additive, so the light theme is unchanged.

## Verification

CSS-only, mirroring the existing recolor block; please verify visually by rendering a sequence diagram on a dark theme. No new stylelint issues introduced.

Fixes #3047

🤖 Generated with [Claude Code](https://claude.com/claude-code)