### PR TITLE
fix(muya): make cpp c++/h++ alias registration idempotent

### DIFF
--- a/packages/muya/src/utils/prism/index.ts
+++ b/packages/muya/src/utils/prism/index.ts
@@ -9,13 +9,18 @@ import('prismjs/plugins/keep-markup/prism-keep-markup');
 
 // prismjs ships C++ without a `c++`/`h++` alias, so fenced blocks tagged
 // ```c++ never resolve to the cpp grammar and stay unhighlighted (#2910).
+// Add each alias only once — `components.languages` is a shared singleton and
+// this module may be evaluated more than once (tests, HMR); pushing duplicates
+// makes prism's dependency loader throw "c++ cannot be alias for both cpp and
+// cpp".
 if (languages.cpp) {
     const existing = languages.cpp.alias;
-    languages.cpp.alias = Array.isArray(existing)
-        ? [...existing, 'c++', 'h++']
-        : existing
-            ? [existing, 'c++', 'h++']
-            : ['c++', 'h++'];
+    const alias = Array.isArray(existing) ? [...existing] : existing ? [existing] : [];
+    for (const name of ['c++', 'h++']) {
+        if (!alias.includes(name))
+            alias.push(name);
+    }
+    languages.cpp.alias = alias;
 }
 
 const langs: {


### PR DESCRIPTION
## Problem

The `c++`/`h++` alias registration added in #2910 (#4794) rebuilds `cpp.alias` as `[...existing, 'c++', 'h++']` every time `prism/index.ts` is evaluated. `components.languages` is a shared singleton, so when the module is evaluated more than once — multiple test files in a suite, or HMR — the aliases accumulate duplicates. prism's dependency loader then throws:

```
Error: c++ cannot be alias for both cpp and cpp
```

This is currently failing the **desktop `test` (unit) job** on every PR whose CI merges against develop.

## Fix

Add each alias only if it isn't already present, so re-evaluation is a no-op.

## Verify

Reproduced with two prism-importing desktop specs (`pdf.spec.ts` + `bundled-fonts.spec.ts`) → threw the duplicate-alias error before, 20/20 pass after. muya `languageAlias.spec` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)