### PR TITLE
fix(muya): keep pasted list items in order when merging mid-list

### DIFF
--- a/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
+++ b/packages/muya/src/clipboard/__tests__/pasteListMerge.spec.ts
@@ -133,4 +133,22 @@ describe('paste — same-type list merges into the enclosing list (A5, muyajs pa
         expect(selection.anchor?.offset).toBe(4);
         expect(selection.focus?.offset).toBe(4);
     });
+
+    // #3549 — pasting into a non-last item must keep the pasted items in order
+    // right after the anchor item, not append them to the end of the list.
+    it('inserts pasted items after the anchor item, not at the list end', async () => {
+        const muya = bootMuya('- Item A\n- \n- Item B\n');
+        const empty = contentBlocks(muya).find(b => b.text === '')!;
+        expect(await paste(muya, empty, 0, 0, '- Item 1\n- Item 2\n- Item 3')).toBe(
+            '- Item A\n- Item 1\n- Item 2\n- Item 3\n- Item B\n',
+        );
+    });
+
+    it('keeps order for an ordered list pasted into the middle', async () => {
+        const muya = bootMuya('1. A\n2. \n3. B\n');
+        const empty = contentBlocks(muya).find(b => b.text === '')!;
+        expect(await paste(muya, empty, 0, 0, '1. one\n2. two')).toBe(
+            '1. A\n2. one\n3. two\n4. B\n',
+        );
+    });
 });

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -239,6 +239,39 @@ function itemParaContent(list: Parent, itemIndex: number, paraIndex: number): Nu
     return para?.firstContentInDescendant() ?? null;
 }
 
+interface IListMergeSeam {
+    foldedOnly: boolean;
+    itemIndex: number;
+    paraIndex: number;
+    head: string;
+    sewOffset: number;
+    canFold: boolean;
+    pastedCount: number;
+    trailingStates: TState[];
+}
+
+// Seat the caret after a list-merge rebuilds the list block: inside the folded
+// paragraph, on trailing non-list content, or on the last pasted item (which is
+// spliced in after the anchor, so it is no longer the list's last descendant).
+function seatListMergeCursor(muya: Muya, newList: Parent, seam: IListMergeSeam): void {
+    const { foldedOnly, itemIndex, paraIndex, head, sewOffset, canFold, pastedCount, trailingStates } = seam;
+    if (foldedOnly) {
+        const cursor = itemParaContent(newList, itemIndex, paraIndex);
+        const offset = head.length + sewOffset;
+        cursor?.setCursor(offset, offset, true);
+
+        return;
+    }
+    if (trailingStates.length > 0) {
+        const last = insertStatesAfter(muya, newList, trailingStates);
+        seatCursorAtSeam(last, sewOffset);
+
+        return;
+    }
+    const lastPastedIndex = itemIndex + pastedCount - (canFold ? 1 : 0);
+    seatCursorAtSeam(newList.find(lastPastedIndex) as Nullable<Parent>, sewOffset);
+}
+
 // Same list kind + same bullet marker / order delimiter.
 function listMarkersMatch(a: TState, b: TState): boolean {
     if (a.name === 'order-list' && b.name === 'order-list')
@@ -301,7 +334,7 @@ function tryMergeListPaste(
     if (canFold) {
         anchorPara.text = head + pastedFirst.text;
         currentItem.children = [...currentItem.children, ...pastedItems[0].children.slice(1)];
-        mergedChildren.push(...pastedItems.slice(1));
+        mergedChildren.splice(itemIndex + 1, 0, ...pastedItems.slice(1));
         // The whole paste folded into `anchorPara` (no extra blocks/items): the
         // caret stays in that paragraph at the seam.
         foldedOnly
@@ -311,7 +344,7 @@ function tryMergeListPaste(
     }
     else {
         anchorPara.text = head;
-        mergedChildren.push(...pastedItems);
+        mergedChildren.splice(itemIndex + 1, 0, ...pastedItems);
     }
 
     const loose = listState.meta.loose || firstState.meta.loose;
@@ -327,15 +360,16 @@ function tryMergeListPaste(
     );
     listBlock.replaceWith(newList);
 
-    if (foldedOnly) {
-        const cursor = itemParaContent(newList, itemIndex, paraIndex);
-        const offset = head.length + sewOffset;
-        cursor?.setCursor(offset, offset, true);
-    }
-    else {
-        const last = insertStatesAfter(clipboard.muya, newList, states.slice(1));
-        seatCursorAtSeam(last, sewOffset);
-    }
+    seatListMergeCursor(clipboard.muya, newList as Parent, {
+        foldedOnly,
+        itemIndex,
+        paraIndex,
+        head,
+        sewOffset,
+        canFold,
+        pastedCount: pastedItems.length,
+        trailingStates: states.slice(1),
+    });
 
     return true;
 }


### PR DESCRIPTION
## Problem

Fixes #3549

Copying a bullet list and pasting it into the **middle** of another bullet list put the items out of order. Pasting `- 1`/`- 2`/`- 3` onto the empty middle item of `- A`/`- ` /`- B` produced:

```
- A
- 1
- B
- 2
- 3
```

instead of the expected:

```
- A
- 1
- 2
- 3
- B
```

## Root cause

`tryMergeListPaste` in `packages/muya/src/clipboard/paste.ts` builds the merged list from `[...listState.children]` and then appended the pasted items with `mergedChildren.push(...)` — always at the end of the list, regardless of where the cursor was. Existing tests only covered pasting into a single-item / last-item list, so the non-last case was unguarded.

## Fix

- Splice the pasted items in at `itemIndex + 1` (right after the anchor item) in both the fold and non-fold branches.
- Because the last pasted item is no longer the list's last descendant, seat the caret on it explicitly. Extracted the post-rebuild caret placement into `seatListMergeCursor` (also keeps `tryMergeListPaste` under the complexity budget).

## Tests

- New cases in `pasteListMerge.spec.ts`: bullet + ordered list pasted onto the empty middle item, asserting the resulting markdown order (and ordered-list renumbering `1. A / 2. one / 3. two / 4. B`).
- Full clipboard suite (134 tests) + CommonMark/GFM spec conformance (1347) unchanged; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)