### PR TITLE
fix(desktop): list bundled fonts in the font picker

### DIFF
--- a/packages/desktop/src/renderer/src/prefComponents/common/fontTextBox/bundledFonts.ts
+++ b/packages/desktop/src/renderer/src/prefComponents/common/fontTextBox/bundledFonts.ts
@@ -1,0 +1,11 @@
+// Fonts MarkText bundles via @font-face (packages/muya/src/assets/styles/index.css).
+// They are the editor/code defaults but are NOT installed system fonts, so the
+// OS font-list IPC never returns them and the picker couldn't reselect them (#3021).
+export const BUNDLED_PROPORTIONAL_FONTS = ['Open Sans']
+export const BUNDLED_MONOSPACE_FONTS = ['DejaVu Sans Mono']
+
+export const withBundledFonts = (systemFonts: string[], onlyMonospace = false): string[] => {
+  const bundled = onlyMonospace ? BUNDLED_MONOSPACE_FONTS : BUNDLED_PROPORTIONAL_FONTS
+  const missing = bundled.filter(font => !systemFonts.includes(font))
+  return [...missing, ...systemFonts]
+}

--- a/packages/desktop/src/renderer/src/prefComponents/common/fontTextBox/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/common/fontTextBox/index.vue
@@ -43,6 +43,7 @@ import { ArrowDown } from '@element-plus/icons-vue'
 import LinkIcon from '@/components/icons/LinkIcon.vue'
 import { useI18n } from 'vue-i18n'
 import type { PrefControlProps } from '../types'
+import { withBundledFonts } from './bundledFonts'
 
 const { t } = useI18n()
 
@@ -96,7 +97,10 @@ const handleMoreClick = () => {
 onMounted(async () => {
   // font-list is a native module; it runs in the main process and is reached via IPC.
   const fonts = await window.fonts.list()
-  fontFamilies.value = (fonts || []).map((f) => f.replace(/"/g, '').trim())
+  const systemFonts = (fonts || []).map((f) => f.replace(/"/g, '').trim())
+  // System fonts don't include the bundled defaults (Open Sans / DejaVu Sans
+  // Mono), so surface them in the picker too (#3021).
+  fontFamilies.value = withBundledFonts(systemFonts, props.onlyMonospace)
 })
 </script>
 

--- a/packages/desktop/test/unit/specs/bundled-fonts.spec.ts
+++ b/packages/desktop/test/unit/specs/bundled-fonts.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BUNDLED_MONOSPACE_FONTS,
+  BUNDLED_PROPORTIONAL_FONTS,
+  withBundledFonts
+} from '@/prefComponents/common/fontTextBox/bundledFonts'
+
+describe('withBundledFonts (#3021)', () => {
+  it('prepends the bundled proportional font when the system list lacks it', () => {
+    const result = withBundledFonts(['Arial', 'Times New Roman'], false)
+    expect(result).toContain('Open Sans')
+    expect(result.indexOf('Open Sans')).toBeLessThan(result.indexOf('Arial'))
+  })
+
+  it('prepends the bundled monospace font for the code-font picker', () => {
+    const result = withBundledFonts(['Menlo', 'Consolas'], true)
+    expect(result).toContain('DejaVu Sans Mono')
+  })
+
+  it('does not duplicate a bundled font already installed on the system', () => {
+    const result = withBundledFonts(['Open Sans', 'Arial'], false)
+    expect(result.filter(f => f === 'Open Sans')).toHaveLength(1)
+  })
+
+  it('exposes the bundled names so they stay in sync with @font-face', () => {
+    expect(BUNDLED_PROPORTIONAL_FONTS).toContain('Open Sans')
+    expect(BUNDLED_MONOSPACE_FONTS).toContain('DejaVu Sans Mono')
+  })
+})


### PR DESCRIPTION
## Problem

The editor/code font pickers in Preferences populate their suggestions only from the OS font list (`window.fonts.list()`). MarkText's own defaults — **Open Sans** (editor) and **DejaVu Sans Mono** (code) — ship bundled via `@font-face` and are not installed system fonts, so they never appear in the list. Once a user picked a different font they could not reselect the bundled default without hand-editing `preferences.json`.

## Root cause

`fontTextBox` builds `fontFamilies` solely from the system font list; the bundled defaults are absent from that list.

## Fix

Extract a small `withBundledFonts(systemFonts, onlyMonospace)` helper that prepends the bundled font for the matching picker (Open Sans for the proportional picker, DejaVu Sans Mono for the `onlyMonospace` code picker), de-duplicating any that are also installed. The component calls it after fetching the system list.

## Test

`packages/desktop/test/unit/specs/bundled-fonts.spec.ts`: bundled font prepended when missing, correct font per picker, no duplication when already installed.

Fixes #3021

🤖 Generated with [Claude Code](https://claude.com/claude-code)