### PR TITLE
fix(muya): stop inline math showing a scrollbar for trailing sub/superscripts (#4837)

### DIFF
--- a/packages/muya/e2e/tests/blocks/inline-math-align.spec.ts
+++ b/packages/muya/e2e/tests/blocks/inline-math-align.spec.ts
@@ -45,6 +45,24 @@ test('a long hidden inline math stays scrollable, not truncated', async ({ page 
   expect(r.scrollable).toBe(true) // content is reachable by scrolling, not cut off
 })
 
+test('a short inline math ending in a subscript shows no scrollbar (#4837)', async ({ page }) => {
+  // KaTeX gives every sub/superscript a 2px `.vlist-s` strut that its
+  // `.vlist-t2` margin cancels visually but not in scrollWidth; the popup's
+  // `overflow: auto` then drew a spurious scrollbar under any short formula
+  // ending in one. The rendered scroll extent must match the visible width.
+  await page.evaluate(() => window.muya!.setContent('inline $x_1$ here'))
+  await page.waitForTimeout(150)
+  const r = await page.evaluate(() => {
+    const render = document.querySelector('.mu-math > .mu-math-render') as HTMLElement
+    return {
+      hidden: render.closest('.mu-math')!.classList.contains('mu-hide'),
+      overflowX: render.scrollWidth - render.clientWidth,
+    }
+  })
+  expect(r.hidden).toBe(true)
+  expect(r.overflowX).toBe(0) // no horizontal overflow, so no scrollbar
+})
+
 test('the inline-math scrollbar is thin (6px, matching code blocks)', async ({ page }) => {
   await page.evaluate(() => window.muya!.setContent('x'))
   await page.waitForTimeout(100)

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -206,6 +206,21 @@ code.mu-inline-rule {
     height: 6px;
 }
 
+/* KaTeX gives every sub/superscript a 2px `.vlist-s` strut that
+   `.vlist-t2 { margin-right: -2px }` cancels visually. The negative margin fixes
+   layout width but not scrollWidth, so the `overflow: auto` above draws a
+   spurious scrollbar under any short formula ending in a sub/superscript
+   (#4837). Zero both to match the scroll extent to the visible width — net-zero
+   visually; a genuinely long formula still overflows and stays scrollable. */
+.mu-math > .mu-math-render .katex .vlist-s {
+    width: 0;
+    min-width: 0;
+}
+
+.mu-math > .mu-math-render .katex .vlist-t2 {
+    margin-right: 0;
+}
+
 .mu-ruby > .mu-ruby-render {
     left: 50%;
 


### PR DESCRIPTION
## Summary

Fixes #4837 — a spurious horizontal scrollbar appears under committed inline math whenever the formula ends in a subscript or superscript (e.g. `$x_1$`).

## Root cause

Committed inline math renders inside a `.mu-math-render` box that #4615 gave `overflow: auto hidden` so genuinely long formulas scroll rather than overflow the editor.

KaTeX renders every sub/superscript with a 2px `.vlist-s` strut, visually compensated by `.vlist-t2 { margin-right: -2px }`. The negative margin corrects the layout width but **not** `scrollWidth` — so the element's scroll extent stays 2px wider than its client width. `overflow-x: auto` draws a scrollbar whenever `scrollWidth > clientWidth`, so any short formula ending in a sub/superscript gets a spurious 2px scrollbar.

Measured (real Chromium + real KaTeX output): `$x_1$` → `scrollWidth 20, clientWidth 18` (the 2px strut); `$x^2$` / `$a+b$` → 0px difference. This matches the "only with a subscript" symptom exactly.

## Fix

Zero the KaTeX strut and its compensating margin inside the inline-math render:

```css
.mu-math > .mu-math-render .katex .vlist-s { width: 0; min-width: 0; }
.mu-math > .mu-math-render .katex .vlist-t2 { margin-right: 0; }
```

- **Net-zero visually** — `top`, `height` and `width` of the rendered math are identical before/after (verified in Chromium), so the #4632 baseline alignment is untouched.
- **No regression to #4615/#4339** — a genuinely long inline formula still overflows and stays horizontally scrollable.

## Testing

- New e2e regression test in `inline-math-align.spec.ts`: a hidden inline `$x_1$` render has zero horizontal overflow. Fails with `overflowX === 2` before the fix, passes after.
- All inline-math e2e specs pass (align ×4 incl. the new test, `inline-math-overflow-4339`, `math-error-nowrap-4100`).
- `stylelint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)