### PR TITLE
feat(source-code): configurable line number frequency

### DIFF
--- a/packages/desktop/src/main/menu/actions/view.ts
+++ b/packages/desktop/src/main/menu/actions/view.ts
@@ -71,6 +71,12 @@ export const toggleTypewriterMode = (win: Win): void => {
   toggleTypeMode(win, 'typewriter')
 }
 
+export const toggleSourceLineNumbers = (win: Win): void => {
+  if (win && win.webContents) {
+    win.webContents.send('mt::toggle-source-line-numbers')
+  }
+}
+
 export const reloadImageCache = (win: Win): void => {
   if (win && win.webContents) {
     win.webContents.send('mt::invalidate-image-cache')
@@ -134,6 +140,9 @@ export const viewLayoutChanged = (
         break
       case 'focus':
         changeMenuByName(focusModeMenuItemId, value)
+        break
+      case 'sourceLineNumbersEnabled':
+        changeMenuByName('sourceLineNumbersMenuItem', value)
         break
     }
   }

--- a/packages/desktop/src/main/menu/templates/view.ts
+++ b/packages/desktop/src/main/menu/templates/view.ts
@@ -46,6 +46,15 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       }
     },
     {
+      id: 'sourceLineNumbersMenuItem',
+      label: t('menu.view.showLineNumbers'),
+      type: 'checkbox',
+      checked: true,
+      click(_item, focusedWindow) {
+        actions.toggleSourceLineNumbers(focusedWindow as BrowserWindow | undefined)
+      }
+    },
+    {
       type: 'separator'
     },
     {

--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -120,6 +120,11 @@
     "type": "boolean",
     "default": true
   },
+  "sourceLineNumberFrequency": {
+    "description": "Editor--Line number display frequency in source code mode (0 = off)",
+    "type": "number",
+    "default": 10
+  },
   "trimUnnecessaryCodeBlockEmptyLines": {
     "description": "Editor--Trim the beginning and ending empty lines in code block",
     "type": "boolean",

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
@@ -10,6 +10,7 @@ import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { usePreferencesStore } from '@/store/preferences'
 import { findMarkdownHeadingLine, scrollSourceEditorToLine } from '@/util/sourceModeToc'
+import { makeLineNumberFormatter } from '@/util/sourceLineNumbers'
 import { storeToRefs } from 'pinia'
 import codeMirror, { setCursorAtFirstLine, setTextDirection } from '../../codeMirror'
 import { wordCount as getWordCount } from '@muyajs/core'
@@ -43,7 +44,7 @@ const commitTimer = ref<ReturnType<typeof setTimeout> | null>(null)
 const viewDestroyed = ref(false)
 const tabId = ref<string | null>(null)
 
-const { theme, sourceCode } = storeToRefs(preferencesStore)
+const { theme, sourceCode, sourceLineNumberFrequency } = storeToRefs(preferencesStore)
 const { currentFile: currentTab } = storeToRefs(editorStore)
 
 const isValidMuyaIndexCursor = (cursor: unknown): cursor is MuyaIndexCursorLike => {
@@ -59,6 +60,15 @@ watch(
     }
   }
 )
+
+watch(sourceLineNumberFrequency, (freq) => {
+  if (!editor.value) return
+  editor.value.setOption('lineNumbers', freq !== 0)
+  editor.value.setOption('lineNumberFormatter', makeLineNumberFormatter(freq))
+  // Force the gutter to repaint; toggling `lineNumbers` alone doesn't redraw
+  // existing rows.
+  editor.value.refresh()
+})
 
 const getMarkdownAndCursor = (cm: CMInstance) => {
   let focus = cm.getCursor('head')
@@ -335,19 +345,13 @@ onMounted(() => {
   const container = sourceCodeContainer.value
   const codeMirrorConfig: Record<string, unknown> = {
     value: markdown,
-    lineNumbers: true,
+    lineNumbers: sourceLineNumberFrequency.value !== 0,
     autofocus: true,
     lineWrapping: true,
     styleActiveLine: true,
     direction: textDirection,
     viewportMargin: Infinity,
-    lineNumberFormatter (line: number) {
-      if (line % 10 === 0 || line === 1) {
-        return line
-      } else {
-        return ''
-      }
-    }
+    lineNumberFormatter: makeLineNumberFormatter(sourceLineNumberFrequency.value)
   }
 
   if (railscastsThemes.includes(theme.value)) {

--- a/packages/desktop/src/renderer/src/prefComponents/editor/config.ts
+++ b/packages/desktop/src/renderer/src/prefComponents/editor/config.ts
@@ -21,6 +21,33 @@ export const tabSizeOptions: PrefSelectOption<number>[] = [
   }
 ]
 
+export const getSourceLineNumberOptions = (): PrefSelectOption<number>[] => [
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.off'),
+    value: 0
+  },
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.everyLine'),
+    value: 1
+  },
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.every5'),
+    value: 5
+  },
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.every10'),
+    value: 10
+  },
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.every20'),
+    value: 20
+  },
+  {
+    label: t('preferences.editor.codeBlock.sourceLineNumbers.every50'),
+    value: 50
+  }
+]
+
 export const getEndOfLineOptions = (): PrefSelectOption<string>[] => [
   {
     label: t('preferences.editor.fileRepresentation.endOfLine.default'),

--- a/packages/desktop/src/renderer/src/prefComponents/editor/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/editor/index.vue
@@ -72,6 +72,12 @@
           :bool="trimUnnecessaryCodeBlockEmptyLines"
           :on-change="(value) => onSelectChange('trimUnnecessaryCodeBlockEmptyLines', value)"
         />
+        <cur-select
+          :description="t('preferences.editor.codeBlock.sourceLineNumbers.title')"
+          :value="sourceLineNumberFrequency"
+          :options="sourceLineNumberOptions"
+          :on-change="(value) => onSelectChange('sourceLineNumberFrequency', value)"
+        />
         <bool
           :description="t('preferences.editor.misc.wrapCodeBlocks')"
           :bool="wrapCodeBlocks"
@@ -195,6 +201,7 @@ import Bool from '../common/bool/index.vue'
 import TextBox from '../common/textBox/index.vue'
 import {
   tabSizeOptions,
+  getSourceLineNumberOptions,
   getEndOfLineOptions,
   getTextDirectionOptions,
   getTrimTrailingNewlineOptions,
@@ -205,6 +212,7 @@ const { t } = useI18n()
 const preferenceStore = usePreferencesStore()
 
 const defaultEncodingOptions = getDefaultEncodingOptions()
+const sourceLineNumberOptions = getSourceLineNumberOptions()
 
 const {
   fontSize,
@@ -219,6 +227,7 @@ const {
   codeFontSize,
   codeFontFamily,
   codeBlockLineNumbers,
+  sourceLineNumberFrequency,
   trimUnnecessaryCodeBlockEmptyLines,
   hideQuickInsertHint,
   hideLinkPopup,

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -45,6 +45,7 @@ export interface PreferencesState {
   codeFontSize: number
   codeFontFamily: string
   codeBlockLineNumbers: boolean
+  sourceLineNumberFrequency: number
   trimUnnecessaryCodeBlockEmptyLines: boolean
   wrapCodeBlocks: boolean
   editorLineWidth: string
@@ -162,6 +163,7 @@ export const usePreferencesStore = defineStore('preferences', {
     codeFontSize: 14,
     codeFontFamily: 'DejaVu Sans Mono',
     codeBlockLineNumbers: false,
+    sourceLineNumberFrequency: 10,
     trimUnnecessaryCodeBlockEmptyLines: true,
     wrapCodeBlocks: false,
     editorLineWidth: '',
@@ -260,6 +262,12 @@ export const usePreferencesStore = defineStore('preferences', {
       if (lang && lang !== oldLanguage) {
         setLanguage(lang)
       }
+
+      // Sync the View-menu "Show Line Numbers" checkbox with the loaded value.
+      const freq = (preference as { sourceLineNumberFrequency?: number }).sourceLineNumberFrequency
+      if (typeof freq === 'number') {
+        this.DISPATCH_EDITOR_VIEW_STATE({ sourceLineNumbersEnabled: freq !== 0 })
+      }
     },
 
     SET_MODE({ type, checked }: ModeTogglePayload): void {
@@ -313,6 +321,13 @@ export const usePreferencesStore = defineStore('preferences', {
         this.TOGGLE_VIEW_MODE(entryName)
         const target = this as unknown as Record<string, unknown>
         this.DISPATCH_EDITOR_VIEW_STATE({ [entryName]: target[entryName] })
+      })
+      window.electron.ipcRenderer.on('mt::toggle-source-line-numbers', () => {
+        // Off restores the shipped default (every 10 lines) rather than the
+        // previous frequency; the View-menu toggle is a coarse on/off switch.
+        const value = this.sourceLineNumberFrequency === 0 ? 10 : 0
+        this.SET_SINGLE_PREFERENCE({ type: 'sourceLineNumberFrequency', value })
+        this.DISPATCH_EDITOR_VIEW_STATE({ sourceLineNumbersEnabled: value !== 0 })
       })
     },
 

--- a/packages/desktop/src/renderer/src/util/sourceLineNumbers.ts
+++ b/packages/desktop/src/renderer/src/util/sourceLineNumbers.ts
@@ -1,0 +1,23 @@
+// CodeMirror's `lineNumberFormatter` receives a 1-based line number and returns
+// the label to render in the gutter; returning '' hides the label for that row.
+
+type LineNumberFormatter = (line: number) => number | string
+
+/**
+ * Build a `lineNumberFormatter` for source-code mode.
+ *
+ * @param freq How often a line number is shown: 1 labels every line, N labels
+ *   every Nth line. Line 1 is always labelled (existing convention) so the top
+ *   of the document keeps a reference number. `freq` of 0 means "no numbers";
+ *   callers disable the gutter entirely in that case, so the returned formatter
+ *   is never invoked and simply hides every label.
+ */
+export const makeLineNumberFormatter = (freq: number): LineNumberFormatter => {
+  if (freq <= 0) {
+    return () => ''
+  }
+  if (freq === 1) {
+    return (line: number) => line
+  }
+  return (line: number) => (line % freq === 0 || line === 1 ? line : '')
+}

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -274,6 +274,7 @@ export interface IpcMainEventChannels {
   'mt::tab-saved': [tabId: string]
   'mt::tabs-cycle-left': []
   'mt::tabs-cycle-right': []
+  'mt::toggle-source-line-numbers': []
   'mt::toggle-view-layout-entry': [entry: string]
   'mt::toggle-view-mode-entry': [entry: string]
   'mt::update-file': [payload: { type: 'add' | 'change' | 'unlink'; change: FileChangeDetail }]

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Quellcode-Modus",
       "typewriterMode": "Schreibmaschinen-Modus",
       "focusMode": "Fokus-Modus",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "Inhaltsverzeichnis umschalten",
       "reloadImages": "Bilder neu laden",
       "showDeveloperTools": "Entwicklertools anzeigen",
@@ -517,7 +518,16 @@
         "fontSize": "Schriftgröße",
         "fontFamily": "Schriftfamilie",
         "showLineNumbers": "Zeilennummern anzeigen",
-        "removeEmptyLines": "Leere Zeilen entfernen"
+        "removeEmptyLines": "Leere Zeilen entfernen",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Schreibverhalten",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Source Code Mode",
       "typewriterMode": "Typewriter Mode",
       "focusMode": "Focus Mode",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "Toggle Table of Contents",
       "reloadImages": "Reload Images",
       "showDeveloperTools": "Show Developer Tools",
@@ -517,7 +518,16 @@
         "fontSize": "Font size",
         "fontFamily": "Font family",
         "showLineNumbers": "Show line numbers",
-        "removeEmptyLines": "Remove empty lines"
+        "removeEmptyLines": "Remove empty lines",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Writing Behavior",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Modo Código Fuente",
       "typewriterMode": "Modo Máquina de Escribir",
       "focusMode": "Modo Enfoque",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "Alternar Tabla de Contenidos",
       "reloadImages": "Recargar Imágenes",
       "showDeveloperTools": "Mostrar Herramientas de Desarrollador",
@@ -517,7 +518,16 @@
         "fontSize": "Tamaño de fuente",
         "fontFamily": "Familia de fuente",
         "showLineNumbers": "Mostrar números de línea",
-        "removeEmptyLines": "Eliminar líneas vacías"
+        "removeEmptyLines": "Eliminar líneas vacías",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Comportamiento de Escritura",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Mode code source",
       "typewriterMode": "Mode machine à écrire",
       "focusMode": "Mode focus",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "Basculer la table des matières",
       "reloadImages": "Recharger les images",
       "showDeveloperTools": "Afficher les outils de développement",
@@ -517,7 +518,16 @@
         "fontSize": "Taille de police",
         "fontFamily": "Famille de police",
         "showLineNumbers": "Afficher les numéros de ligne",
-        "removeEmptyLines": "Supprimer les lignes vides"
+        "removeEmptyLines": "Supprimer les lignes vides",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Comportement d'écriture",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "ソースコードモード",
       "typewriterMode": "タイプライターモード",
       "focusMode": "フォーカスモード",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "目次の切り替え",
       "reloadImages": "画像を再読み込み",
       "showDeveloperTools": "開発者ツールを表示",
@@ -517,7 +518,16 @@
         "fontSize": "フォントサイズ",
         "fontFamily": "フォントファミリー",
         "showLineNumbers": "行番号を表示",
-        "removeEmptyLines": "空行を削除"
+        "removeEmptyLines": "空行を削除",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "書き込み動作",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "소스 코드 모드",
       "typewriterMode": "타자기 모드",
       "focusMode": "집중 모드",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "목차 토글",
       "reloadImages": "이미지 새로고침",
       "showDeveloperTools": "개발자 도구 보기",
@@ -517,7 +518,16 @@
         "fontSize": "글꼴 크기",
         "fontFamily": "글꼴 패밀리",
         "showLineNumbers": "줄 번호 보기",
-        "removeEmptyLines": "빈 줄 제거"
+        "removeEmptyLines": "빈 줄 제거",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "작성 동작",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Modo Código Fonte",
       "typewriterMode": "Modo Máquina de Escrever",
       "focusMode": "Modo Foco",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "Alternar Índice",
       "reloadImages": "Recarregar Imagens",
       "showDeveloperTools": "Mostrar Ferramentas de Desenvolvedor",
@@ -517,7 +518,16 @@
         "fontSize": "Tamanho da fonte",
         "fontFamily": "Família da fonte",
         "showLineNumbers": "Mostrar números de linha",
-        "removeEmptyLines": "Remover linhas vazias"
+        "removeEmptyLines": "Remover linhas vazias",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Comportamento de Escrita",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "Kaynak Kod Modu",
       "typewriterMode": "Daktilo Modu",
       "focusMode": "Odak Modu",
+      "showLineNumbers": "Show Line Numbers",
       "toggleTableOfContents": "İçindekileri Aç/Kapat",
       "reloadImages": "Görselleri Yeniden Yükle",
       "showDeveloperTools": "Geliştirici Araçlarını Göster",
@@ -517,7 +518,16 @@
         "fontSize": "Yazı tipi boyutu",
         "fontFamily": "Yazı tipi ailesi",
         "showLineNumbers": "Satır numaralarını göster",
-        "removeEmptyLines": "Boş satırları kaldır"
+        "removeEmptyLines": "Boş satırları kaldır",
+        "sourceLineNumbers": {
+          "title": "Source code line numbers",
+          "off": "Off",
+          "everyLine": "Every line",
+          "every5": "Every 5 lines",
+          "every10": "Every 10 lines",
+          "every20": "Every 20 lines",
+          "every50": "Every 50 lines"
+        }
       },
       "writingBehavior": {
         "title": "Yazma Davranışı",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "源码模式",
       "typewriterMode": "打字机模式",
       "focusMode": "专注模式",
+      "showLineNumbers": "显示行号",
       "toggleTableOfContents": "切换目录",
       "reloadImages": "重新加载图片",
       "showDeveloperTools": "显示开发者工具",
@@ -517,7 +518,16 @@
         "fontSize": "字体大小",
         "fontFamily": "字体系列",
         "showLineNumbers": "显示行号",
-        "removeEmptyLines": "删除空行"
+        "removeEmptyLines": "删除空行",
+        "sourceLineNumbers": {
+          "title": "源码模式行号",
+          "off": "关闭",
+          "everyLine": "每行",
+          "every5": "每 5 行",
+          "every10": "每 10 行",
+          "every20": "每 20 行",
+          "every50": "每 50 行"
+        }
       },
       "writingBehavior": {
         "title": "写作行为",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -116,6 +116,7 @@
       "sourceCodeMode": "原始碼模式",
       "typewriterMode": "打字機模式",
       "focusMode": "專注模式",
+      "showLineNumbers": "顯示行號",
       "toggleTableOfContents": "切換目錄",
       "reloadImages": "重新載入圖片",
       "showDeveloperTools": "顯示開發者工具",
@@ -517,7 +518,16 @@
         "fontSize": "字型大小",
         "fontFamily": "字型系列",
         "showLineNumbers": "顯示行號",
-        "removeEmptyLines": "移除空行"
+        "removeEmptyLines": "移除空行",
+        "sourceLineNumbers": {
+          "title": "原始碼模式行號",
+          "off": "關閉",
+          "everyLine": "每行",
+          "every5": "每 5 行",
+          "every10": "每 10 行",
+          "every20": "每 20 行",
+          "every50": "每 50 行"
+        }
       },
       "writingBehavior": {
         "title": "寫作行為",

--- a/packages/desktop/test/unit/specs/source-line-numbers.spec.ts
+++ b/packages/desktop/test/unit/specs/source-line-numbers.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { makeLineNumberFormatter } from '@/util/sourceLineNumbers'
+
+describe('makeLineNumberFormatter', () => {
+  it('hides every label when frequency is 0', () => {
+    const format = makeLineNumberFormatter(0)
+    expect(format(1)).toBe('')
+    expect(format(10)).toBe('')
+    expect(format(37)).toBe('')
+  })
+
+  it('labels every line when frequency is 1', () => {
+    const format = makeLineNumberFormatter(1)
+    expect(format(1)).toBe(1)
+    expect(format(2)).toBe(2)
+    expect(format(99)).toBe(99)
+  })
+
+  it('labels every Nth line plus line 1 for frequency 5', () => {
+    const format = makeLineNumberFormatter(5)
+    expect(format(1)).toBe(1)
+    expect(format(5)).toBe(5)
+    expect(format(10)).toBe(10)
+    expect(format(2)).toBe('')
+    expect(format(7)).toBe('')
+  })
+
+  it.each([10, 20, 50])('labels multiples of %i and always line 1', (freq) => {
+    const format = makeLineNumberFormatter(freq)
+    expect(format(1)).toBe(1)
+    expect(format(freq)).toBe(freq)
+    expect(format(freq * 3)).toBe(freq * 3)
+    expect(format(freq + 1)).toBe('')
+    expect(format(freq - 1)).toBe('')
+  })
+
+  // Line 1 is always labelled even when it isn't a multiple of the frequency,
+  // so the top of the document keeps a reference number.
+  it('always labels line 1 regardless of frequency', () => {
+    for (const freq of [5, 10, 20, 50]) {
+      expect(makeLineNumberFormatter(freq)(1)).toBe(1)
+    }
+  })
+
+  // Guard against a corrupted/negative preference value: treat it as "off"
+  // rather than throwing or producing a modulo-by-negative surprise.
+  it('hides every label for negative frequency', () => {
+    const format = makeLineNumberFormatter(-5)
+    expect(format(1)).toBe('')
+    expect(format(10)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Source Code mode previously hard-coded line numbers to show only every
10th line. This makes the frequency configurable so users who want a line
number on every line — useful for referencing exact positions when
reviewing or discussing a document — can have it.

Closes #4033
Closes #3477

## What changed

- New persisted preference `sourceLineNumberFrequency`
  (Off / every 1, 5, 10, 20, 50 lines). Default stays **every 10 lines**,
  so existing behavior is unchanged.
- Preferences → Editor: a dropdown to pick the frequency.
- View menu: a "Show Line Numbers" checkbox as a quick on/off toggle,
  kept in sync with the preference (off = 0, on = 10).
- The frequency drives the CodeMirror `lineNumberFormatter` and applies
  live, without reopening the window.

Only the Source Code (CodeMirror) editor is affected — the WYSIWYG (Muya)
editor is intentionally untouched, since its rendered blocks don't map
1:1 to source lines.

## Tests

- Added unit tests for `makeLineNumberFormatter` covering frequencies
  0 / 1 / 5 / 10 / 20 / 50, the "line 1 is always labelled" convention,
  and negative-value guarding.
- `pnpm run typecheck` and `pnpm run lint` pass (0 errors).

## i18n

Added keys to all 10 locales. English and Chinese (zh-CN / zh-TW) are
fully translated; the other 7 use the English string as a placeholder
pending native translation.
