### PR TITLE
fix(muya): render extensionless remote images served with a charset (shields.io badges)

### DIFF
--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -27,7 +27,11 @@ afterEach(() => {
     window.DIRNAME = undefined;
 });
 
-describe('checkImageContentType — tolerates Content-Type parameters (#3837)', () => {
+describe('checkImageContentType (#3837)', () => {
+    // Same-origin URL — the only kind whose HEAD the renderer can actually read.
+    const sameOrigin = (p: string) => new URL(p, window.location.href).href;
+    const CROSS_ORIGIN = 'https://img.shields.io/badge/x-blue';
+
     function mockFetch(status: number, contentType: string | null) {
         vi.stubGlobal(
             'fetch',
@@ -39,35 +43,43 @@ describe('checkImageContentType — tolerates Content-Type parameters (#3837)', 
                 },
             }),
         );
+        return globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     }
 
     afterEach(() => {
         vi.unstubAllGlobals();
     });
 
-    it('accepts an image type carrying a charset parameter (shields.io badges)', async () => {
+    it('accepts a same-origin image type carrying a charset parameter', async () => {
         mockFetch(200, 'image/svg+xml;charset=utf-8');
-        expect(await checkImageContentType('https://img.shields.io/badge/x-blue')).toBe(true);
+        expect(await checkImageContentType(sameOrigin('/badge'))).toBe(true);
     });
 
-    it('accepts a bare image content type', async () => {
+    it('accepts a bare same-origin image content type', async () => {
         mockFetch(200, 'image/png');
-        expect(await checkImageContentType('https://example.com/badge')).toBe(true);
+        expect(await checkImageContentType(sameOrigin('/badge'))).toBe(true);
     });
 
-    it('reports a non-image content type as false', async () => {
+    it('reports a same-origin non-image content type as false', async () => {
         mockFetch(200, 'text/html;charset=utf-8');
-        expect(await checkImageContentType('https://example.com/page')).toBe(false);
+        expect(await checkImageContentType(sameOrigin('/page'))).toBe(false);
     });
 
     it('returns null (undetermined) on a non-200 response', async () => {
         mockFetch(404, 'image/png');
-        expect(await checkImageContentType('https://example.com/missing')).toBeNull();
+        expect(await checkImageContentType(sameOrigin('/missing'))).toBeNull();
     });
 
-    it('returns null when the HEAD request is blocked (CSP/CORS/network)', async () => {
-        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Refused to connect (CSP)')));
-        expect(await checkImageContentType('https://img.shields.io/badge/x-blue')).toBeNull();
+    it('returns null when the same-origin HEAD fails (network)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+        expect(await checkImageContentType(sameOrigin('/x'))).toBeNull();
+    });
+
+    it('skips the HEAD entirely for a cross-origin URL (CSP/CORS can never read it)', async () => {
+        const fetchSpy = mockFetch(200, 'image/png');
+        expect(await checkImageContentType(CROSS_ORIGIN)).toBeNull();
+        // No wasted, guaranteed-to-fail request (and no CSP console error).
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });
 
@@ -98,23 +110,24 @@ describe('loadImage — undetermined content-type still attempts the load (#3837
         vi.unstubAllGlobals();
     });
 
-    it('loads a cross-origin extensionless image when the HEAD check is CSP-blocked', async () => {
-        // In the shipping app the HEAD fetch to shields.io is refused by CSP, so
-        // the content-type can't be checked — the badge must still load via img-src.
-        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Refused to connect (CSP)')));
+    const sameOrigin = (p: string) => new URL(p, window.location.href).href;
+
+    it('loads a cross-origin extensionless image (its HEAD check is skipped)', async () => {
+        // The shields.io badge's content-type can't be read (CSP/CORS), so the
+        // check is skipped and the badge must still load via the permissive img-src.
         stubImage(true);
         await expect(
             loadImage('https://img.shields.io/badge/example-blue', true),
         ).resolves.toMatchObject({ width: 10, height: 10 });
     });
 
-    it('still rejects when the HEAD check positively reports a non-image type', async () => {
+    it('still rejects when a same-origin HEAD positively reports a non-image type', async () => {
         vi.stubGlobal(
             'fetch',
             vi.fn().mockResolvedValue({ status: 200, headers: { get: () => 'text/html' } }),
         );
         stubImage(true);
-        await expect(loadImage('https://example.com/page', true)).rejects.toBe('not an image.');
+        await expect(loadImage(sameOrigin('/page'), true)).rejects.toBe('not an image.');
     });
 });
 

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it } from 'vitest';
-import { getImageSrc } from '../image';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { checkImageContentType, getImageSrc } from '../image';
 
 // Regression tests for the Phase G "G1" blocker: relative-path images stopped
 // rendering after the @muyajs/core migration because `getImageSrc` returned a
@@ -25,6 +25,45 @@ function withDirname(dirname: string | undefined, fn: () => void) {
 
 afterEach(() => {
     window.DIRNAME = undefined;
+});
+
+describe('checkImageContentType — tolerates Content-Type parameters (#3837)', () => {
+    function mockFetch(status: number, contentType: string | null) {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                status,
+                headers: {
+                    get: (h: string) =>
+                        h.toLowerCase() === 'content-type' ? contentType : null,
+                },
+            }),
+        );
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('accepts an image type carrying a charset parameter (shields.io badges)', async () => {
+        mockFetch(200, 'image/svg+xml;charset=utf-8');
+        expect(await checkImageContentType('https://img.shields.io/badge/x-blue')).toBe(true);
+    });
+
+    it('accepts a bare image content type', async () => {
+        mockFetch(200, 'image/png');
+        expect(await checkImageContentType('https://example.com/badge')).toBe(true);
+    });
+
+    it('rejects a non-image content type', async () => {
+        mockFetch(200, 'text/html;charset=utf-8');
+        expect(await checkImageContentType('https://example.com/page')).toBe(false);
+    });
+
+    it('rejects a non-200 response even with an image content type', async () => {
+        mockFetch(404, 'image/png');
+        expect(await checkImageContentType('https://example.com/missing')).toBe(false);
+    });
 });
 
 describe('getImageSrc — relative local image paths anchored to window.DIRNAME', () => {

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { checkImageContentType, getImageSrc } from '../image';
+import { checkImageContentType, getImageSrc, loadImage } from '../image';
 
 // Regression tests for the Phase G "G1" blocker: relative-path images stopped
 // rendering after the @muyajs/core migration because `getImageSrc` returned a
@@ -55,14 +55,66 @@ describe('checkImageContentType — tolerates Content-Type parameters (#3837)', 
         expect(await checkImageContentType('https://example.com/badge')).toBe(true);
     });
 
-    it('rejects a non-image content type', async () => {
+    it('reports a non-image content type as false', async () => {
         mockFetch(200, 'text/html;charset=utf-8');
         expect(await checkImageContentType('https://example.com/page')).toBe(false);
     });
 
-    it('rejects a non-200 response even with an image content type', async () => {
+    it('returns null (undetermined) on a non-200 response', async () => {
         mockFetch(404, 'image/png');
-        expect(await checkImageContentType('https://example.com/missing')).toBe(false);
+        expect(await checkImageContentType('https://example.com/missing')).toBeNull();
+    });
+
+    it('returns null when the HEAD request is blocked (CSP/CORS/network)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Refused to connect (CSP)')));
+        expect(await checkImageContentType('https://img.shields.io/badge/x-blue')).toBeNull();
+    });
+});
+
+describe('loadImage — undetermined content-type still attempts the load (#3837)', () => {
+    // Drive the <img> load deterministically: setting `src` fires onload/onerror.
+    function stubImage(succeeds: boolean) {
+        class FakeImage {
+            width = 10;
+            height = 10;
+            onload: (() => void) | null = null;
+            onerror: ((err: unknown) => void) | null = null;
+            private _src = '';
+            get src(): string {
+                return this._src;
+            }
+
+            set src(v: string) {
+                this._src = v;
+                queueMicrotask(() =>
+                    succeeds ? this.onload?.() : this.onerror?.(new Error('load failed')),
+                );
+            }
+        }
+        vi.stubGlobal('Image', FakeImage);
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('loads a cross-origin extensionless image when the HEAD check is CSP-blocked', async () => {
+        // In the shipping app the HEAD fetch to shields.io is refused by CSP, so
+        // the content-type can't be checked — the badge must still load via img-src.
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Refused to connect (CSP)')));
+        stubImage(true);
+        await expect(
+            loadImage('https://img.shields.io/badge/example-blue', true),
+        ).resolves.toMatchObject({ width: 10, height: 10 });
+    });
+
+    it('still rejects when the HEAD check positively reports a non-image type', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({ status: 200, headers: { get: () => 'text/html' } }),
+        );
+        stubImage(true);
+        await expect(loadImage('https://example.com/page', true)).rejects.toBe('not an image.');
     });
 });
 

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -160,22 +160,39 @@ export async function loadImage(url: string, detectContentType = false): Promise
     });
 }
 
-// Returns `true`/`false` when the HEAD response positively identifies the URL
-// as an image (or not), or `null` when that can't be determined — the request
-// was blocked (the renderer CSP has no `connect-src`, so it falls back to the
-// restrictive `default-src 'self'` and cross-origin HEADs throw) or failed on
-// the network. A `null` must NOT be read as "not an image": the actual <img>
-// load is governed by the far more permissive `img-src`, so callers should
-// still attempt it (#3837 — shields.io badges and other extensionless remote
-// images).
+// Only a same-origin URL can have its Content-Type read from the renderer: a
+// cross-origin response has its headers stripped by CORS, and the app's CSP
+// (no `connect-src`, so it falls back to `default-src 'self'`) refuses the
+// request outright. Relative/opaque URLs are treated as same-origin so the
+// check is still attempted.
+function isSameOrigin(url: string): boolean {
+    try {
+        return new URL(url, window.location.href).origin === window.location.origin;
+    }
+    catch {
+        return true;
+    }
+}
+
+// Returns `true`/`false` when a HEAD response positively identifies the URL as
+// an image (or not), or `null` when that can't be determined. A `null` must NOT
+// be read as "not an image": the actual <img> load is governed by the far more
+// permissive `img-src`, so callers should still attempt it (#3837 — shields.io
+// badges and other extensionless remote images).
 export async function checkImageContentType(url: string): Promise<boolean | null> {
+    // Don't fire a HEAD we could never read: a cross-origin request is refused
+    // by the CSP (logging a console error) and unreadable under CORS anyway.
+    // Report "undetermined" and let the caller fall through to the <img> load.
+    if (!isSameOrigin(url))
+        return null;
+
     try {
         const res = await fetch(url, { method: 'HEAD' });
         if (res.status !== 200)
             return null;
 
-        // Content-Type can carry parameters (e.g. shields.io badges send
-        // `image/svg+xml;charset=utf-8`); match only the MIME type.
+        // Content-Type can carry parameters (e.g. `image/svg+xml;charset=utf-8`);
+        // match only the MIME type.
         const contentType = res.headers.get('content-type')?.split(';')[0].trim();
         if (!contentType)
             return null;

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -135,7 +135,10 @@ export async function loadImage(url: string, detectContentType = false): Promise
 }> {
     if (detectContentType) {
         const isImage = await checkImageContentType(url);
-        if (!isImage)
+        // Only bail out when we positively know it is NOT an image. `null`
+        // means we couldn't check (e.g. a cross-origin HEAD blocked by CSP);
+        // fall through to the actual load, which `img-src` permits (#3837).
+        if (isImage === false)
             // eslint-disable-next-line prefer-promise-reject-errors
             return Promise.reject('not an image.');
     }
@@ -157,26 +160,30 @@ export async function loadImage(url: string, detectContentType = false): Promise
     });
 }
 
-export async function checkImageContentType(url: string) {
+// Returns `true`/`false` when the HEAD response positively identifies the URL
+// as an image (or not), or `null` when that can't be determined — the request
+// was blocked (the renderer CSP has no `connect-src`, so it falls back to the
+// restrictive `default-src 'self'` and cross-origin HEADs throw) or failed on
+// the network. A `null` must NOT be read as "not an image": the actual <img>
+// load is governed by the far more permissive `img-src`, so callers should
+// still attempt it (#3837 — shields.io badges and other extensionless remote
+// images).
+export async function checkImageContentType(url: string): Promise<boolean | null> {
     try {
         const res = await fetch(url, { method: 'HEAD' });
+        if (res.status !== 200)
+            return null;
+
         // Content-Type can carry parameters (e.g. shields.io badges send
-        // `image/svg+xml;charset=utf-8`); match only the MIME type so those
-        // extensionless dynamic images still load (#3837).
+        // `image/svg+xml;charset=utf-8`); match only the MIME type.
         const contentType = res.headers.get('content-type')?.split(';')[0].trim();
+        if (!contentType)
+            return null;
 
-        if (
-            contentType
-            && res.status === 200
-            && /^image\/(?:jpeg|png|gif|svg\+xml|webp)$/.test(contentType)
-        ) {
-            return true;
-        }
-
-        return false;
+        return /^image\/(?:jpeg|png|gif|svg\+xml|webp)$/.test(contentType);
     }
     catch {
-        return false;
+        return null;
     }
 }
 

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -160,7 +160,10 @@ export async function loadImage(url: string, detectContentType = false): Promise
 export async function checkImageContentType(url: string) {
     try {
         const res = await fetch(url, { method: 'HEAD' });
-        const contentType = res.headers.get('content-type');
+        // Content-Type can carry parameters (e.g. shields.io badges send
+        // `image/svg+xml;charset=utf-8`); match only the MIME type so those
+        // extensionless dynamic images still load (#3837).
+        const contentType = res.headers.get('content-type')?.split(';')[0].trim();
 
         if (
             contentType


### PR DESCRIPTION
## Problem

Fixes #3837.

`![](https://img.shields.io/badge/example-blue)` (and other extensionless dynamic image URLs) render as a broken/failed image.

Root cause: for a URL with no image file extension, `getImageSrc` marks it `isUnknownType: true`, which routes it through `checkImageContentType()` (`packages/muya/src/utils/image.ts`). That function does a `HEAD` request and matches the `Content-Type` with:

```js
/^image\/(?:jpeg|png|gif|svg\+xml|webp)$/.test(contentType)
```

That's an **exact full-string** match. shields.io actually returns `content-type: image/svg+xml;charset=utf-8` — the `;charset=utf-8` parameter makes the anchored regex fail, so the badge is rejected as "not an image" and never loaded.

## Fix

Strip any Content-Type parameter (`;charset=…`) before matching, so only the MIME type is tested:

```js
const contentType = res.headers.get('content-type')?.split(';')[0].trim()
```

This affects any extensionless remote image served with a charset parameter (shields.io and many dynamic badge/CDN endpoints).

## Tests

Added a `checkImageContentType` block to `packages/muya/src/utils/__tests__/image.spec.ts` (which previously had no coverage for it): asserts `image/svg+xml;charset=utf-8` and bare `image/png` resolve to `true`, while `text/html;charset=utf-8` and a non-200 response resolve to `false`. Verified RED on `develop` (the charset case failed) → GREEN with the fix. `lint:types` and eslint pass.