### PR TITLE
fix(muya): preserve fenced code block info string on round-trip (#4770)

### DIFF
--- a/packages/muya/src/state/__tests__/codeFenceInfoString.spec.ts
+++ b/packages/muya/src/state/__tests__/codeFenceInfoString.spec.ts
@@ -1,0 +1,53 @@
+// Regression for #4770: a fenced code block's info string must survive a
+// markdown -> state -> markdown round-trip. MarkText used only the first word
+// of the info string as the language (for highlighting) and serialized just
+// that word back, so `` ```{example, listing1-name} `` was rewritten to
+// `` ```{example, `` on save — dropping everything after the first space.
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
+import ExportMarkdown from '../stateToMarkdown';
+
+function roundTrip(md: string): string {
+    const states = new MarkdownToState().generate(md);
+    return new ExportMarkdown({ listIndentation: 1 }).generate(states);
+}
+
+describe('#4770: fenced code block info string round-trip', () => {
+    it('preserves a Pandoc/RMarkdown-style attribute info string', () => {
+        const md = '```{example, listing1-name}\nlabel for code listing 1\n```\n';
+        expect(roundTrip(md)).toContain('```{example, listing1-name}');
+    });
+
+    it('preserves a language followed by attributes', () => {
+        const md = '```js title="app.js"\nconst a = 1\n```\n';
+        expect(roundTrip(md)).toContain('```js title="app.js"');
+    });
+
+    it('leaves a plain single-word language unchanged (no regression)', () => {
+        const out = roundTrip('```js\nconst a = 1\n```\n');
+        expect(out).toContain('```js\n');
+    });
+
+    it('leaves a language-less fence unchanged (no regression)', () => {
+        const out = roundTrip('```\nplain\n```\n');
+        expect(out).toContain('```\n');
+        expect(out).not.toContain('```undefined');
+    });
+
+    it('uses the edited language when a stored info string is now stale', () => {
+    // Emulates the user opening ```{example, listing1-name} then changing the
+    // language to `python` via the language input: `lang` no longer matches the
+    // stored info's first word, so serialization must emit the edited language.
+        const states = [
+            {
+                name: 'code-block' as const,
+                meta: { type: 'fenced', lang: 'python', info: '{example, listing1-name}' },
+                text: 'x',
+            },
+        ];
+        const out = new ExportMarkdown({ listIndentation: 1 }).generate(states);
+        expect(out).toContain('```python\n');
+        expect(out).not.toContain('example');
+    });
+});

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -449,12 +449,17 @@ export class MarkdownToState {
         // but `'fenced'` reaches us at runtime via the
         // walkTokens assignment — hence the cast.
         const isFenced = (codeBlockStyle as 'indented' | 'fenced' | undefined) === 'fenced';
+        // Preserve the full info string when it carries more than the language
+        // word (attributes like `title="x"`, or a Pandoc/RMarkdown `{…}` block),
+        // so the fence round-trips instead of collapsing to its first word (#4770).
+        const info = infoString || '';
         return {
             name: 'code-block' as const,
             meta: {
                 type: isFenced ? 'fenced' : 'indented',
                 lang,
                 ...(isFenced && fenceLength && fenceLength > 3 ? { fenceLength } : {}),
+                ...(isFenced && info !== lang ? { info } : {}),
             },
             text: value,
         };

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -354,10 +354,16 @@ export default class ExportMarkdown {
         const { text, meta } = state;
         const textList = text.split('\n');
         const { type, lang } = meta;
+        // Emit the preserved full info string (`js title="x"`, Pandoc `{…}`
+        // attributes), but only while `lang` is still its first word: once the
+        // language is edited the stored info is stale, so the edited language
+        // wins (#4770).
+        const info
+            = meta.info && meta.info.match(/\S*/)?.[0] === lang ? meta.info : lang;
 
         if (type === 'fenced') {
             const fence = '`'.repeat(this._codeFenceLength(text, meta.fenceLength));
-            result.push(`${indent}${lang ? `${fence}${lang}\n` : `${fence}\n`}`);
+            result.push(`${indent}${info ? `${fence}${info}\n` : `${fence}\n`}`);
             textList.forEach((text) => {
                 result.push(`${indent}${text}\n`);
             });

--- a/packages/muya/src/state/types.ts
+++ b/packages/muya/src/state/types.ts
@@ -31,6 +31,11 @@ export interface ICodeBlockState {
         type: string; // "indented" | "fenced";
         lang: string;
         fenceLength?: number;
+        // Full fenced info string when it carries more than the language word
+        // (e.g. `js title="x"` or a Pandoc/RMarkdown `{…}` attribute block).
+        // `lang` keeps just the first word for highlighting; `info` preserves
+        // the whole string so the fence round-trips losslessly (#4770).
+        info?: string;
     };
     text: string;
 }


### PR DESCRIPTION
## Summary

Fixes #4770. A fenced code block's **info string** was truncated to its first word when the document was saved:

- ` ```{example, listing1-name} ` → ` ```{example, ` (a Pandoc/RMarkdown attribute block)
- ` ```js title="app.js" ` → ` ```js ` (a language followed by attributes)

## Root cause

At parse time (`markdownToState._buildCodeState`) the info string is reduced to its first word for `meta.lang`, which drives syntax highlighting:

```ts
const lang = (infoString || '').match(/\S*/)?.[0] ?? ''
```

The serializer then emitted only `meta.lang`, so everything after the first space was lost on save.

`meta.lang` **must** stay a single word — the code-block content renderer does `wrapper.classList.add(\`language-${lang}\`)`, and a `lang` containing spaces would break `classList.add`. So widening `lang` to the full info string is not an option.

## Fix

Preserve the full info string **additively** in a new optional `meta.info`, set at parse time only when the info string carries more than the language word, and emit it on serialize:

- `meta.lang` (first word) still drives highlighting / the `language-*` class / diagram detection — unchanged.
- `meta.info` (full string) makes the fence round-trip losslessly.
- Serialization uses `meta.info` **only while `lang` is still its first word**, so editing the language (which rewrites `lang`) correctly drops the now-stale attributes rather than re-emitting them.

Plain single-word languages and language-less fences produce no `meta.info` and are byte-identical to before.

## Tests

New `codeFenceInfoString.spec.ts` (markdown → state → markdown round-trip):
- preserves ` ```{example, listing1-name} `
- preserves ` ```js title="app.js" `
- plain ` ```js ` and language-less ` ``` ` unchanged (no regression)
- an edited language wins over a now-stale stored info string

RED before the fix (both info-string cases truncated), GREEN after. Full muya unit suite (1389), CommonMark/GFM spec conformance (1347), and typecheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)