### PR TITLE
fix(desktop): handle malformed percent-encoded local links

### DIFF
--- a/packages/desktop/src/main/menu/actions/file.ts
+++ b/packages/desktop/src/main/menu/actions/file.ts
@@ -614,7 +614,13 @@ ipcMain.on('mt::format-link-click', (e, { data, dirname }: FormatLinkPayload) =>
 
   if (pathname) {
     // decodeURIComponent() CommonMark #503, allow percent encoded path names to open files. https://github.com/marktext/marktext/issues/57
-    pathname = path.normalize(decodeURIComponent(pathname))
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(pathname)
+    } catch {
+      decoded = pathname
+    }
+    pathname = path.normalize(decoded)
     if (isMarkdownFile(pathname)) {
       const innerWin = BrowserWindow.fromWebContents(e.sender)
       if (innerWin) {


### PR DESCRIPTION
Fixes #4749.

## Problem

Clicking a local link with malformed percent encoding, for example `bad%zz.md`, throws an unhandled `URIError` in the main process.

## Cause

Support for percent-encoded local paths was added during the Electron Vite refactor (#4001). The new `decodeURIComponent()` call correctly handles valid paths, but it throws when the input contains invalid percent encoding.

## Fix

Wrap `decodeURIComponent()` in a `try/catch`.

If decoding fails, fall back to the original pathname and continue with the existing path handling. This keeps the current behavior for valid paths and avoids crashing on malformed input.

## Verification

- Reproduced the issue from #4749
- Verified malformed paths no longer throw
- Verified valid percent-encoded paths still work
- Project builds successfully