### PR TITLE
feat: support multiple spellchecker dictionaries

### DIFF
--- a/packages/desktop/src/main/preferences/index.ts
+++ b/packages/desktop/src/main/preferences/index.ts
@@ -86,6 +86,11 @@ class Preference extends TypedEmitter<PreferenceEvents> {
       throw new Error('Can not load static preference.json file')
     }
 
+    const configuredSpellcheckerLanguages = this.store.get('spellcheckerLanguage')
+    if (typeof configuredSpellcheckerLanguages === 'string') {
+      this.store.set('spellcheckerLanguage', [configuredSpellcheckerLanguages])
+    }
+
     // I don't know why `this.store.size` is 3 when first load, so I just check file existed.
     if (!this.hasPreferencesFile) {
       this.store.set(defaultSettings)

--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -329,10 +329,23 @@
     "default": false
   },
   "spellcheckerLanguage": {
-    "description": "Spelling--The spell checker language",
-    "type": "string",
-    "pattern": "^[a-z]{2,3}(?:[-](?:[0-9]|[a-zA-Z]){2,}){0,2}$",
-    "default": "en-US"
+    "description": "Spelling--The spell checker languages",
+    "oneOf": [
+      {
+        "type": "string",
+        "pattern": "^[a-z]{2,3}(?:[-](?:[0-9]|[a-zA-Z]){2,}){0,2}$"
+      },
+      {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^[a-z]{2,3}(?:[-](?:[0-9]|[a-zA-Z]){2,}){0,2}$"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      }
+    ],
+    "default": ["en-US"]
   },
   "imageInsertAction": {
     "description": "Image--The default behavior after insert image from local folder",

--- a/packages/desktop/src/main/spellchecker/index.ts
+++ b/packages/desktop/src/main/spellchecker/index.ts
@@ -19,7 +19,7 @@ export const removeFromDictionary = (win: BrowserWindow, word: string): boolean 
 /**
  * Returns a list of all words in the custom dictionary.
  */
-export const getCustomDictionaryWords = async(win: BrowserWindow): Promise<string[]> => {
+export const getCustomDictionaryWords = async (win: BrowserWindow): Promise<string[]> => {
   return win.webContents.session.listWordsInSpellCheckerDictionary()
 }
 
@@ -32,10 +32,23 @@ export const setSpellCheckerEnabled = (win: BrowserWindow, enabled: boolean): bo
 }
 
 /**
- * Switch the spellchecker to the given language and enable the builtin spell checker.
+ * Set the languages used by the builtin spell checker.
  */
-export const switchLanguage = (win: BrowserWindow, lang: string): void => {
-  win.webContents.session.setSpellCheckerLanguages([lang])
+export const setLanguages = (win: BrowserWindow, languages: string[]): void => {
+  const selectedLanguages = [...new Set(languages)]
+  if (selectedLanguages.length === 0) {
+    throw new Error('Expected at least one language for spell checker.')
+  }
+
+  const availableLanguages = new Set(getAvailableDictionaries(win))
+  const unavailableLanguage = selectedLanguages.find(
+    (language) => !availableLanguages.has(language)
+  )
+  if (unavailableLanguage) {
+    throw new Error(`Spell checker language is unavailable: ${unavailableLanguage}`)
+  }
+
+  win.webContents.session.setSpellCheckerLanguages(selectedLanguages)
 }
 
 /**
@@ -56,23 +69,23 @@ export const getAvailableDictionaries = (win: BrowserWindow): string[] => {
 }
 
 const registerSpellcheckerHandlers = (): void => {
-  ipcMain.handle('mt::spellchecker-remove-word', async(e, word: string) => {
+  ipcMain.handle('mt::spellchecker-remove-word', async (e, word: string) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     if (!win) return false
     return removeFromDictionary(win, word)
   })
-  ipcMain.handle('mt::spellchecker-switch-language', async(e, lang: string) => {
+  ipcMain.handle('mt::spellchecker-switch-language', async (e, languages: string[]) => {
     const win = BrowserWindow.fromWebContents(e.sender)
-    if (win) switchLanguage(win, lang)
+    if (win) setLanguages(win, languages)
     return null
   })
-  ipcMain.handle('mt::spellchecker-get-available-dictionaries', async(e) => {
+  ipcMain.handle('mt::spellchecker-get-available-dictionaries', async (e) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     if (!win) return []
     return getAvailableDictionaries(win)
   })
-  // We have to set a language or call `switchLanguage` on Linux and Windows.
-  ipcMain.handle('mt::spellchecker-set-enabled', async(e, enabled: boolean) => {
+  // Linux and Windows require at least one configured language when enabling spellcheck.
+  ipcMain.handle('mt::spellchecker-set-enabled', async (e, enabled: boolean) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     if (!win) return false
     if (!setSpellCheckerEnabled(win, enabled)) {
@@ -81,7 +94,7 @@ const registerSpellcheckerHandlers = (): void => {
     }
     return true
   })
-  ipcMain.handle('mt::spellchecker-get-custom-dictionary-words', async(e) => {
+  ipcMain.handle('mt::spellchecker-get-custom-dictionary-words', async (e) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     if (!win) return []
     return getCustomDictionaryWords(win)

--- a/packages/desktop/src/main/windows/editor.ts
+++ b/packages/desktop/src/main/windows/editor.ts
@@ -10,7 +10,7 @@ import { ensureWindowPosition, zoomIn, zoomOut } from './utils'
 import { TITLE_BAR_HEIGHT, editorWinOptions, isLinux, isOsx } from '../config'
 import { showEditorContextMenu } from '../contextMenu/editor'
 import { loadMarkdownFile } from '../filesystem/markdown'
-import { switchLanguage } from '../spellchecker'
+import { setLanguages } from '../spellchecker'
 import fs from 'fs'
 
 type RawMarkdownDocument = Awaited<ReturnType<typeof loadMarkdownFile>>
@@ -148,7 +148,10 @@ class EditorWindow extends BaseWindow {
 
     if (spellcheckerEnabled && !isOsx) {
       try {
-        switchLanguage(win, spellcheckerLanguage as string)
+        const languages = Array.isArray(spellcheckerLanguage)
+          ? spellcheckerLanguage
+          : [spellcheckerLanguage ?? 'en-US']
+        setLanguages(win, languages)
       } catch (error) {
         log.error('Unable to set spell checker language on startup:', error)
       }
@@ -203,7 +206,7 @@ class EditorWindow extends BaseWindow {
       )
     })
 
-    win.webContents.once('render-process-gone', async(_event, { reason }) => {
+    win.webContents.once('render-process-gone', async (_event, { reason }) => {
       if (reason === 'clean-exit') {
         return
       }

--- a/packages/desktop/src/renderer/src/commands/spellcheckerLanguage.ts
+++ b/packages/desktop/src/renderer/src/commands/spellcheckerLanguage.ts
@@ -35,7 +35,7 @@ class SpellcheckerLanguageCommand {
     this.subcommandSelectedIndex = -1
   }
 
-  run = async(): Promise<void> => {
+  run = async (): Promise<void> => {
     const langs = await SpellChecker.getAvailableDictionaries()
 
     const finalLangs: string[] = langs.length > 0 ? langs : ['en-US']
@@ -47,22 +47,31 @@ class SpellcheckerLanguageCommand {
         value: lang
       }
     })
-    const currentLanguage = this.spellchecker.lang
-    this.subcommandSelectedIndex = this.subcommands.findIndex(
-      (cmd) => cmd.value === currentLanguage
+    const currentLanguages = this.spellchecker.languages
+    this.subcommandSelectedIndex = this.subcommands.findIndex((cmd) =>
+      currentLanguages.includes(cmd.value)
     )
   }
 
-  execute = async(): Promise<void> => {
+  execute = async (): Promise<void> => {
     // Timeout to hide the command palette and then show again to prevent issues.
     await delay(100)
     bus.emit('show-command-palette', this)
   }
 
-  executeSubcommand = async(id: string): Promise<void> => {
+  executeSubcommand = async (id: string): Promise<void> => {
     const command = this.subcommands.find((cmd) => cmd.id === id)
+    if (!command) return
+
     if (this.spellchecker.isEnabled) {
-      bus.emit('switch-spellchecker-language', command?.value)
+      const currentLanguages = this.spellchecker.languages
+      const languages = currentLanguages.includes(command.value)
+        ? currentLanguages.filter((language) => language !== command.value)
+        : [...currentLanguages, command.value]
+
+      if (languages.length > 0) {
+        bus.emit('switch-spellchecker-language', languages)
+      }
     } else {
       notice.notify({
         title: 'Spelling',

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -798,7 +798,7 @@ watch(spellcheckerNoUnderline, (value, oldValue) => {
 
 watch(spellcheckerLanguage, (value, oldValue) => {
   if (value !== oldValue) {
-    spellchecker.lang = value
+    spellchecker.languages = value
   }
 })
 
@@ -1005,7 +1005,7 @@ const setImageViewerVisible = (status: boolean) => {
   }
 }
 
-const switchSpellcheckLanguage = (languageCode: unknown) => {
+const switchSpellcheckLanguage = (languages: unknown) => {
   const { isEnabled } = spellchecker
 
   // This method is also called from bus, so validate state before continuing.
@@ -1013,21 +1013,25 @@ const switchSpellcheckLanguage = (languageCode: unknown) => {
     throw new Error(t('editor.spellcheck.disabledError'))
   }
 
+  if (!Array.isArray(languages) || !languages.every((language) => typeof language === 'string')) {
+    throw new Error('Expected spell checker languages.')
+  }
+
   spellchecker
-    .switchLanguage(languageCode)
-    .then((langCode: string | null | undefined) => {
-      if (!langCode) {
+    .setLanguages(languages)
+    .then((changed: boolean) => {
+      if (!changed) {
         // Unable to switch language due to missing dictionary. The spell checker is now in an invalid state.
         notice.notify({
           title: t('editor.spellcheck.title'),
           type: 'warning',
-          message: t('editor.spellcheck.languageMissing', { languageCode: languageCode as string })
+          message: t('editor.spellcheck.languageMissing', { languageCode: languages.join(', ') })
         })
       }
     })
     .catch((error: unknown) => {
       log.error(
-        t('editor.spellcheck.errorSwitchingLanguage', { languageCode: languageCode as string })
+        t('editor.spellcheck.errorSwitchingLanguage', { languageCode: languages.join(', ') })
       )
       log.error(error)
 
@@ -1036,7 +1040,7 @@ const switchSpellcheckLanguage = (languageCode: unknown) => {
         title: t('editor.spellcheck.title'),
         type: 'error',
         message: t('editor.spellcheck.switchError', {
-          languageCode: languageCode as string,
+          languageCode: languages.join(', '),
           error: errMsg
         })
       })

--- a/packages/desktop/src/renderer/src/prefComponents/spellchecker/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/spellchecker/index.vue
@@ -23,14 +23,30 @@
           :disable="true"
           :on-change="noop"
         />
-        <cur-select
+        <section
           v-show="!isOsx"
-          :description="t('preferences.spellchecker.defaultLanguage')"
-          :value="spellcheckerLanguage"
-          :options="availableDictionaries"
-          :disable="!spellcheckerEnabled"
-          :on-change="handleSpellcheckerLanguage"
-        />
+          class="pref-select-item"
+        >
+          <div class="description">
+            {{ t('preferences.spellchecker.defaultLanguage') }}:
+          </div>
+          <el-select
+            :model-value="spellcheckerLanguage"
+            :disabled="!spellcheckerEnabled"
+            multiple
+            filterable
+            collapse-tags
+            collapse-tags-tooltip
+            @change="handleSpellcheckerLanguages"
+          >
+            <el-option
+              v-for="item in availableDictionaries"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+        </section>
       </template>
     </compound>
 
@@ -89,7 +105,6 @@ import type { PreferencesState } from '@/store/preferences'
 import { ref, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import Compound from '../common/compound/index.vue'
-import CurSelect from '../common/select/index.vue'
 import Bool from '../common/bool/index.vue'
 import { isOsx as checkIsOsx } from '@/util'
 import { SpellChecker } from '@/spellchecker'
@@ -140,13 +155,11 @@ const getAvailableDictionaries = async (): Promise<PrefSelectOption<string>[]> =
   })
 }
 
-const handleSpellcheckerLanguage = async (languageCode: string | number | boolean): Promise<void> => {
-  onSelectChange('spellcheckerLanguage', languageCode)
+const handleSpellcheckerLanguages = async (languages: string[]): Promise<void> => {
+  if (languages.length === 0) return
 
-  await window.electron.ipcRenderer.invoke(
-    'mt::spellchecker-switch-language',
-    String(languageCode)
-  )
+  onSelectChange('spellcheckerLanguage', languages)
+  await window.electron.ipcRenderer.invoke('mt::spellchecker-switch-language', languages)
 }
 
 const handleSpellcheckerEnabled = (isEnabled: boolean): void => {

--- a/packages/desktop/src/renderer/src/spellchecker/index.ts
+++ b/packages/desktop/src/renderer/src/spellchecker/index.ts
@@ -5,12 +5,12 @@ import { isOsx } from '@/util'
  */
 export class SpellChecker {
   enabled: boolean
-  currentSpellcheckerLanguage: string
+  currentSpellcheckerLanguages: string[]
   isProviderAvailable: boolean
 
-  constructor(enabled = true, lang = '') {
+  constructor(enabled = true, languages: string[] = []) {
     this.enabled = enabled
-    this.currentSpellcheckerLanguage = lang
+    this.currentSpellcheckerLanguages = languages
 
     // Helper to forbid the usage of the spell checker (e.g. failed to create
     // native spell checker), even if spell checker is enabled in settings.
@@ -25,9 +25,9 @@ export class SpellChecker {
   }
 
   /**
-   * Enable the spell checker and sets `lang` or tries to find a fallback.
+   * Enable the spell checker and set the configured languages.
    */
-  async activateSpellchecker(lang?: string): Promise<boolean> {
+  async activateSpellchecker(languages?: string[]): Promise<boolean> {
     try {
       this.enabled = true
       this.isProviderAvailable = true
@@ -36,7 +36,7 @@ export class SpellChecker {
         await window.electron.ipcRenderer.invoke('mt::spellchecker-set-enabled', true)
         return true
       }
-      return await this.switchLanguage(lang || this.currentSpellcheckerLanguage)
+      return await this.setLanguages(languages ?? this.currentSpellcheckerLanguages)
     } catch (error) {
       this.deactivateSpellchecker()
       throw error
@@ -53,33 +53,33 @@ export class SpellChecker {
   }
 
   /**
-   * Return the current language.
+   * Return the current languages.
    */
-  get lang(): string {
+  get languages(): string[] {
     if (this.isEnabled) {
-      return this.currentSpellcheckerLanguage
+      return this.currentSpellcheckerLanguages
     }
-    return ''
+    return []
   }
 
-  set lang(lang: string) {
-    this.currentSpellcheckerLanguage = lang
+  set languages(languages: string[]) {
+    this.currentSpellcheckerLanguages = languages
   }
 
   /**
-   * Explicitly switch the language to a specific language.
+   * Set the languages used by the spell checker.
    *
    * NOTE: This function can throw an exception.
    */
-  async switchLanguage(lang: string): Promise<boolean> {
+  async setLanguages(languages: string[]): Promise<boolean> {
     if (isOsx) {
       // NB: macOS uses the OS spell checker and detects language automatically.
       return true
-    } else if (!lang) {
-      throw new Error('Expected non-empty language for spell checker.')
+    } else if (languages.length === 0) {
+      throw new Error('Expected at least one language for spell checker.')
     } else if (this.isEnabled) {
-      await window.electron.ipcRenderer.invoke('mt::spellchecker-switch-language', lang)
-      this.lang = lang
+      await window.electron.ipcRenderer.invoke('mt::spellchecker-switch-language', languages)
+      this.languages = languages
       return true
     }
     return false

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -92,7 +92,7 @@ export interface PreferencesState {
   // ----- Spellchecker -----
   spellcheckerEnabled: boolean
   spellcheckerNoUnderline: boolean
-  spellcheckerLanguage: string
+  spellcheckerLanguage: string[]
 
   // ----- Side bar / tab bar visibility (persisted) -----
   sideBarVisibility: boolean
@@ -206,7 +206,7 @@ export const usePreferencesStore = defineStore('preferences', {
 
     spellcheckerEnabled: false,
     spellcheckerNoUnderline: false,
-    spellcheckerLanguage: 'en-US',
+    spellcheckerLanguage: ['en-US'],
 
     // Default values that are overwritten with the entries below.
     sideBarVisibility: false,

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -76,7 +76,7 @@ export interface IpcInvokeChannels {
   'mt::spellchecker-get-custom-dictionary-words': { args: []; ret: string[] }
   'mt::spellchecker-remove-word': { args: [word: string]; ret: boolean }
   'mt::spellchecker-set-enabled': { args: [enabled: boolean]; ret: void }
-  'mt::spellchecker-switch-language': { args: [language: string]; ret: void }
+  'mt::spellchecker-switch-language': { args: [languages: string[]]; ret: void }
   'mt::uploader::upload': { args: [req: unknown]; ret: unknown }
   'mt::win::is-fullscreen': { args: []; ret: boolean }
   'mt::win::is-maximized': { args: []; ret: boolean }
@@ -130,7 +130,9 @@ export interface IpcSendChannels {
   'mt::open-file-by-window-id': [windowId: number, filePath: string, options?: unknown]
   'mt::open-keybindings-config': []
   'mt::open-setting-window': []
-  'mt::rename': [payload: { id: string; pathname: string; newPathname: string; currentFile?: unknown }]
+  'mt::rename': [
+    payload: { id: string; pathname: string; newPathname: string; currentFile?: unknown }
+  ]
   'mt::request-keybindings': []
   'mt::set-editor-format-menus-enabled': [windowId: number, enabled: boolean]
   'mt::response-export': [

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -48,7 +48,7 @@ export interface IUserPreferences {
   theme?: string
   spellcheckerEnabled?: boolean
   spellcheckerNoUnderline?: boolean
-  spellcheckerLanguage?: string
+  spellcheckerLanguage?: string | string[]
   imageInsertAction?: 'upload' | 'folder' | 'path'
   imagePreferRelativePath?: boolean
   imageFolderPath?: string

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -65,7 +65,7 @@
 
   "spellcheckerEnabled": false,
   "spellcheckerNoUnderline": false,
-  "spellcheckerLanguage": "en-US",
+  "spellcheckerLanguage": ["en-US"],
 
   "sideBarVisibility": false,
   "tabBarVisibility": false,

--- a/packages/desktop/test/unit/specs/spellchecker-language-command.spec.ts
+++ b/packages/desktop/test/unit/specs/spellchecker-language-command.spec.ts
@@ -12,9 +12,9 @@ import bus from '@/bus'
 import notice from '@/services/notification'
 
 // Minimal stand-in for the renderer SpellChecker instance the command reads
-// (`lang` and `isEnabled` only).
-const makeChecker = (lang: string, isEnabled: boolean): SpellChecker =>
-  ({ lang, isEnabled }) as unknown as SpellChecker
+// (`languages` and `isEnabled` only).
+const makeChecker = (languages: string[], isEnabled: boolean): SpellChecker =>
+  ({ languages, isEnabled }) as unknown as SpellChecker
 
 describe('SpellcheckerLanguageCommand', () => {
   let emitSpy: Mock
@@ -25,13 +25,13 @@ describe('SpellcheckerLanguageCommand', () => {
   })
 
   describe('run() — building subcommands from available dictionaries', () => {
-    it('builds one subcommand per available dictionary and selects the current lang', async() => {
+    it('builds one subcommand per available dictionary and selects the current lang', async () => {
       vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue([
         'en-US',
         'de-DE',
         'fr-FR'
       ])
-      const command = new SpellcheckerLanguageCommand(makeChecker('de-DE', true))
+      const command = new SpellcheckerLanguageCommand(makeChecker(['de-DE'], true))
 
       await command.run()
 
@@ -42,9 +42,9 @@ describe('SpellcheckerLanguageCommand', () => {
       expect(command.subcommandSelectedIndex).toBe(1)
     })
 
-    it('falls back to ["en-US"] when the dictionary list is empty', async() => {
+    it('falls back to ["en-US"] when the dictionary list is empty', async () => {
       vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue([])
-      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', true))
+      const command = new SpellcheckerLanguageCommand(makeChecker(['en-US'], true))
 
       await command.run()
 
@@ -53,9 +53,9 @@ describe('SpellcheckerLanguageCommand', () => {
       expect(command.subcommandSelectedIndex).toBe(0)
     })
 
-    it('sets subcommandSelectedIndex to -1 when the current lang is not offered', async() => {
+    it('sets subcommandSelectedIndex to -1 when the current lang is not offered', async () => {
       vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'fr-FR'])
-      const command = new SpellcheckerLanguageCommand(makeChecker('de-DE', true))
+      const command = new SpellcheckerLanguageCommand(makeChecker(['de-DE'], true))
 
       await command.run()
 
@@ -64,28 +64,35 @@ describe('SpellcheckerLanguageCommand', () => {
   })
 
   describe('executeSubcommand() — enabled vs disabled', () => {
-    it('emits switch-spellchecker-language with the picked value when enabled', async() => {
+    it('adds the picked language without clearing current languages when enabled', async () => {
       vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'de-DE'])
-      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', true))
+      const command = new SpellcheckerLanguageCommand(makeChecker(['en-US'], true))
       await command.run()
 
       await command.executeSubcommand('spellchecker.switch-language-id-de-DE')
 
-      expect(emitSpy).toHaveBeenCalledWith('switch-spellchecker-language', 'de-DE')
+      expect(emitSpy).toHaveBeenCalledWith('switch-spellchecker-language', ['en-US', 'de-DE'])
       expect(notice.notify).not.toHaveBeenCalled()
     })
 
-    it('does NOT emit and notifies a warning when the spellchecker is disabled', async() => {
+    it('does not remove the only active language', async () => {
       vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'de-DE'])
-      const command = new SpellcheckerLanguageCommand(makeChecker('en-US', false))
+      const command = new SpellcheckerLanguageCommand(makeChecker(['en-US'], true))
+      await command.run()
+
+      await command.executeSubcommand('spellchecker.switch-language-id-en-US')
+
+      expect(emitSpy).not.toHaveBeenCalledWith('switch-spellchecker-language', expect.anything())
+    })
+
+    it('does NOT emit and notifies a warning when the spellchecker is disabled', async () => {
+      vi.spyOn(SpellChecker, 'getAvailableDictionaries').mockResolvedValue(['en-US', 'de-DE'])
+      const command = new SpellcheckerLanguageCommand(makeChecker(['en-US'], false))
       await command.run()
 
       await command.executeSubcommand('spellchecker.switch-language-id-de-DE')
 
-      expect(emitSpy).not.toHaveBeenCalledWith(
-        'switch-spellchecker-language',
-        expect.anything()
-      )
+      expect(emitSpy).not.toHaveBeenCalledWith('switch-spellchecker-language', expect.anything())
       expect(notice.notify).toHaveBeenCalledTimes(1)
       expect(notice.notify).toHaveBeenCalledWith({
         title: 'Spelling',

--- a/packages/desktop/test/unit/specs/spellchecker-languages-main.spec.ts
+++ b/packages/desktop/test/unit/specs/spellchecker-languages-main.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow } from 'electron'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  ipcMain: { handle: vi.fn() }
+}))
+
+vi.mock('../../../src/main/config', () => ({ isOsx: false }))
+
+import { setLanguages } from '../../../src/main/spellchecker'
+
+const setSpellCheckerLanguages = vi.fn()
+
+const makeWindow = (availableSpellCheckerLanguages: string[]): BrowserWindow =>
+  ({
+    webContents: {
+      session: {
+        availableSpellCheckerLanguages,
+        isSpellCheckerEnabled: vi.fn(() => true),
+        setSpellCheckerLanguages
+      }
+    }
+  }) as unknown as BrowserWindow
+
+describe('main spellchecker setLanguages', () => {
+  beforeEach(() => {
+    setSpellCheckerLanguages.mockClear()
+  })
+
+  it('deduplicates selected languages before passing them to Electron', () => {
+    setLanguages(makeWindow(['en-US', 'en-GB']), ['en-US', 'en-GB', 'en-US'])
+
+    expect(setSpellCheckerLanguages).toHaveBeenCalledWith(['en-US', 'en-GB'])
+  })
+
+  it('rejects an empty language list', () => {
+    expect(() => setLanguages(makeWindow(['en-US']), [])).toThrow(
+      'Expected at least one language for spell checker.'
+    )
+    expect(setSpellCheckerLanguages).not.toHaveBeenCalled()
+  })
+
+  it('rejects a language that Electron does not advertise', () => {
+    expect(() => setLanguages(makeWindow(['en-US']), ['en-US', 'xx-XX'])).toThrow(
+      'Spell checker language is unavailable: xx-XX'
+    )
+    expect(setSpellCheckerLanguages).not.toHaveBeenCalled()
+  })
+})

--- a/packages/desktop/test/unit/specs/spellchecker-switch-language.spec.ts
+++ b/packages/desktop/test/unit/specs/spellchecker-switch-language.spec.ts
@@ -8,13 +8,13 @@ const win = window as unknown as {
   electron?: { ipcRenderer: { invoke: Mock } }
 }
 
-const loadSpellChecker = async(isOsx: boolean) => {
+const loadSpellChecker = async (isOsx: boolean) => {
   vi.resetModules()
   vi.doMock('@/util', () => ({ isOsx }))
   return (await import('../../../src/renderer/src/spellchecker/index')).SpellChecker
 }
 
-describe('renderer SpellChecker.switchLanguage', () => {
+describe('renderer SpellChecker.setLanguages', () => {
   let invoke: Mock
 
   beforeEach(() => {
@@ -27,49 +27,49 @@ describe('renderer SpellChecker.switchLanguage', () => {
     vi.doUnmock('@/util')
   })
 
-  it('invokes the IPC channel once and records the new language (non-macOS, enabled)', async() => {
+  it('invokes the IPC channel once and records the new languages (non-macOS, enabled)', async () => {
     const SpellChecker = await loadSpellChecker(false)
-    const checker = new SpellChecker(true, 'en-US')
+    const checker = new SpellChecker(true, ['en-US'])
 
-    const result = await checker.switchLanguage('de-DE')
+    const result = await checker.setLanguages(['en-US', 'de-DE'])
 
     expect(result).toBe(true)
     expect(invoke).toHaveBeenCalledTimes(1)
-    expect(invoke).toHaveBeenCalledWith('mt::spellchecker-switch-language', 'de-DE')
-    expect(checker.lang).toBe('de-DE')
-    expect(checker.currentSpellcheckerLanguage).toBe('de-DE')
+    expect(invoke).toHaveBeenCalledWith('mt::spellchecker-switch-language', ['en-US', 'de-DE'])
+    expect(checker.languages).toEqual(['en-US', 'de-DE'])
+    expect(checker.currentSpellcheckerLanguages).toEqual(['en-US', 'de-DE'])
   })
 
-  it('short-circuits to true on macOS without touching IPC', async() => {
+  it('short-circuits to true on macOS without touching IPC', async () => {
     const SpellChecker = await loadSpellChecker(true)
-    const checker = new SpellChecker(true, 'en-US')
+    const checker = new SpellChecker(true, ['en-US'])
 
-    const result = await checker.switchLanguage('de-DE')
+    const result = await checker.setLanguages(['de-DE'])
 
     expect(result).toBe(true)
     expect(invoke).not.toHaveBeenCalled()
     // The OS spell checker auto-detects language, so the stored language is
     // left untouched.
-    expect(checker.currentSpellcheckerLanguage).toBe('en-US')
+    expect(checker.currentSpellcheckerLanguages).toEqual(['en-US'])
   })
 
-  it('returns false without IPC when the spell checker is disabled (non-macOS)', async() => {
+  it('returns false without IPC when the spell checker is disabled (non-macOS)', async () => {
     const SpellChecker = await loadSpellChecker(false)
-    const checker = new SpellChecker(false, 'en-US')
+    const checker = new SpellChecker(false, ['en-US'])
 
-    const result = await checker.switchLanguage('de-DE')
+    const result = await checker.setLanguages(['de-DE'])
 
     expect(result).toBe(false)
     expect(invoke).not.toHaveBeenCalled()
-    expect(checker.currentSpellcheckerLanguage).toBe('en-US')
+    expect(checker.currentSpellcheckerLanguages).toEqual(['en-US'])
   })
 
-  it('throws on an empty language when enabled (non-macOS) and never invokes IPC', async() => {
+  it('throws on an empty language list when enabled (non-macOS) and never invokes IPC', async () => {
     const SpellChecker = await loadSpellChecker(false)
-    const checker = new SpellChecker(true, 'en-US')
+    const checker = new SpellChecker(true, ['en-US'])
 
-    await expect(checker.switchLanguage('')).rejects.toThrow(
-      'Expected non-empty language for spell checker.'
+    await expect(checker.setLanguages([])).rejects.toThrow(
+      'Expected at least one language for spell checker.'
     )
     expect(invoke).not.toHaveBeenCalled()
   })

--- a/packages/website/content/docs/end-user/PREFERENCES.md
+++ b/packages/website/content/docs/end-user/PREFERENCES.md
@@ -80,7 +80,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | ---------------------- | ------- | ------- | ---------------------------------------------------------------------------- |
 | spellcheckerEnabled    | Boolean | `false` | Whether spell checking is enabled.                                           |
 | spellcheckerNoUnderline | Boolean | `false` | Don't underline spelling mistakes.                                          |
-| spellcheckerLanguage   | String  | `en-US` | The spell-checker language (BCP-47, e.g. `en-US`, `de-DE`, `zh-CN`).         |
+| spellcheckerLanguage   | String[] | `["en-US"]` | The spell-checker languages (BCP-47, e.g. `en-US`, `de-DE`, `zh-CN`).       |
 
 #### Image
 


### PR DESCRIPTION
## Summary

- allow selecting multiple spellchecker dictionaries in Preferences
- migrate the existing scalar `spellcheckerLanguage` preference to an array without losing user settings
- validate and deduplicate language selections before passing them to Electron
- make command-palette language actions toggle dictionaries while keeping at least one active
- update typed IPC, startup restoration, documentation, and focused tests

Closes #4907.

## User impact

Writers can enable combinations such as `en-US` and `en-GB`, so both regional spellings are accepted. The searchable multi-select also supports genuinely multilingual documents. macOS keeps its existing OS-level automatic language detection.

## Validation

- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings remain)
- focused Vitest suite: 13/13 passing
- full unit suite: 728 passing, 1 skipped; 10 failures in unrelated Windows path/PDF tests (`move-image-to-folder.spec.ts`, `pdf.spec.ts`)
- `git diff --check`