### PR TITLE
fix(muya): harden History against identity (null) json-change ops

### DIFF
--- a/packages/muya/src/history/__tests__/identityOpJsonChange.spec.ts
+++ b/packages/muya/src/history/__tests__/identityOpJsonChange.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+// Regression for #4806: an identity (`null`) ot-json1 op must never crash
+// History. `compose()` legitimately yields `null` when queued ops cancel out
+// (e.g. IME edits), and both the deferred-flush emitter and the `dispatch`
+// path can surface it through `json-change`. `History` reads `op.length`, so a
+// forwarded `null` threw `Cannot read properties of null (reading 'length')`.
+
+import * as json1 from 'ot-json1';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+import { asDoc } from '../../state';
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function undoDepth(muya: Muya): number {
+    // @ts-expect-error — reach into the private stack for test assertions.
+    return muya.editor.history._stack.undo.length;
+}
+
+describe('identity (null) op via json-change — #4806', () => {
+    it('updateContents(null) does not crash History and records nothing', () => {
+        const muya = bootMuya('hello\n');
+
+        // `Editor.updateContents` deliberately forwards the identity op to
+        // `dispatch`, which emits a `json-change` carrying `op: null`.
+        expect(() => muya.editor.updateContents(null, null, 'user')).not.toThrow();
+
+        expect(muya.getMarkdown().trim()).toBe('hello');
+        expect(undoDepth(muya)).toBe(0);
+    });
+
+    it('flushing a compose-to-null batch is a no-op (locks #4815)', () => {
+        const muya = bootMuya('hello\n');
+        const jsonState = muya.editor.jsonState;
+
+        // A real op and its exact inverse compose to the identity op — the
+        // op-level shape of an IME insert cancelled by a delete in one frame.
+        const op = json1.insertOp([1], asDoc({ name: 'paragraph', text: 'x' } as never))!;
+        const inverse = json1.type.invert(op);
+        expect(json1.type.compose(op, inverse)).toBe(null);
+
+        let changes = 0;
+        muya.eventCenter.on('json-change', () => {
+            changes += 1;
+        });
+
+        // @ts-expect-error — drive the private deferred-flush path directly.
+        jsonState._operationCache.push(op, inverse);
+        // @ts-expect-error — the function the crash stack named.
+        expect(() => jsonState._flushOperationCache()).not.toThrow();
+
+        expect(changes).toBe(0);
+        expect(muya.getMarkdown().trim()).toBe('hello');
+        expect(undoDepth(muya)).toBe(0);
+    });
+});

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -130,12 +130,19 @@ class History {
                 source,
                 prevDoc,
             }: {
-                op: JSONOpList;
+                op: Nullable<JSONOpList>;
                 source: string;
                 prevDoc: TState[];
                 doc: TState[];
             }) => {
                 if (this._ignoreChange)
+                    return;
+
+                // The identity op (`null`) carries no change to record or
+                // transform. It can still reach here through `json-change` when
+                // queued ops compose away (e.g. IME edits, #4806); `_record`
+                // would otherwise crash reading `op.length`.
+                if (op == null)
                     return;
 
                 if (!this._options.userOnly || source === 'user')


### PR DESCRIPTION
Refs #4806. Follow-up hardening for #4815.

## Summary

`ot-json1.compose()` legitimately returns the identity operation (`null`)
when queued operations cancel each other out — for example during IME
composition, where an insert and a delete land in the same animation frame.

#4815 fixed the reported crash by stopping the **deferred-flush** emitter
(`JSONState._flushOperationCache`) from forwarding that `null` through
`json-change`. This PR closes the same crash at the **consumer**, covering
the remaining emitter that #4815 did not touch.

## Why a second fix

`JSONState.dispatch()` — used by `Editor.updateContents` and
`Editor.rebuildContents` — still forwards the identity op deliberately. The
`updateContents` contract even documents this ("the ot-json1 no-op is
forwarded to dispatch … so listeners still see a json-change event for the
no-op"). But `History`'s `json-change` listener handed the op straight to
`_record` / `_transform`, both of which read `op.length`:

```text
TypeError: Cannot read properties of null (reading 'length')
```

Today that path only fires under History's own `_ignoreChange` guard (undo/
redo, `replaceContent`), so it does not crash in production — but it is a
latent trap: any future caller invoking `updateContents(null)` outside that
guard reproduces the identical crash via a different stack.

## Change

Ignore identity ops in History's `json-change` listener — a no-op has
nothing to record or transform. This makes History crash-proof against a
`null` op regardless of which emitter produced it, and leaves `dispatch`'s
existing "forward the no-op" contract intact.

## Test plan

- [x] `packages/muya` unit tests — new `identityOpJsonChange.spec.ts`:
  - `updateContents(null)` no longer crashes History and records no undo entry (fails without this fix).
  - Flushing a compose-to-null batch stays silent (locks the #4815 fix).
- [x] Full `history` + `state` suites green (222 tests).
- [x] `lint` + `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)