### PR TITLE
feat: default sidebar to TOC tab and remember last active tab on restart

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -357,7 +357,7 @@
   "sideBarVisibility": {
     "description": "View--Whether the side bar is visible.--internal",
     "type": "boolean",
-    "default": false
+    "default": true
   },
   "tabBarVisibility": {
     "description": "View--Whether the tabs are shown.--internal",

--- a/packages/desktop/src/renderer/src/store/layout.ts
+++ b/packages/desktop/src/renderer/src/store/layout.ts
@@ -46,8 +46,8 @@ const initialWidth = localStorage.getItem('side-bar-width')
 const initialSideBarWidth = normalizeSideBarWidth(initialWidth)
 
 export const useLayoutStore = defineStore('layout', () => {
-  const rightColumn = ref<string>('files')
-  const showSideBar = ref(false)
+  const rightColumn = ref<string>('toc')
+  const showSideBar = ref(true)
   const showTabBar = ref(false)
   const sideBarWidth = ref<number>(initialSideBarWidth)
 

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -67,7 +67,7 @@
   "spellcheckerNoUnderline": false,
   "spellcheckerLanguage": "en-US",
 
-  "sideBarVisibility": false,
+  "sideBarVisibility": true,
   "tabBarVisibility": false,
   "sourceCodeModeEnabled": false,
   "openedFilesInSidebar": true,


### PR DESCRIPTION
- layout.ts: change rightColumn default from 'files' to 'toc', showSideBar default to true (first launch)
- preference.json: change sideBarVisibility default from false to true
- schema.json: change sideBarVisibility default from false to true, consistent with preference.json

When buffered state exists, RESTORE_BUFFERED_STATE restores the last active sidebar tab, so closing on TOC reopens on TOC, closing on Files reopens on Files.

<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #

## Summary

<!-- A concise description of what this PR does and why -->

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New tests added (or explain why not needed)
- [ ] Manually tested on: <!-- macOS / Windows / Linux -->

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
