### PR TITLE
fix(muya): follow the link on Ctrl/Cmd-click for reference-linked and raw-HTML linked images (#4865)

### DIFF
--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -393,9 +393,9 @@ blockquote .mu-hide.mu-math > .mu-math-render {
     background: transparent;
 }
 
-.mu-inline-image a.mu-image-icon-success,
-.mu-inline-image a.mu-image-icon-fail,
-.mu-inline-image a.mu-image-icon-close {
+.mu-inline-image .mu-image-icon-success,
+.mu-inline-image .mu-image-icon-fail,
+.mu-inline-image .mu-image-icon-close {
     position: absolute;
     top: 15px;
 
@@ -404,8 +404,8 @@ blockquote .mu-hide.mu-math > .mu-math-render {
     height: 20px;
 }
 
-.mu-inline-image a.mu-image-icon-success,
-.mu-inline-image a.mu-image-icon-fail {
+.mu-inline-image .mu-image-icon-success,
+.mu-inline-image .mu-image-icon-fail {
     left: 15px;
 }
 
@@ -478,17 +478,17 @@ blockquote .mu-hide.mu-math > .mu-math-render {
     content: attr(fail-text);
 }
 
-.mu-inline-image.mu-image-loading a.mu-image-icon-success,
-.mu-inline-image.mu-empty-image a.mu-image-icon-success {
+.mu-inline-image.mu-image-loading .mu-image-icon-success,
+.mu-inline-image.mu-empty-image .mu-image-icon-success {
     display: block;
 }
 
-.mu-inline-image.mu-image-fail a.mu-image-icon-fail {
+.mu-inline-image.mu-image-fail .mu-image-icon-fail {
     display: block;
 }
 
-.mu-inline-image.mu-empty-image:hover a.mu-image-icon-close,
-.mu-inline-image.mu-image-fail:hover a.mu-image-icon-close {
+.mu-inline-image.mu-empty-image:hover .mu-image-icon-close,
+.mu-inline-image.mu-image-fail:hover .mu-image-icon-close {
     right: 15px;
     z-index: 1;
 

--- a/packages/muya/src/inlineRenderer/__tests__/referenceLinkImageAnchor.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/referenceLinkImageAnchor.spec.ts
@@ -1,0 +1,51 @@
+import type { ReferenceLinkToken, Token } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+// #4865: a full reference link whose text is an image — `[![alt](img)][ref]`,
+// the standard README-badge pattern — must tokenize as ONE reference_link
+// carrying the image as its child. The anchor group used `[^\]]+?`, which
+// stopped at the image's inner `]`, so the input fragmented into a bare image
+// plus a separate empty reference link and the image never nested in the link.
+
+function toks(src: string): Token[] {
+    const labels = new Map([['ref', { href: 'https://example.com/dst', title: '' }]]);
+    return tokenizer(src, { labels } as Parameters<typeof tokenizer>[1]);
+}
+
+describe('reference link with an image anchor (#4865)', () => {
+    it('tokenizes `[![alt](img)][ref]` as a single reference_link wrapping the image', () => {
+        const result = toks('[![alt](https://example.com/badge.svg)][ref]');
+
+        expect(result).toHaveLength(1);
+        const link = result[0] as ReferenceLinkToken;
+        expect(link.type).toBe('reference_link');
+        expect(link.isFullLink).toBe(true);
+        expect(link.label).toBe('ref');
+
+        expect(link.children).toHaveLength(1);
+        const image = link.children[0] as Token & { attrs?: { src: string; alt: string } };
+        expect(image.type).toBe('image');
+        expect(image.attrs?.src).toBe('https://example.com/badge.svg');
+        expect(image.attrs?.alt).toBe('alt');
+    });
+
+    it('still tokenizes a plain-text reference link `[text][ref]` unchanged', () => {
+        const result = toks('[text][ref]');
+
+        expect(result).toHaveLength(1);
+        const link = result[0] as ReferenceLinkToken;
+        expect(link.type).toBe('reference_link');
+        expect(link.children).toHaveLength(1);
+        expect(link.children[0].type).toBe('text');
+    });
+
+    it('does not treat `[![alt](img)][ref]` as a link when the ref is undefined', () => {
+        // No matching definition ⇒ not a reference link (CommonMark); the image
+        // stays a standalone image, never a fabricated link.
+        const result = tokenizer('[![alt](https://example.com/badge.svg)][missing]');
+
+        expect(result.some(t => t.type === 'reference_link')).toBe(false);
+        expect(result.some(t => t.type === 'image')).toBe(true);
+    });
+});

--- a/packages/muya/src/inlineRenderer/renderer/image.ts
+++ b/packages/muya/src/inlineRenderer/renderer/image.ts
@@ -10,7 +10,12 @@ import { CLASS_NAMES } from '../../config';
 import { getImageSrc } from '../../utils/image';
 
 function renderIcon(h: H, className: string, icon: string) {
-    const selector = `a.${className}`;
+    // A `<span>`, not an `<a>`: these hover controls carry no href, and an `<a>`
+    // here nests illegally when the image sits inside a real anchor (e.g. a
+    // reference-linked image `[![alt](img)][ref]`). The HTML parser closes the
+    // outer anchor early on the nested `<a>`, hoisting the image out of the link
+    // (#4865).
+    const selector = `span.${className}`;
     const iconVnode = h(
         'i.icon',
         h(

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -31,8 +31,12 @@ export const commonMarkRules = {
     image: /^(!\[)(.*?)(\\*)\]\((.*)(\\*)\)/,
     // eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/optimal-quantifier-concatenation, regexp/no-misleading-capturing-group
     link: /^(\[)((?:\[[^\]]*\]|[^[\]]|\](?=[^[]*\]))*?)(\\*)\]\((.*)(\\*)\)/, // can nest
+    // Link text can hold balanced brackets — notably an image `![alt](src)` —
+    // so mirror `link`'s nesting-capable anchor group instead of the bracket-
+    // free `[^\]]+?`, which stopped at the image's inner `]` and broke
+    // `[![alt](img)][ref]` (#4865).
     // eslint-disable-next-line regexp/no-super-linear-backtracking
-    reference_link: /^\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
+    reference_link: /^\[((?:\[[^\]]*\]|[^[\]]|\](?=[^[]*\]))*?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
     // eslint-disable-next-line regexp/no-super-linear-backtracking
     reference_image: /^!\[([^\]]+?)(\\*)\](?:\[([^\]]*?)(\\*)\])?/,
     html_tag:

--- a/packages/muya/src/selection/__tests__/linkedImageClick.spec.ts
+++ b/packages/muya/src/selection/__tests__/linkedImageClick.spec.ts
@@ -92,3 +92,28 @@ describe('linked image modifier-click does not pop the image preview (#3835)', (
         expect(types).toContain('image');
     });
 });
+
+// #4865: a reference-linked image `[![alt](src)][ref]` must render the image
+// inside `a.mu-reference-link`, so the #3835 guard applies and Ctrl/Cmd-click
+// follows the link. The inline tokenizer previously fragmented it into a bare
+// image plus a separate empty reference link (its anchor group stopped at the
+// image's inner `]`), leaving the image unwrapped.
+describe('reference-linked image modifier-click follows the link (#4865)', () => {
+    it('renders the image inside a.mu-reference-link and suppresses the image format-click', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`[![alt](${src})][ref]\n\n[ref]: https://link.example.com`);
+
+        const wrapper = muya.domNode.querySelector<HTMLElement>(
+            `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+        )!;
+        expect(wrapper).not.toBeNull();
+        expect(wrapper.closest(`a.${CLASS_NAMES.MU_REFERENCE_LINK}`)).not.toBeNull();
+
+        const img = injectImg(muya, src);
+        const types = captureFormatClickTypes(muya);
+
+        ctrlClick(img);
+
+        expect(types).not.toContain('image');
+    });
+});

--- a/packages/muya/src/selection/__tests__/rawHtmlLinkedImageClick.spec.ts
+++ b/packages/muya/src/selection/__tests__/rawHtmlLinkedImageClick.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// #4865 (raw-HTML case): a raw-HTML linked image `<a href><img></a>` renders
+// its `<a>` as a real anchor (`a.mu-raw-html`) — an image's hover icons used to
+// be `<a>` elements, so nesting them produced invalid `<a>`-inside-`<a>` and the
+// HTML parser hoisted the image out of the link. Icons are now `<span>`, so the
+// image stays inside the anchor and Ctrl/Cmd-click follows the link.
+//
+// This runs under jsdom, NOT happy-dom: DOMPurify strips the `<a>` under
+// happy-dom (the raw-HTML tag would render as a `<span>`, masking the anchor
+// nesting the fix addresses). jsdom keeps it, matching the real Electron app.
+
+const bootedMuyas: Muya[] = [];
+
+beforeEach(() => {
+    (window as unknown as { MUYA_VERSION?: string }).MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
+    delete (window as unknown as { MUYA_VERSION?: string }).MUYA_VERSION;
+});
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedMuyas.push(muya);
+    return muya;
+}
+
+function injectImg(muya: Muya, src: string): HTMLImageElement {
+    const wrapper = muya.domNode.querySelector<HTMLElement>(
+        `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+    )!;
+    const container = wrapper.querySelector<HTMLElement>(
+        `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+    )!;
+    const img = document.createElement('img');
+    img.setAttribute('src', src);
+    container.appendChild(img);
+    return img;
+}
+
+function captureFormatClickTypes(muya: Muya): string[] {
+    const types: string[] = [];
+    muya.eventCenter.on('format-click', (payload: { formatType?: string }) => {
+        if (payload && payload.formatType)
+            types.push(payload.formatType);
+    });
+    return types;
+}
+
+describe('raw-HTML linked image modifier-click follows the link (#4865)', () => {
+    it('renders the image inside a.mu-raw-html and suppresses the image format-click', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`<a href="https://link.example.com"><img src="${src}"></a>`);
+
+        const wrapper = muya.domNode.querySelector<HTMLElement>(
+            `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+        )!;
+        expect(wrapper).not.toBeNull();
+        // The <a> is a real anchor; the image (and its container) must stay
+        // inside it rather than being hoisted out by an invalid nested <a>.
+        expect(wrapper.closest(`a.${CLASS_NAMES.MU_RAW_HTML}`)).not.toBeNull();
+        expect(wrapper.querySelector(`.${CLASS_NAMES.MU_IMAGE_CONTAINER}`)).not.toBeNull();
+
+        const img = injectImg(muya, src);
+        const types = captureFormatClickTypes(muya);
+
+        img.dispatchEvent(
+            new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }),
+        );
+
+        expect(types).not.toContain('image');
+    });
+});


### PR DESCRIPTION
## What

Ctrl/Cmd-clicking a **reference-linked** image `[![alt](img)][ref]` or a
**raw-HTML linked** image `<a href><img></a>` popped the in-app image preview
instead of following the link. Fixes #4865 (follow-up to #3835 / #4858, which
fixed the plain `[![alt](img)](href)` form).

Two distinct root causes, one per commit:

### 1. Reference link with an image text (`[![alt](img)][ref]`) — inline tokenizer
The `reference_link` rule's anchor group was `[^\]]+?`, which stops at the
image's inner `]`. So `[![alt](img)][ref]` fragmented into a bare image plus a
separate empty reference link, and the image was never nested inside the link.
Mirroring the inline `link` rule's nesting-capable anchor group captures the
image as the link's child (this is valid CommonMark — link text may contain an
image).

### 2. Image hover icons were `<a>` — invalid nested anchors
An inline image's hover controls (success/fail/close icons) were `<a>` elements
with no href. When an image sits inside a **real** anchor — a reference-linked
image (`a.mu-reference-link`) or a raw-HTML linked image (`a.mu-raw-html`) — the
nested `<a>`-inside-`<a>` is invalid HTML. muya serializes the vnode tree to an
HTML string and assigns it via `innerHTML`, so the parser closes the outer
anchor early and **hoists the image out of the link**. The image then renders
outside the anchor: it is not recognised as a linked image, so the modifier
click pops the preview instead of following the link.

Rendering the icons as `<span>` (they are decorative controls, not links)
eliminates the invalid nesting. The image stays inside the anchor, the #3835
`ImageSelection` guard (`!imageWrapper.closest(LINK_SELECTOR)`) applies, and the
link is followed. Both `a.mu-reference-link` and `a.mu-raw-html` are already in
`LINK_SELECTOR`, so no selector change is needed.

## Why the raw-HTML test uses jsdom
happy-dom's DOMPurify strips the raw `<a>` tag, so under happy-dom the raw-HTML
link renders as a `<span>` and the anchor nesting the fix addresses never
occurs. jsdom keeps the tag, matching the real Electron app, so the raw-HTML
regression test runs under jsdom.

## Stacked on #4858
This depends on #4858's exported `LINK_SELECTOR`, the `ImageSelection`
modifier-click guard, and `linkedImageClick.spec.ts`, none of which are on
`develop` yet. Base is `fix/3835-linked-image-click`; retarget to `develop`
once #4858 merges.

## Tests
- `referenceLinkImageAnchor.spec.ts` — tokenizer: `[![alt](img)][ref]` is one
  `reference_link` wrapping the image; plain `[text][ref]` unchanged; an
  undefined ref stays a bare image (not a fabricated link).
- `linkedImageClick.spec.ts` — a reference-linked image renders inside
  `a.mu-reference-link` and does not emit an image `format-click` on Ctrl-click.
- `rawHtmlLinkedImageClick.spec.ts` (jsdom) — a raw-HTML linked image stays
  inside `a.mu-raw-html` and does not emit an image `format-click`.

muya unit suite (206 files) + CommonMark/GFM conformance (locked) both green;
lint, stylelint, typecheck, madge clean.
