### PR TITLE
feat: default sidebar to TOC tab and remember last active tab on restart

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -357,7 +357,7 @@
   "sideBarVisibility": {
     "description": "View--Whether the side bar is visible.--internal",
     "type": "boolean",
-    "default": false
+    "default": true
   },
   "tabBarVisibility": {
     "description": "View--Whether the tabs are shown.--internal",

--- a/packages/desktop/src/renderer/src/store/layout.ts
+++ b/packages/desktop/src/renderer/src/store/layout.ts
@@ -46,8 +46,8 @@ const initialWidth = localStorage.getItem('side-bar-width')
 const initialSideBarWidth = normalizeSideBarWidth(initialWidth)
 
 export const useLayoutStore = defineStore('layout', () => {
-  const rightColumn = ref<string>('files')
-  const showSideBar = ref(false)
+  const rightColumn = ref<string>('toc')
+  const showSideBar = ref(true)
   const showTabBar = ref(false)
   const sideBarWidth = ref<number>(initialSideBarWidth)
 

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -67,7 +67,7 @@
   "spellcheckerNoUnderline": false,
   "spellcheckerLanguage": "en-US",
 
-  "sideBarVisibility": false,
+  "sideBarVisibility": true,
   "tabBarVisibility": false,
   "sourceCodeModeEnabled": false,
   "openedFilesInSidebar": true,


### PR DESCRIPTION
## Summary
- `layout.ts`: change `rightColumn` default from `'files'` to `'toc'`, `showSideBar` default to `true` (first launch only)
- `preference.json`: change `sideBarVisibility` default from `false` to `true`
- `schema.json`: change `sideBarVisibility` default from `false` to `true`, consistent with preference.json

When buffered state exists, `RESTORE_BUFFERED_STATE` restores the last active sidebar tab, so closing on TOC reopens on TOC, closing on Files reopens on Files.

## Test plan
- [ ] Fresh launch: sidebar opens on TOC tab by default
- [ ] Switch to Files tab, close and reopen: sidebar stays on Files
- [ ] Switch to TOC tab, close and reopen: sidebar stays on TOC