### PR TITLE
fix(muya): render single-line $$…$$ as display math in the editor (#4782)

### DIFF
--- a/packages/muya/src/inlineRenderer/__tests__/inlineDisplayMath.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/inlineDisplayMath.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+// #4782: single-line display math `$$…$$` was not rendered in the editor. The
+// inline_math rule only matched a single `$` delimiter (and its trailing
+// `(?!\1)` explicitly rejected a doubled `$`), so `$$a+b$$` stayed as literal
+// text — even though the HTML/PDF export path (marked, `${1,2}`) rendered it.
+
+import type { CodeEmojiMathToken } from '../types';
+import { describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+import { tokenizer } from '../lexer';
+
+function mathToken(src: string): CodeEmojiMathToken | undefined {
+    return tokenizer(src).find(t => t.type === 'inline_math') as
+        | CodeEmojiMathToken
+        | undefined;
+}
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    return muya;
+}
+
+describe('inline display math $$…$$ (#4782)', () => {
+    it('tokenizes single-line $$a+b$$ as inline math with a $$ marker', () => {
+        const t = mathToken('$$a+b$$');
+        expect(t?.content).toBe('a+b');
+        expect(t?.marker).toBe('$$');
+        expect(t?.raw).toBe('$$a+b$$');
+    });
+
+    it('still tokenizes single-dollar $a+b$ unchanged', () => {
+        const t = mathToken('$a+b$');
+        expect(t?.content).toBe('a+b');
+        expect(t?.marker).toBe('$');
+    });
+
+    it('preserves an escaped dollar inside $$ math', () => {
+        expect(mathToken('$$y = \\$10$$')?.content).toBe('y = \\$10');
+    });
+
+    it('does not tokenize empty $$$$', () => {
+        expect(mathToken('$$$$')).toBeUndefined();
+    });
+
+    it('renders $$a+b$$ as KaTeX in the editor (display mode)', () => {
+        const muya = boot('$$a+b$$\n');
+        const html = muya.domNode!.innerHTML;
+        expect(/katex/i.test(html)).toBe(true);
+        expect(/katex-display/.test(html)).toBe(true);
+    });
+
+    it('keeps single-dollar $a+b$ rendering inline (not display)', () => {
+        const muya = boot('$a+b$\n');
+        const html = muya.domNode!.innerHTML;
+        expect(/katex/i.test(html)).toBe(true);
+        expect(/katex-display/.test(html)).toBe(false);
+    });
+
+    it('round-trips $$a+b$$ through getMarkdown', () => {
+        const muya = boot('$$a+b$$\n');
+        expect(muya.getMarkdown()).toContain('$$a+b$$');
+    });
+});

--- a/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
+++ b/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
@@ -44,8 +44,11 @@ export default function inlineMath(this: Renderer, {
 
     const { loadMathMap } = this;
 
-    const displayMode = false;
-    const key = `${math}_${type}`;
+    // A `$$…$$` span is display math; `$…$` stays inline (#4782). The cache key
+    // includes the mode so the same expression written both ways doesn't reuse
+    // the wrong render.
+    const displayMode = marker.length === 2;
+    const key = `${math}_${type}_${displayMode}`;
     let mathVnode = null;
     let previewSelector = `span.${CLASS_NAMES.MU_MATH_RENDER}`;
     // Inline math errors stay compact to keep the surrounding text baseline
@@ -86,8 +89,8 @@ export default function inlineMath(this: Renderer, {
                         ? { contenteditable: 'false', title: errorTitle }
                         : { contenteditable: 'false' },
                     dataset: {
-                        start: String(start + 1), // '$'.length
-                        end: String(end - 1), // '$'.length
+                        start: String(start + marker.length), // '$' or '$$'
+                        end: String(end - marker.length),
                     },
                 },
                 mathVnode,

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -63,8 +63,12 @@ export type GfmRules = typeof gfmRules;
 
 // Markdown extensions (not belongs to GFM and Commonmark)
 export const inlineExtensionRules = {
+    // `${1,2}`: `$…$` is inline math, `$$…$$` on one line is display math
+    // (#4782). The `\1` backreference forces a matching close, so the opener
+    // and closer always agree; for a single `$` this stays byte-identical to
+    // the old rule.
     // eslint-disable-next-line regexp/no-super-linear-backtracking
-    inline_math: /^(\$)((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/,
+    inline_math: /^(\${1,2})((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/,
     // This is not the best regexp, because it not support `2^2\\^`.
     superscript: /^(\^)((?:[^^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,
     subscript: /^(~)((?:[^~\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,


### PR DESCRIPTION
## Summary

Fixes #4782. Single-line display math written as `$$…$$` (e.g. `$$\mathbb{V}(\dots)$$` on one line) was **not rendered in the editor** — it stayed as literal text — even though the HTML/PDF **export** path renders it fine. That editor/export inconsistency is the bug.

## Root cause

The editor's inline tokenizer rule only matched a **single** `$` delimiter, and its trailing `(?!\1)` explicitly rejected a doubled `$`:

```ts
inline_math: /^(\$)((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/
```

So `$$a+b$$` matched neither `inline_math` (single `$`) nor `multiple_math` (`/^(\$\$)$/`, a bare `$$` line → math block). Meanwhile the export path (marked) uses `${1,2}` and renders it.

## Fix

Widen the opener to `${1,2}` with the existing `\1` backreference for a matching close:

```ts
inline_math: /^(\${1,2})((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/
```

- `$…$` stays **byte-identical** (when only one `$` is available the group matches one, and the close still can't be followed by another `$`).
- `$$…$$` on one line now tokenizes with a `$$` marker.

In the renderer (`inlineMath.ts`):
- `displayMode = marker.length === 2` — `$$` renders as KaTeX **display** math, `$` stays inline.
- the KaTeX cache key includes the mode, so the same expression written both ways doesn't reuse the wrong render.
- the hidden start/end markers are positioned by `marker.length` instead of a hard-coded `1`.

The bare `$$`-line → math-block trigger (`multiple_math`) is untouched, and `$$…$$` round-trips through `getMarkdown` via the token's raw text.

## Tests

New `inlineDisplayMath.spec.ts`:
- tokenizes `$$a+b$$` (marker `$$`, content `a+b`, raw preserved); `$a+b$` unchanged; escaped `\$` inside `$$` preserved; empty `$$$$` not tokenized
- editor renders `$$a+b$$` as `katex-display`; `$a+b$` stays inline (not display)
- `$$a+b$$` round-trips through `getMarkdown`

RED before the fix (the `$$` cases), GREEN after. Full muya unit suite (1396), CommonMark/GFM spec conformance (1347), typecheck, and lint all pass. Verified the reporter's exact formula renders as display math with no error and round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)