### PR TITLE
fix(desktop): don't crash on unwatchable image directories (UNC/WSL paths)

### DIFF
--- a/packages/desktop/src/main/utils/imagePathAutoComplement.ts
+++ b/packages/desktop/src/main/utils/imagePathAutoComplement.ts
@@ -64,12 +64,28 @@ const rebuild = (directory: string): void => {
 
 const watchDirectory = (directory: string): void => {
   if (watchers.has(directory)) return // Do not duplicate watch the same directory
-  const watcher = fs.watch(directory, (eventType, _filename) => {
-    if (eventType === 'rename') {
-      rebuild(directory)
-    }
-  })
-  watchers.set(directory, watcher)
+  try {
+    const watcher = fs.watch(directory, (eventType, _filename) => {
+      if (eventType === 'rename') {
+        rebuild(directory)
+      }
+    })
+    // Some directories become unwatchable after construction (network mounts
+    // dropping, permission changes); swallow the error and stop watching
+    // rather than leaking an uncaught exception into the main process.
+    watcher.on('error', (err) => {
+      log.error('imagePathAutoComplement::watchDirectory:', err)
+      watcher.close()
+      watchers.delete(directory)
+    })
+    watchers.set(directory, watcher)
+  } catch (err) {
+    // `fs.watch` throws synchronously for directories the OS can't watch —
+    // e.g. UNC / \\wsl.localhost network paths on Windows (EISDIR). Image-path
+    // auto-complete must degrade to "not watching" instead of crashing the
+    // main process with an "Unexpected error" dialog (#3779).
+    log.error('imagePathAutoComplement::watchDirectory:', err)
+  }
 }
 
 export const searchFilesAndDir = (directory: string, key: string): Promise<DirOrImageEntry[]> => {

--- a/packages/desktop/test/unit/specs/image-path-autocomplete.spec.ts
+++ b/packages/desktop/test/unit/specs/image-path-autocomplete.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -102,5 +102,27 @@ describe('searchFilesAndDir', () => {
     const missing = path.join(os.tmpdir(), 'mt-img-ac-does-not-exist-xyz')
 
     await expect(searchFilesAndDir(missing, '')).rejects.toBeTruthy()
+  })
+
+  it('still resolves when the directory cannot be watched (UNC/WSL paths, #3779)', async() => {
+    const dir = seedDir()
+    tmpDirs.push(dir)
+
+    // fs.watch throws synchronously for unwatchable dirs (e.g. \\wsl.localhost
+    // UNC paths on Windows -> EISDIR). This used to escape as an uncaught
+    // exception -> "Unexpected error in the main process" dialog.
+    const spy = vi.spyOn(fs, 'watch').mockImplementation(() => {
+      throw Object.assign(new Error('EISDIR: illegal operation on a directory, watch'), {
+        code: 'EISDIR'
+      })
+    })
+
+    const result = await searchFilesAndDir(dir, '')
+
+    expect(result.some((e) => e.file === 'a.png')).toBe(true)
+    // The unwatchable directory is simply not tracked.
+    expect(watchers.has(dir)).toBe(false)
+
+    spy.mockRestore()
   })
 })


### PR DESCRIPTION
## Problem

Fixes #3779.

Typing an image path (or loading a document that references one) whose directory lives on an unwatchable location — e.g. a `\\wsl.localhost\...` UNC path on Windows — pops the generic **"Unexpected error occurred in the main process"** dialog:

```
Unexpected error: EISDIR: illegal operation on a directory, watch '\\wsl.localhost\Ubuntu\...\md-images'
```

Root cause: the image-path auto-complete helper (`packages/desktop/src/main/utils/imagePathAutoComplement.ts`) starts an `fs.watch()` on the scanned directory with no error handling. `fs.watch()` throws **synchronously** for directories the OS can't watch (UNC/network mounts, some WSL paths → `EISDIR`). Because the call runs inside the `fs.readdir` callback of `searchFilesAndDir`, the throw escapes as an uncaught exception caught only by the global `uncaughtException` handler, whose message is exactly the reported dialog text.

## Fix

Wrap the `fs.watch()` call in try/catch and attach an `'error'` listener to the returned watcher (for failures that surface after construction). When a directory can't be watched, auto-complete simply degrades to "not watching" it — the scan result is still returned — instead of crashing the main process.

## Tests

Added to `test/unit/specs/image-path-autocomplete.spec.ts`: **"still resolves when the directory cannot be watched (UNC/WSL paths, #3779)"** — stubs `fs.watch` to throw `EISDIR` and asserts `searchFilesAndDir` still resolves with the scanned entries and leaves the directory untracked. Verified RED on `develop` (the throw escaped as an uncaught exception / hung the promise) → GREEN with the fix. Existing tests in the spec stay green; `typecheck` and `eslint` pass.