### PR TITLE
fix(desktop): prevent CodeMirror line tree corruption

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
+import { ref, markRaw, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useEditorStore } from '@/store/editor'
 import { usePreferencesStore } from '@/store/preferences'
 import { findMarkdownHeadingLine, scrollSourceEditorToLine } from '@/util/sourceModeToc'
@@ -365,9 +365,8 @@ onMounted(() => {
   bus.on('image-action', handleImageAction)
   bus.on('scroll-to-header', handleScrollToHeader)
 
-  // For some reason, code mirror does not seem to play well with Vue's refs if we reference editor.value directly.
-  // See https://github.com/codemirror/codemirror5/issues/6886 - hence, we need to use a local variable first.
-  const codeMirrorInstance = codeMirror(container, codeMirrorConfig)
+  // CodeMirror's line tree relies on object identity and must not be proxied by Vue.
+  const codeMirrorInstance = markRaw(codeMirror(container, codeMirrorConfig))
 
   // `markdown-math` wraps the standard Markdown mode and delegates `$...$` and
   // `$$...$$` spans to stex so subscript underscores in math do not flip the

--- a/packages/desktop/test/e2e/issue-4921-codemirror-tree.spec.ts
+++ b/packages/desktop/test/e2e/issue-4921-codemirror-tree.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication } from 'playwright'
+import {
+  clearRendererErrors,
+  enterSourceMode,
+  launchWithMarkdown,
+  sendIpcToRenderer,
+  waitForRendererError
+} from './helpers'
+
+const BASH_SCRIPT = `#!/usr/bin/env bash
+
+type_slowly() {
+  local text="$1"
+  local pause_after="$2"
+  local pause_clear="$3"
+  local i
+
+  printf '\\n'
+
+  for ((i = 0; i < \${#text}; i++)); do
+    printf '%s' "\${text:i:1}"
+    sleep 0.1
+  done
+
+  sleep "$pause_after"
+  clear
+  sleep "$pause_clear"
+}
+
+matrix() {
+  clear
+  type_slowly "Wake up, Neo..." 2 1
+  type_slowly "The Matrix has you" 3 1
+  type_slowly "Follow the white rabbit." 2 2
+  type_slowly "Knock, knock, Neo." 4 3
+}
+
+matrix
+`
+
+const reportExternalChange = async(
+  app: ElectronApplication,
+  pathname: string,
+  markdown: string
+): Promise<void> => {
+  await sendIpcToRenderer(app, 'mt::update-file', {
+    type: 'change',
+    change: {
+      pathname,
+      mtimeMs: 1,
+      data: {
+        markdown,
+        filename: 'note.md',
+        pathname,
+        encoding: { encoding: 'utf8', hasBOM: false },
+        lineEnding: 'lf',
+        adjustLineEndingOnSave: false,
+        trimTrailingNewline: 1,
+        isMixedLineEndings: false
+      }
+    }
+  })
+}
+
+test('Issue #4921: source-mode updates preserve CodeMirror line-tree identity', async() => {
+  const { app, page, filePath } = await launchWithMarkdown('initial\n', {
+    suppressErrorDialog: true
+  })
+
+  try {
+    await sendIpcToRenderer(app, 'mt::user-preference', { autoSave: true })
+    await page.waitForTimeout(100)
+    await enterSourceMode(page, app)
+    await clearRendererErrors(app)
+
+    const updatedMarkdown = BASH_SCRIPT.repeat(3)
+    await reportExternalChange(app, filePath, updatedMarkdown)
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const wrapper = document.querySelector('.source-code .CodeMirror') as
+            | (Element & { CodeMirror?: { getValue(): string } })
+            | null
+          return wrapper?.CodeMirror?.getValue() ?? ''
+        })
+      )
+      .toBe(updatedMarkdown)
+
+    const result = await page.evaluate((bashScript) => {
+      interface LeafChunk {
+        parent: DocumentChunk
+        lines: Array<{ parent: LeafChunk }>
+      }
+      interface DocumentChunk {
+        children: LeafChunk[]
+      }
+      interface CodeMirrorInternal {
+        doc: DocumentChunk
+        focus(): void
+        getInputField(): HTMLTextAreaElement
+        getValue(): string
+      }
+
+      const wrapper = document.querySelector('.source-code .CodeMirror') as
+        | (Element & { CodeMirror?: CodeMirrorInternal })
+        | null
+      const cm = wrapper?.CodeMirror
+      if (!cm) return false
+
+      cm.focus()
+      const beforePaste = cm.getValue()
+      const clipboardData = new DataTransfer()
+      clipboardData.setData('Text', bashScript)
+      cm.getInputField().dispatchEvent(
+        new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true })
+      )
+
+      const { doc } = cm
+      const lineTreeIntact = doc.children.every(
+        (leaf) => leaf.parent === doc && leaf.lines.every((line) => line.parent === leaf)
+      )
+      return { lineTreeIntact, pasteApplied: cm.getValue() !== beforePaste }
+    }, BASH_SCRIPT)
+
+    expect(result).toEqual({ lineTreeIntact: true, pasteApplied: true })
+    const rendererError = await waitForRendererError(app, () => true, 1000)
+    expect(rendererError).toBeNull()
+  } finally {
+    await app.close()
+  }
+})


### PR DESCRIPTION
<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #4921
Closes #4456

## Summary

Prevents Vue from deep-proxying the stateful CodeMirror instance used by Source Code mode. CodeMirror's document tree relies on strict object identity between documents, leaf chunks, and lines; proxying the instance can break those parent relationships and surface as the reported `lineNo` / `chunkSize` renderer crash.

The instance is now wrapped with Vue's `markRaw`, matching the existing Muya integration. A focused Electron e2e regression covers the real file-update path followed by the reported Bash-script paste, verifies the CodeMirror line tree remains consistent, confirms the paste changes the document, and checks for renderer errors.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Windows (Electron e2e)

The following checks passed: desktop build, TypeScript typecheck, targeted ESLint, and the related Source Code e2e suite (18 passed, 1 existing skip).

## Notes for reviewers [optional]

The final regression spec was verified red/green against both implementations: without `markRaw`, the paste was applied but `lineTreeIntact` was `false`; with `markRaw`, the same test passes. Both linked issues report the same CodeMirror `lineNo` / `chunkSize` stack. #4921 supplies the Bash paste case; #4456 has no reproduction steps but hits the same remaining CodeMirror-backed Source Code path.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
