### PR TITLE
fix(desktop): make crash-recovery buffer writes durable against power loss

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -107,7 +107,8 @@
     "vega-embed": "^7.1.0",
     "vue-i18n": "^11.4.6",
     "vue-router": "^4.6.4",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "write-file-atomic": "^7.0.1"
   },
   "optionalDependencies": {
     "native-keymap": "^3.3.9"
@@ -126,6 +127,7 @@
     "@types/node": "^22.20.0",
     "@types/turndown": "^5.0.6",
     "@types/webfontloader": "^1.6.38",
+    "@types/write-file-atomic": "^4.0.3",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "cross-env": "^10.1.0",

--- a/packages/desktop/src/main/editorBufferStore/index.ts
+++ b/packages/desktop/src/main/editorBufferStore/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import writeFileAtomic from 'write-file-atomic'
 import { BrowserWindow, ipcMain, type IpcMainInvokeEvent } from 'electron'
 import { TypedEmitter } from '@shared/types/typedEmitter'
 import type BaseWindow from '../windows/base'
@@ -32,7 +33,6 @@ class EditorBufferStore extends TypedEmitter<EditorBufferStoreEvents> {
   bufferStores: Record<string, BufferStoreEntry> | null
   serviceName: string
   encryptKeys: string[]
-  writeSequence: number
 
   constructor(paths: EditorBufferStorePaths) {
     super()
@@ -45,7 +45,6 @@ class EditorBufferStore extends TypedEmitter<EditorBufferStoreEvents> {
     this.bufferStores = null
     this.serviceName = 'marktext'
     this.encryptKeys = []
-    this.writeSequence = 0
 
     this.init()
   }
@@ -177,26 +176,12 @@ class EditorBufferStore extends TypedEmitter<EditorBufferStoreEvents> {
   }
 
   writeBufferStoreFile(filePath: string, newState: unknown): void {
-    const tempPath = path.join(
-      path.dirname(filePath),
-      `.${path.basename(filePath)}.${process.pid}.${Date.now()}.${++this.writeSequence}.tmp`
-    )
-
-    try {
-      // Write temp file first, then rename to the final file for atomicity
-      // and reduced risk of data corruption.
-      fs.writeFileSync(tempPath, JSON.stringify(newState), 'utf8')
-      fs.renameSync(tempPath, filePath)
-    } catch (err) {
-      try {
-        if (fs.existsSync(tempPath)) {
-          fs.unlinkSync(tempPath)
-        }
-      } catch (cleanupErr) {
-        console.error('Failed to clean up temporary buffer store file', cleanupErr)
-      }
-      throw err
-    }
+    // Durable atomic write: write-file-atomic writes to a temp file, fsyncs it,
+    // then renames it over the target. The previous temp-file + rename here was
+    // namespace-atomic (crash-safe) but omitted the fsync, so a power loss could
+    // still leave this crash-recovery buffer — which holds unsaved tab content —
+    // truncated or zero-filled, the same gap the document save path had (#3786).
+    writeFileAtomic.sync(filePath, JSON.stringify(newState), 'utf8')
   }
 
   updateBufferState(e: IpcMainInvokeEvent, newState: unknown): boolean {

--- a/packages/desktop/test/unit/specs/buffer-store-durable.spec.ts
+++ b/packages/desktop/test/unit/specs/buffer-store-durable.spec.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The store registers ipcMain handlers in its constructor; stub electron so the
+// module imports without a real main process. writeBufferStoreFile no longer
+// touches `this`, so we exercise it via the prototype without booting the store.
+vi.mock('electron', () => ({}))
+
+const { default: EditorBufferStore } = await import('main_renderer/editorBufferStore')
+
+// #4852 follow-up: the crash-recovery buffer holds unsaved tab content but used
+// a temp+rename with no fsync — the same power-loss zero-fill gap the document
+// save path had. writeBufferStoreFile now writes durably via write-file-atomic.
+const writeBufferStoreFile = EditorBufferStore.prototype.writeBufferStoreFile
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'mt-buf-'))
+  dirs.push(d)
+  return d
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe('EditorBufferStore.writeBufferStoreFile — durable atomic write (#4852 follow-up)', () => {
+  it('writes the state as JSON and leaves no temp file behind', () => {
+    const dir = tempDir()
+    const target = path.join(dir, 'buffer.json')
+    const state = { tabs: [{ id: '1', markdown: 'hello' }] }
+
+    writeBufferStoreFile(target, state)
+
+    expect(JSON.parse(readFileSync(target, 'utf8'))).toEqual(state)
+    // The temp file was renamed over the target — nothing left in the dir.
+    expect(readdirSync(dir)).toEqual(['buffer.json'])
+  })
+
+  it('overwrites an existing buffer file', () => {
+    const dir = tempDir()
+    const target = path.join(dir, 'buffer.json')
+
+    writeBufferStoreFile(target, { tabs: ['old'] })
+    writeBufferStoreFile(target, { tabs: ['new'] })
+
+    expect(JSON.parse(readFileSync(target, 'utf8'))).toEqual({ tabs: ['new'] })
+    expect(readdirSync(dir)).toEqual(['buffer.json'])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       webfontloader:
         specifier: ^1.6.28
         version: 1.6.28
+      write-file-atomic:
+        specifier: ^7.0.1
+        version: 7.0.1
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.4
@@ -259,6 +262,9 @@ importers:
       '@types/webfontloader':
         specifier: ^1.6.38
         version: 1.6.38
+      '@types/write-file-atomic':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -3560,6 +3566,9 @@ packages:
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/write-file-atomic@4.0.3':
+    resolution: {integrity: sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -12503,6 +12512,10 @@ snapshots:
   '@types/webfontloader@1.6.38': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/write-file-atomic@4.0.3':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Problem

Follow-up to the #3786 / #3828 review (#4852): the atomic-save discussion noted that the crash-recovery buffer store — the precedent that change cited — shares the same durability gap.

`EditorBufferStore.writeBufferStoreFile` persists **unsaved tab content** (the buffer restored after a crash) with a temp-file + `renameSync`. That is namespace-atomic, so it survives an **application crash**, but it omits `fsync`. After a **power loss / OS reboot** the kernel can commit the new directory entry (rename) while the temp file's data blocks were never flushed — leaving the buffer truncated or full-length zero-filled. Same failure class as the document save path in #3786.

## Fix

Write through `write-file-atomic`'s sync API (`writeFileAtomic.sync`), which fsyncs the temp file before the atomic rename. This also removes the hand-rolled temp/rename/cleanup block and the `writeSequence` counter — `write-file-atomic` handles unique temp naming and cleanup internally.

## Notes

- Scoped to the buffer store only. The other main-process writers (generic `mt::fs::*` IPC handlers, keybindings/recents config, the debug dump, the upload temp file) aren't document-critical or are inherently temporary, so they're intentionally left as-is.
- `write-file-atomic` (+ `@types`) is also added by #4852 for the document save path; whichever merges first, the other's dependency addition is a no-op.

## Tests

`test/unit/specs/buffer-store-durable.spec.ts`: asserts `writeBufferStoreFile` writes the state as JSON, overwrites cleanly, and leaves no temp file behind. `typecheck`, `eslint`, and `build:unpack` (confirming the new main-process import externalizes) all pass.