### PR TITLE
fix(desktop): keep TOC collapse state across tab switches

### DIFF
--- a/packages/desktop/src/renderer/src/components/sideBar/toc.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/toc.vue
@@ -26,6 +26,7 @@
 import { computed, ref } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { usePreferencesStore } from '@/store/preferences'
+import { deriveKeyedToc, type KeyedTocNode } from '@/util/tocKeys'
 import bus from '../../bus'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
@@ -44,33 +45,9 @@ const defaultProps = {
 const { toc } = storeToRefs(editorStore)
 const { wordWrapInToc } = storeToRefs(preferencesStore)
 
-interface KeyedTocNode {
-  key: string
-  label: unknown
-  slug: unknown
-  children: KeyedTocNode[]
-}
-
-// The TOC nodes carry no stable id, so el-tree (without a node-key) discarded
-// the user's expand/collapse state on every content edit (#3028). Derive a
-// stable key per node — its slug, deduplicated in document order so duplicate
-// headings stay unique — and let el-tree preserve state by that key.
-const keyedToc = computed<KeyedTocNode[]>(() => {
-  const seen = new Map<string, number>()
-  const assign = (nodes: Array<Record<string, unknown>>): KeyedTocNode[] =>
-    nodes.map((node) => {
-      const base = typeof node.slug === 'string' && node.slug ? node.slug : 'heading'
-      const count = seen.get(base) ?? 0
-      seen.set(base, count + 1)
-      return {
-        key: count === 0 ? base : `${base}-${count}`,
-        label: node.label,
-        slug: node.slug,
-        children: assign((node.children as Array<Record<string, unknown>>) ?? [])
-      }
-    })
-  return assign(toc.value as unknown as Array<Record<string, unknown>>)
-})
+// Stable per-node key so el-tree preserves the user's expand/collapse state
+// across content edits (#3028) and tab switches (#3791). See deriveKeyedToc.
+const keyedToc = computed<KeyedTocNode[]>(() => deriveKeyedToc(toc.value))
 
 // Track which headings the user collapsed, by stable key (#3028). Headings are
 // expanded by default; a collapse is remembered here.

--- a/packages/desktop/src/renderer/src/util/listToTree.ts
+++ b/packages/desktop/src/renderer/src/util/listToTree.ts
@@ -15,6 +15,7 @@ export interface TreeNode<T extends ListItem = ListItem> {
   lvl: number | null
   label: unknown
   slug: unknown
+  githubSlug: unknown
   children: Array<TreeNode<T>>
 }
 
@@ -23,6 +24,7 @@ class Node<T extends ListItem> implements TreeNode<T> {
   lvl: number | null
   label: unknown
   slug: unknown
+  githubSlug: unknown
   children: Array<TreeNode<T>>
 
   constructor(item: {
@@ -30,12 +32,16 @@ class Node<T extends ListItem> implements TreeNode<T> {
     lvl: number | null
     content?: unknown
     slug?: unknown
+    githubSlug?: unknown
   }) {
-    const { parent, lvl, content, slug } = item
+    const { parent, lvl, content, slug, githubSlug } = item
     this.parent = parent
     this.lvl = lvl
     this.label = content
     this.slug = slug
+    // Carried through for the TOC: a content-derived id that, unlike `slug`
+    // (a per-render object id), survives a document reload / tab switch (#3791).
+    this.githubSlug = githubSlug
     this.children = []
   }
 

--- a/packages/desktop/src/renderer/src/util/tocKeys.ts
+++ b/packages/desktop/src/renderer/src/util/tocKeys.ts
@@ -1,0 +1,37 @@
+export interface KeyedTocNode {
+  key: string
+  label: unknown
+  slug: unknown
+  children: KeyedTocNode[]
+}
+
+interface TocLike {
+  label?: unknown
+  slug?: unknown
+  githubSlug?: unknown
+  children?: TocLike[]
+}
+
+// Give each TOC node a stable key so el-tree can preserve the user's
+// expand/collapse state. The key is the heading's content-derived `githubSlug`,
+// deduplicated in document order so duplicate headings stay distinct. This is
+// stable across content edits (#3028) AND across a document reload / tab switch
+// (#3791) — unlike the per-render object id `slug`, which every switch rebuilds.
+// `slug` is still carried for the click-to-scroll anchor payload.
+export function deriveKeyedToc(nodes: TocLike[]): KeyedTocNode[] {
+  const seen = new Map<string, number>()
+  const assign = (list: TocLike[]): KeyedTocNode[] =>
+    list.map((node) => {
+      const base =
+        typeof node.githubSlug === 'string' && node.githubSlug ? node.githubSlug : 'heading'
+      const count = seen.get(base) ?? 0
+      seen.set(base, count + 1)
+      return {
+        key: count === 0 ? base : `${base}-${count}`,
+        label: node.label,
+        slug: node.slug,
+        children: assign(node.children ?? [])
+      }
+    })
+  return assign(nodes)
+}

--- a/packages/desktop/test/unit/specs/toc-keys.spec.ts
+++ b/packages/desktop/test/unit/specs/toc-keys.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { deriveKeyedToc } from '@/util/tocKeys'
+
+// #3791: the TOC's collapse state is remembered by these keys. They must be
+// derived from the content-based `githubSlug` so they survive a tab switch
+// (which rebuilds every heading block with a fresh object-identity `slug`),
+// not only same-tab edits (#3028).
+
+const flatKeys = (nodes: ReturnType<typeof deriveKeyedToc>): string[] =>
+  nodes.flatMap((n) => [n.key, ...flatKeys(n.children)])
+
+describe('deriveKeyedToc', () => {
+  it('keys nodes by githubSlug, deduplicated in document order', () => {
+    const keyed = deriveKeyedToc([
+      { label: 'Intro', slug: 'uid-1', githubSlug: 'intro', children: [] },
+      { label: 'Intro', slug: 'uid-2', githubSlug: 'intro', children: [] }
+    ])
+    expect(keyed.map((n) => n.key)).toEqual(['intro', 'intro-1'])
+  })
+
+  it('produces identical keys when the same document is rebuilt with fresh slugs (tab switch)', () => {
+    // Same headings/content, different per-render object-identity slugs — this
+    // is exactly what Editor.setContent does when you switch back to a tab.
+    const doc = (p: string) => [
+      {
+        label: 'A',
+        slug: `${p}-1`,
+        githubSlug: 'a',
+        children: [{ label: 'B', slug: `${p}-2`, githubSlug: 'b', children: [] }]
+      },
+      { label: 'C', slug: `${p}-3`, githubSlug: 'c', children: [] }
+    ]
+
+    const before = deriveKeyedToc(doc('old'))
+    const after = deriveKeyedToc(doc('new'))
+
+    // Keys are stable across the rebuild, so collapse state keyed by them
+    // survives the switch (they would differ if keyed by `slug`).
+    expect(flatKeys(after)).toEqual(flatKeys(before))
+    expect(flatKeys(after)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('falls back to a stable placeholder for unsluggable headings', () => {
+    const keyed = deriveKeyedToc([
+      { label: '🎉', slug: 'uid-1', githubSlug: '', children: [] },
+      { label: '🎊', slug: 'uid-2', githubSlug: '', children: [] }
+    ])
+    expect(keyed.map((n) => n.key)).toEqual(['heading', 'heading-1'])
+  })
+
+  it('preserves slug (for the scroll-to-heading payload) while keying by githubSlug', () => {
+    const keyed = deriveKeyedToc([
+      { label: 'A', slug: 'uid-42', githubSlug: 'a', children: [] }
+    ])
+    expect(keyed[0].slug).toBe('uid-42')
+    expect(keyed[0].key).toBe('a')
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #3791.

Collapse a group in the outline/TOC sidebar, switch to another file's tab, switch back — the outline is fully expanded again. (Collapsing *does* survive an in-place content edit, which is the #3028 fix.)

Root cause: `toc.vue` keyed el-tree nodes by the heading's `slug`, which is `getTOC`'s `stableSlug` — a `WeakMap<block, id>` keyed by the **live block object's identity**. Switching tabs runs `Editor.setContent` → `ScrollPage.updateState`, which rebuilds every top-level block as a **brand-new object**, so the same heading gets a fresh random slug on return. `collapsedKeys` (holding the old keys) no longer matches, and every node re-expands. In-place edits don't hit this because they mutate the existing block objects, so the WeakMap entry survives — which is why #3028 worked but tab switches didn't.

## Fix

Key the tree by the **content-derived `githubSlug`** (already computed by `getTOC`, and used elsewhere for anchor ids) instead of the object-identity `slug`. `githubSlug` is stable across both content edits *and* document reloads/tab switches. `slug` is still carried through for the click-to-scroll payload (`scroll-to-header`).

- `listToTree.ts` now threads `githubSlug` through each tree node.
- The key-derivation is extracted from `toc.vue` into a pure, unit-testable `deriveKeyedToc` helper (`util/tocKeys.ts`).

## Tests

`test/unit/specs/toc-keys.spec.ts`: the decisive case — **"produces identical keys when the same document is rebuilt with fresh slugs (tab switch)"** — feeds the same headings with different object-identity `slug`s (exactly what `setContent` does) and asserts the derived keys are identical, so collapse state keyed by them survives. (Verified this fails when keyed by `slug`.) Plus dedup, unsluggable-heading fallback, and slug-preservation cases.

The existing same-tab e2e `toc-collapse-state-3028.spec.ts` continues to guard the #3028 path; `typecheck` and `eslint` pass.