### PR TITLE
fix(muya): isolate mermaid render failures during export (#4812)

### DIFF
--- a/packages/muya/src/state/__tests__/mermaidExportResilience.spec.ts
+++ b/packages/muya/src/state/__tests__/mermaidExportResilience.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+// Regression for #4812: a single mermaid diagram with a syntax error must not
+// abort the whole document export. The styled-HTML / PDF export path renders
+// every `code.language-mermaid` via `mermaid.run`; a batch run rejects entirely
+// on the first parse error, so one bad diagram threw all the way up to the
+// desktop wrapper ("Failed to export document") and no file was written.
+//
+// `mermaid` can't run under jsdom, so we mock the diagram-renderer loader to
+// return a fake mermaid whose `run` throws like the real parser does on invalid
+// input. That isolates the behaviour under test — per-diagram error containment.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mermaidRun = vi.fn();
+
+vi.mock('../../utils/diagram', () => ({
+    default: vi.fn(async (name: string) => {
+        if (name === 'mermaid') {
+            return {
+                initialize: vi.fn(),
+                run: mermaidRun,
+            };
+        }
+        throw new Error(`unexpected renderer ${name}`);
+    }),
+}));
+
+// Import AFTER the mock is registered.
+const { MarkdownToHtml } = await import('../markdownToHtml');
+
+beforeEach(() => {
+    mermaidRun.mockReset();
+});
+
+const INVALID_MERMAID = [
+    '# Title',
+    '',
+    'Intro paragraph.',
+    '',
+    '```mermaid',
+    'graph LR',
+    'H[a|b|c]',
+    '```',
+    '',
+    'Trailing paragraph.',
+    '',
+].join('\n');
+
+describe('#4812: mermaid syntax error must not abort export', () => {
+    it('renderHtml resolves even when a mermaid diagram fails to parse', async () => {
+        // Real mermaid rejects on a parse error; emulate that.
+        mermaidRun.mockRejectedValue(new Error('Parse error on line 2: ... got \'PIPE\''));
+
+        const md2html = new MarkdownToHtml(INVALID_MERMAID);
+        const html = await md2html.renderHtml();
+
+        // The surrounding document still exports.
+        expect(html).toContain('Title');
+        expect(html).toContain('Intro paragraph.');
+        expect(html).toContain('Trailing paragraph.');
+        // The broken diagram degrades to the same placeholder the other
+        // diagram renderers use, instead of throwing.
+        expect(html).toContain('&lt; Invalid Diagram &gt;');
+    });
+
+    it('one broken diagram does not stop a later valid diagram from rendering', async () => {
+        // First diagram throws, second succeeds. A batch run would abort both.
+        mermaidRun
+            .mockRejectedValueOnce(new Error('Parse error'))
+            .mockResolvedValueOnce(undefined);
+
+        const TWO = [
+            '```mermaid',
+            'graph LR',
+            'H[a|b|c]',
+            '```',
+            '',
+            '```mermaid',
+            'graph TD; A-->B',
+            '```',
+            '',
+        ].join('\n');
+
+        const html = await new MarkdownToHtml(TWO).renderHtml();
+
+        expect(mermaidRun).toHaveBeenCalledTimes(2);
+        expect(html).toContain('&lt; Invalid Diagram &gt;');
+    });
+});

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -49,6 +49,10 @@ export class MarkdownToHtml {
             mermaidContainer.classList.add('mermaid');
             preEle.replaceWith(mermaidContainer);
         }
+        const nodes = [...this._exportContainer!.querySelectorAll('div.mermaid')];
+        if (nodes.length === 0)
+            return;
+
         const mermaid = await loadRenderer('mermaid');
         // We only export light theme, so set mermaid theme to `default`, in the future, we can choose which theme to export.
         mermaid.initialize({
@@ -56,9 +60,18 @@ export class MarkdownToHtml {
             securityLevel: 'strict',
             theme: 'default',
         });
-        await mermaid.run({
-            nodes: [...this._exportContainer!.querySelectorAll('div.mermaid')],
-        });
+        // Render each diagram in isolation: `mermaid.run` rejects the whole
+        // batch on the first parse error, so one invalid diagram used to abort
+        // the entire export (#4812). Contain the failure to that diagram and
+        // fall back to the same placeholder the other diagram renderers use.
+        for (const node of nodes) {
+            try {
+                await mermaid.run({ nodes: [node] });
+            }
+            catch {
+                node.innerHTML = '< Invalid Diagram >';
+            }
+        }
         if (this._muya) {
             mermaid.initialize({
                 securityLevel: 'strict',


### PR DESCRIPTION
## Summary

Fixes #4812. Exporting a document to PDF/HTML failed entirely (`Failed to export document`, no file written) when it contained a mermaid diagram with a syntax error — e.g. a `|` inside a node label like `H[拼装 head|sign|content]`.

## Root cause

The styled-HTML / PDF export renderer (`MarkdownToHtml._renderMermaid`) renders **all** mermaid diagrams with a single batched call:

```ts
await mermaid.run({ nodes: [...allMermaidDivs] })
```

`mermaid.run` rejects the whole batch on the first parse error, and `_renderMermaid` did not catch it, so the rejection propagated up through `renderHtml` → `generate` → the desktop export wrapper, aborting the entire export.

By contrast, the sibling `_renderDiagram` (flowchart/sequence/plantuml/vega-lite) already wraps **each** diagram in a `try/catch` and falls back to a `< Invalid Diagram >` placeholder, and the inline editor (`diagramPreview.ts`) wraps its mermaid render too — which is why the invalid diagram renders fine in the editor but broke export.

## Fix

Render each mermaid diagram in its own `mermaid.run` inside a `try/catch`, degrading a broken diagram to the same `< Invalid Diagram >` placeholder the other renderers use, so the rest of the document still exports. Also skip loading mermaid when the document contains none.

## Tests

Added `mermaidExportResilience.spec.ts` (mocks the diagram loader so mermaid's parser can be simulated under jsdom):
- `renderHtml` resolves and still emits the surrounding document when a mermaid diagram fails to parse, with the placeholder in place of the diagram.
- One broken diagram does not stop a later valid diagram from rendering (proves the per-diagram isolation vs. the old batch behavior).

RED before the fix (both threw `Parse error`), GREEN after. Full export suite (`parityExportHtml`, `footnoteExportHtml`, `exportHtmlDir`, `renderToStaticHTML`) + typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)