### PR TITLE
fix(desktop): New File on a collapsed sidebar folder expands it

### DIFF
--- a/packages/desktop/src/renderer/src/components/sideBar/treeFolder.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/treeFolder.vue
@@ -91,13 +91,17 @@ const { activeItem } = storeToRefs(projectStore)
 const { clipboard } = storeToRefs(projectStore)
 
 const handleInputFocus = (): void => {
+  // Only the folder that is the create target reacts. Expand it FIRST so the
+  // create input renders even when the folder was collapsed, then focus it on
+  // the next tick — previously the expand sat behind `if (input.value)`, which
+  // is null while collapsed, so New File on a collapsed folder did nothing
+  // (#3439).
+  if (createCache.value.dirname !== props.folder.pathname) return
+  isCollapsed.value = false
   nextTick(() => {
     if (input.value) {
       input.value.focus()
       createName.value = ''
-      if (props.folder) {
-        isCollapsed.value = false
-      }
     }
   })
 }

--- a/packages/desktop/test/e2e/new-file-collapsed-folder-3439.spec.ts
+++ b/packages/desktop/test/e2e/new-file-collapsed-folder-3439.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchElectron } from './helpers'
+
+// #3439 — invoking "New File" (sidebar context menu) on a COLLAPSED folder did
+// nothing: the create <input> only renders inside the folder's expanded
+// contents, and handleInputFocus guarded the expand behind `if (input.value)`,
+// which is null while collapsed — so the folder never expanded and no input
+// appeared.
+
+// A collapsed sidebar folder's create-input is visible once the folder expands.
+const visibleNewInput = (page: Page): Promise<number> =>
+  page.evaluate(
+    () =>
+      Array.from(
+        document.querySelectorAll('.side-bar-folder .folder-contents input.new-input')
+      ).filter((el) => (el as HTMLElement).offsetParent !== null).length
+  )
+
+test.describe('New File on a collapsed folder (#3439)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    // launchElectron opens the desktop package folder in the sidebar (its
+    // sub-folders render as collapsed tree-folders).
+    const launched = await launchElectron()
+    app = launched.app
+    page = launched.page
+    await page.waitForSelector('.side-bar-folder .folder-name', { timeout: 10000 })
+
+    // Replace the sidebar context-menu popup handler so it does NOT open a real
+    // native menu (which would hang the headless run); instead resolve the
+    // template to the "New File" item and dispatch its click straight back to
+    // the renderer, driving the real context-menu → bus → store → tree-folder
+    // path.
+    await app.evaluate(({ ipcMain }) => {
+      const findId = (items: Array<{ id?: string, submenu?: unknown }>): string | null => {
+        for (const it of items || []) {
+          if (it?.id && String(it.id).startsWith('newFileMenuItem')) return it.id
+          if (it?.submenu) {
+            const r = findId(it.submenu as Array<{ id?: string }>)
+            if (r) return r
+          }
+        }
+        return null
+      }
+      ipcMain.removeAllListeners('mt::menu::popup')
+      ipcMain.on('mt::menu::popup', (event, template) => {
+        const id = findId(template as Array<{ id?: string }>)
+        if (id) {
+          setTimeout(() => {
+            try {
+              event.sender.send('mt::menu::click', { id })
+            } catch { /* window gone */ }
+          }, 30)
+        }
+      })
+    })
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('the create input appears when New File targets a collapsed folder', async() => {
+    // No tree-folder create input is rendered initially.
+    expect(await visibleNewInput(page)).toBe(0)
+
+    // Right-click the first (collapsed) sub-folder → sets it active + pops the
+    // context menu, which the main-side hook resolves to "New File".
+    await page.evaluate(() => {
+      const fn = document.querySelector('.side-bar-folder .folder-name') as HTMLElement | null
+      if (!fn) throw new Error('no sub-folder in sidebar')
+      const r = fn.getBoundingClientRect()
+      fn.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: r.left + 5,
+          clientY: r.top + 5
+        })
+      )
+    })
+
+    // The targeted folder must expand and reveal its create input.
+    await expect.poll(() => visibleNewInput(page), { timeout: 6000 }).toBeGreaterThanOrEqual(1)
+
+    await page.keyboard.press('Escape')
+  })
+})


### PR DESCRIPTION
## Problem

Invoking **New File** (sidebar context menu) on a **collapsed** folder did nothing — no name input appeared, so no file could be created.

## Root cause

The create `<input>` only renders inside the folder's expanded contents (`v-if="!isCollapsed"`). `handleInputFocus` guarded the expand (`isCollapsed = false`) behind `if (input.value)`, but `input.value` is `null` while the folder is collapsed (the input isn't in the DOM yet), so the folder never expanded and the input never appeared. The handler also ran on every tree-folder without checking which one was the create target.

## Fix

Scope `handleInputFocus` to the create-target folder (`createCache.dirname === folder.pathname`), expand it **first**, then focus the input on the next tick once it has rendered.

## Test

`packages/desktop/test/e2e/new-file-collapsed-folder-3439.spec.ts` (real built app): drives the real context-menu → bus → store → tree-folder path (injecting the "New File" menu click) on a collapsed folder and asserts the create input becomes visible. Verified RED→GREEN; existing sidebar e2e still pass.

Fixes #3439

🤖 Generated with [Claude Code](https://claude.com/claude-code)