### PR TITLE
feat: default sidebar to TOC tab and remember last active tab on restart

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -357,7 +357,7 @@
   "sideBarVisibility": {
     "description": "View--Whether the side bar is visible.--internal",
     "type": "boolean",
-    "default": false
+    "default": true
   },
   "tabBarVisibility": {
     "description": "View--Whether the tabs are shown.--internal",

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -901,7 +901,7 @@ export const useEditorStore = defineStore('editor', {
         mainStore.SET_INITIALIZED()
         preferencesStore.SET_USER_PREFERENCE({ endOfLine: lineEnding })
         layoutStore.SET_LAYOUT({
-          rightColumn: 'files',
+          rightColumn: 'toc',
           showSideBar: !!sideBarVisibility,
           showTabBar: !!tabBarVisibility
         })

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -67,7 +67,7 @@
   "spellcheckerNoUnderline": false,
   "spellcheckerLanguage": "en-US",
 
-  "sideBarVisibility": false,
+  "sideBarVisibility": true,
   "tabBarVisibility": false,
   "sourceCodeModeEnabled": false,
   "openedFilesInSidebar": true,


### PR DESCRIPTION
问题：展开左侧栏，切换到目录，关闭软件，再次打开文件时，左侧栏没有停留在目录项，而是跑到打开文件项了
应该：关闭软件再打开时应该还是在目录项上（关闭前的状态）

- editor.ts: change hardcoded rightColumn from 'files' to 'toc' in mt::bootstrap-editor handler (first launch default)
- preference.json: change sideBarVisibility default from false to true
- schema.json: change sideBarVisibility default from false to true, consistent with preference.json

RESTORE_BUFFERED_STATE already restores the last active sidebar tab, so closing on TOC reopens on TOC, closing on Files reopens on Files.

<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #

## Summary

<!-- A concise description of what this PR does and why -->

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New tests added (or explain why not needed)
- [ ] Manually tested on: <!-- macOS / Windows / Linux -->

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
