### PR TITLE
fix(desktop): apply editor max-width preference to @muyajs/core content column (#4828)

### DIFF
--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -201,8 +201,11 @@ export const setEditorWidth = (value: string): void => {
   const EDITOR_WIDTH_STYLE_ID = 'editor-width'
   let result = ''
   if (value && /^[0-9]+(?:ch|px|%)$/.test(value)) {
-    // Overwrite the theme value and add 100px for padding.
-    result = `:root { --editorAreaWidth: calc(100px + ${value}); }`
+    // Add 100px for the container's horizontal padding. Set both the legacy
+    // camelCase var (source mode) and the kebab-case var the active
+    // @muyajs/core engine reads for `.mu-container` max-width (issue #4828).
+    const width = `calc(100px + ${value})`
+    result = `:root { --editorAreaWidth: ${width}; --editor-area-width: ${width}; }`
   }
   let styleEle = document.querySelector(`#${EDITOR_WIDTH_STYLE_ID}`) as HTMLStyleElement | null
   if (!styleEle) {

--- a/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
@@ -83,10 +83,20 @@ describe('theme.ts style injection helpers', () => {
         setEditorWidth(value)
 
         expect(styleHtml(WIDTH_STYLE_ID)).toBe(
-          `:root { --editorAreaWidth: calc(100px + ${value}); }`
+          `:root { --editorAreaWidth: calc(100px + ${value}); --editor-area-width: calc(100px + ${value}); }`
         )
       }
     )
+
+    it('overrides the active @muyajs/core width variable, not only the legacy one', () => {
+      // The WYSIWYG engine reads the kebab-case `--editor-area-width`
+      // (`.mu-container` max-width); the legacy camelCase `--editorAreaWidth`
+      // only reaches source mode. Both must be set or the preference is a no-op
+      // on the default theme (issue #4828).
+      setEditorWidth('60%')
+
+      expect(styleHtml(WIDTH_STYLE_ID)).toContain('--editor-area-width: calc(100px + 60%);')
+    })
 
     it('clears the override (empty innerHTML) for an empty string', () => {
       setEditorWidth('800px')


### PR DESCRIPTION
## Summary

Fixes #4828. The **editor max width** preference (Preferences → Editor → Text Editor, accepts `60%` / `800px` / `60ch`) had no effect on the default light theme in 0.20.0-beta.x, though it worked in 0.19.1.

## Root cause

The regression came from the editor engine migration (`muyajs` → `@muyajs/core`), not from the preference wiring, which is intact end-to-end (`editorLineWidth` → `setEditorWidth`).

- `setEditorWidth` (`packages/desktop/src/renderer/src/util/theme.ts`) injected **only** the legacy camelCase variable `--editorAreaWidth`, which the old `muyajs` engine read.
- The active `@muyajs/core` engine sizes its content column via the kebab-case `--editor-area-width` (`.mu-container { max-width: var(--editor-area-width, 800px) }`), with its own `800px` default.
- The camelCase→kebab bridge (`--editor-area-width: var(--editorAreaWidth)`) lives **only** in the named theme CSS files. The **default light theme has no such bridge**, so the override targeted a variable nothing consumes and the width stayed pinned at muya's 800px.
- Confirming symptom: source mode (CodeMirror) still honored the pref because it reads the camelCase var directly — the breakage was WYSIWYG-only.

## Fix

Set **both** variables in the injected `#editor-width` override so the width applies uniformly across every theme. The style element is appended last to `<head>`, so at equal `:root` specificity it wins by source order over both muya's default and the theme values. `calc(100px + value)` accounts for `.mu-container`'s 100px horizontal padding (unchanged semantics).

## Verification

- **TDD**: updated the `setEditorWidth` unit spec to assert the active-engine variable — RED before the fix, GREEN after (`editor-theme-style.spec.ts`, 14 tests pass).
- **Real-browser cascade probe** (system Chrome, replicating muya's actual stylesheet layering):
  - Before (camelCase only): `.mu-container` stuck at **800px** — reproduces the bug.
  - After (both vars): `max-width` becomes `calc(60% + 100px)` and scales with the percentage.
- `pnpm lint` and `vue-tsc` typecheck pass.

## Notes

The reporter also noted the input format (`%` / `px` / `ch`) is undocumented — that is a separate i18n/docs concern (`maxWidthNotes`) and is out of scope for this functional fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)