### PR TITLE
fix(muya): skip identity operations during deferred flush

### DIFF
--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -272,8 +272,9 @@ class JSONState {
         // (acc, current, index, array) to the callback, but
         // `json1.type.compose` only accepts (op1, op2). Without the
         // wrapper TS rejects the signature mismatch.
-        // `compose` returns JSONOp (= null | JSONOpList); a non-empty cache
-        // (guarded above) always composes to a non-null op.
+        // `compose` returns JSONOp (= null | JSONOpList). Multiple queued
+        // operations may cancel each other out (for example during IME
+        // composition), producing the identity operation (`null`).
         const op = this._operationCache.reduce(
             (acc, curr) => json1.type.compose(acc, curr) as JSONOpList,
         );
@@ -284,6 +285,10 @@ class JSONState {
         // Clear before emitting: a listener that edits synchronously then starts
         // a fresh batch instead of mutating the one being flushed.
         this._operationCache = [];
+
+        if (op === null)
+            return;
+
         this._muya.eventCenter.emit('json-change', {
             op,
             source: 'user',


### PR DESCRIPTION
Fixes #4806

## Summary

Fix a crash caused by forwarding identity JSON operations (`null`) emitted by `ot-json1.compose()`.

During deferred operation flushing, queued operations may cancel each other out (for example during IME composition), causing `compose()` to legitimately return `null`.

`JSONState._flushOperationCache()` forwarded this identity operation through the `json-change` event, while downstream consumers such as `History` expected a `JSONOpList`, resulting in:

```text
TypeError: Cannot read properties of null (reading 'length')
```

This change skips emitting `json-change` events for identity operations.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New tests added (not needed)
- [x] Manually tested on: macOS

### Manual verification

- Reproduced the crash using the Korean IME.
- Verified that deleting a composing syllable no longer crashes the editor.
- Verified that normal text editing continues to work after the change.

## Demo

The attached recording reproduces the crash.

https://github.com/user-attachments/assets/40c715e0-be76-434a-8e55-d7b097167c6c

> **Note:** The `op >>` log is a temporary debug log added in
> `packages/muya/src/state/index.ts:282` (`JSONState._flushOperationCache()`)
> to inspect the result of `ot-json1.type.compose()`.

## Notes for reviewers

`ot-json1.type.compose()` returns `JSONOp` (`null | JSONOpList`), where
`null` represents the identity operation.

This change preserves the `ot-json1` contract by preventing identity
operations from being forwarded through the `json-change` event.