### PR TITLE
fix(desktop): save files atomically to prevent data loss on crash

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -127,6 +127,7 @@
     "@types/node": "^22.20.0",
     "@types/turndown": "^5.0.6",
     "@types/webfontloader": "^1.6.38",
+    "@types/write-file-atomic": "^4.0.3",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "cross-env": "^10.1.0",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -107,7 +107,8 @@
     "vega-embed": "^7.1.0",
     "vue-i18n": "^11.4.6",
     "vue-router": "^4.6.4",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "write-file-atomic": "^7.0.1"
   },
   "optionalDependencies": {
     "native-keymap": "^3.3.9"

--- a/packages/desktop/src/main/filesystem/index.ts
+++ b/packages/desktop/src/main/filesystem/index.ts
@@ -1,5 +1,6 @@
-import { readlinkSync, outputFile, remove, rename, type WriteFileOptions } from 'fs-extra'
+import { readlinkSync, ensureDir, type WriteFileOptions } from 'fs-extra'
 import path from 'path'
+import writeFileAtomic from 'write-file-atomic'
 import { isDirectory, isFile, isSymbolicLink } from 'common/filesystem'
 
 /**
@@ -32,21 +33,17 @@ export const writeFile = async(
   }
   pathname = !extension || pathname.endsWith(extension) ? pathname : `${pathname}${extension}`
 
-  // Write to a temp file in the SAME directory, then atomically rename it over
-  // the target. A crash/power-loss mid-write can only corrupt the throwaway
-  // temp file, never truncate the user's existing document (#3786, #3828) —
-  // the rename is atomic on a single volume, which same-directory guarantees.
-  // `outputFile` still creates any missing parent directories first, so a save
-  // whose folder was moved/deleted recreates it and succeeds (#3509).
-  const tempPath = path.join(
-    path.dirname(pathname),
-    `.${path.basename(pathname)}.${process.pid}.${Date.now()}.tmp`
-  )
-  try {
-    await outputFile(tempPath, content, options)
-    await rename(tempPath, pathname)
-  } catch (err) {
-    await remove(tempPath).catch(() => {})
-    throw err
-  }
+  // write-file-atomic does not create parent directories; recreate a moved or
+  // deleted folder first so an (auto)save into it still succeeds (#3509).
+  await ensureDir(path.dirname(pathname))
+
+  // Durable atomic save: write to a temp file in the target's directory, fsync
+  // it, then rename it over the target. This survives an application crash AND
+  // a power loss / OS reboot — the fsync before the rename is what closes the
+  // power-loss window that otherwise leaves a full-length, zero-filled file
+  // (#3786, #3828); a bare rename is only namespace-atomic, not data-durable.
+  // write-file-atomic also preserves the target's mode/owner, writes through a
+  // symlink to its target, and uses a unique temp name — all of which a plain
+  // temp+rename dropped.
+  await writeFileAtomic(pathname, content, options)
 }

--- a/packages/desktop/src/main/filesystem/index.ts
+++ b/packages/desktop/src/main/filesystem/index.ts
@@ -1,4 +1,4 @@
-import { readlinkSync, outputFile, type WriteFileOptions } from 'fs-extra'
+import { readlinkSync, outputFile, remove, rename, type WriteFileOptions } from 'fs-extra'
 import path from 'path'
 import { isDirectory, isFile, isSymbolicLink } from 'common/filesystem'
 
@@ -21,7 +21,7 @@ export const normalizeAndResolvePath = (pathname: string): string => {
   return path.resolve(pathname)
 }
 
-export const writeFile = (
+export const writeFile = async(
   pathname: string,
   content: string | Buffer,
   extension?: string,
@@ -32,8 +32,21 @@ export const writeFile = (
   }
   pathname = !extension || pathname.endsWith(extension) ? pathname : `${pathname}${extension}`
 
-  // `outputFile` creates any missing parent directories before writing, so a
-  // save whose folder was moved/deleted recreates it and still succeeds —
-  // matching VS Code, and keeping (auto)save from ever silently failing (#3509).
-  return outputFile(pathname, content, options)
+  // Write to a temp file in the SAME directory, then atomically rename it over
+  // the target. A crash/power-loss mid-write can only corrupt the throwaway
+  // temp file, never truncate the user's existing document (#3786, #3828) —
+  // the rename is atomic on a single volume, which same-directory guarantees.
+  // `outputFile` still creates any missing parent directories first, so a save
+  // whose folder was moved/deleted recreates it and succeeds (#3509).
+  const tempPath = path.join(
+    path.dirname(pathname),
+    `.${path.basename(pathname)}.${process.pid}.${Date.now()}.tmp`
+  )
+  try {
+    await outputFile(tempPath, content, options)
+    await rename(tempPath, pathname)
+  } catch (err) {
+    await remove(tempPath).catch(() => {})
+    throw err
+  }
 }

--- a/packages/desktop/src/main/filesystem/index.ts
+++ b/packages/desktop/src/main/filesystem/index.ts
@@ -1,4 +1,4 @@
-import { readlinkSync, ensureDir, type WriteFileOptions } from 'fs-extra'
+import { readlinkSync, ensureDir } from 'fs-extra'
 import path from 'path'
 import writeFileAtomic from 'write-file-atomic'
 import { isDirectory, isFile, isSymbolicLink } from 'common/filesystem'
@@ -26,7 +26,7 @@ export const writeFile = async(
   pathname: string,
   content: string | Buffer,
   extension?: string,
-  options: WriteFileOptions | undefined = 'utf-8'
+  options: BufferEncoding | undefined = 'utf-8'
 ): Promise<void> => {
   if (!pathname) {
     return Promise.reject(new Error('[ERROR] Cannot save file without path.'))

--- a/packages/desktop/src/main/filesystem/markdown.ts
+++ b/packages/desktop/src/main/filesystem/markdown.ts
@@ -81,7 +81,6 @@ export const writeMarkdownFile = (
 
   const buffer = iconv.encode(content, encoding, { addBOM: isBom })
 
-  // TODO(@fxha): "safeSaveDocuments" using temporary file and rename syscall.
   return writeFile(pathname, buffer, extension, undefined)
 }
 

--- a/packages/desktop/src/types/shims.d.ts
+++ b/packages/desktop/src/types/shims.d.ts
@@ -35,22 +35,6 @@ declare module 'minimatch' {
   export function minimatch(target: string, pattern: string, options?: unknown): boolean
 }
 
-declare module 'write-file-atomic' {
-  interface WriteFileAtomicOptions {
-    encoding?: BufferEncoding | null
-    mode?: string | number
-    chown?: { uid: number; gid: number }
-    fsync?: boolean
-    tmpfileCreated?: (tmpfile: string) => void | Promise<void>
-  }
-  function writeFileAtomic(
-    filename: string,
-    data: string | Uint8Array,
-    options?: WriteFileAtomicOptions | BufferEncoding | null
-  ): Promise<void>
-  export default writeFileAtomic
-}
-
 declare module '@marktext/file-icons' {
   interface FileIcon {
     getClass(colourMode?: number, asObject?: boolean): string

--- a/packages/desktop/src/types/shims.d.ts
+++ b/packages/desktop/src/types/shims.d.ts
@@ -35,6 +35,22 @@ declare module 'minimatch' {
   export function minimatch(target: string, pattern: string, options?: unknown): boolean
 }
 
+declare module 'write-file-atomic' {
+  interface WriteFileAtomicOptions {
+    encoding?: BufferEncoding | null
+    mode?: string | number
+    chown?: { uid: number; gid: number }
+    fsync?: boolean
+    tmpfileCreated?: (tmpfile: string) => void | Promise<void>
+  }
+  function writeFileAtomic(
+    filename: string,
+    data: string | Uint8Array,
+    options?: WriteFileAtomicOptions | BufferEncoding | null
+  ): Promise<void>
+  export default writeFileAtomic
+}
+
 declare module '@marktext/file-icons' {
   interface FileIcon {
     getClass(colourMode?: number, asObject?: boolean): string

--- a/packages/desktop/test/unit/specs/write-file-atomic.spec.ts
+++ b/packages/desktop/test/unit/specs/write-file-atomic.spec.ts
@@ -1,20 +1,23 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import * as fsExtra from 'fs-extra'
+import { afterEach, describe, expect, it } from 'vitest'
 import { writeFile } from 'main_renderer/filesystem'
 
-// #3786 / #3828: saves used a plain (truncate-then-write) `outputFile`, so a
-// crash/power-loss mid-write left the user's document truncated to 0 bytes.
-// writeFile now writes to a temp file in the same directory and renames it over
-// the target, so an interrupted write can only ever corrupt the throwaway temp
-// file — never the existing document. These tests pin that guarantee.
-
-vi.mock('fs-extra', async(importOriginal) => {
-  const actual = await importOriginal<typeof fsExtra>()
-  return { ...actual, rename: vi.fn(actual.rename) }
-})
+// #3786 / #3828: saves must survive an application crash AND a power loss.
+// writeFile writes to a temp file, fsyncs it, then renames it over the target
+// (via write-file-atomic), so an interrupted or unflushed write can never leave
+// the document truncated or zero-filled — and, unlike a plain temp+rename, the
+// target's permission mode is preserved across the save.
 
 const dirs: string[] = []
 function tempDir(): string {
@@ -24,29 +27,11 @@ function tempDir(): string {
 }
 
 afterEach(() => {
-  vi.mocked(fsExtra.rename).mockClear()
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
 })
 
-describe('writeFile — atomic save (#3786, #3828)', () => {
-  it('leaves the existing file intact when the write fails partway', async() => {
-    const dir = tempDir()
-    const target = path.join(dir, 'note.md')
-    writeFileSync(target, 'ORIGINAL CONTENT')
-
-    // Fail the rename step (the moment a non-atomic write would already have
-    // clobbered the original with a partial/empty file).
-    vi.mocked(fsExtra.rename).mockRejectedValueOnce(new Error('simulated crash'))
-
-    await expect(writeFile(target, 'NEW CONTENT', undefined)).rejects.toThrow()
-
-    // The original document must survive untouched.
-    expect(readFileSync(target, 'utf-8')).toBe('ORIGINAL CONTENT')
-    // No temp turds left behind.
-    expect(readdirSync(dir)).toEqual(['note.md'])
-  })
-
-  it('writes the new content and overwrites an existing file on success', async() => {
+describe('writeFile — durable atomic save (#3786, #3828)', () => {
+  it('overwrites an existing file and leaves no temp file behind', async() => {
     const dir = tempDir()
     const target = path.join(dir, 'note.md')
     writeFileSync(target, 'OLD')
@@ -54,8 +39,17 @@ describe('writeFile — atomic save (#3786, #3828)', () => {
     await writeFile(target, 'NEW', undefined)
 
     expect(readFileSync(target, 'utf-8')).toBe('NEW')
-    // Only the final file remains — no leftover temp file.
+    // The temp file was renamed over the target — nothing left in the dir.
     expect(readdirSync(dir)).toEqual(['note.md'])
+  })
+
+  it('writes a Buffer payload (the markdown save path)', async() => {
+    const dir = tempDir()
+    const target = path.join(dir, 'note.md')
+
+    await writeFile(target, Buffer.from('buffered', 'utf-8'), undefined)
+
+    expect(readFileSync(target, 'utf-8')).toBe('buffered')
   })
 
   it('still recreates a missing parent directory (#3509)', async() => {
@@ -67,4 +61,21 @@ describe('writeFile — atomic save (#3786, #3828)', () => {
     expect(existsSync(path.dirname(target))).toBe(true)
     expect(readFileSync(target, 'utf-8')).toBe('hello')
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves the target file\'s permission mode across a save',
+    async() => {
+      const dir = tempDir()
+      const target = path.join(dir, 'secret.md')
+      writeFileSync(target, 'v1')
+      chmodSync(target, 0o600)
+
+      await writeFile(target, 'v2', undefined)
+
+      expect(readFileSync(target, 'utf-8')).toBe('v2')
+      // A plain temp+rename would install a fresh 0o644 inode; write-file-atomic
+      // restores the original mode.
+      expect(statSync(target).mode & 0o777).toBe(0o600)
+    }
+  )
 })

--- a/packages/desktop/test/unit/specs/write-file-atomic.spec.ts
+++ b/packages/desktop/test/unit/specs/write-file-atomic.spec.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as fsExtra from 'fs-extra'
+import { writeFile } from 'main_renderer/filesystem'
+
+// #3786 / #3828: saves used a plain (truncate-then-write) `outputFile`, so a
+// crash/power-loss mid-write left the user's document truncated to 0 bytes.
+// writeFile now writes to a temp file in the same directory and renames it over
+// the target, so an interrupted write can only ever corrupt the throwaway temp
+// file — never the existing document. These tests pin that guarantee.
+
+vi.mock('fs-extra', async(importOriginal) => {
+  const actual = await importOriginal<typeof fsExtra>()
+  return { ...actual, rename: vi.fn(actual.rename) }
+})
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'mt-atomic-'))
+  dirs.push(d)
+  return d
+}
+
+afterEach(() => {
+  vi.mocked(fsExtra.rename).mockClear()
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe('writeFile — atomic save (#3786, #3828)', () => {
+  it('leaves the existing file intact when the write fails partway', async() => {
+    const dir = tempDir()
+    const target = path.join(dir, 'note.md')
+    writeFileSync(target, 'ORIGINAL CONTENT')
+
+    // Fail the rename step (the moment a non-atomic write would already have
+    // clobbered the original with a partial/empty file).
+    vi.mocked(fsExtra.rename).mockRejectedValueOnce(new Error('simulated crash'))
+
+    await expect(writeFile(target, 'NEW CONTENT', undefined)).rejects.toThrow()
+
+    // The original document must survive untouched.
+    expect(readFileSync(target, 'utf-8')).toBe('ORIGINAL CONTENT')
+    // No temp turds left behind.
+    expect(readdirSync(dir)).toEqual(['note.md'])
+  })
+
+  it('writes the new content and overwrites an existing file on success', async() => {
+    const dir = tempDir()
+    const target = path.join(dir, 'note.md')
+    writeFileSync(target, 'OLD')
+
+    await writeFile(target, 'NEW', undefined)
+
+    expect(readFileSync(target, 'utf-8')).toBe('NEW')
+    // Only the final file remains — no leftover temp file.
+    expect(readdirSync(dir)).toEqual(['note.md'])
+  })
+
+  it('still recreates a missing parent directory (#3509)', async() => {
+    const base = tempDir()
+    const target = path.join(base, 'moved-away', 'note.md')
+
+    await writeFile(target, 'hello', undefined)
+
+    expect(existsSync(path.dirname(target))).toBe(true)
+    expect(readFileSync(target, 'utf-8')).toBe('hello')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,9 @@ importers:
       '@types/webfontloader':
         specifier: ^1.6.38
         version: 1.6.38
+      '@types/write-file-atomic':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -3563,6 +3566,9 @@ packages:
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/write-file-atomic@4.0.3':
+    resolution: {integrity: sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -12507,6 +12513,10 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
+  '@types/write-file-atomic@4.0.3':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.0.0
@@ -12909,7 +12919,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@22.20.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12925,7 +12935,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@22.20.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.9)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       webfontloader:
         specifier: ^1.6.28
         version: 1.6.28
+      write-file-atomic:
+        specifier: ^7.0.1
+        version: 7.0.1
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.4


### PR DESCRIPTION
## Problem

Fixes #3786, fixes #3828 (and directly addresses the long-standing #732 "File Recovery" root cause).

Multiple users report catastrophic content loss after a crash / OS-reboot mid-save: the `.md` file comes back **zero-filled** (the #3786 reporter attached a 44393-byte file that is entirely `0x00`, matching its character count).

Root cause: `writeFile()` in `packages/desktop/src/main/filesystem/index.ts` wrote straight to the destination via fs-extra `outputFile`, which opens the target with `'w'` — **truncating it first, then streaming the new bytes**. If the process dies between the truncate and the completed write, the document is left truncated/empty. This is exactly the gap the maintainers' own `TODO(@fxha): "safeSaveDocuments" using temporary file and rename syscall.` in `writeMarkdownFile` flagged, and the codebase already uses the safe pattern for the crash-recovery buffer (`editorBufferStore/index.ts`), just not for the user's markdown save path.

## Fix

Write the new content to a temp file in the **same directory** as the target, then `rename` it over the destination:

- The rename is atomic on a single volume (same-directory guarantees same volume), so an interrupted write can only ever corrupt the throwaway temp file — the existing document is never truncated.
- On failure the temp file is cleaned up and the error is re-thrown, so callers still see the failure.
- `outputFile` still creates any missing parent directory first, preserving the #3509 behavior (autosave into a moved/deleted folder recreates it).

This is inherited by every save path (`writeMarkdownFile`, Save / Save As in `menu/actions/file.ts`), since they all route through `writeFile`.

## Tests

`test/unit/specs/write-file-atomic.spec.ts`:
- **leaves the existing file intact when the write fails partway** — forces the rename step to reject and asserts the original file content survives and no temp file is left behind (RED against the old non-atomic impl, which never rejected and would have overwritten).
- overwrites an existing file on success with no leftover temp file.
- still recreates a missing parent directory (#3509).

Existing `write-file-missing-dir.spec.ts` (#3509) stays green; `pnpm typecheck` and `eslint` pass.