### PR TITLE
fix(desktop): preserve RTL text direction in PDF and print export

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -1327,7 +1327,7 @@ const handleExport = async (options: unknown) => {
           headerFooterStyled: headerFooterStyled as boolean | undefined,
           dir: props.textDirection
         })
-        printer!.renderMarkdown(html, true)
+        printer!.renderMarkdown(html, true, props.textDirection)
         editorStore.EXPORT({ type, pageOptions })
       } catch (err) {
         log.error('Failed to export document:', err)
@@ -1353,7 +1353,7 @@ const handleExport = async (options: unknown) => {
           headerFooterStyled: headerFooterStyled as boolean | undefined,
           dir: props.textDirection
         })
-        printer!.renderMarkdown(html, true)
+        printer!.renderMarkdown(html, true, props.textDirection)
         editorStore.PRINT_RESPONSE()
       } catch (err) {
         log.error('Failed to export document:', err)

--- a/packages/desktop/src/renderer/src/services/printService.ts
+++ b/packages/desktop/src/renderer/src/services/printService.ts
@@ -9,11 +9,18 @@ class MarkdownPrint {
    *
    * @param html HTML string
    * @param renderStatic Render for static files like PDF documents
+   * @param dir Text direction to mirror onto the container. `innerHTML` drops
+   *   the exporter's outer `<html dir=…>` shell and the container is a sibling
+   *   of `.editor-wrapper`, so RTL documents print LTR unless we set it here
+   *   (#4833). LTR is the default and stays implicit.
    */
-  renderMarkdown(html: string, renderStatic?: boolean): void {
+  renderMarkdown(html: string, renderStatic?: boolean, dir?: string): void {
     this.clearup()
     const printContainer = document.createElement('article')
     printContainer.classList.add('print-container')
+    if (dir === 'rtl' || dir === 'auto') {
+      printContainer.setAttribute('dir', dir)
+    }
     this.container = printContainer
     printContainer.innerHTML = html
 

--- a/packages/desktop/test/unit/specs/printService-direction.spec.ts
+++ b/packages/desktop/test/unit/specs/printService-direction.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// `printService` imports `resolveLocalImageSrc`, which reads `window.path` /
+// `window.DIRNAME` for its relative-resolve branch. Stub those preload
+// surfaces before the hoisted import runs (mirrors printService-image.spec.ts).
+vi.hoisted(() => {
+  const w = globalThis as unknown as {
+    window?: { path?: { sep: string }; DIRNAME?: string }
+  }
+  w.window ??= {}
+  w.window.path ??= { sep: '/' }
+  w.window.DIRNAME = '/docs'
+})
+
+import MarkdownPrint from '@/services/printService'
+
+// PDF / print render into an `<article class="print-container">` appended to
+// `document.body` (a sibling of `.editor-wrapper`), and `innerHTML = html`
+// discards the outer `<html dir="rtl">` shell produced by the exporter. Without
+// propagating the direction onto the container itself, RTL documents print LTR
+// (#4833). These specs pin that the container carries the direction.
+describe('MarkdownPrint — text direction on the print container', () => {
+  afterEach(() => {
+    document.body.querySelectorAll('article.print-container').forEach((n) => n.remove())
+  })
+
+  const article = '<article class="markdown-body"><p>سلام</p></article>'
+
+  it('sets dir="rtl" on the print container for an RTL export', () => {
+    new MarkdownPrint().renderMarkdown(article, true, 'rtl')
+    const container = document.body.querySelector('article.print-container')
+    expect(container?.getAttribute('dir')).toBe('rtl')
+  })
+
+  it('sets dir="auto" on the print container for an auto export', () => {
+    new MarkdownPrint().renderMarkdown(article, true, 'auto')
+    const container = document.body.querySelector('article.print-container')
+    expect(container?.getAttribute('dir')).toBe('auto')
+  })
+
+  it('leaves the container without a dir attribute for LTR (unchanged default)', () => {
+    new MarkdownPrint().renderMarkdown(article, true, 'ltr')
+    const container = document.body.querySelector('article.print-container')
+    expect(container?.hasAttribute('dir')).toBe(false)
+  })
+
+  it('leaves the container without a dir attribute when no direction is passed', () => {
+    new MarkdownPrint().renderMarkdown(article, true)
+    const container = document.body.querySelector('article.print-container')
+    expect(container?.hasAttribute('dir')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4833 — RTL documents (e.g. Persian) exported to PDF or printed came out **left-aligned with reversed word order**, even though the editor renders them right-to-left.

## Root cause

`#4553` added a `dir` attribute to the exporter's `<html>` shell (`MarkdownToHtml.generate({ dir })`), which works for the **styled-HTML** export because that string is written to disk verbatim.

But the **PDF / print** path feeds the same HTML through `printer.renderMarkdown(html)`, which assigns it to `printContainer.innerHTML`. That **drops the outer `<html dir="rtl">` wrapper** — only body-level content survives `innerHTML`. The `<article class="print-container">` is then appended to `document.body` as a **sibling** of `.editor-wrapper` (which carries the live `:dir="textDirection"`), so it inherits no direction. `webContents.printToPDF` prints that container LTR.

## Fix

Propagate the text direction onto the print container itself, mirroring exactly how the editor applies `dir` to its wrapper (native browser bidi + logical-property CSS handle the rest):

- `renderMarkdown(html, renderStatic?, dir?)` sets `dir` on the container when it is `rtl`/`auto`. LTR stays implicit, so existing exports are unchanged.
- Both PDF and print call sites in `editor.vue` pass `props.textDirection`.

## Testing

- New `test/unit/specs/printService-direction.spec.ts` (jsdom): asserts the container gets `dir="rtl"`/`"auto"` and stays unset for LTR / the default. Verified RED before the fix, GREEN after.
- `pnpm run lint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)