### PR TITLE
fix(muya): follow the link when modifier-clicking a linked image

### DIFF
--- a/packages/muya/src/editor/linkMouseEvents.ts
+++ b/packages/muya/src/editor/linkMouseEvents.ts
@@ -36,7 +36,7 @@ import { getLinkInfo } from '../utils/getLinkInfo';
 // `mu-raw-html` is added to every inline HTML tag (`<u>`, `<mark>`,
 // `<sub>`, `<sup>`, `<a>` …), so we can't match it loosely — narrow
 // each entry by the actual tag the renderer emits.
-const LINK_SELECTOR = [
+export const LINK_SELECTOR = [
     `span.${CLASS_NAMES.MU_LINK}`,
     `a.${CLASS_NAMES.MU_REFERENCE_LINK}`,
     `a.${CLASS_NAMES.MU_RAW_HTML}`,

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -3,6 +3,7 @@ import type { Muya } from '../muya';
 import type Selection from './index';
 import type { IImageSelectionData } from './types';
 import { BLOCK_DOM_PROPERTY, CLASS_NAMES } from '../config';
+import { LINK_SELECTOR } from '../editor/linkMouseEvents';
 import { isHTMLElement, isKeyboardEvent } from '../utils';
 import { getImageInfo, getImageSrc } from '../utils/image';
 import { findContentDOM } from './dom';
@@ -102,12 +103,17 @@ class ImageSelection {
         }
 
         if (isHTMLElement(target) && target.tagName === 'IMG') {
-            // A linked image `[![alt](src)](href)` renders its image wrapper
-            // inside a `span.mu-link`. On modifier-click the link handler
-            // (linkMouseEvents) opens the URL; don't also emit the image
-            // preview, which would pop a viewer over the navigation (#3835).
-            const insideLink = !!imageWrapper.closest(`.${CLASS_NAMES.MU_LINK}`);
-            if (!insideLink && event instanceof MouseEvent && (event.metaKey || event.ctrlKey)) {
+            // A linked image (e.g. `[![alt](src)](href)`) renders its image
+            // wrapper inside a link element. On modifier-click the link handler
+            // (linkMouseEvents) opens the URL; don't also emit the image preview,
+            // which would pop a viewer over the navigation (#3835). Reuse
+            // linkMouseEvents' selector so every link variant is covered (plain,
+            // reference, autolink, raw-HTML anchor), not just `mu-link`.
+            if (
+                event instanceof MouseEvent
+                && (event.metaKey || event.ctrlKey)
+                && !imageWrapper.closest(LINK_SELECTOR)
+            ) {
                 const tokenSrc = imageInfo.token.src || imageInfo.token.attrs.src || '';
                 const src = getImageSrc(tokenSrc).src || target.getAttribute('src') || '';
                 if (src) {

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -102,7 +102,12 @@ class ImageSelection {
         }
 
         if (isHTMLElement(target) && target.tagName === 'IMG') {
-            if (event instanceof MouseEvent && (event.metaKey || event.ctrlKey)) {
+            // A linked image `[![alt](src)](href)` renders its image wrapper
+            // inside a `span.mu-link`. On modifier-click the link handler
+            // (linkMouseEvents) opens the URL; don't also emit the image
+            // preview, which would pop a viewer over the navigation (#3835).
+            const insideLink = !!imageWrapper.closest(`.${CLASS_NAMES.MU_LINK}`);
+            if (!insideLink && event instanceof MouseEvent && (event.metaKey || event.ctrlKey)) {
                 const tokenSrc = imageInfo.token.src || imageInfo.token.attrs.src || '';
                 const src = getImageSrc(tokenSrc).src || target.getAttribute('src') || '';
                 if (src) {

--- a/packages/muya/src/selection/__tests__/linkedImageClick.spec.ts
+++ b/packages/muya/src/selection/__tests__/linkedImageClick.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// #3835: Ctrl/Cmd-clicking a linked image `[![alt](src)](href)` popped the
+// image preview (ImageSelection's 'image' format-click) on top of the link
+// navigation (linkMouseEvents' 'link' format-click), so the link appeared not
+// to open. ImageSelection now skips emitting the image preview for an image
+// that lives inside a link when the click carries a modifier.
+
+const bootedMuyas: Muya[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedMuyas.push(muya);
+    return muya;
+}
+
+// The async image load never resolves under happy-dom, so inject the <img> the
+// loaded path would have produced.
+function injectImg(muya: Muya, src: string): HTMLImageElement {
+    const wrapper = muya.domNode.querySelector<HTMLElement>(
+        `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+    )!;
+    const container = wrapper.querySelector<HTMLElement>(
+        `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+    )!;
+    const img = document.createElement('img');
+    img.setAttribute('src', src);
+    container.appendChild(img);
+    return img;
+}
+
+function ctrlClick(img: HTMLImageElement): void {
+    img.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }),
+    );
+}
+
+function captureFormatClickTypes(muya: Muya): string[] {
+    const types: string[] = [];
+    muya.eventCenter.on('format-click', (payload: { formatType?: string }) => {
+        if (payload && payload.formatType)
+            types.push(payload.formatType);
+    });
+    return types;
+}
+
+describe('linked image modifier-click does not pop the image preview (#3835)', () => {
+    it('a linked image does not emit an image format-click on Ctrl-click', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`[![alt](${src})](https://link.example.com)`);
+
+        // The image wrapper renders inside the link span; the fix keys off this.
+        const wrapper = muya.domNode.querySelector<HTMLElement>(
+            `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+        )!;
+        expect(wrapper.closest(`.${CLASS_NAMES.MU_LINK}`)).not.toBeNull();
+
+        const img = injectImg(muya, src);
+        const types = captureFormatClickTypes(muya);
+
+        ctrlClick(img);
+
+        expect(types).not.toContain('image');
+    });
+
+    it('a plain (non-linked) image still emits an image format-click on Ctrl-click', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`![alt](${src})`);
+
+        const img = injectImg(muya, src);
+        const types = captureFormatClickTypes(muya);
+
+        ctrlClick(img);
+
+        expect(types).toContain('image');
+    });
+});


### PR DESCRIPTION
## Problem

Fixes #3835.

Ctrl/Cmd-clicking a linked image — `[![alt](img)](https://example.com/)` — does not open the link.

Root cause: two independent `click` listeners are attached to the same editor node:
- `ImageSelection._handleClickInlineImage` (`packages/muya/src/selection/ImageSelection.ts`) — on a modifier-click of an `<img>`, emits `format-click` `{ formatType: 'image' }`, which the desktop shell turns into an in-app image-preview overlay.
- `linkMouseEvents` (`packages/muya/src/editor/linkMouseEvents.ts`) — resolves the ancestor `span.mu-link` and emits `format-click` `{ formatType: 'link' }`, which opens the URL.

For a linked image both fire on the same Ctrl/Cmd-click (`stopPropagation` doesn't suppress a sibling listener on the same node). The link-open IPC *does* fire, but the image-preview overlay opens in the same tick and dominates the reaction — so the link looks broken.

## Fix

When the clicked image lives inside a link (`imageWrapper.closest('.mu-link')`) and the click carries a modifier, skip ImageSelection's image-preview emission and let the link handler open the URL. Plain (non-linked) images preview exactly as before.

## Tests

`packages/muya/src/selection/__tests__/linkedImageClick.spec.ts` (happy-dom, boots a real Muya, dispatches a real Ctrl-click):
- a **linked** image does **not** emit an `image` format-click on Ctrl-click (RED on `develop` → GREEN with the fix);
- a plain image **still** emits an `image` format-click on Ctrl-click (guards against regressing normal image preview).

Existing `duplicateImageResize` / `parityPreviewImage` selection specs stay green; `lint:types` and eslint pass.