### PR TITLE
fix(muya): show escaped pipe in table cell code as | not \| (#4849)

### DIFF
--- a/packages/muya/src/state/__tests__/tableEscapedPipe.spec.ts
+++ b/packages/muya/src/state/__tests__/tableEscapedPipe.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+// #4849: an escaped pipe inside a table cell's inline code (`` `\|` ``) was
+// displayed with the backslash (`\|`) instead of the intended `|`. GFM escapes
+// `|` in table cells with a backslash; after the table is parsed that escape is
+// a literal `|`, so `` `\|` `` must render as <code>|</code> (as the HTML/PDF
+// export already does). The stored cell text re-added the escape, which leaks
+// into the editor's inline-code display (the backslash rule doesn't apply
+// inside code). Serialization re-escapes on its own, so the round-trip is kept.
+
+import { describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+import { MarkdownToState } from '../markdownToState';
+import ExportMarkdown from '../stateToMarkdown';
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    return muya;
+}
+
+function codeTexts(muya: Muya): string[] {
+    return [...muya.domNode!.querySelectorAll('td code')].map(c => c.textContent ?? '');
+}
+
+function roundTrip(md: string): string {
+    const states = new MarkdownToState().generate(md);
+    return new ExportMarkdown({ listIndentation: 1 }).generate(states);
+}
+
+const TABLE = [
+    '| a | b |',
+    '| --- | --- |',
+    '| `\\|` | x |',
+    '| `\\|\\|` | y |',
+    '',
+].join('\n');
+
+describe('#4849: escaped pipe in a table cell', () => {
+    it('renders `\\|` inside code as | (no backslash) in the editor', () => {
+        const muya = boot(TABLE);
+        expect(codeTexts(muya)).toEqual(['|', '||']);
+    });
+
+    it('keeps the table structure (2 columns, 3 rows)', () => {
+        const muya = boot(TABLE);
+        expect(muya.domNode!.querySelectorAll('tr').length).toBe(3);
+        expect(muya.domNode!.querySelectorAll('tr')[2].querySelectorAll('td').length).toBe(2);
+    });
+
+    it('round-trips the escaped pipes back to `\\|` / `\\|\\|`', () => {
+        const md = roundTrip(TABLE);
+        expect(md).toContain('`\\|`');
+        expect(md).toContain('`\\|\\|`');
+    });
+
+    it('round-trips an escaped pipe in plain cell text', () => {
+        const md = roundTrip('| a | b |\n| --- | --- |\n| x \\| y | z |\n');
+        expect(md).toContain('x \\| y');
+    });
+});

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -14,11 +14,6 @@ import logger from '../utils/logger';
 import { lexBlock } from '../utils/marked';
 
 const debug = logger('import markdown: ');
-function restoreTableEscapeCharacters(text: string) {
-    // NOTE: markedjs replaces all escaped "|" ("\|") characters inside a cell with "|".
-    //       We have to re-escape the character to not break the table.
-    return text.replace(/\|/g, '\\|');
-}
 
 interface IMarkdownToStateOptions {
     footnote: boolean;
@@ -299,12 +294,17 @@ export class MarkdownToState {
                     children: [],
                 };
 
+                // Store the cell text as marked emits it (with the table `\|`
+                // escape already resolved to a literal `|`), so the editor shows
+                // `` `|` `` rather than the escaped `` `\|` `` inside inline code
+                // (#4849). `escapeText` re-adds the `\|` escape on serialization,
+                // keeping the markdown round-trip intact.
                 tableState.children.push({
                     name: 'table.row',
                     children: header.map((h, i) => ({
                         name: 'table.cell' as const,
                         meta: { align: align[i] || 'none' },
-                        text: restoreTableEscapeCharacters(h.text),
+                        text: h.text,
                     })),
                 });
 
@@ -314,7 +314,7 @@ export class MarkdownToState {
                         children: row.map((c, i) => ({
                             name: 'table.cell' as const,
                             meta: { align: align[i] || 'none' },
-                            text: restoreTableEscapeCharacters(c.text),
+                            text: c.text,
                         })),
                     })),
                 );


### PR DESCRIPTION
## Summary

Fixes #4849. An escaped pipe inside a table cell's inline code — `` `\|` `` — was displayed **with the backslash** (`\|`) instead of the intended `|`. In the reporter's C-operator-precedence table, the bitwise-OR / logical-OR rows (`` `\|` ``, `` `\|\|` ``, `` `\|=` ``) showed the stray backslashes.

## Root cause

GFM escapes a literal `|` in a table cell as `\|`; once the table is parsed, that escape is a literal pipe, so `` `\|` `` should render as `<code>|</code>` — which the **HTML/PDF export already does**.

But on import, `restoreTableEscapeCharacters` re-added the `\|` escape into the **stored cell text**. Outside code the inline `backlash` rule hides the backslash, but **inside inline code** (where markdown escapes don't apply) the backslash leaked straight into the display.

That re-escaping was also redundant: `stateToMarkdown.escapeText` already re-escapes any unescaped `|` in a cell on serialization.

## Fix

Store the cell text as marked emits it (the `\|` escape already resolved to a literal `|`), and let `escapeText` re-add the escape on the way out. The editor now shows the pipe correctly, and the markdown still round-trips to `` `\|` ``.

- `\|` **inside** table-cell code → renders `|` ✅ (was `\|`)
- `\|` in plain cell text → unchanged (already rendered `|` via the backslash rule)
- serialization re-escapes `|` → `\|`, so the round-trip is preserved

## Tests

New `tableEscapedPipe.spec.ts`:
- editor renders `` `\|` `` / `` `\|\|` `` as `<code>|</code>` / `<code>||</code>`
- table structure preserved (2 columns, 3 rows)
- round-trips `` `\|` `` / `` `\|\|` `` and an escaped pipe in plain cell text

RED before the fix (in-code display showed `\|`), GREEN after. Full muya unit suite (1393) and **CommonMark/GFM spec conformance (1347)** pass; typecheck + lint clean. Verified the reporter's exact table renders `|`, `||`, `|=` in the affected cells and round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)