### PR TITLE
fix(desktop): flush pending edits before saving (dropped last keystroke)

### DIFF
--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -502,6 +502,11 @@ export const useEditorStore = defineStore('editor', {
 
     FILE_SAVE(): void {
       if (!this.currentFile) return
+      // Flush any edit still queued in the engine's rAF batch into currentFile
+      // before reading its markdown, otherwise a keystroke typed in the same
+      // frame as Cmd+S is dropped from the saved file (#3803). Mirrors the
+      // tab-switch flush in UPDATE_CURRENT_FILE.
+      bus.emit('flush-active-editor')
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
@@ -531,6 +536,8 @@ export const useEditorStore = defineStore('editor', {
 
     FILE_SAVE_AS(): void {
       if (!this.currentFile) return
+      // See FILE_SAVE: flush pending edits before snapshotting markdown (#3803).
+      bus.emit('flush-active-editor')
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -500,13 +500,18 @@ export const useEditorStore = defineStore('editor', {
       }
     },
 
+    // Flush any edit still queued in the engine's rAF batch into the active
+    // tab's `currentFile` before its markdown is read to persist — otherwise an
+    // edit made in the same frame as the read is silently dropped from the
+    // written file (#3803), the way tab switching already guards (#2938). Safe
+    // no-op when nothing is pending.
+    flushActiveEditor(): void {
+      bus.emit('flush-active-editor')
+    },
+
     FILE_SAVE(): void {
       if (!this.currentFile) return
-      // Flush any edit still queued in the engine's rAF batch into currentFile
-      // before reading its markdown, otherwise a keystroke typed in the same
-      // frame as Cmd+S is dropped from the saved file (#3803). Mirrors the
-      // tab-switch flush in UPDATE_CURRENT_FILE.
-      bus.emit('flush-active-editor')
+      this.flushActiveEditor()
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
@@ -536,8 +541,7 @@ export const useEditorStore = defineStore('editor', {
 
     FILE_SAVE_AS(): void {
       if (!this.currentFile) return
-      // See FILE_SAVE: flush pending edits before snapshotting markdown (#3803).
-      bus.emit('flush-active-editor')
+      this.flushActiveEditor()
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
@@ -712,6 +716,7 @@ export const useEditorStore = defineStore('editor', {
 
     MOVE_FILE_TO(): void {
       if (!this.currentFile) return
+      this.flushActiveEditor()
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
@@ -754,6 +759,7 @@ export const useEditorStore = defineStore('editor', {
 
     RESPONSE_FOR_RENAME(): void {
       if (!this.currentFile) return
+      this.flushActiveEditor()
       const projectStore = useProjectStore()
       const { id, filename, pathname, markdown } = this.currentFile
       const options = getOptionsFromState(this.currentFile)
@@ -819,7 +825,7 @@ export const useEditorStore = defineStore('editor', {
         // Must run while `currentFile` still points at the outgoing tab, so its
         // flushed edit is attributed to that tab and not lost on switch (#2938).
         if (oldCurrentFile) {
-          bus.emit('flush-active-editor')
+          this.flushActiveEditor()
         }
         window.DIRNAME = pathname ? window.path.dirname(pathname) : ''
         this.currentFile = currentFile

--- a/packages/desktop/test/unit/specs/flush-before-save.spec.ts
+++ b/packages/desktop/test/unit/specs/flush-before-save.spec.ts
@@ -85,4 +85,21 @@ describe('editor store — flush pending edits before saving (#3803)', () => {
     expect(saveAsCall).toBeTruthy()
     expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
   })
+
+  // The same "read currentFile.markdown then persist" pattern also lives in
+  // MOVE_FILE_TO / RESPONSE_FOR_RENAME, which now flush through the shared
+  // helper too so those paths don't drop the last keystroke either (#3803).
+  it('MOVE_FILE_TO flushes the active editor before sending its IPC', () => {
+    const store = useEditorStore()
+    seedCurrentFile(store)
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.MOVE_FILE_TO()
+
+    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
+    expect(sendSpy).toHaveBeenCalled()
+    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+  })
 })

--- a/packages/desktop/test/unit/specs/flush-before-save.spec.ts
+++ b/packages/desktop/test/unit/specs/flush-before-save.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 
 // `@/store/editor` reads `window.path` at module load and `window.electron`
@@ -31,75 +31,139 @@ import bus from '@/bus'
 // #3803: the store snapshots `currentFile.markdown` (refreshed only on the
 // engine's deferred rAF `json-change`) to send to the main process. A keystroke
 // typed in the same frame as Cmd+S was therefore dropped from the saved file.
-// FILE_SAVE / FILE_SAVE_AS now emit `flush-active-editor` first, which the
-// editor synchronously flushes into `currentFile.markdown` before it is read.
+// The save/move/rename paths now emit `flush-active-editor` first, which the
+// editor synchronously commits into `currentFile.markdown` before it is read.
+//
+// The bug lives at the `const { …, markdown } = this.currentFile` READ, which
+// sits between the flush and the send — so an emit-order assertion (flush < send)
+// alone would still pass if a regression moved the flush past the read. These
+// tests instead wire a real `flush-active-editor` listener that commits the
+// pending keystroke (mirroring editor.vue → `editor.flush()` → `json-change` →
+// LISTEN_FOR_CONTENT_CHANGE) and assert the SENT PAYLOAD carries it: a flush
+// moved after the read would send the stale snapshot and fail here.
 
-function seedCurrentFile(store: ReturnType<typeof useEditorStore>) {
+const STALE = 'hello' // what the pre-flush snapshot holds
+const FLUSHED = 'hello world!' // the last keystroke the editor commits on flush
+const MARKDOWN_ARG = 4 // send(channel, id, filename, pathname, markdown, …)
+
+function seedCurrentFile(
+  store: ReturnType<typeof useEditorStore>,
+  overrides: Record<string, unknown> = {}
+) {
   store.currentFile = {
     id: 'tab-1',
     filename: 'note.md',
     pathname: '/tmp/note.md',
-    markdown: 'hello',
+    markdown: STALE,
     isSaved: false,
     encoding: { encoding: 'utf8', isBom: false },
     lineEnding: 'lf',
     adjustLineEndingOnSave: false,
-    trimTrailingNewline: 2
+    trimTrailingNewline: 2,
+    ...overrides
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
 
+// Mirror editor.vue's listener: commit the pending keystroke into the store on
+// flush. Returns a detach fn (the bus is a module singleton — listeners leak
+// across tests otherwise).
+function onFlushCommit(store: ReturnType<typeof useEditorStore>) {
+  const handler = () => {
+    if (store.currentFile) store.currentFile.markdown = FLUSHED
+  }
+  bus.on('flush-active-editor', handler)
+  return () => bus.off('flush-active-editor', handler)
+}
+
+// Global invocation order of a given emitted event, located by event name (not
+// array position) so an unrelated earlier emit can't mask a moved flush.
+function emitOrderOf(emitSpy: ReturnType<typeof vi.spyOn>, event: string): number | undefined {
+  const i = emitSpy.mock.calls.findIndex((c: unknown[]) => c[0] === event)
+  return i === -1 ? undefined : emitSpy.mock.invocationCallOrder[i]
+}
+
 describe('editor store — flush pending edits before saving (#3803)', () => {
+  let detach: (() => void) | undefined
+
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
   })
 
-  it('FILE_SAVE emits flush-active-editor before sending the save IPC', () => {
+  afterEach(() => {
+    detach?.()
+    detach = undefined
+  })
+
+  it('FILE_SAVE sends the flushed markdown, not the stale pre-flush snapshot', () => {
     const store = useEditorStore()
     seedCurrentFile(store)
-
-    const emitSpy = vi.spyOn(bus, 'emit')
+    detach = onFlushCommit(store)
     const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
 
     store.FILE_SAVE()
 
-    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
-    const saveCall = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save')
-    expect(saveCall).toBeTruthy()
-    // The flush must happen before the save payload is sent.
-    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+    const call = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save')
+    expect(call).toBeDefined()
+    expect(call?.[MARKDOWN_ARG]).toBe(FLUSHED)
   })
 
-  it('FILE_SAVE_AS emits flush-active-editor before sending the save-as IPC', () => {
+  it('FILE_SAVE_AS sends the flushed markdown, not the stale pre-flush snapshot', () => {
     const store = useEditorStore()
     seedCurrentFile(store)
-
-    const emitSpy = vi.spyOn(bus, 'emit')
+    detach = onFlushCommit(store)
     const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
 
     store.FILE_SAVE_AS()
 
-    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
-    const saveAsCall = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save-as')
-    expect(saveAsCall).toBeTruthy()
-    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+    const call = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save-as')
+    expect(call).toBeDefined()
+    expect(call?.[MARKDOWN_ARG]).toBe(FLUSHED)
   })
 
-  // The same "read currentFile.markdown then persist" pattern also lives in
-  // MOVE_FILE_TO / RESPONSE_FOR_RENAME, which now flush through the shared
-  // helper too so those paths don't drop the last keystroke either (#3803).
-  it('MOVE_FILE_TO flushes the active editor before sending its IPC', () => {
+  // MOVE_FILE_TO / RESPONSE_FOR_RENAME only transmit `markdown` in their untitled
+  // (no-pathname) branch, which reuses `mt::response-file-save` — that is where
+  // the flush actually matters, so assert the payload there too.
+  it('MOVE_FILE_TO (untitled) sends the flushed markdown', () => {
     const store = useEditorStore()
-    seedCurrentFile(store)
-
-    const emitSpy = vi.spyOn(bus, 'emit')
+    seedCurrentFile(store, { pathname: '' })
+    detach = onFlushCommit(store)
     const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
 
     store.MOVE_FILE_TO()
 
-    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
-    expect(sendSpy).toHaveBeenCalled()
-    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+    const call = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save')
+    expect(call).toBeDefined()
+    expect(call?.[MARKDOWN_ARG]).toBe(FLUSHED)
+  })
+
+  it('RESPONSE_FOR_RENAME (untitled) sends the flushed markdown', () => {
+    const store = useEditorStore()
+    seedCurrentFile(store, { pathname: '' })
+    detach = onFlushCommit(store)
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.RESPONSE_FOR_RENAME()
+
+    const call = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save')
+    expect(call).toBeDefined()
+    expect(call?.[MARKDOWN_ARG]).toBe(FLUSHED)
+  })
+
+  // The existing-file rename branch emits 'rename' (no markdown payload); guard
+  // that the flush still precedes it so it can't be silently dropped later.
+  it('RESPONSE_FOR_RENAME (existing file) flushes before emitting rename', () => {
+    const store = useEditorStore()
+    seedCurrentFile(store, { pathname: '/tmp/note.md' })
+    const emitSpy = vi.spyOn(bus, 'emit')
+
+    store.RESPONSE_FOR_RENAME()
+
+    const flushOrder = emitOrderOf(emitSpy, 'flush-active-editor')
+    const renameOrder = emitOrderOf(emitSpy, 'rename')
+    expect(flushOrder).toBeDefined()
+    expect(renameOrder).toBeDefined()
+    expect(flushOrder as number).toBeLessThan(renameOrder as number)
   })
 })

--- a/packages/desktop/test/unit/specs/flush-before-save.spec.ts
+++ b/packages/desktop/test/unit/specs/flush-before-save.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+// `@/store/editor` reads `window.path` at module load and `window.electron`
+// at runtime; stub those surfaces before the hoisted imports run.
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: {
+      path?: { sep: string; dirname: (p: string) => string }
+      electron?: {
+        clipboard: { writeText: (s: string) => void }
+        ipcRenderer: { send: (...a: unknown[]) => void; on: (...a: unknown[]) => void }
+      }
+    }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/', dirname: (p: string) => p }
+  w.window.electron ??= {
+    clipboard: { writeText: () => {} },
+    ipcRenderer: { send: () => {}, on: () => {} }
+  }
+})
+
+vi.mock('@/services/notification', () => ({
+  default: { notify: vi.fn(), name: 'notify' }
+}))
+
+import { useEditorStore } from '@/store/editor'
+import bus from '@/bus'
+
+// #3803: the store snapshots `currentFile.markdown` (refreshed only on the
+// engine's deferred rAF `json-change`) to send to the main process. A keystroke
+// typed in the same frame as Cmd+S was therefore dropped from the saved file.
+// FILE_SAVE / FILE_SAVE_AS now emit `flush-active-editor` first, which the
+// editor synchronously flushes into `currentFile.markdown` before it is read.
+
+function seedCurrentFile(store: ReturnType<typeof useEditorStore>) {
+  store.currentFile = {
+    id: 'tab-1',
+    filename: 'note.md',
+    pathname: '/tmp/note.md',
+    markdown: 'hello',
+    isSaved: false,
+    encoding: { encoding: 'utf8', isBom: false },
+    lineEnding: 'lf',
+    adjustLineEndingOnSave: false,
+    trimTrailingNewline: 2
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe('editor store — flush pending edits before saving (#3803)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('FILE_SAVE emits flush-active-editor before sending the save IPC', () => {
+    const store = useEditorStore()
+    seedCurrentFile(store)
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FILE_SAVE()
+
+    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
+    const saveCall = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save')
+    expect(saveCall).toBeTruthy()
+    // The flush must happen before the save payload is sent.
+    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+  })
+
+  it('FILE_SAVE_AS emits flush-active-editor before sending the save-as IPC', () => {
+    const store = useEditorStore()
+    seedCurrentFile(store)
+
+    const emitSpy = vi.spyOn(bus, 'emit')
+    const sendSpy = vi.spyOn(window.electron.ipcRenderer, 'send')
+
+    store.FILE_SAVE_AS()
+
+    expect(emitSpy).toHaveBeenCalledWith('flush-active-editor')
+    const saveAsCall = sendSpy.mock.calls.find((c) => c[0] === 'mt::response-file-save-as')
+    expect(saveAsCall).toBeTruthy()
+    expect(emitSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSpy.mock.invocationCallOrder[0])
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #3803.

Reports of "lost content despite saving" — most dramatically the tab-switch corruption already fixed in #2938 (PR #4658), but a narrower path survives that fix: the **save** itself can drop the last keystroke.

The engine commits edits into the renderer store's `currentFile.markdown` on a **deferred `requestAnimationFrame`** (`json-change`). `FILE_SAVE` / `FILE_SAVE_AS` (`packages/desktop/src/renderer/src/store/editor.ts`) read `currentFile.markdown` and send it to the main process **without flushing** that pending op first. So a keystroke typed in the same frame as `Cmd+S` (or Save As) is written to disk as the *previous* content — with no dirty indicator, matching the "a trailing character went missing" reports. The window is ~16 ms normally, but widens under main-thread congestion (large docs, spellcheck, diagram re-render).

Tab switching already handles this: `UPDATE_CURRENT_FILE` emits `bus.emit('flush-active-editor')` before reading, which the editor flushes into `currentFile` **synchronously** (the #2938 mechanism). The save paths just never did.

## Fix

Emit `flush-active-editor` at the start of `FILE_SAVE` and `FILE_SAVE_AS`, before snapshotting `currentFile.markdown`. This reuses the existing, synchronous flush wiring (`editor.vue` `flushActiveEditor` → `editor.flush()` → `json-change` → `LISTEN_FOR_CONTENT_CHANGE`), so the latest keystroke is captured in the saved file.

## Tests

`test/unit/specs/flush-before-save.spec.ts` (Pinia store, modeled on `editor-store-anchor.spec.ts`): asserts `FILE_SAVE` and `FILE_SAVE_AS` each emit `flush-active-editor` **before** sending their save IPC (`mt::response-file-save` / `-save-as`). Verified RED on `develop` (no flush emitted) → GREEN with the fix. `typecheck` and `eslint` pass.

The end-to-end no-lost-keystroke behavior depends on the already-tested flush mechanism (#2938's `flushPendingOps.spec.ts` + the `flush-active-editor` wiring); this PR adds the missing emit on the save paths and guards it.