### PR TITLE
fix(muya): keep image resize handles attached on layout reflow

### DIFF
--- a/packages/muya/e2e/tests/drag/image-resize-bar-reflow-2939.spec.ts
+++ b/packages/muya/e2e/tests/drag/image-resize-bar-reflow-2939.spec.ts
@@ -1,0 +1,56 @@
+import type { Locator } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor, floats } from '../helpers/selectors';
+
+/**
+ * #2939 — the ImageResizeBar positioned its left/right handles once on image
+ * click and never tracked layout reflow (unlike imageToolbar, which rides
+ * baseFloat's `autoUpdate`). When the surrounding layout shifted — the desktop
+ * sidebar toggling, or any window/ancestor resize — the handles stayed at their
+ * stale coordinates, detached from the image.
+ *
+ * Reproduce the reflow with a viewport resize (the muya container is centered,
+ * so narrowing the viewport moves the image's left edge) and assert the left
+ * handle stays aligned with the image.
+ */
+
+const DATA_URI =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+
+test.describe('ImageResizeBar reflow (#2939)', () => {
+    test('left handle tracks the image when the viewport resizes', async ({ page }) => {
+        await page.setViewportSize({ width: 1400, height: 900 });
+        await page.evaluate(uri => window.muya!.setContent(`![alt](${uri})`), DATA_URI);
+
+        const image = page.locator(editor.image).first();
+        await expect(image).toBeVisible();
+        await expect.poll(async () => image.evaluate(el =>
+            el.classList.contains('mu-image-success')), { timeout: 5_000 }).toBe(true);
+
+        const innerImg = image.locator('img').first();
+        await innerImg.click();
+
+        const leftHandle = page.locator(`${floats.imageTransformer} .bar.left`);
+        await expect(leftHandle).toBeVisible();
+
+        const offsetBefore = await getHandleOffset(innerImg, leftHandle);
+        expect(Math.abs(offsetBefore)).toBeLessThan(4);
+
+        // Narrow the viewport: the centered container — and the image — shift right.
+        await page.setViewportSize({ width: 760, height: 900 });
+
+        await expect.poll(async () => Math.abs(await getHandleOffset(innerImg, leftHandle)), {
+            timeout: 5_000,
+            intervals: [50, 100, 250, 500],
+        }).toBeLessThan(4);
+    });
+});
+
+async function getHandleOffset(img: Locator, handle: Locator): Promise<number> {
+    const imgBox = await img.boundingBox();
+    const handleBox = await handle.boundingBox();
+    if (!imgBox || !handleBox)
+        throw new Error('missing bounding box');
+    // The left handle sits at `image.left - 5` (CIRCLE_RADIO); compare centers.
+    return (handleBox.x + handleBox.width / 2) - imgBox.x;
+}

--- a/packages/muya/src/ui/imageResizeBar/index.ts
+++ b/packages/muya/src/ui/imageResizeBar/index.ts
@@ -1,6 +1,7 @@
 import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
 import type { ImageToken } from '../../inlineRenderer/types';
+import { autoUpdate } from '@floating-ui/dom';
 
 import { isHTMLElement, isMouseEvent } from '../../utils';
 import { findScrollContainer } from '../../utils/dom';
@@ -26,6 +27,8 @@ export class ImageResizeBar {
     private _eventId: string[] = [];
     private _lastScrollTop: number | null = null;
     private _resizing: boolean = false;
+    // Stops the autoUpdate reposition loop set up in `_render`.
+    private _cleanup: (() => void) | null = null;
     // A container for storing drag strips
     private _container: HTMLDivElement;
 
@@ -89,6 +92,9 @@ export class ImageResizeBar {
 
         this._createElements();
         this._update();
+        // Reposition the handles whenever the image moves (window/ancestor
+        // resize, sidebar toggle, scroll), so they stay attached to it (#2939).
+        this._cleanup = autoUpdate(this._reference!, this._container, () => this._update());
         eventCenter.emit('muya-float', this, true);
     }
 
@@ -202,6 +208,8 @@ export class ImageResizeBar {
 
     hide() {
         const { eventCenter } = this.muya;
+        this._cleanup?.();
+        this._cleanup = null;
         const circles = this._container.querySelectorAll('.bar');
         Array.from(circles).forEach(c => c.remove());
         this._status = false;
@@ -211,6 +219,8 @@ export class ImageResizeBar {
     // Remove the `.mu-transformer` container appended to document.body in the
     // constructor; invoked by `Muya.destroy()` so it is not leaked (#3315).
     destroy() {
+        this._cleanup?.();
+        this._cleanup = null;
         this._container.remove();
     }
 }


### PR DESCRIPTION
## Problem

After selecting an image, its left/right resize handles are positioned once and never follow layout reflow. Toggling the desktop sidebar or resizing the window leaves the handles stranded at their old coordinates, detached from the image.

## Root cause

`ImageResizeBar._update()` runs only on image click (and during an active drag). Unlike `imageToolbar`, which rides `baseFloat`'s `@floating-ui/dom` `autoUpdate`, the resize bar has no reflow listener — its scroll handler only *hides* the bar past a 50px threshold.

## Fix

Drive repositioning with `@floating-ui/dom`'s `autoUpdate` (already a muya dependency, used by `baseFloat`): set it up in `_render()` to call `_update()` on any ancestor resize/scroll/layout shift, and tear it down in `hide()`/`destroy()`.

## Test (real-browser, reproduced RED→GREEN)

`packages/muya/e2e/tests/drag/image-resize-bar-reflow-2939.spec.ts`: select an image, narrow the viewport (the centered container shifts the image), and assert the left handle stays aligned. Before the fix the handle drifts ~284px off; after, it tracks within a few px. The existing drag test still passes.

Fixes #2939

🤖 Generated with [Claude Code](https://claude.com/claude-code)