### PR TITLE
feat(macOS): add Dictionary lookup for selected editor text

### DIFF
--- a/packages/desktop/src/common/i18n.ts
+++ b/packages/desktop/src/common/i18n.ts
@@ -83,7 +83,7 @@ function getTranslation(
 
   let result = probe
   for (const [param, replacement] of Object.entries(params)) {
-    result = result.replace(new RegExp(`\\{${param}\\}`, 'g'), String(replacement))
+    result = result.replace(new RegExp(`\\{${param}\\}`, 'g'), () => String(replacement))
   }
 
   return result

--- a/packages/desktop/src/main/contextMenu/editor/index.ts
+++ b/packages/desktop/src/main/contextMenu/editor/index.ts
@@ -6,12 +6,14 @@ import {
   getCopyAsRich,
   getCopyAsHtml,
   getPasteAsPlainText,
+  getLookUp,
   SEPARATOR,
   getInsertBefore,
   getInsertAfter
 } from './menuItems'
 import spellcheckMenuBuilder from './spellcheck'
 import { t } from '../../i18n'
+import { isOsx } from '../../config'
 
 // Electron's ContextMenuParams shape we rely on. Kept narrow — the renderer
 // supplies the full surface so we only annotate the fields we use.
@@ -43,7 +45,7 @@ type ContextMenuEvent = {
 }
 
 // Dynamically fetch menu items to ensure correct translation
-const getContextItems = (): MenuItemConstructorOptions[] => [
+const getContextItems = (selectionText: string): MenuItemConstructorOptions[] => [
   getInsertBefore(),
   getInsertAfter(),
   SEPARATOR,
@@ -53,7 +55,8 @@ const getContextItems = (): MenuItemConstructorOptions[] => [
   SEPARATOR,
   getCopyAsRich(),
   getCopyAsHtml(),
-  getPasteAsPlainText()
+  getPasteAsPlainText(),
+  ...(isOsx && selectionText.trim().length > 0 ? [SEPARATOR, getLookUp(selectionText)] : [])
 ]
 
 const isInsideEditor = (params: ContextMenuParams): boolean => {
@@ -103,7 +106,7 @@ export const showEditorContextMenu = (
       menu.append(new MenuItem(SEPARATOR))
     }
 
-    const contextItems = getContextItems()
+    const contextItems = getContextItems(selectionText)
     const copyItems = [contextItems[3], contextItems[4], contextItems[8], contextItems[7]] // CUT, COPY, COPY_AS_HTML, COPY_AS_RICH
     copyItems.forEach((item) => {
       if (item) item.enabled = canCopy

--- a/packages/desktop/src/main/contextMenu/editor/index.ts
+++ b/packages/desktop/src/main/contextMenu/editor/index.ts
@@ -45,7 +45,7 @@ type ContextMenuEvent = {
 }
 
 // Dynamically fetch menu items to ensure correct translation
-const getContextItems = (selectionText: string): MenuItemConstructorOptions[] => [
+const getContextItems = (): MenuItemConstructorOptions[] => [
   getInsertBefore(),
   getInsertAfter(),
   SEPARATOR,
@@ -55,8 +55,7 @@ const getContextItems = (selectionText: string): MenuItemConstructorOptions[] =>
   SEPARATOR,
   getCopyAsRich(),
   getCopyAsHtml(),
-  getPasteAsPlainText(),
-  ...(isOsx && selectionText.trim().length > 0 ? [SEPARATOR, getLookUp(selectionText)] : [])
+  getPasteAsPlainText()
 ]
 
 const isInsideEditor = (params: ContextMenuParams): boolean => {
@@ -91,6 +90,11 @@ export const showEditorContextMenu = (
     const isMisspelled = isEditable && !!selectionText && !!misspelledWord
 
     const menu = new Menu()
+    if (isOsx && hasText) {
+      menu.append(new MenuItem(getLookUp(selectionText)))
+      menu.append(new MenuItem(SEPARATOR))
+    }
+
     if (isSpellcheckerEnabled) {
       const spellingSubmenu = spellcheckMenuBuilder(
         isMisspelled,
@@ -106,12 +110,17 @@ export const showEditorContextMenu = (
       menu.append(new MenuItem(SEPARATOR))
     }
 
-    const contextItems = getContextItems(selectionText)
-    const copyItems = [contextItems[3], contextItems[4], contextItems[8], contextItems[7]] // CUT, COPY, COPY_AS_HTML, COPY_AS_RICH
-    copyItems.forEach((item) => {
-      if (item) item.enabled = canCopy
-    })
+    const contextItems = getContextItems()
+    const copyItemIds = new Set([
+      'cutMenuItem',
+      'copyMenuItem',
+      'copyAsHtmlMenuItem',
+      'copyAsRichMenuItem'
+    ])
     contextItems.forEach((item) => {
+      if (item.id && copyItemIds.has(item.id)) {
+        item.enabled = canCopy
+      }
       menu.append(new MenuItem(item))
     })
     // The original JS passes an array literal here, which Electron treats as

--- a/packages/desktop/src/main/contextMenu/editor/menuItems.ts
+++ b/packages/desktop/src/main/contextMenu/editor/menuItems.ts
@@ -1,6 +1,6 @@
 // NOTE: This are mutable fields that may change at runtime.
 
-import { shell, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { type BaseWindow, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { t } from '../../i18n'
 
 // Use function form to avoid calling the translation function during module load
@@ -52,21 +52,40 @@ export const getPasteAsPlainText = (): MenuItemConstructorOptions => ({
   }
 })
 
-export const lookUpSelection = (selectionText: string): boolean => {
+type LookupTarget = BaseWindow & {
+  webContents: {
+    showDefinitionForSelection: () => void
+  }
+}
+
+const canShowDefinitionForSelection = (
+  targetWindow?: BaseWindow | null
+): targetWindow is LookupTarget => {
+  const candidate = targetWindow as (BaseWindow & {
+    webContents?: { showDefinitionForSelection?: unknown }
+  }) | null | undefined
+
+  return typeof candidate?.webContents?.showDefinitionForSelection === 'function'
+}
+
+export const lookUpSelection = (
+  selectionText: string,
+  targetWindow?: BaseWindow | null
+): boolean => {
   const selection = selectionText.trim()
-  if (!selection) {
+  if (!selection || !canShowDefinitionForSelection(targetWindow)) {
     return false
   }
 
-  shell.openExternal(`dict://${encodeURIComponent(selection)}`)
+  targetWindow.webContents.showDefinitionForSelection()
   return true
 }
 
 export const getLookUp = (selectionText: string): MenuItemConstructorOptions => ({
-  label: t('contextMenu.lookUp'),
+  label: t('contextMenu.lookUp', { selection: selectionText.trim() }),
   id: 'lookUpMenuItem',
-  click() {
-    lookUpSelection(selectionText)
+  click(_menuItem, targetWindow) {
+    lookUpSelection(selectionText, targetWindow)
   }
 })
 

--- a/packages/desktop/src/main/contextMenu/editor/menuItems.ts
+++ b/packages/desktop/src/main/contextMenu/editor/menuItems.ts
@@ -1,6 +1,6 @@
 // NOTE: This are mutable fields that may change at runtime.
 
-import { type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
+import { shell, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { t } from '../../i18n'
 
 // Use function form to avoid calling the translation function during module load
@@ -49,6 +49,24 @@ export const getPasteAsPlainText = (): MenuItemConstructorOptions => ({
     if (targetWindow) {
       ;(targetWindow as BrowserWindow).webContents.send('mt::cm-paste-as-plain-text')
     }
+  }
+})
+
+export const lookUpSelection = (selectionText: string): boolean => {
+  const selection = selectionText.trim()
+  if (!selection) {
+    return false
+  }
+
+  shell.openExternal(`dict://${encodeURIComponent(selection)}`)
+  return true
+}
+
+export const getLookUp = (selectionText: string): MenuItemConstructorOptions => ({
+  label: t('contextMenu.lookUp'),
+  id: 'lookUpMenuItem',
+  click() {
+    lookUpSelection(selectionText)
   }
 })
 

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Als Rich Text kopieren",
     "copyAsHtml": "Als HTML kopieren",
     "pasteAsPlainText": "Als reinen Text einfügen",
+    "lookUp": "Nachschlagen",
     "insertParagraphBefore": "Absatz davor einfügen",
     "insertParagraphAfter": "Absatz danach einfügen",
     "spelling": "Rechtschreibung...",

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Als Rich Text kopieren",
     "copyAsHtml": "Als HTML kopieren",
     "pasteAsPlainText": "Als reinen Text einfügen",
-    "lookUp": "Nachschlagen",
+    "lookUp": "\"{selection}\" nachschlagen",
     "insertParagraphBefore": "Absatz davor einfügen",
     "insertParagraphAfter": "Absatz danach einfügen",
     "spelling": "Rechtschreibung...",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Copy As Rich Text",
     "copyAsHtml": "Copy As HTML",
     "pasteAsPlainText": "Paste as Plain Text",
-    "lookUp": "Look Up",
+    "lookUp": "Look Up \"{selection}\"",
     "insertParagraphBefore": "Insert Paragraph Before",
     "insertParagraphAfter": "Insert Paragraph After",
     "spelling": "Spelling...",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Copy As Rich Text",
     "copyAsHtml": "Copy As HTML",
     "pasteAsPlainText": "Paste as Plain Text",
+    "lookUp": "Look Up",
     "insertParagraphBefore": "Insert Paragraph Before",
     "insertParagraphAfter": "Insert Paragraph After",
     "spelling": "Spelling...",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Copiar Como Texto Enriquecido",
     "copyAsHtml": "Copiar Como HTML",
     "pasteAsPlainText": "Pegar como Texto Plano",
-    "lookUp": "Buscar",
+    "lookUp": "Buscar \"{selection}\"",
     "insertParagraphBefore": "Insertar Párrafo Antes",
     "insertParagraphAfter": "Insertar Párrafo Después",
     "spelling": "Ortografía...",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Copiar Como Texto Enriquecido",
     "copyAsHtml": "Copiar Como HTML",
     "pasteAsPlainText": "Pegar como Texto Plano",
+    "lookUp": "Buscar",
     "insertParagraphBefore": "Insertar Párrafo Antes",
     "insertParagraphAfter": "Insertar Párrafo Después",
     "spelling": "Ortografía...",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Copier en texte riche",
     "copyAsHtml": "Copier en HTML",
     "pasteAsPlainText": "Coller en texte brut",
-    "lookUp": "Rechercher",
+    "lookUp": "Rechercher \"{selection}\"",
     "insertParagraphBefore": "Insérer un paragraphe avant",
     "insertParagraphAfter": "Insérer un paragraphe après",
     "spelling": "Orthographe...",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Copier en texte riche",
     "copyAsHtml": "Copier en HTML",
     "pasteAsPlainText": "Coller en texte brut",
+    "lookUp": "Rechercher",
     "insertParagraphBefore": "Insérer un paragraphe avant",
     "insertParagraphAfter": "Insérer un paragraphe après",
     "spelling": "Orthographe...",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -184,6 +184,7 @@
     "copyAsRich": "リッチテキストとしてコピー",
     "copyAsHtml": "HTMLとしてコピー",
     "pasteAsPlainText": "プレーンテキストとして貼り付け",
+    "lookUp": "調べる",
     "insertParagraphBefore": "前に段落を挿入",
     "insertParagraphAfter": "後に段落を挿入",
     "spelling": "スペルチェック...",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -184,7 +184,7 @@
     "copyAsRich": "リッチテキストとしてコピー",
     "copyAsHtml": "HTMLとしてコピー",
     "pasteAsPlainText": "プレーンテキストとして貼り付け",
-    "lookUp": "調べる",
+    "lookUp": "\"{selection}\"を調べる",
     "insertParagraphBefore": "前に段落を挿入",
     "insertParagraphAfter": "後に段落を挿入",
     "spelling": "スペルチェック...",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -184,6 +184,7 @@
     "copyAsRich": "서식 있는 텍스트로 복사",
     "copyAsHtml": "HTML로 복사",
     "pasteAsPlainText": "일반 텍스트로 붙여넣기",
+    "lookUp": "찾아보기",
     "insertParagraphBefore": "앞에 단락 삽입",
     "insertParagraphAfter": "뒤에 단락 삽입",
     "spelling": "맞춤법...",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -184,7 +184,7 @@
     "copyAsRich": "서식 있는 텍스트로 복사",
     "copyAsHtml": "HTML로 복사",
     "pasteAsPlainText": "일반 텍스트로 붙여넣기",
-    "lookUp": "찾아보기",
+    "lookUp": "\"{selection}\" 찾아보기",
     "insertParagraphBefore": "앞에 단락 삽입",
     "insertParagraphAfter": "뒤에 단락 삽입",
     "spelling": "맞춤법...",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Copiar como Rich Text",
     "copyAsHtml": "Copiar como HTML",
     "pasteAsPlainText": "Colar como Texto Simples",
+    "lookUp": "Consultar",
     "insertParagraphBefore": "Inserir Parágrafo Antes",
     "insertParagraphAfter": "Inserir Parágrafo Depois",
     "spelling": "Ortografia...",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Copiar como Rich Text",
     "copyAsHtml": "Copiar como HTML",
     "pasteAsPlainText": "Colar como Texto Simples",
-    "lookUp": "Consultar",
+    "lookUp": "Consultar \"{selection}\"",
     "insertParagraphBefore": "Inserir Parágrafo Antes",
     "insertParagraphAfter": "Inserir Parágrafo Depois",
     "spelling": "Ortografia...",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -184,7 +184,7 @@
     "copyAsRich": "Zengin Metin Olarak Kopyala",
     "copyAsHtml": "HTML Olarak Kopyala",
     "pasteAsPlainText": "Düz Metin Olarak Yapıştır",
-    "lookUp": "Ara",
+    "lookUp": "\"{selection}\" Ara",
     "insertParagraphBefore": "Önüne Paragraf Ekle",
     "insertParagraphAfter": "Arkasına Paragraf Ekle",
     "spelling": "Yazım...",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -184,6 +184,7 @@
     "copyAsRich": "Zengin Metin Olarak Kopyala",
     "copyAsHtml": "HTML Olarak Kopyala",
     "pasteAsPlainText": "Düz Metin Olarak Yapıştır",
+    "lookUp": "Ara",
     "insertParagraphBefore": "Önüne Paragraf Ekle",
     "insertParagraphAfter": "Arkasına Paragraf Ekle",
     "spelling": "Yazım...",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -184,7 +184,7 @@
     "copyAsRich": "复制为富文本",
     "copyAsHtml": "复制为 HTML",
     "pasteAsPlainText": "粘贴为纯文本",
-    "lookUp": "查询",
+    "lookUp": "查询“{selection}”",
     "insertParagraphBefore": "在前面插入段落",
     "insertParagraphAfter": "在后面插入段落",
     "spelling": "拼写…",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -184,6 +184,7 @@
     "copyAsRich": "复制为富文本",
     "copyAsHtml": "复制为 HTML",
     "pasteAsPlainText": "粘贴为纯文本",
+    "lookUp": "查询",
     "insertParagraphBefore": "在前面插入段落",
     "insertParagraphAfter": "在后面插入段落",
     "spelling": "拼写…",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -184,7 +184,7 @@
     "copyAsRich": "複製為富文本",
     "copyAsHtml": "複製為 HTML",
     "pasteAsPlainText": "貼上為純文字",
-    "lookUp": "查詢",
+    "lookUp": "查詢「{selection}」",
     "insertParagraphBefore": "在前面插入段落",
     "insertParagraphAfter": "在後面插入段落",
     "spelling": "拼字檢查…",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -184,6 +184,7 @@
     "copyAsRich": "複製為富文本",
     "copyAsHtml": "複製為 HTML",
     "pasteAsPlainText": "貼上為純文字",
+    "lookUp": "查詢",
     "insertParagraphBefore": "在前面插入段落",
     "insertParagraphAfter": "在後面插入段落",
     "spelling": "拼字檢查…",

--- a/packages/desktop/test/unit/specs/context-menu-locales.spec.ts
+++ b/packages/desktop/test/unit/specs/context-menu-locales.spec.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+import { getSupportedLanguages } from 'common/i18n'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const localesDir = path.resolve(__dirname, '../../../static/locales')
+
+describe('context menu locale coverage', () => {
+  it('defines Look Up for every supported desktop locale', () => {
+    for (const language of getSupportedLanguages()) {
+      const localePath = path.join(localesDir, `${language}.json`)
+      const locale = JSON.parse(fs.readFileSync(localePath, 'utf8')) as {
+        contextMenu?: { lookUp?: unknown }
+      }
+
+      expect(locale.contextMenu?.lookUp, `${language} contextMenu.lookUp`).toEqual(expect.any(String))
+      expect(locale.contextMenu?.lookUp).not.toBe('')
+    }
+  })
+})

--- a/packages/desktop/test/unit/specs/context-menu-locales.spec.ts
+++ b/packages/desktop/test/unit/specs/context-menu-locales.spec.ts
@@ -16,8 +16,10 @@ describe('context menu locale coverage', () => {
         contextMenu?: { lookUp?: unknown }
       }
 
-      expect(locale.contextMenu?.lookUp, `${language} contextMenu.lookUp`).toEqual(expect.any(String))
-      expect(locale.contextMenu?.lookUp).not.toBe('')
+      const lookUp = locale.contextMenu?.lookUp
+      expect(lookUp, `${language} contextMenu.lookUp`).toEqual(expect.any(String))
+      expect(lookUp).not.toBe('')
+      expect(lookUp).toContain('{selection}')
     }
   })
 })

--- a/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shell } from 'electron'
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn()
+  }
+}))
+
+const { getLookUp, lookUpSelection } = await import('main_renderer/contextMenu/editor/menuItems')
+
+describe('editor context menu Look Up', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens selected text with the macOS Dictionary URL scheme', () => {
+    expect(lookUpSelection(' apple ')).toBe(true)
+
+    expect(shell.openExternal).toHaveBeenCalledWith('dict://apple')
+  })
+
+  it('URL-encodes spaces and unicode characters', () => {
+    expect(lookUpSelection('cafe au lait')).toBe(true)
+    expect(lookUpSelection('na\u00efve fa\u00e7ade')).toBe(true)
+
+    expect(shell.openExternal).toHaveBeenNthCalledWith(1, 'dict://cafe%20au%20lait')
+    expect(shell.openExternal).toHaveBeenNthCalledWith(2, 'dict://na%C3%AFve%20fa%C3%A7ade')
+  })
+
+  it('does not open Dictionary for blank selections', () => {
+    expect(lookUpSelection('   ')).toBe(false)
+
+    expect(shell.openExternal).not.toHaveBeenCalled()
+  })
+
+  it('wires the context-menu item to the lookup action', () => {
+    const item = getLookUp(' markdown ')
+
+    item.click?.({} as never, undefined as never, {} as never)
+
+    expect(item.id).toBe('lookUpMenuItem')
+    expect(shell.openExternal).toHaveBeenCalledWith('dict://markdown')
+  })
+})

--- a/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
@@ -45,4 +45,10 @@ describe('editor context menu Look Up', () => {
     expect(item.label).toBe('Look Up "markdown"')
     expect(showDefinitionForSelection).toHaveBeenCalledOnce()
   })
+
+  it('renders lookup labels with literal dollar-sign replacement patterns', () => {
+    const item = getLookUp(" $& a$'b $$ $1 ")
+
+    expect(item.label).toBe('Look Up "$& a$\'b $$ $1"')
+  })
 })

--- a/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-context-lookup.spec.ts
@@ -1,45 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { shell } from 'electron'
 
-vi.mock('electron', () => ({
-  shell: {
-    openExternal: vi.fn()
-  }
-}))
+vi.hoisted(() => {
+  process.env.PERF_TESTING = 'true'
+})
 
 const { getLookUp, lookUpSelection } = await import('main_renderer/contextMenu/editor/menuItems')
 
 describe('editor context menu Look Up', () => {
+  const showDefinitionForSelection = vi.fn()
+  const targetWindow = {
+    webContents: {
+      showDefinitionForSelection
+    }
+  } as never
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('opens selected text with the macOS Dictionary URL scheme', () => {
-    expect(lookUpSelection(' apple ')).toBe(true)
+  it('shows the native macOS lookup panel for selected text', () => {
+    expect(lookUpSelection(' apple ', targetWindow)).toBe(true)
 
-    expect(shell.openExternal).toHaveBeenCalledWith('dict://apple')
+    expect(showDefinitionForSelection).toHaveBeenCalledOnce()
   })
 
-  it('URL-encodes spaces and unicode characters', () => {
-    expect(lookUpSelection('cafe au lait')).toBe(true)
-    expect(lookUpSelection('na\u00efve fa\u00e7ade')).toBe(true)
+  it('does not show the lookup panel for blank selections', () => {
+    expect(lookUpSelection('   ', targetWindow)).toBe(false)
 
-    expect(shell.openExternal).toHaveBeenNthCalledWith(1, 'dict://cafe%20au%20lait')
-    expect(shell.openExternal).toHaveBeenNthCalledWith(2, 'dict://na%C3%AFve%20fa%C3%A7ade')
+    expect(showDefinitionForSelection).not.toHaveBeenCalled()
   })
 
-  it('does not open Dictionary for blank selections', () => {
-    expect(lookUpSelection('   ')).toBe(false)
+  it('does not show the lookup panel without a target window', () => {
+    expect(lookUpSelection('markdown')).toBe(false)
 
-    expect(shell.openExternal).not.toHaveBeenCalled()
+    expect(showDefinitionForSelection).not.toHaveBeenCalled()
   })
 
   it('wires the context-menu item to the lookup action', () => {
     const item = getLookUp(' markdown ')
 
-    item.click?.({} as never, undefined as never, {} as never)
+    item.click?.({} as never, targetWindow, {} as never)
 
     expect(item.id).toBe('lookUpMenuItem')
-    expect(shell.openExternal).toHaveBeenCalledWith('dict://markdown')
+    expect(item.label).toBe('Look Up "markdown"')
+    expect(showDefinitionForSelection).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
Closes #4813

## Summary

Adds a macOS-only `Look Up "{selection}"` item to the top of the editor context menu when text is selected. The action uses Electron's native macOS Lookup support (`webContents.showDefinitionForSelection()`), which opens the inline Dictionary/Thesaurus/Siri Knowledge popover rather than launching Dictionary.app or calling an external dictionary provider.

The PR also adds `contextMenu.lookUp` to every desktop locale and unit coverage for the lookup action and locale coverage.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: macOS

Manual macOS verification:

- [x] Selected a word in the MarkText editor
- [x] Control-clicked/right-clicked inside the editor
- [x] Confirmed `Look Up "{selection}"` appears at the top of the menu
- [x] Confirmed clicking it opens the native macOS Lookup popover

Validation run:

- [x] `corepack pnpm --filter marktext exec vitest run test/unit/specs/editor-context-lookup.spec.ts test/unit/specs/context-menu-locales.spec.ts`
- [x] `corepack pnpm --filter marktext run typecheck`
- [x] `corepack pnpm run lint`
- [x] `corepack pnpm --filter marktext exec vitest run test/unit --testTimeout 10000`

Note: `corepack pnpm --filter marktext run test:unit` hits an existing `pdf.spec.ts` 5s timeout cascade in the full parallel suite on this machine; `pdf.spec.ts` passes by itself, and the full unit suite passes with a 10s Vitest timeout.

## Notes for reviewers [optional]

This intentionally avoids command-click handling and web dictionary integrations for the first iteration. The change is limited to the existing editor context menu and only appears on macOS when selected text is present.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
