### PR TITLE
fix(desktop): make Paragraph/Format commands inert in source mode (grey out menus)

### DIFF
--- a/packages/desktop/src/main/menu/index.ts
+++ b/packages/desktop/src/main/menu/index.ts
@@ -511,6 +511,18 @@ class AppMenu {
       updateSelectionMenus(this.getWindowMenuById(windowId), changes)
     })
 
+    // In source-code mode the Paragraph and Format commands act on the hidden
+    // WYSIWYG engine, so grey them out; on return to WYSIWYG they are re-enabled
+    // and the next selection change refines them (#3531).
+    ipcMain.on('mt::set-editor-format-menus-enabled', (_e, windowId: number, enabled: boolean) => {
+      if (!this.has(windowId)) return
+      const menu = this.getWindowMenuById(windowId)
+      for (const id of ['paragraphMenuEntry', 'formatMenuItem']) {
+        const entry = menu.getMenuItemById(id)
+        entry?.submenu?.items.forEach((item) => (item.enabled = enabled))
+      }
+    })
+
     onInternalChannel('menu-add-recently-used', (pathname: string) => {
       this.addRecentlyUsedDocument(pathname)
     })

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -547,11 +547,22 @@ watch(focus, (value) => {
 })
 
 // In source-code mode the Paragraph and Format menus operate on the hidden
-// WYSIWYG engine, so ask the main process to grey them out; re-enable on the
-// way back (the next selection change then refines them) (#3531).
+// WYSIWYG engine, so grey them out. On return to WYSIWYG, re-apply the menu
+// state for the CURRENT cursor context (a code block/table still disables some
+// items) rather than blanket-enabling everything (#3531).
 watch(sourceCode, (isSource) => {
   const windowId = window.marktext?.env?.windowId ?? -1
-  window.electron.ipcRenderer.send('mt::set-editor-format-menus-enabled', windowId, !isSource)
+  if (isSource) {
+    window.electron.ipcRenderer.send('mt::set-editor-format-menus-enabled', windowId, false)
+    return
+  }
+  nextTick(() => {
+    if (selectionChange.value) {
+      pushSelectionMenuState(selectionChange.value as MuyaChange)
+    } else {
+      window.electron.ipcRenderer.send('mt::set-editor-format-menus-enabled', windowId, true)
+    }
+  })
 })
 
 watch(fontSize, (value, oldValue) => {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1371,6 +1371,12 @@ const pushSelectionMenuState = (changes: MuyaChange) => {
 }
 
 const handleEditParagraph = (type: unknown) => {
+  // These commands act on the hidden WYSIWYG engine, so block them in
+  // source-code mode (mirrors handleUndo/handleSelectAll) — otherwise e.g. the
+  // Insert Table wizard opens and writes to the invisible editor (#3531).
+  if (sourceCode.value) {
+    return
+  }
   if (type === 'table') {
     tableChecker.rows = 4
     tableChecker.columns = 3
@@ -1391,6 +1397,9 @@ const handleEditParagraph = (type: unknown) => {
 
 // handle `duplicate`, `delete`, `create paragraph below`
 const handleParagraph = (type: unknown) => {
+  if (sourceCode.value) {
+    return
+  }
   if (editor.value) {
     switch (type) {
       case 'duplicate': {
@@ -1409,6 +1418,9 @@ const handleParagraph = (type: unknown) => {
 }
 
 const handleInlineFormat = (type: unknown) => {
+  if (sourceCode.value) {
+    return
+  }
   editor.value && editor.value.format(type)
 }
 

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -546,6 +546,14 @@ watch(focus, (value) => {
   }
 })
 
+// In source-code mode the Paragraph and Format menus operate on the hidden
+// WYSIWYG engine, so ask the main process to grey them out; re-enable on the
+// way back (the next selection change then refines them) (#3531).
+watch(sourceCode, (isSource) => {
+  const windowId = window.marktext?.env?.windowId ?? -1
+  window.electron.ipcRenderer.send('mt::set-editor-format-menus-enabled', windowId, !isSource)
+})
+
 watch(fontSize, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ fontSize: value })

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -132,6 +132,7 @@ export interface IpcSendChannels {
   'mt::open-setting-window': []
   'mt::rename': [payload: { id: string; pathname: string; newPathname: string; currentFile?: unknown }]
   'mt::request-keybindings': []
+  'mt::set-editor-format-menus-enabled': [windowId: number, enabled: boolean]
   'mt::response-export': [
     payload: {
       type: ExportType

--- a/packages/desktop/test/e2e/source-mode-menu-disabled-3531.spec.ts
+++ b/packages/desktop/test/e2e/source-mode-menu-disabled-3531.spec.ts
@@ -51,3 +51,34 @@ test.describe('paragraph/format menus disabled in source mode (#3531)', () => {
     })
   })
 })
+
+test.describe('menus reflect cursor context after exiting source mode (#3531)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('```js\nconst x = 1\n```\n\n# Heading\n', {
+      suppressErrorDialog: true
+    })
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('a cursor in a code block keeps Format items disabled after a source-mode round-trip', async() => {
+    // Put the caret inside the fenced code block; its context disables the Format menu.
+    await page.locator('.editor-component pre.mu-code-block .mu-codeblock-content').first().click()
+    await expect.poll(() => readEnabled(app).then((s) => s.strong)).toBe(false)
+
+    await enterSourceMode(page, app)
+    await expect.poll(() => readEnabled(app).then((s) => s.strong)).toBe(false)
+
+    await exitSourceMode(page, app)
+    // The fix: the menu is re-applied for the code-block cursor, NOT blanket-enabled.
+    await expect.poll(() => readEnabled(app).then((s) => s.strong)).toBe(false)
+  })
+})

--- a/packages/desktop/test/e2e/source-mode-menu-disabled-3531.spec.ts
+++ b/packages/desktop/test/e2e/source-mode-menu-disabled-3531.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown, focusEditor, enterSourceMode, exitSourceMode } from './helpers'
+
+// #3531 — Paragraph and Format menu commands act on the hidden WYSIWYG engine,
+// so they must be greyed out in source-code mode and re-enabled on return.
+
+const readEnabled = (app: ElectronApplication) =>
+  app.evaluate(({ Menu }) => {
+    const m = Menu.getApplicationMenu()
+    const get = (id: string) => {
+      const i = m?.getMenuItemById(id)
+      return i ? i.enabled : null
+    }
+    return {
+      table: get('tableMenuItem'),
+      heading1: get('heading1MenuItem'),
+      strong: get('strongMenuItem'),
+      emphasis: get('emphasisMenuItem')
+    }
+  })
+
+test.describe('paragraph/format menus disabled in source mode (#3531)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\nhello world\n', { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('menus are enabled in WYSIWYG, disabled in source mode, restored on exit', async() => {
+    await expect.poll(() => readEnabled(app)).toEqual({
+      table: true, heading1: true, strong: true, emphasis: true
+    })
+
+    await enterSourceMode(page, app)
+    await expect.poll(() => readEnabled(app)).toEqual({
+      table: false, heading1: false, strong: false, emphasis: false
+    })
+
+    await exitSourceMode(page, app)
+    await expect.poll(() => readEnabled(app)).toEqual({
+      table: true, heading1: true, strong: true, emphasis: true
+    })
+  })
+})

--- a/packages/desktop/test/e2e/source-mode-table-wizard-3531.spec.ts
+++ b/packages/desktop/test/e2e/source-mode-table-wizard-3531.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  launchWithMarkdown,
+  focusEditor,
+  enterSourceMode,
+  exitSourceMode,
+  sendIpcToRenderer
+} from './helpers'
+
+// #3531 — the paragraph edit commands (e.g. the "Insert Table" wizard) still
+// fired in source-code mode, where they operate on the hidden WYSIWYG engine
+// instead of the visible CodeMirror source. Like undo/redo/selectAll, these
+// must be blocked while in source mode.
+
+const TABLE_DIALOG = '.ag-insert-table-dialog'
+
+test.describe('paragraph edit commands are suppressed in source mode (#3531)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown('# Doc\n\nsome text\n', {
+      suppressErrorDialog: true
+    })
+    app = launched.app
+    page = launched.page
+    await focusEditor(page)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('the Insert Table wizard does not open while in source-code mode', async() => {
+    await enterSourceMode(page, app)
+
+    // Fire the "insert table" paragraph action (menu / shortcut path).
+    await sendIpcToRenderer(app, 'mt::editor-paragraph-action', { type: 'table' })
+    await page.waitForTimeout(400)
+
+    // The table wizard dialog must NOT appear in source mode.
+    await expect(page.locator(TABLE_DIALOG)).toHaveCount(0)
+
+    await exitSourceMode(page, app)
+
+    // Sanity: in WYSIWYG mode the same action DOES open the wizard.
+    await focusEditor(page)
+    await sendIpcToRenderer(app, 'mt::editor-paragraph-action', { type: 'table' })
+    await expect(page.locator(TABLE_DIALOG)).toBeVisible({ timeout: 5000 })
+  })
+})


### PR DESCRIPTION
## Problem

In source-code mode, the **Paragraph** and **Format/Style** menu commands still fire — but they operate on the hidden WYSIWYG engine, which is reloaded from the source text on exit (`setContent`). So they either silently mutate a discarded engine (no visible result) or, for **Paragraph → Table**, spawn an **inert invisible dialog** (the reporter's "the window darkens but no dialog"; #3531). The menu items stay enabled, so they look usable but aren't.

## Fix

1. **Grey out the Paragraph + Format menu entries in source-code mode**, and re-enable them on return to WYSIWYG (the next selection change then refines the exact state). Driven by a `sourceCode` watcher in the renderer → `mt::set-editor-format-menus-enabled` IPC → main disables/enables the `paragraphMenuEntry` and `formatMenuItem` submenus.
2. **Keep the renderer-side guards** (`handleEditParagraph` / `handleParagraph` / `handleInlineFormat` return early in source mode) as defense-in-depth for any non-menu trigger.

## Tests

- `source-mode-menu-disabled-3531.spec.ts` — menus enabled in WYSIWYG → disabled in source mode → restored on exit (real app).
- `source-mode-table-wizard-3531.spec.ts` — the Insert Table wizard doesn't open in source mode.

Fixes #3531

🤖 Generated with [Claude Code](https://claude.com/claude-code)