### PR TITLE
fix: #4896 guard selectLanguage against a stale code-picker block

### DIFF
--- a/packages/desktop/src/types/muya.d.ts
+++ b/packages/desktop/src/types/muya.d.ts
@@ -65,6 +65,11 @@ declare module 'muya/lib/contentState' {
   export default contentState
 }
 
+declare module 'muya/lib/contentState/codeBlockCtrl' {
+  const codeBlockCtrl: (ContentState: any) => void
+  export default codeBlockCtrl
+}
+
 declare module 'muya/lib/eventHandler/event' {
   const event: any
   export default event

--- a/packages/desktop/test/unit/specs/code-picker-select-language.spec.ts
+++ b/packages/desktop/test/unit/specs/code-picker-select-language.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import codeBlockCtrl from 'muya/lib/contentState/codeBlockCtrl'
+
+// codeBlockCtrl is a mixin factory: it installs selectLanguage /
+// updateCodeLanguage onto a ContentState class. Drive selectLanguage off a
+// minimal fake so the spec needs no Muya/DOM bootstrap — the same approach as
+// packages/muya's codeBlockLanguageSelector/__tests__/selectItem.spec.ts.
+class FakeContentState {
+  blocks: Record<string, unknown> = {}
+
+  getBlock(id: string) {
+    return this.blocks[id] ?? null
+  }
+}
+codeBlockCtrl(FakeContentState)
+
+type SelectLanguageState = FakeContentState & {
+  selectLanguage(paragraph: { id: string }, lang: string): void
+  updateCodeLanguage(block: unknown, lang: string): void
+}
+
+describe('selectLanguage (#4896)', () => {
+  // Regression: confirming a language with the keyboard after the paragraph
+  // was already converted into a code block left the picker callback holding
+  // a stale paragraph id — selectLanguage passed the null block into
+  // updateCodeLanguage, which crashed reading `functionType`. The real
+  // updateCodeLanguage stays in place here so the spec fails without the
+  // guard, exactly like the reported crash.
+  it('bails without crashing when the picked block no longer exists', () => {
+    const state = new FakeContentState() as SelectLanguageState
+    const spy = vi.spyOn(state, 'updateCodeLanguage')
+
+    expect(() => state.selectLanguage({ id: 'ag-gone' }, 'python')).not.toThrow()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('still applies the language when the block is present', () => {
+    const state = new FakeContentState() as SelectLanguageState
+    state.updateCodeLanguage = vi.fn()
+    const block = { functionType: 'languageInput', text: '' }
+    state.blocks['ag-1'] = block
+
+    state.selectLanguage({ id: 'ag-1' }, 'python')
+
+    expect(state.updateCodeLanguage).toHaveBeenCalledWith(block, 'python')
+  })
+})

--- a/packages/muyajs/lib/contentState/codeBlockCtrl.js
+++ b/packages/muyajs/lib/contentState/codeBlockCtrl.js
@@ -36,6 +36,13 @@ const codeBlockCtrl = (ContentState) => {
 
   ContentState.prototype.selectLanguage = function(paragraph, lang) {
     const block = this.getBlock(paragraph.id)
+    // The code picker captures `paragraph` when it opens; by the time the user
+    // confirms a language the block may already have been converted or removed
+    // (e.g. Enter turned the paragraph into a code block, GH#4896). Same
+    // detached-block guard as the @muyajs/core selector (GH#4654).
+    if (!block) {
+      return
+    }
     if (lang === 'math' && this.isGitlabCompatibilityEnabled && this.updateMathBlock(block)) {
       return
     }


### PR DESCRIPTION
## Description

Fixes #4896 — selecting a code-fence language from the autocomplete with the keyboard (Arrow keys + Enter) crashed the renderer with:

```
TypeError: Cannot read properties of null (reading 'functionType')
    at ContentState.updateCodeLanguage
    at ContentState.selectLanguage
```

## Root cause

The code picker's callback captures the paragraph DOM node when the picker opens (`eventHandler/keyboard.js` → `muya-code-picker` dispatch). By the time the selection is confirmed via the keyboard, that paragraph can already have been converted into a code block, so `selectLanguage`'s `this.getBlock(paragraph.id)` returns `null` — and `updateCodeLanguage` dereferences it (`block.functionType`). The mouse path happens not to hit the stale window, which matches the report (mouse works, keyboard crashes).

This is the legacy-engine analog of #4654, where the `@muyajs/core` code-block language selector gained a detached-block guard (`packages/muya/src/ui/codeBlockLanguageSelector`). This PR applies the same bail-out to `packages/muyajs`.

## Fix

One guard in `ContentState.selectLanguage`: if the picked block no longer resolves, return without mutating. This is the single place a null block can enter `updateCodeLanguage` — the other callers (`enterCtrl`, `pasteCtrl`) already hold non-null blocks.

## Tests

`test/unit/specs/code-picker-select-language.spec.ts` drives `selectLanguage` off a minimal fake ContentState (same approach as muya's `selectItem.spec.ts`):
- stale block → no crash, no mutation — **fails without the guard with the exact reported `TypeError`**
- present block → language still applied

`pnpm run lint` and `pnpm run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)