### PR TITLE
fix: #4890 use file extension for side bar icons

### DIFF
--- a/packages/desktop/src/renderer/src/components/sideBar/fileIconClass.ts
+++ b/packages/desktop/src/renderer/src/components/sideBar/fileIconClass.ts
@@ -1,0 +1,27 @@
+import fileIcons from '@marktext/file-icons'
+
+const getClassByName = (name: string): string | null => {
+  const icon = fileIcons.matchName(name)
+  return icon ? icon.getClass(0, false) : null
+}
+
+/**
+ * Resolve the icon CSS classes for a file name shown in the side bar tree.
+ *
+ * file-icons tests whole-name rules before extension rules, so a markdown
+ * file whose name resembles another tool's (`Dockerfile-Notes.md`) picks up
+ * that tool's icon (#4890). The tree only lists files with markdown
+ * extensions (see main/filesystem/watcher.ts), so the extension is the
+ * reliable signal — match on it first and use the full name only as a
+ * fallback for extensionless names.
+ */
+export const getFileIconClasses = (fileName: string): string[] => {
+  const name = fileName || 'mock.md'
+  const dotIndex = name.lastIndexOf('.')
+  const classNames =
+    (dotIndex !== -1 ? getClassByName(`mock${name.slice(dotIndex)}`) : null) ??
+    getClassByName(name) ??
+    // Use fallback icon when the icon is unknown.
+    getClassByName('mock.md')
+  return (classNames ?? '').split(/\s/)
+}

--- a/packages/desktop/src/renderer/src/components/sideBar/icon.vue
+++ b/packages/desktop/src/renderer/src/components/sideBar/icon.vue
@@ -1,31 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import fileIcons from '@marktext/file-icons'
 import '@marktext/file-icons/build/index.css'
+import { getFileIconClasses } from './fileIconClass'
 
 const props = defineProps<{
   name: string
 }>()
 
-// The legacy `muya/lib/ui/fileIcons` wrapper added a `getClassByName(name)`
-// helper around the raw package's `matchName(name)?.getClass(0, false)`.
-// Inline that here so we depend on `@marktext/file-icons` directly.
-const getClassByName = (name: string): string | null => {
-  const icon = fileIcons.matchName(name)
-  return icon ? icon.getClass(0, false) : null
-}
-
-const className = computed<string[]>(() => {
-  let classNames: string | null | undefined = getClassByName(
-    props.name ? props.name : 'mock.md'
-  )
-
-  if (!classNames) {
-    // Use fallback icon when the icon is unknown.
-    classNames = getClassByName('mock.md')
-  }
-  return (classNames ?? '').split(/\s/)
-})
+const className = computed<string[]>(() => getFileIconClasses(props.name))
 </script>
 
 <template>

--- a/packages/desktop/test/unit/specs/file-icon-class.spec.ts
+++ b/packages/desktop/test/unit/specs/file-icon-class.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { getFileIconClasses } from '@/components/sideBar/fileIconClass'
+
+describe('getFileIconClasses (#4890)', () => {
+  it('gives markdown files the markdown icon even when the name starts with "Dockerfile"', () => {
+    expect(getFileIconClasses('Dockerfile-Notes.md')).toContain('markdown-icon')
+  })
+
+  it('matches by extension for regular markdown files', () => {
+    expect(getFileIconClasses('notes.md')).toContain('markdown-icon')
+  })
+
+  it('still matches whole-name rules for extensionless names', () => {
+    expect(getFileIconClasses('Dockerfile')).toContain('docker-icon')
+  })
+
+  it('keeps the docker icon for real docker files', () => {
+    expect(getFileIconClasses('app.dockerfile')).toContain('docker-icon')
+  })
+
+  it('falls back to the markdown icon for unknown extensions and empty names', () => {
+    expect(getFileIconClasses('zzz.zzznope')).toContain('markdown-icon')
+    expect(getFileIconClasses('')).toContain('markdown-icon')
+  })
+})


### PR DESCRIPTION
## Description

Fixes #4890 — a markdown file whose name starts with `Dockerfile` (e.g. `Dockerfile-Notes.md`) was shown with the Docker icon in the side bar instead of the Markdown icon.

## Root cause

`@marktext/file-icons` tests whole-name rules before extension rules, and its Docker rule is an unanchored prefix match (`/^(?:Dockerfile|docker-compose)|\.docker(?:file|ignore)$/i`), so any file name starting with `Dockerfile` matches it — including markdown files.

## Fix

The side bar tree only lists files with markdown extensions (the directory watcher in `main/filesystem/watcher.ts` filters out everything else), so the extension is the reliable signal. The icon lookup (extracted from `icon.vue` into `fileIconClass.ts` so it can be unit-tested) now matches on the extension first and falls back to the full name only for extensionless names:

- `Dockerfile-Notes.md` → markdown icon ✅ (was docker)
- `notes.md`, unknown/empty names → markdown icon (unchanged)
- `Dockerfile`, `app.dockerfile` → docker icon (unchanged)

The durable upstream fix would be anchoring the Docker regex in [marktext/file-icons](https://github.com/marktext/file-icons) (e.g. `/^(?:Dockerfile|docker-compose)(?:$|\.)/`), which would also benefit the other consumers — happy to send that PR too if wanted.

## Tests

Added `test/unit/specs/file-icon-class.spec.ts` covering the cases above; it passes against the current (unfixed) `@marktext/file-icons`, i.e. the fix is fully app-side. `pnpm run lint` and `pnpm run typecheck` pass.

> Note: I couldn't produce a screenshot — my Windows environment lacks the native build toolchain so the app doesn't run locally. The behavior change is captured by the unit tests; happy to add a screenshot if someone can run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)