### PR TITLE
fix: sync the inline format toolbar with custom keybindings

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -123,6 +123,7 @@ import { SpellChecker } from '@/spellchecker'
 import { isOsx, animatedScrollTo } from '@/util'
 import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
+import { buildInlineFormatShortcuts } from '@/util/formatShortcuts'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
 import { resolveTocHeadingElement } from '@/util/tocNavigation'
 import { addCommonStyle, setEditorWidth } from '@/util/theme'
@@ -1689,6 +1690,22 @@ const handleLanguageChanged = (newLocale?: unknown) => {
     editor.value.locale(getMuyaLocale(locale))
   }
 }
+
+// Keep the inline format toolbar's shortcut hints and internal key handling
+// in sync with the user's current keybindings (#4687). Fired via the editor
+// store's `mt::keybindings-response` re-broadcast — at startup and every time
+// the user saves Preferences → Keybindings.
+const handleKeybindingsChanged = (keybindingMap: unknown) => {
+  if (!editor.value || !keybindingMap || typeof keybindingMap !== 'object') {
+    return
+  }
+  editor.value.setOptions({
+    inlineFormatShortcuts: buildInlineFormatShortcuts(
+      keybindingMap as Record<string, string>,
+      isOsx
+    )
+  })
+}
 const resizeObserverForEditor = new ResizeObserver(handleResetPaddingBottom)
 
 onMounted(() => {
@@ -1808,6 +1825,12 @@ onMounted(() => {
 
   // Listen for language changes and update the engine locale.
   bus.on('language-changed', handleLanguageChanged)
+
+  // Sync the format toolbar with the current keybindings, and re-request them:
+  // the store's bootstrap request can fire before this component subscribes,
+  // so a fresh response guarantees the newly created engine gets today's map.
+  bus.on('keybindings-changed', handleKeybindingsChanged)
+  window.electron.ipcRenderer.send('mt::request-keybindings')
 
   // Create spell check wrapper and enable spell checking if preferred.
   spellchecker = new SpellChecker(spellcheckerEnabled.value, spellcheckerLanguage.value)
@@ -2007,6 +2030,7 @@ onBeforeUnmount(() => {
   bus.off('open-command-spellchecker-switch-language', openSpellcheckerLanguageCommand)
   bus.off('replace-misspelling', replaceMisspelling)
   bus.off('language-changed', handleLanguageChanged)
+  bus.off('keybindings-changed', handleKeybindingsChanged)
 
   document.removeEventListener('keyup', keyup)
 

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -874,6 +874,13 @@ export const useEditorStore = defineStore('editor', {
         }, 100)
       }, 400)
 
+      // Re-broadcast the main process's keybinding map on the renderer bus so
+      // editor.vue can push the format shortcuts into muya (#4687) — the muya
+      // instance lives in the component, out of this store's reach.
+      window.electron.ipcRenderer.on('mt::keybindings-response', (_, keybindingMap) => {
+        bus.emit('keybindings-changed', keybindingMap)
+      })
+
       window.electron.ipcRenderer.on('mt::bootstrap-editor', (_, config) => {
         const {
           addBlankTab,

--- a/packages/desktop/src/renderer/src/util/formatShortcuts.ts
+++ b/packages/desktop/src/renderer/src/util/formatShortcuts.ts
@@ -1,0 +1,94 @@
+import { acceleratorToTokens } from './accelerator'
+
+// Desktop format command ids → the muya inline format toolbar's format types.
+const FORMAT_COMMAND_TO_TYPE: Record<string, string> = {
+  'format.strong': 'strong',
+  'format.emphasis': 'em',
+  'format.underline': 'u',
+  'format.strike': 'del',
+  'format.highlight': 'mark',
+  'format.inline-code': 'inline_code',
+  'format.inline-math': 'inline_math',
+  'format.hyperlink': 'link',
+  'format.image': 'image',
+  'format.clear-format': 'clear'
+}
+
+// Mirrors muya's `IInlineFormatShortcut`. Restated here because the desktop
+// consumes `@muyajs/core` through the permissive hand-written stub
+// (`src/types/muya-core.d.ts`), which does not re-export the engine's types.
+export interface InlineFormatShortcut {
+  label: string
+  key?: string
+  shiftKey?: boolean
+  altKey?: boolean
+}
+
+// Convert one Electron accelerator into a muya shortcut entry. A `key`
+// matcher is only emitted for combos muya's Cmd/Ctrl-gated internal handler
+// can express — Cmd/Ctrl (+Shift/+Alt) plus a single printable key. Anything
+// else (function keys, named keys like `Plus`, combos without Cmd/Ctrl) is
+// hint-only: the application menu owns applying those.
+const toShortcut = (accelerator: string, isOsx: boolean): InlineFormatShortcut => {
+  const label = acceleratorToTokens(accelerator, isOsx).join('+')
+  let hasCmdOrCtrl = false
+  let shiftKey = false
+  let altKey = false
+  const keys: string[] = []
+
+  for (const part of accelerator.split('+')) {
+    const token = part.trim()
+    if (!token) {
+      continue
+    }
+    switch (token.toLowerCase()) {
+      case 'cmdorctrl':
+      case 'commandorcontrol':
+      case 'command':
+      case 'cmd':
+      case 'control':
+      case 'ctrl':
+      case 'meta':
+      case 'super':
+        hasCmdOrCtrl = true
+        break
+      case 'shift':
+        shiftKey = true
+        break
+      case 'alt':
+      case 'option':
+        altKey = true
+        break
+      default:
+        keys.push(token)
+    }
+  }
+
+  if (!hasCmdOrCtrl || keys.length !== 1 || keys[0].length !== 1) {
+    return { label }
+  }
+  return { label, key: keys[0].toLowerCase(), shiftKey, altKey }
+}
+
+/**
+ * Build the `inlineFormatShortcuts` muya option from the keybinding map the
+ * main process broadcasts (`mt::keybindings-response`, command id →
+ * accelerator), so the inline format toolbar advertises and applies the
+ * user's CURRENT bindings instead of muya's bundled defaults (#4687). An
+ * unbound command ('') yields a hint-less, matcher-less entry — the stale
+ * default combo must neither show nor keep working.
+ */
+export const buildInlineFormatShortcuts = (
+  keybindings: Record<string, string>,
+  isOsx: boolean
+): Record<string, InlineFormatShortcut> => {
+  const shortcuts: Record<string, InlineFormatShortcut> = {}
+  for (const [commandId, type] of Object.entries(FORMAT_COMMAND_TO_TYPE)) {
+    const accelerator = keybindings[commandId]
+    if (typeof accelerator !== 'string') {
+      continue
+    }
+    shortcuts[type] = accelerator === '' ? { label: '' } : toShortcut(accelerator, isOsx)
+  }
+  return shortcuts
+}

--- a/packages/desktop/test/unit/specs/inline-format-shortcuts.spec.ts
+++ b/packages/desktop/test/unit/specs/inline-format-shortcuts.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { buildInlineFormatShortcuts } from '@/util/formatShortcuts'
+
+// #4687: the inline format toolbar must advertise and apply the user's
+// CURRENT keybindings. This util turns the `mt::keybindings-response` map
+// (command id → Electron accelerator) into muya's `inlineFormatShortcuts`
+// option: a display label plus — when the combo is expressible for muya's
+// Cmd/Ctrl-gated internal handler — a key matcher.
+
+describe('buildInlineFormatShortcuts', () => {
+  it('maps the macOS defaults to symbol labels and lowercase key matchers', () => {
+    const shortcuts = buildInlineFormatShortcuts(
+      {
+        'format.strong': 'Command+B',
+        'format.highlight': 'Shift+Command+H',
+        'format.inline-code': 'Command+`'
+      },
+      true
+    )
+
+    expect(shortcuts.strong).toEqual({ label: '⌘+B', key: 'b', shiftKey: false, altKey: false })
+    expect(shortcuts.mark).toEqual({ label: '⇧+⌘+H', key: 'h', shiftKey: true, altKey: false })
+    expect(shortcuts.inline_code).toEqual({ label: '⌘+`', key: '`', shiftKey: false, altKey: false })
+  })
+
+  it('maps Windows/Linux accelerators to word labels', () => {
+    const shortcuts = buildInlineFormatShortcuts(
+      {
+        'format.strong': 'Ctrl+B',
+        // Linux's inline-code default diverges from the hardcoded muya hint —
+        // exactly the case the dynamic map exists for.
+        'format.inline-code': 'Ctrl+Y'
+      },
+      false
+    )
+
+    expect(shortcuts.strong).toEqual({ label: 'Ctrl+B', key: 'b', shiftKey: false, altKey: false })
+    expect(shortcuts.inline_code).toEqual({ label: 'Ctrl+Y', key: 'y', shiftKey: false, altKey: false })
+  })
+
+  it('understands CmdOrCtrl and Alt/Option modifiers', () => {
+    const shortcuts = buildInlineFormatShortcuts(
+      {
+        'format.strong': 'CmdOrCtrl+Alt+B'
+      },
+      false
+    )
+
+    expect(shortcuts.strong).toEqual({ label: 'Ctrl+Alt+B', key: 'b', shiftKey: false, altKey: true })
+  })
+
+  it('emits a hint-less, matcher-less entry for an unbound command', () => {
+    const shortcuts = buildInlineFormatShortcuts({ 'format.strong': '' }, true)
+
+    expect(shortcuts.strong).toEqual({ label: '' })
+  })
+
+  it('emits a hint-only entry for combos muya cannot match internally', () => {
+    const shortcuts = buildInlineFormatShortcuts(
+      {
+        // No Cmd/Ctrl — the application menu owns applying it.
+        'format.strong': 'F6',
+        // Named (multi-character) key.
+        'format.emphasis': 'Ctrl+Plus'
+      },
+      false
+    )
+
+    expect(shortcuts.strong).toEqual({ label: 'F6' })
+    expect(shortcuts.em).toEqual({ label: 'Ctrl+Plus' })
+  })
+
+  it('leaves format types absent from the payload on their muya defaults', () => {
+    const shortcuts = buildInlineFormatShortcuts({ 'format.strong': 'Ctrl+B' }, false)
+
+    expect(Object.keys(shortcuts)).toEqual(['strong'])
+  })
+
+  it('ignores non-format command ids', () => {
+    const shortcuts = buildInlineFormatShortcuts(
+      {
+        'file.save': 'Ctrl+S',
+        'format.strong': 'Ctrl+B'
+      },
+      false
+    )
+
+    expect(Object.keys(shortcuts)).toEqual(['strong'])
+  })
+})

--- a/packages/muya/e2e/tests/inline/shortcuts.spec.ts
+++ b/packages/muya/e2e/tests/inline/shortcuts.spec.ts
@@ -5,6 +5,13 @@ import { editor } from '../helpers/selectors';
 
 async function tripleClickFirstParagraph(page: import('@playwright/test').Page) {
     await page.locator(editor.paragraph).first().click({ clickCount: 3 });
+    // The keystroke races the selection: pressing the shortcut before the
+    // triple-click selection settles formats nothing (the known flake in
+    // this suite). Gate on a real, non-collapsed selection.
+    await page.waitForFunction(() => {
+        const selection = window.getSelection();
+        return !!selection && !selection.isCollapsed && selection.toString().length > 0;
+    });
 }
 
 test.describe('keyboard shortcuts', () => {
@@ -22,11 +29,29 @@ test.describe('keyboard shortcuts', () => {
         expect(await getMarkdown(page)).toMatch(/[*_]emph text[*_]/);
     });
 
-    test('Cmd/Ctrl+E applies inline code', async ({ page }) => {
+    // The internal default follows the ADVERTISED binding (Cmd/Ctrl+`);
+    // the legacy Cmd/Ctrl+E stopped applying when the two were unified (#4687).
+    test('Cmd/Ctrl+` applies inline code', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('codeblock'));
+        await tripleClickFirstParagraph(page);
+        await page.keyboard.press(`${metaKey()}+\``);
+        expect(await getMarkdown(page)).toContain('`codeblock`');
+    });
+
+    test('Cmd/Ctrl+E no longer applies inline code', async ({ page }) => {
         await page.evaluate(() => window.muya!.setContent('codeblock'));
         await tripleClickFirstParagraph(page);
         await page.keyboard.press(`${metaKey()}+e`);
-        expect(await getMarkdown(page)).toContain('`codeblock`');
+        expect(await getMarkdown(page)).not.toContain('`codeblock`');
+    });
+
+    // Shift-modified defaults arrive as an uppercase `event.key`; matching is
+    // case-insensitive since #4687 (they could never fire before).
+    test('Cmd/Ctrl+Shift+H applies highlight to the selection', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('marked text'));
+        await tripleClickFirstParagraph(page);
+        await page.keyboard.press(`${metaKey()}+Shift+h`);
+        expect(await getMarkdown(page)).toContain('<mark>marked text</mark>');
     });
 
     test('Cmd/Ctrl+D applies strikethrough to the selection', async ({ page }) => {

--- a/packages/muya/src/editor/__tests__/nativeFormatSuppression.spec.ts
+++ b/packages/muya/src/editor/__tests__/nativeFormatSuppression.spec.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+// marktext #4687 follow-through: once a format combo is no longer claimed by
+// an embedder accelerator or the toolbar's internal handler (e.g. Cmd+B after
+// rebinding Bold), the keystroke reaches the contenteditable and Chromium's
+// NATIVE rich-text editing kicks in — styling the DOM behind the model's
+// back, invisible to the serialized markdown. The editor must cancel every
+// `format*` beforeinput; the model is the only writer of formatting.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function dispatchBeforeInput(muya: Muya, inputType: string): boolean {
+    const event = new Event('beforeinput', { cancelable: true, bubbles: true });
+    Object.defineProperty(event, 'inputType', { value: inputType });
+    muya.domNode.dispatchEvent(event);
+    return event.defaultPrevented;
+}
+
+describe('native rich-text formatting is suppressed', () => {
+    it.each(['formatBold', 'formatItalic', 'formatUnderline', 'formatStrikeThrough'])(
+        'cancels a %s beforeinput',
+        (inputType) => {
+            const muya = bootMuya('hello world\n');
+            expect(dispatchBeforeInput(muya, inputType)).toBe(true);
+        },
+    );
+
+    it('leaves text insertion and composition untouched', () => {
+        const muya = bootMuya('hello world\n');
+        expect(dispatchBeforeInput(muya, 'insertText')).toBe(false);
+        expect(dispatchBeforeInput(muya, 'insertCompositionText')).toBe(false);
+    });
+
+    it('leaves history inputTypes untouched', () => {
+        const muya = bootMuya('hello world\n');
+        expect(dispatchBeforeInput(muya, 'historyUndo')).toBe(false);
+    });
+});

--- a/packages/muya/src/editor/index.ts
+++ b/packages/muya/src/editor/index.ts
@@ -282,6 +282,19 @@ export class Editor {
         this.scrollPage = ScrollPage.create(muya, state);
 
         this._dispatchEvents();
+        // The document model is the only writer of inline formatting: cancel
+        // the browser's native rich-text editing on the contenteditable
+        // (Cmd/Ctrl+B/I/U fire `beforeinput` with a `format*` inputType and
+        // would style the DOM behind the model's back — visible bold that
+        // never reaches the serialized markdown). Reached whenever a format
+        // combo is NOT claimed by an embedder accelerator or the inline
+        // format toolbar's own handler, e.g. after rebinding (#4687).
+        // Cleanup is handled by `muya.destroy()` → `detachAllDomEvents`.
+        muya.eventCenter.attachDOMEvent(muya.domNode, 'beforeinput', (event) => {
+            const { inputType } = event as InputEvent;
+            if (typeof inputType === 'string' && inputType.startsWith('format'))
+                event.preventDefault();
+        });
         // Hovering a rendered link wrapper dispatches `muya-link-tools` so the
         // staged popover lights up. Cleanup is handled by `muya.destroy()` →
         // `detachAllDomEvents`.

--- a/packages/muya/src/index.ts
+++ b/packages/muya/src/index.ts
@@ -7,7 +7,7 @@ export { MarkdownToHtml } from './state/markdownToHtml';
 export { renderToStaticHTML } from './state/renderToStaticHTML';
 export type { IRenderToStaticHTMLOptions } from './state/renderToStaticHTML';
 export type { TState } from './state/types';
-export type { IMuyaOptions } from './types';
+export type { IInlineFormatShortcut, IMuyaOptions, TInlineFormatShortcutMap } from './types';
 
 export { CodeBlockLanguageSelector } from './ui/codeBlockLanguageSelector';
 // Export ui tools.

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -1,5 +1,29 @@
 import type { TState } from './state/types';
 
+/**
+ * One inline-format shortcut as the format toolbar consumes it: the hint text
+ * rendered in the button tooltip plus the key the editor's internal
+ * Cmd/Ctrl-gated keydown handler matches. An entry without `key` shows the
+ * hint only — the embedder owns the combo (e.g. through its application menu).
+ */
+export interface IInlineFormatShortcut {
+    /** Tooltip hint, e.g. '⇧+⌘+H'. An empty string hides the hint line. */
+    label: string;
+    /**
+     * `KeyboardEvent.key` to match, compared case-insensitively so
+     * Shift-modified letters ('H') still hit their lowercase entry. Cmd or
+     * Ctrl must be held regardless — that gate is not expressible here.
+     */
+    key?: string;
+    /** Shift must be held iff true. */
+    shiftKey?: boolean;
+    /** Alt/Option must be held iff true. */
+    altKey?: boolean;
+}
+
+/** Format type (e.g. 'strong', 'inline_code') → its shortcut override. */
+export type TInlineFormatShortcutMap = Partial<Record<string, IInlineFormatShortcut>>;
+
 export interface IMuyaOptions {
     fontSize: number;
     lineHeight: number;
@@ -35,6 +59,15 @@ export interface IMuyaOptions {
     isGitlabCompatibilityEnabled: boolean;
     autoMoveCheckedToEnd: boolean;
     disableHtml: boolean;
+    /**
+     * Per-format overrides for the inline format toolbar's shortcut hints and
+     * its internal Cmd/Ctrl key handling, replacing the bundled defaults for
+     * the given format types (missing types keep their default). Embedders
+     * whose accelerators are rebindable pass the current bindings here and
+     * push changes at runtime via `setOptions({ inlineFormatShortcuts })` so
+     * the toolbar never advertises — or keeps applying — a stale combo.
+     */
+    inlineFormatShortcuts?: TInlineFormatShortcutMap;
     locale: {
         name: string;
         resource: {

--- a/packages/muya/src/ui/inlineFormatToolbar/__tests__/shortcutOverrides.spec.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/__tests__/shortcutOverrides.spec.ts
@@ -1,0 +1,205 @@
+// @vitest-environment happy-dom
+
+import type Format from '../../../block/base/format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+import icons from '../config';
+import { InlineFormatToolbar } from '../index';
+
+// marktext #4687: the toolbar's shortcut hints and its internal Cmd/Ctrl
+// keydown handler were hardcoded, so an embedder that rebinds its
+// accelerators kept advertising — and applying — the stale defaults. Both
+// now resolve through the `inlineFormatShortcuts` muya option (falling back
+// to the bundled defaults), updatable at runtime via `setOptions`.
+
+const bootedHosts: HTMLElement[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+    // baseFloat observes its container with a ResizeObserver; happy-dom doesn't
+    // ship one, so stand in a no-op.
+    if (typeof globalThis.ResizeObserver === 'undefined') {
+        globalThis.ResizeObserver = class {
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        } as never;
+    }
+});
+
+afterEach(() => {
+    while (bootedHosts.length) bootedHosts.pop()!.remove();
+    // A range left pointing into a removed host corrupts the next test's
+    // `setCursor` (the DOM selection is document-global).
+    document.getSelection()?.removeAllRanges();
+});
+
+function bootMuya(markdown: string, options: Record<string, unknown> = {}): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown, ...options } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function openToolbar(muya: Muya): InlineFormatToolbar {
+    const toolbar = new InlineFormatToolbar(muya);
+    toolbar.status = true;
+    // Re-rendering on selection-change is how an open toolbar refreshes; it
+    // also renders the buttons without a real floating-ui reference element.
+    muya.eventCenter.emit('selection-change', {
+        formats: [],
+        isCollapsed: false,
+        isSelectionInSameBlock: true,
+    });
+    return toolbar;
+}
+
+function titleOf(toolbar: InlineFormatToolbar, type: string): string {
+    const item = toolbar.container!.querySelector(`li.item.${type}`);
+    expect(item, `no toolbar item rendered for type=${type}`).toBeTruthy();
+    return item!.getAttribute('title') ?? '';
+}
+
+// Select `hello` in the document's first block so the internal keydown
+// handler sees a same-block, Format-typed selection. happy-dom's `Selection`
+// does not track range offsets — a real `setCursor(0, 5)` round-trips through
+// `getCursor()` as a collapsed `{0,0}` — so stub the block's `getCursor` the
+// way `formatToggle.spec.ts` does; everything below it (the keydown gate, the
+// shortcut matching, `format()`'s text surgery) is the genuine code path.
+function selectHello(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(0, 0, true);
+    (content as unknown as { getCursor: () => unknown }).getCursor = () => ({
+        start: { offset: 0 },
+        end: { offset: 5 },
+        anchor: { offset: 0 },
+        focus: { offset: 5 },
+        isCollapsed: false,
+        isSelectionInSameBlock: true,
+        direction: 'forward',
+        type: 'Range',
+    });
+    return content;
+}
+
+function pressOnEditor(
+    muya: Muya,
+    key: string,
+    modifiers: { ctrlKey?: boolean; shiftKey?: boolean; altKey?: boolean } = {},
+): void {
+    muya.domNode.dispatchEvent(
+        new KeyboardEvent('keydown', { key, ctrlKey: true, cancelable: true, ...modifiers }),
+    );
+}
+
+describe('tooltip shortcut hints (#4687)', () => {
+    it('falls back to the bundled default hint when no override is passed', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = openToolbar(muya);
+
+        const defaultStrong = icons.find(i => i.type === 'strong')!;
+        expect(titleOf(toolbar, 'strong')).toContain(defaultStrong.shortcut);
+    });
+
+    it('renders the override label and leaves other buttons on their defaults', () => {
+        const muya = bootMuya('hello world\n', {
+            inlineFormatShortcuts: { strong: { label: 'Ctrl+Shift+7' } },
+        });
+        const toolbar = openToolbar(muya);
+
+        expect(titleOf(toolbar, 'strong')).toContain('Ctrl+Shift+7');
+
+        const defaultEm = icons.find(i => i.type === 'em')!;
+        expect(titleOf(toolbar, 'em')).toContain(defaultEm.shortcut);
+    });
+
+    it('hides the hint line entirely for an empty override label (unbound command)', () => {
+        const muya = bootMuya('hello world\n', {
+            inlineFormatShortcuts: { strong: { label: '' } },
+        });
+        const toolbar = openToolbar(muya);
+
+        expect(titleOf(toolbar, 'strong')).not.toContain('\n');
+    });
+
+    it('applies a runtime setOptions change on the next re-render', () => {
+        const muya = bootMuya('hello world\n');
+        const toolbar = openToolbar(muya);
+
+        const defaultStrong = icons.find(i => i.type === 'strong')!;
+        expect(titleOf(toolbar, 'strong')).toContain(defaultStrong.shortcut);
+
+        muya.setOptions({ inlineFormatShortcuts: { strong: { label: 'F6' } } });
+        muya.eventCenter.emit('selection-change', {
+            formats: [],
+            isCollapsed: false,
+            isSelectionInSameBlock: true,
+        });
+
+        expect(titleOf(toolbar, 'strong')).toContain('F6');
+    });
+});
+
+describe('internal format keydown handler (#4687)', () => {
+    it('applies the default combo when no override is passed', () => {
+        const muya = bootMuya('hello world\n');
+        openToolbar(muya);
+        const content = selectHello(muya);
+
+        pressOnEditor(muya, 'b');
+
+        expect(content.text).toBe('**hello** world');
+    });
+
+    it('matches Shift-modified combos although KeyboardEvent.key arrives uppercase', () => {
+        // The pre-#4687 handler looked the raw key up in a lowercase map, so
+        // its Shift entries (mark, image, clear, inline_math) never fired.
+        const muya = bootMuya('hello world\n');
+        openToolbar(muya);
+        const content = selectHello(muya);
+
+        pressOnEditor(muya, 'H', { shiftKey: true });
+
+        expect(content.text).toBe('<mark>hello</mark> world');
+    });
+
+    it('stops applying the default combo once the format is rebound', () => {
+        const muya = bootMuya('hello world\n', {
+            inlineFormatShortcuts: { strong: { label: 'Ctrl+Shift+7', key: '7', shiftKey: true } },
+        });
+        openToolbar(muya);
+        const content = selectHello(muya);
+
+        pressOnEditor(muya, 'b');
+        expect(content.text).toBe('hello world');
+
+        pressOnEditor(muya, '7', { shiftKey: true });
+        expect(content.text).toBe('**hello** world');
+    });
+
+    it('leaves the combo to the embedder when the override carries no key', () => {
+        const muya = bootMuya('hello world\n', {
+            inlineFormatShortcuts: { strong: { label: 'F6' } },
+        });
+        openToolbar(muya);
+        const content = selectHello(muya);
+
+        pressOnEditor(muya, 'b');
+
+        expect(content.text).toBe('hello world');
+    });
+
+    it('requires the Alt state to match, so Ctrl+Alt combos no longer collide', () => {
+        const muya = bootMuya('hello world\n');
+        openToolbar(muya);
+        const content = selectHello(muya);
+
+        // AltGr arrives as ctrlKey+altKey on Windows layouts; it must not bold.
+        pressOnEditor(muya, 'b', { altKey: true });
+
+        expect(content.text).toBe('hello world');
+    });
+});

--- a/packages/muya/src/ui/inlineFormatToolbar/config.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/config.ts
@@ -12,35 +12,57 @@ import { isOsx } from '../../config';
 
 const COMMAND_KEY = isOsx ? '⌘' : 'Ctrl';
 
-const icons = [
+/**
+ * One toolbar button plus its DEFAULT shortcut: `shortcut` is the tooltip
+ * hint, `key`/`shiftKey` what the internal Cmd/Ctrl-gated keydown handler
+ * matches. Both are overridable per format type via the
+ * `inlineFormatShortcuts` muya option — these values only apply when the
+ * embedder passes no override.
+ */
+export interface IFormatToolIcon {
+    type: string;
+    tooltip: string;
+    shortcut: string;
+    key: string;
+    shiftKey?: boolean;
+    icon: string;
+}
+
+const icons: IFormatToolIcon[] = [
     {
         type: 'strong',
         tooltip: 'Emphasize',
         shortcut: `${COMMAND_KEY}+B`,
+        key: 'b',
         icon: strongIcon,
     },
     {
         type: 'em',
         tooltip: 'Italic',
         shortcut: `${COMMAND_KEY}+I`,
+        key: 'i',
         icon: emphasisIcon,
     },
     {
         type: 'u',
         tooltip: 'Underline',
         shortcut: `${COMMAND_KEY}+U`,
+        key: 'u',
         icon: underlineIcon,
     },
     {
         type: 'del',
         tooltip: 'Strikethrough',
         shortcut: `${COMMAND_KEY}+D`,
+        key: 'd',
         icon: strikeIcon,
     },
     {
         type: 'mark',
         tooltip: 'Highlight',
         shortcut: `⇧+${COMMAND_KEY}+H`,
+        key: 'h',
+        shiftKey: true,
         icon: highlightIcon,
     },
     {
@@ -48,6 +70,7 @@ const icons = [
         tooltip: 'Inline Code',
         // Default keybinding is Cmd/Ctrl+` (Linux uses Ctrl+Y); was wrongly +E.
         shortcut: `${COMMAND_KEY}+\``,
+        key: '`',
         icon: codeIcon,
     },
     {
@@ -55,28 +78,35 @@ const icons = [
         tooltip: 'Inline Math',
         // Default keybinding is Shift+Cmd/Ctrl+M; was wrongly +E.
         shortcut: `⇧+${COMMAND_KEY}+M`,
+        key: 'm',
+        shiftKey: true,
         icon: mathIcon,
     },
     {
         type: 'link',
         tooltip: 'Link',
         shortcut: `${COMMAND_KEY}+L`,
+        key: 'l',
         icon: linkIcon,
     },
     {
         type: 'image',
         tooltip: 'Image',
         shortcut: `⇧+${COMMAND_KEY}+I`,
+        key: 'i',
+        shiftKey: true,
         icon: imageIcon,
     },
     {
         type: 'clear',
         tooltip: 'Eliminate',
         shortcut: `⇧+${COMMAND_KEY}+R`,
+        key: 'r',
+        shiftKey: true,
         icon: clearIcon,
     },
 ];
 
-export type FormatToolIcon = typeof icons[number];
+export type FormatToolIcon = IFormatToolIcon;
 
 export default icons;

--- a/packages/muya/src/ui/inlineFormatToolbar/index.ts
+++ b/packages/muya/src/ui/inlineFormatToolbar/index.ts
@@ -1,6 +1,7 @@
 import type { VNode } from 'snabbdom';
 import type { Muya } from '../../index';
 import type { Token } from '../../inlineRenderer/types';
+import type { IInlineFormatShortcut } from '../../types';
 import type { IBaseOptions } from '../types';
 
 import type { FormatToolIcon } from './config';
@@ -21,24 +22,6 @@ const defaultOptions = {
     },
     showArrow: false,
 };
-
-/** Format keyboard shortcuts without shift modifier */
-const FORMAT_SHORTCUTS = {
-    b: 'strong',
-    i: 'em',
-    u: 'u',
-    d: 'del',
-    e: 'inline_code',
-    l: 'link',
-} as const;
-
-/** Format keyboard shortcuts with shift modifier */
-const FORMAT_SHORTCUTS_SHIFT = {
-    h: 'mark',
-    e: 'inline_math',
-    i: 'image',
-    r: 'clear',
-} as const;
 
 /** Keys that should not trigger toolbar hiding */
 const NON_EDITING_KEYS = new Set([
@@ -140,7 +123,7 @@ export class InlineFormatToolbar extends BaseFloat {
         if (!isKeyboardEvent(event))
             return;
 
-        const { key, shiftKey, metaKey, ctrlKey } = event;
+        const { key, metaKey, ctrlKey } = event;
         const selection = editor.selection.getSelection();
         if (!selection)
             return;
@@ -158,7 +141,7 @@ export class InlineFormatToolbar extends BaseFloat {
         }
 
         // Handle format shortcuts
-        this._handleFormatShortcut(event, key, shiftKey, anchorBlock);
+        this._handleFormatShortcut(event, anchorBlock);
     }
 
     /**
@@ -178,24 +161,43 @@ export class InlineFormatToolbar extends BaseFloat {
     }
 
     /**
-     * Handle format keyboard shortcuts
+     * Resolve the effective shortcut for a toolbar button: the embedder's
+     * `inlineFormatShortcuts` entry when one exists for the format type,
+     * otherwise the bundled default from `config.ts`. Read per event/render
+     * (not cached) so `setOptions` changes apply immediately.
+     */
+    private _shortcutFor(icon: FormatToolIcon): IInlineFormatShortcut {
+        const override = this.muya.options.inlineFormatShortcuts?.[icon.type];
+
+        return override ?? { label: icon.shortcut, key: icon.key, shiftKey: icon.shiftKey };
+    }
+
+    /**
+     * Apply the format whose effective shortcut matches the pressed key.
+     * Only reached with Cmd/Ctrl held (gated in `_handleKeydown`). Keys are
+     * compared case-insensitively because Shift-modified letters arrive
+     * uppercase in `KeyboardEvent.key`.
      * @param event - Keyboard event
-     * @param key - Key name
-     * @param shiftKey - Shift key state
      * @param anchorBlock - Anchor block
      */
-    private _handleFormatShortcut(
-        event: KeyboardEvent,
-        key: string,
-        shiftKey: boolean,
-        anchorBlock: Format,
-    ) {
-        const shortcuts = shiftKey ? FORMAT_SHORTCUTS_SHIFT : FORMAT_SHORTCUTS;
-        const formatType = shortcuts[key as keyof typeof shortcuts];
+    private _handleFormatShortcut(event: KeyboardEvent, anchorBlock: Format) {
+        const pressedKey = event.key.toLowerCase();
 
-        if (formatType) {
+        for (const icon of this._icons) {
+            const { key, shiftKey, altKey } = this._shortcutFor(icon);
+            if (
+                !key
+                || key.toLowerCase() !== pressedKey
+                || !!shiftKey !== event.shiftKey
+                || !!altKey !== event.altKey
+            ) {
+                continue;
+            }
+
             event.preventDefault();
-            anchorBlock.format(formatType);
+            anchorBlock.format(icon.type);
+
+            return;
         }
     }
 
@@ -241,12 +243,13 @@ export class InlineFormatToolbar extends BaseFloat {
         );
 
         const itemSelector = `li.item.${icon.type}${isActive ? '.active' : ''}`;
+        const { label } = this._shortcutFor(icon);
 
         return h(
             itemSelector,
             {
                 attrs: {
-                    title: `${i18n.t(icon.tooltip)}\n${icon.shortcut}`,
+                    title: label ? `${i18n.t(icon.tooltip)}\n${label}` : i18n.t(icon.tooltip),
                 },
                 on: {
                     click: event => this._selectItem(event, icon),


### PR DESCRIPTION
## Problem

Fixes #4687.

The inline format toolbar hardcodes its shortcut hints (`inlineFormatToolbar/config.ts`) and applies format shortcuts through a hardcoded internal key map (`FORMAT_SHORTCUTS` / `FORMAT_SHORTCUTS_SHIFT`). After rebinding a format command in Preferences → Keybindings:

- the button tooltip keeps advertising the old default, while the menu bar / command palette (since #4681) already show the new one;
- the old combo keeps applying the format — the desktop unregisters the old accelerator, so the key falls through to muya's internal handler.

Hand-testing the fix surfaced a third leak behind the same combo: once the old accelerator no longer claims the key (and the toolbar handler correctly stops matching it), the keystroke reaches the contenteditable and **Chromium's native rich-text editing** bolds the DOM directly — visible styling that lives outside the document model and never reaches the serialized markdown.

## Fix

Following the direction sketched in the issue, the engine stays unaware of the desktop key map:

**muya** (`@muyajs/core`)
- New optional `inlineFormatShortcuts` option: per format type, a tooltip `label` plus an optional `key`/`shiftKey`/`altKey` matcher for the internal Cmd/Ctrl-gated handler. Missing types keep the bundled defaults, so standalone muya (examples, website) is unaffected; runtime changes go through the pre-existing `muya.setOptions(...)` mechanism. The toolbar resolves both the tooltip hint and the keydown matching through this map.
- The editor now cancels every `format*` `beforeinput` on the contenteditable — the document model is the only writer of formatting, so the browser's native Cmd/Ctrl+B/I/U editing must never mutate the DOM behind it.

**desktop**
- `util/formatShortcuts.ts` converts the `mt::keybindings-response` map (command id → Electron accelerator) into the muya option: labels via the same `acceleratorToTokens` the command palette uses; a key matcher only when the combo is expressible for the internal handler (Cmd/Ctrl + optional Shift/Alt + a single printable key) — anything else stays hint-only and owned by the application menu.
- The editor store re-broadcasts `mt::keybindings-response` on the renderer bus; `editor.vue` pushes the rebuilt map into the engine at mount and on every keybindings save, so the toolbar follows live without a restart.

## Deliberate engine-default changes

- The internal handler's defaults now match the *advertised* defaults: inline code is Cmd/Ctrl+` and inline math Shift+Cmd/Ctrl+M (the handler still listened for the pre-#3630 Cmd/Ctrl+E variants).
- Key matching is case-insensitive, so the Shift-modified defaults (highlight, inline math, image, clear) actually fire now — `KeyboardEvent.key` arrives uppercase with Shift held, so the old lowercase-keyed map could never match them.
- The Alt state must match, so Ctrl+Alt combos (AltGr on Windows layouts) no longer trigger formats bound to Ctrl-only combos.

In the desktop app these combos are normally consumed by the application menu before reaching the DOM, so the default changes matter mainly for standalone muya embedders.

## Platform note

The map is built from the live per-platform bindings, so Linux's inline-code tooltip now correctly shows `Ctrl+Y` (the hardcoded hint claimed ``Ctrl+` ``).

## Tests

- muya `src/ui/inlineFormatToolbar/__tests__/shortcutOverrides.spec.ts` — tooltip fallback / override / empty-label / runtime `setOptions`, plus the internal handler's default, rebound, matcher-less, Shift-uppercase and Alt-mismatch paths.
- muya `src/editor/__tests__/nativeFormatSuppression.spec.ts` — `format*` beforeinputs are cancelled; text insertion, composition and history inputTypes pass through.
- desktop `test/unit/specs/inline-format-shortcuts.spec.ts` — accelerator → map conversion across platforms, modifiers, unbound and inexpressible combos.

## Verification

- Suites green: muya `test` (1415) / `lint` / `lint:types` / `check-circular`; desktop `lint` / `typecheck` / `test:unit` (721).
- Manually verified on macOS (dev build): rebound Bold away from ⌘B → the toolbar tooltip follows the new binding live, the new combo applies bold, and the old ⌘B neither formats through muya nor through Chromium's native editing.
- Windows/Linux behavior is code-confirmed and unit-tested (`isOsx` false paths); I don't have the hardware for a hands-on check.

While hand-testing we also found a separate, pre-existing recorder bug in the keybindings dialog (Shift is silently dropped when recording digit/punctuation combos, e.g. pressing ⌘⇧7 records ⌘+7); it is unrelated to this change and will be filed as its own issue.
