### PR TITLE
fix(desktop): preserve Shift for Cmd/Ctrl+digit keybindings (#4863)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
+      # The setup action installs with --ignore-scripts, so patch-package never
+      # runs. Apply the dependency patches so unit tests exercise the same
+      # patched libraries the app ships (e.g. the @hfelix keybinding fix).
+      - name: Apply dependency patches
+        run: pnpm -C packages/desktop exec patch-package
+
       - name: Run Unit Tests
         run: pnpm test

--- a/packages/desktop/patches/@hfelix+electron-localshortcut+4.0.1.patch
+++ b/packages/desktop/patches/@hfelix+electron-localshortcut+4.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@hfelix/electron-localshortcut/src/atom-keymap/helpers.js b/node_modules/@hfelix/electron-localshortcut/src/atom-keymap/helpers.js
+index 1111111..2222222 100644
+--- a/node_modules/@hfelix/electron-localshortcut/src/atom-keymap/helpers.js
++++ b/node_modules/@hfelix/electron-localshortcut/src/atom-keymap/helpers.js
+@@ -402,7 +402,7 @@
+   keyInputEvent.ctrl = key === 'ctrl' || !!ctrlKey
+   keyInputEvent.alt = key === 'alt' || !!altKey
+ 
+-  if (key === 'shift' || (shiftKey && (isNonCharacterKey || (isLatinCharacter(key) && isUpperCaseCharacter(key))))) {
++  if (key === 'shift' || (shiftKey && (isNonCharacterKey || ctrlKey || metaKey || (isLatinCharacter(key) && isUpperCaseCharacter(key))))) {
+     keyInputEvent.shift = true
+   }
+ 

--- a/packages/desktop/test/unit/specs/keybinding-shift-modifier.spec.ts
+++ b/packages/desktop/test/unit/specs/keybinding-shift-modifier.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { getAcceleratorFromKeyboardEvent } from '@hfelix/electron-localshortcut'
+
+// #4863: the atom-keymap port keeps Shift as a modifier only for non-character
+// keys and upper-case Latin letters. For digits/punctuation held with a primary
+// modifier (Cmd/Ctrl) the OS reports the base character (⌘⇧7 -> key "7"), so
+// Shift was dropped from BOTH the recorded accelerator and the runtime match,
+// leaving the binding unreachable. The patch in
+// `packages/desktop/patches/@hfelix+electron-localshortcut+4.0.1.patch` also
+// preserves Shift whenever ctrl/meta is held.
+//
+// This exercises the patched library through its public recorder API. The Ctrl
+// path is platform-independent (Ctrl is honoured on every OS; the meta path is
+// gated on macOS inside the library), so it fails on CI too if the patch is lost.
+// Recorder and matcher share the same `normalizeKeyboardEvent`, so guarding the
+// recorded string guards the match as well.
+
+const press = (o: Record<string, unknown>): KeyboardEvent =>
+  ({
+    type: 'keydown',
+    altKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    metaKey: false,
+    getModifierState: () => false,
+    ...o
+  }) as unknown as KeyboardEvent
+
+const accelOf = (o: Record<string, unknown>): string =>
+  (getAcceleratorFromKeyboardEvent(press(o)) as { accelerator: string }).accelerator
+
+describe('atom-keymap Shift preservation with a primary modifier (#4863)', () => {
+  it('keeps Shift for Ctrl+Shift+digit', () => {
+    expect(accelOf({ key: '7', code: 'Digit7', ctrlKey: true, shiftKey: true })).toBe('ctrl+shift+7')
+  })
+
+  it('keeps Shift for Ctrl+Shift+punctuation', () => {
+    expect(accelOf({ key: '/', code: 'Slash', ctrlKey: true, shiftKey: true })).toBe('ctrl+shift+/')
+  })
+
+  it('keeps a plain Ctrl+digit distinct from the shifted combo', () => {
+    expect(accelOf({ key: '7', code: 'Digit7', ctrlKey: true })).toBe('ctrl+7')
+  })
+
+  it('still records the shifted character when no primary modifier is held', () => {
+    // Shift+7 alone is intentionally recorded as the shifted character (US "&").
+    expect(accelOf({ key: '&', code: 'Digit7', shiftKey: true })).toBe('&')
+  })
+
+  it('leaves upper-case letter combos unchanged', () => {
+    expect(accelOf({ key: 'B', code: 'KeyB', ctrlKey: true, shiftKey: true })).toBe('ctrl+shift+B')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4863. Two symptoms, one root cause:

1. **Recording** ⌘⇧7 in Preferences → Key Bindings showed and saved `Cmd+7` — Shift silently dropped (the reported bug).
2. **At runtime**, even a correctly-spelled `Cmd+Shift+7` binding never fired — the rebind was dead.

## Root cause

Both the recorder (`key-input-dialog.vue` → `getAcceleratorFromKeyboardEvent`) and the shortcut matcher (`electronLocalshortcut`'s `before-input-event` handler in the main process) run the **same** `normalizeKeyboardEvent` from `@hfelix/electron-localshortcut`'s atom-keymap port. It keeps Shift as a modifier only for non-character keys and upper-case Latin letters:

```js
if (key === 'shift' || (shiftKey && (isNonCharacterKey || (isLatinCharacter(key) && isUpperCaseCharacter(key))))) {
    keyInputEvent.shift = true
}
```

For shifted digits/punctuation the port records the *shifted character* instead (Shift+7 → `&`, Atom philosophy). But when a primary modifier is held, macOS reports the **base** character for `KeyboardEvent.key` (⌘⇧7 → `7`), so neither the shifted character nor Shift survives:

- Recording normalizes ⌘⇧7 → `cmd+7`.
- Matching normalizes a physical ⌘⇧7 → `cmd+7` too, which can never equal the stamped `shift+cmd+7` → **the command never fires**.

Verified against the real library: `equals(toKeyEvent('shift+cmd+7'), normalize(physical ⌘⇧7)) === false`.

## Fix

Since recorder and matcher share `normalizeKeyboardEvent`, fixing it there repairs both consistently. Patch the library (via **patch-package**, the mechanism already used for `native-keymap`) to also keep Shift whenever a primary modifier (Cmd/Ctrl) is held:

```diff
-  if (key === 'shift' || (shiftKey && (isNonCharacterKey || (isLatinCharacter(key) && isUpperCaseCharacter(key))))) {
+  if (key === 'shift' || (shiftKey && (isNonCharacterKey || ctrlKey || metaKey || (isLatinCharacter(key) && isUpperCaseCharacter(key))))) {
```

After the patch (verified against the real library, record + match):

| Press | Recorded | Matches physical press |
|---|---|---|
| ⌘⇧7 | `shift+cmd+7` | ✅ |
| ⌃⇧7 | `ctrl+shift+7` | ✅ |
| ⌘⇧/ | `shift+cmd+/` | ✅ |
| ⌘7 (no Shift) | `cmd+7` | ✅ (now distinct from the shifted combo) |
| ⇧7 (no primary modifier) | `&` | unchanged (Atom shifted-char behaviour) |
| ⌘⇧B (letter) | `shift+cmd+B` | unchanged |

## Tests

`test/unit/specs/keybinding-shift-modifier.spec.ts` drives the patched library through its public recorder API on the platform-independent Ctrl path (Ctrl is honoured on every OS; the meta path is gated on macOS inside the library). Since recorder and matcher share the normalize function, guarding the recorded string guards the match.

`pnpm run lint`, `pnpm run typecheck`, and the keybinding unit specs pass. The record+match fix is verified end-to-end against the real library (patched `normalize` makes `equals(toKeyEvent(accel), normalize(physical press))` true); in-app keystroke verification in a dev build is the final manual check.

> Note: an upstream fix in `@hfelix/electron-localshortcut` would be preferable long-term; the patch-package patch keeps MarkText working today without forking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
