### PR TITLE
fix(desktop): select the query when re-opening the Find bar

### DIFF
--- a/packages/desktop/src/renderer/src/components/search/index.vue
+++ b/packages/desktop/src/renderer/src/components/search/index.vue
@@ -249,6 +249,9 @@ const listenFind = () => {
   type.value = 'search'
   nextTick(() => {
     search.value?.focus()
+    // Select the existing term so re-opening Find types over it instead of
+    // appending to the previous query (#3458).
+    search.value?.select()
     if (searchValue.value) {
       searchFn()
     }

--- a/packages/desktop/test/e2e/find-reopen-select-3458.spec.ts
+++ b/packages/desktop/test/e2e/find-reopen-select-3458.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, sendIpcToRenderer, focusEditor } from './helpers'
+
+// #3458 — re-pressing Find (Cmd/Ctrl-F) while the bar is already open just
+// re-focused the input without selecting it, so the caret landed after the
+// existing term and the next keystroke appended ("accretion"). Re-opening
+// should highlight the current term so it can be typed over.
+
+const FIND_INPUT = '.search-bar .search input'
+
+test.describe('Find bar reopen selects the existing term (#3458)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('apple banana apple cherry\n')
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('re-opening Find highlights the existing query so it can be typed over', async() => {
+    await sendIpcToRenderer(app, 'mt::editor-edit-action', 'find')
+    await expect(page.locator('.search-bar')).toBeVisible({ timeout: 5000 })
+    await page.locator(FIND_INPUT).fill('apple')
+    // Let the search settle (active match selected) before re-opening.
+    await expect.poll(() => page.locator('.search-bar .search-result').innerText())
+      .toContain('/ 2')
+
+    // Re-trigger Find while the bar is already open with a term present.
+    await sendIpcToRenderer(app, 'mt::editor-edit-action', 'find')
+
+    // The whole term must be selected (so a keystroke replaces it), not left
+    // with a collapsed caret at the end.
+    await expect
+      .poll(() =>
+        page.evaluate((sel) => {
+          const el = document.querySelector(sel) as HTMLInputElement | null
+          if (!el) return null
+          return { start: el.selectionStart, end: el.selectionEnd, len: el.value.length }
+        }, FIND_INPUT)
+      )
+      .toEqual({ start: 0, end: 5, len: 5 })
+
+    // Typing over the selection replaces the term rather than appending to it.
+    await page.keyboard.type('cherry')
+    await expect.poll(() => page.locator(FIND_INPUT).inputValue()).toBe('cherry')
+  })
+})


### PR DESCRIPTION
## Problem

Re-pressing Find (Cmd/Ctrl-F) while the find bar was already open just re-focused the input, leaving the caret **after** the existing search term. The next keystroke appended to the old term instead of replacing it ("accretion").

## Root cause

`listenFind()` calls `search.value?.focus()` but never `select()`, so a re-open lands a collapsed caret at the end of the populated input.

## Fix

Call `search.value?.select()` right after focusing, so the current term is highlighted and a keystroke types over it (harmless when the input is empty).

## Test

`packages/desktop/test/e2e/find-reopen-select-3458.spec.ts` (real built app): type a query, re-trigger Find, assert the whole term is selected (`selectionStart=0`, `selectionEnd=len`) and that typing replaces it. Verified RED→GREEN; existing `find-replace.spec.ts` still passes.

Fixes #3458

🤖 Generated with [Claude Code](https://claude.com/claude-code)