### PR TITLE
fix(desktop): keep diagram content when exporting with Header & Footer

### DIFF
--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -81,26 +81,36 @@ const styledClass = (value: boolean | undefined): string => {
   return value ? ' styled' : ' simple'
 }
 
+// Header/footer left/center/right are user-supplied, so sanitize them here.
+// The article body is NOT sanitized again (it was already sanitized by the
+// engine during render); re-sanitizing it strips diagram <foreignObject>
+// labels and drops mermaid content from the export (#3359).
+const hf = (value: string): string => sanitize(value, EXPORT_DOMPURIFY_CONFIG) as string
+
 const createTableHeader = (header: HeaderFooterPart, headerFooterStyled?: boolean): string => {
   const { type, left = '', center = '', right = '' } = header
-  const headerClass = (type === 1 ? 'single' : '') + styledClass(headerFooterStyled)
-  return `<thead class="page-header ${headerClass}"><tr><th>
+  const headerClass = `page-header ${(type === 1 ? 'single' : '') + styledClass(headerFooterStyled)}`
+    .replace(/\s+/g, ' ')
+    .trim()
+  return `<thead class="${headerClass}"><tr><th>
   <div class="hf-container">
-    <div class="header-content-left">${left}</div>
-    <div class="header-content">${center}</div>
-    <div class="header-content-right">${right}</div>
+    <div class="header-content-left">${hf(left)}</div>
+    <div class="header-content">${hf(center)}</div>
+    <div class="header-content-right">${hf(right)}</div>
   </div>
 </th></tr></thead>`
 }
 
 const createRealFooter = (footer: HeaderFooterPart, headerFooterStyled?: boolean): string => {
   const { type, left = '', center = '', right = '' } = footer
-  const footerClass = (type === 1 ? 'single' : '') + styledClass(headerFooterStyled)
-  return `<div class="page-footer ${footerClass}">
+  const footerClass = `page-footer ${(type === 1 ? 'single' : '') + styledClass(headerFooterStyled)}`
+    .replace(/\s+/g, ' ')
+    .trim()
+  return `<div class="${footerClass}">
   <div class="hf-container">
-    <div class="footer-content-left">${left}</div>
-    <div class="footer-content">${center}</div>
-    <div class="footer-content-right">${right}</div>
+    <div class="footer-content-left">${hf(left)}</div>
+    <div class="footer-content">${hf(center)}</div>
+    <div class="footer-content-right">${hf(right)}</div>
   </div>
 </div>`
 }
@@ -216,7 +226,7 @@ export const exportStyledHTML = async(
     }
     output += createTableBody(`<article class="markdown-body">${article}</article>`)
     output += HF_TABLE_END
-    bodyHtml = sanitize(output, EXPORT_DOMPURIFY_CONFIG) as string
+    bodyHtml = output
   }
 
   // Re-emit the engine document shell with the (possibly augmented) body.

--- a/packages/desktop/test/unit/specs/export-header-footer-diagram.spec.ts
+++ b/packages/desktop/test/unit/specs/export-header-footer-diagram.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// #3359 — exporting with Header & Footer enabled dropped diagram (mermaid)
+// content. The header/footer branch re-sanitized the WHOLE already-rendered
+// article with the export DOMPurify config, which strips the <foreignObject>
+// that mermaid renders its node labels into; the no-header/footer branch never
+// re-sanitized, so the same document exported fine without header/footer.
+
+const FULL_DOC =
+  '<html><head></head><body>' +
+  '<article class="markdown-body">' +
+  '<figure class="mu-diagram-block"><svg class="mermaid"><g class="node">' +
+  '<foreignObject width="80" height="20"><div xmlns="http://www.w3.org/1999/xhtml">' +
+  '<span class="nodeLabel"><p>DiagramLabel</p></span></div></foreignObject>' +
+  '</g></svg></figure>' +
+  '</article></body></html>'
+
+vi.mock('@muyajs/core', () => ({
+  MarkdownToHtml: class {
+    async generate(): Promise<string> {
+      return FULL_DOC
+    }
+  }
+}))
+
+vi.mock('@/util/resolveImageSrc', () => ({ resolveLocalImageSrc: (s: string) => s }))
+vi.mock('@/util/resolveLinkHref', () => ({ resolveLocalLinkHref: (s: string) => s }))
+
+const { exportStyledHTML } = await import('@/util/exportHtml')
+
+const fakeMuya = {} as never
+
+describe('export with Header & Footer preserves diagram content (#3359)', () => {
+  it('keeps the mermaid foreignObject label when a header is present', async() => {
+    const html = await exportStyledHTML(fakeMuya, '```mermaid\ngraph LR\n```', {
+      header: { type: 0, left: '', center: 'My Title', right: '' }
+    })
+    expect(html).toContain('DiagramLabel')
+    expect(html).toContain('My Title')
+  })
+
+  it('still strips unsafe markup from the user-supplied header text', async() => {
+    const html = await exportStyledHTML(fakeMuya, 'x', {
+      header: { type: 0, left: '', center: '<script>alert(1)</script>Safe', right: '' }
+    })
+    expect(html).toContain('Safe')
+    expect(html).not.toContain('<script>')
+  })
+})


### PR DESCRIPTION
## Problem

Exporting a document that contains a Mermaid (or other) diagram to PDF/HTML **with Header & Footer enabled** silently dropped the diagram's content. Exporting the same document **without** Header & Footer worked fine.

## Root cause

`exportStyledHTML` has two branches. The no-header/footer branch returns the rendered article as-is. The header/footer branch re-ran `sanitize(output, EXPORT_DOMPURIFY_CONFIG)` over the **whole** assembled document — including the already-rendered article. The export DOMPurify config strips the `<foreignObject>` element that Mermaid 11 renders its node labels into (htmlLabels are on by default for `graph LR`), so every diagram label was removed.

## Fix

The article is already sanitized by the engine during render, so re-sanitizing it is redundant and lossy. Sanitize only the **user-supplied** header/footer text fields (`left`/`center`/`right`) and leave the rendered article untouched — matching the no-header/footer branch. Also trims the header/footer class strings (the whole-output sanitize had been incidentally collapsing their whitespace).

## Test

`packages/desktop/test/unit/specs/export-header-footer-diagram.spec.ts`: a diagram `foreignObject` label survives export when a header is present, and unsafe markup in the header text is still stripped. Existing `exportHtml.spec.ts` (19 tests) still pass.

Fixes #3359

🤖 Generated with [Claude Code](https://claude.com/claude-code)