### PR TITLE
docs: #3991 add macOS Gatekeeper and Apple Silicon install troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ You can either download the latest `marktext-mac-(arm64|x64)-%version%.dmg` from
 brew install --cask mark-text
 ```
 
+**Troubleshooting**
+
+- **"MarkText is damaged and can't be opened."** The macOS builds are ad-hoc signed and are not notarized, so Gatekeeper quarantines them on first launch (see [#3991](https://github.com/marktext/marktext/issues/3991) and [#3729](https://github.com/marktext/marktext/issues/3729)). After installing, remove the quarantine attribute and reopen the app:
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/MarkText.app
+  ```
+
+  Alternatively, right-click the app in Finder, choose **Open**, and confirm the prompt once.
+
+- **The app feels slow on Apple Silicon.** Make sure you installed the `arm64` build rather than the `x64` build running under Rosetta. If you install with Homebrew, run it from a native arm64 Homebrew (`/opt/homebrew`); an Intel Homebrew (`/usr/local`) runs under Rosetta, reports itself as `x86_64`, and therefore fetches the `x64` dmg. Verify the installed architecture with:
+
+  ```bash
+  file /Applications/MarkText.app/Contents/MacOS/marktext   # should report "arm64"
+  ```
+
 #### Windows
 
 Requires Windows 10 or 11. Both x64 and arm64 installers are published — pick the architecture that matches your machine.


### PR DESCRIPTION
## Problem

On macOS the release builds are **ad-hoc signed and not notarized**
(`codesign` reports `Signature=adhoc`, `TeamIdentifier=not set`; `spctl -a`
returns `rejected`). As a result Gatekeeper quarantines the app on first
launch and users see **"MarkText is damaged and can't be opened."**

This is the most persistent macOS install complaint in the tracker:

- #3991 — *Mac install using brew is broken* (open)
- #3729 — *Can't Open on M2 Macbook* (open)
- plus closed duplicates #4140, #4096, #3889, #3427, #3333, #3180

It is also why the Homebrew cask is currently `disabled` with
`:fails_gatekeeper_check`.

A second, separate pitfall: installing via an **Intel Homebrew** (which runs
under Rosetta and reports itself as `x86_64`) makes the cask fetch the `x64`
dmg, so Apple Silicon users end up running the app slowly under emulation
without realizing it.

## What this PR does

This does **not** fix the root cause. Proper notarization requires an Apple
Developer certificate and CI secrets that only the maintainers can add, so
this PR is limited to **documentation** of the reliable, verifiable
workarounds, added to the macOS section of the README:

1. Clear the quarantine attribute (`xattr -dr com.apple.quarantine ...`) or
   right-click → **Open**.
2. On Apple Silicon, use the `arm64` dmg / a native arm64 Homebrew
   (`/opt/homebrew`), and how to verify the installed architecture with
   `file`.

Every command was verified on macOS 26 (Apple Silicon).

## Notes

- Docs-only change (README), so no screen recording applies. Rendered
  preview:

  > **"MarkText is damaged and can't be opened."** … remove the quarantine
  > attribute and reopen the app: `xattr -dr com.apple.quarantine /Applications/MarkText.app`

- Investigated and written together by @ZainnQureshii and Claude (Anthropic).

Refs #3991 · Refs #3729
