### PR TITLE
fix: #4926 prevent emoji deletion from splitting surrogate pairs

### DIFF
--- a/packages/desktop/test/e2e/issue-4926-emoji-delete.spec.ts
+++ b/packages/desktop/test/e2e/issue-4926-emoji-delete.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  clearRendererErrors,
+  expectNoRendererErrors,
+  launchWithMarkdown,
+  placeCaretInEditor,
+  waitForRendererError
+} from './helpers'
+
+const PASTED_TEXT = '\u{1F642}(\u5FAE\u7B11)\u{1F600}(\u5927\u7B11)'
+const FIRST_EMOJI = '\u{1F642}'
+const TEXT_AFTER_FIRST_EMOJI = PASTED_TEXT.slice(FIRST_EMOJI.length)
+const TRAILING_EMOJI_TEXT = `abc${FIRST_EMOJI}`
+const DELETE_KEYS = ['Backspace', 'Delete'] as const
+
+test.describe('Emoji deletion (#4926)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('\n', { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  const pasteText = async(text: string) => {
+    await app.evaluate(({ clipboard }, value) => clipboard.writeText(value), text)
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+V' : 'Control+V')
+    const paragraph = page.locator('.editor-component span.mu-paragraph-content').first()
+    await expect(paragraph).toHaveText(text)
+    return paragraph
+  }
+
+  const expectRendererToRemainHealthy = async() => {
+    await page.evaluate(async() => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+    })
+    expect(await waitForRendererError(app, () => true)).toBeNull()
+    await expectNoRendererErrors(app)
+  }
+
+  for (const key of DELETE_KEYS) {
+    test(`handles ${key} inside a pasted emoji`, async() => {
+      const paragraph = await pasteText(PASTED_TEXT)
+
+      const caretPlaced = await page.evaluate((emoji) => {
+        const root = document.querySelector('.editor-component') as HTMLElement | null
+        const target = root?.querySelector('span.mu-paragraph-content') ?? null
+        if (!root || !target) return false
+
+        const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT)
+        let textNode = walker.nextNode()
+        while (textNode instanceof Text && !textNode.data.includes(emoji)) {
+          textNode = walker.nextNode()
+        }
+        if (!(textNode instanceof Text)) return false
+
+        // Offset 1 is between this emoji's two UTF-16 code units.
+        const offset = textNode.data.indexOf(emoji) + 1
+        if (offset < 1) return false
+
+        root.focus()
+        const range = document.createRange()
+        range.setStart(textNode, offset)
+        range.collapse(true)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+        document.dispatchEvent(new Event('selectionchange'))
+        root.dispatchEvent(
+          new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true, cancelable: true })
+        )
+        return true
+      }, FIRST_EMOJI)
+      expect(caretPlaced).toBe(true)
+
+      await page.keyboard.press(key)
+      await expect(paragraph).toHaveText(TEXT_AFTER_FIRST_EMOJI)
+      await page.keyboard.type('x')
+      await expect(paragraph).toHaveText(`x${TEXT_AFTER_FIRST_EMOJI}`)
+      await expectRendererToRemainHealthy()
+    })
+  }
+
+  test('Backspace removes a trailing pasted emoji as one code point', async() => {
+    const paragraph = await pasteText(TRAILING_EMOJI_TEXT)
+
+    await page.keyboard.press('Backspace')
+    await expect(paragraph).toHaveText('abc')
+    await page.keyboard.type('x')
+    await expect(paragraph).toHaveText('abcx')
+    await expectRendererToRemainHealthy()
+  })
+})

--- a/packages/desktop/test/e2e/issue-4926-emoji-delete.spec.ts
+++ b/packages/desktop/test/e2e/issue-4926-emoji-delete.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  clearRendererErrors,
+  expectNoRendererErrors,
+  launchWithMarkdown,
+  placeCaretInEditor,
+  waitForRendererError
+} from './helpers'
+
+const PASTED_TEXT = '\u{1F642}(\u5FAE\u7B11)\u{1F600}(\u5927\u7B11)'
+const FIRST_EMOJI = '\u{1F642}'
+const TEXT_AFTER_FIRST_EMOJI = PASTED_TEXT.slice(FIRST_EMOJI.length)
+const TRAILING_EMOJI_TEXT = `abc${FIRST_EMOJI}`
+// A ZWJ sequence: five code points and eight UTF-16 code units, but a single
+// character to the user, so one Backspace / Delete has to take all of it.
+const FAMILY = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}'
+const FAMILY_TEXT = `abc${FAMILY}def`
+const TEXT_WITHOUT_FAMILY = 'abcdef'
+const DELETE_KEYS = ['Backspace', 'Delete'] as const
+
+test.describe('Emoji deletion (#4926)', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeEach(async() => {
+    const launched = await launchWithMarkdown('\n', { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await placeCaretInEditor(page)
+    await clearRendererErrors(app)
+  })
+
+  test.afterEach(async() => {
+    if (app) await app.close()
+  })
+
+  const pasteText = async(text: string) => {
+    await app.evaluate(({ clipboard }, value) => clipboard.writeText(value), text)
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+V' : 'Control+V')
+    const paragraph = page.locator('.editor-component span.mu-paragraph-content').first()
+    await expect(paragraph).toHaveText(text)
+    return paragraph
+  }
+
+  const expectRendererToRemainHealthy = async() => {
+    await page.evaluate(async() => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+    })
+    expect(await waitForRendererError(app, () => true)).toBeNull()
+    await expectNoRendererErrors(app)
+  }
+
+  // Park the collapsed caret between the first two UTF-16 code units of the
+  // first `emoji` in the paragraph: the state a paste, or Muya's own offset
+  // arithmetic, can leave behind — and the one #4926 reported.
+  const placeCaretInsidePastedEmoji = async(emoji: string) =>
+    page.evaluate((needle) => {
+      const root = document.querySelector('.editor-component') as HTMLElement | null
+      const target = root?.querySelector('span.mu-paragraph-content') ?? null
+      if (!root || !target) return false
+
+      const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT)
+      let textNode = walker.nextNode()
+      while (textNode instanceof Text && !textNode.data.includes(needle)) {
+        textNode = walker.nextNode()
+      }
+      if (!(textNode instanceof Text)) return false
+
+      // Offset 1 is between this emoji's first two code units.
+      const offset = textNode.data.indexOf(needle) + 1
+      if (offset < 1) return false
+
+      root.focus()
+      const range = document.createRange()
+      range.setStart(textNode, offset)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      document.dispatchEvent(new Event('selectionchange'))
+      root.dispatchEvent(
+        new KeyboardEvent('keyup', { key: 'ArrowRight', bubbles: true, cancelable: true })
+      )
+      return true
+    }, emoji)
+
+  for (const key of DELETE_KEYS) {
+    test(`handles ${key} inside a pasted emoji`, async() => {
+      const paragraph = await pasteText(PASTED_TEXT)
+
+      expect(await placeCaretInsidePastedEmoji(FIRST_EMOJI)).toBe(true)
+
+      await page.keyboard.press(key)
+      await expect(paragraph).toHaveText(TEXT_AFTER_FIRST_EMOJI)
+      await page.keyboard.type('x')
+      await expect(paragraph).toHaveText(`x${TEXT_AFTER_FIRST_EMOJI}`)
+      await expectRendererToRemainHealthy()
+    })
+
+    test(`handles ${key} inside a pasted ZWJ sequence`, async() => {
+      const paragraph = await pasteText(FAMILY_TEXT)
+
+      expect(await placeCaretInsidePastedEmoji(FAMILY)).toBe(true)
+
+      await page.keyboard.press(key)
+      await expect(paragraph).toHaveText(TEXT_WITHOUT_FAMILY)
+      await page.keyboard.type('x')
+      await expect(paragraph).toHaveText('abcxdef')
+      await expectRendererToRemainHealthy()
+    })
+  }
+
+  test('Backspace removes a trailing pasted emoji as one code point', async() => {
+    const paragraph = await pasteText(TRAILING_EMOJI_TEXT)
+
+    await page.keyboard.press('Backspace')
+    await expect(paragraph).toHaveText('abc')
+    await page.keyboard.type('x')
+    await expect(paragraph).toHaveText('abcx')
+    await expectRendererToRemainHealthy()
+  })
+
+  test('Backspace removes a trailing pasted ZWJ sequence as one character', async() => {
+    const paragraph = await pasteText(`abc${FAMILY}`)
+
+    await page.keyboard.press('Backspace')
+    await expect(paragraph).toHaveText('abc')
+    await page.keyboard.type('x')
+    await expect(paragraph).toHaveText('abcx')
+    await expectRendererToRemainHealthy()
+  })
+})

--- a/packages/muya/e2e/tests/editing/search-replace.spec.ts
+++ b/packages/muya/e2e/tests/editing/search-replace.spec.ts
@@ -30,10 +30,8 @@ test.describe('search and replace', () => {
         await page.locator(toolbar.replace).click();
         await slowType(page, 'bar');
         await page.locator(toolbar.single).click();
-        const md = await getMarkdown(page);
-        // After replacing one occurrence: at least one 'foo' becomes 'bar'.
-        expect(md).toContain('bar');
-        expect(md.match(/foo/g)?.length ?? 0).toBeLessThanOrEqual(2);
+        // Replacement reaches the JSON state read by getMarkdown on the next frame.
+        await expect.poll(() => getMarkdown(page)).toBe('bar foo foo\n');
     });
 
     test('#all replaces every occurrence', async ({ page }) => {
@@ -45,8 +43,7 @@ test.describe('search and replace', () => {
         await page.locator(toolbar.replace).click();
         await slowType(page, 'dog');
         await page.locator(toolbar.all).click();
-        const md = await getMarkdown(page);
-        expect(md).not.toContain('cat');
-        expect(md.match(/dog/g)?.length).toBe(3);
+        // Wait for the deferred state update and verify that every match was replaced.
+        await expect.poll(() => getMarkdown(page)).toBe('dog dog dog\n');
     });
 });

--- a/packages/muya/src/block/base/__tests__/formatBackspace.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatBackspace.spec.ts
@@ -70,6 +70,15 @@ function pressBackspace(content: Format): Event {
     return event;
 }
 
+function pressBackspaceThroughKeydown(content: Format): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        cancelable: true,
+    });
+    content.keydownHandler(event);
+    return event;
+}
+
 describe('format.backspaceHandler — closing-marker boundary (muya#113)', () => {
     it('just-outside the closing `**`: removes one marker char, no doubled markers', () => {
         // Caret at offset 14, immediately after the whole `**strong**` close.
@@ -164,6 +173,33 @@ describe('format.backspaceHandler — plain-text boundaries (no markers involved
         const event = pressBackspace(content);
 
         expect(content.text).toBe('oo **strong**');
+        expect(content.getCursor()!.start.offset).toBe(0);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret after a trailing astral character: removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('abc\u{1F642}\n'), 5);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret inside a trailing astral character: snaps then removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('abc\u{1F642}\n'), 4);
+        const event = pressBackspaceThroughKeydown(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('caret after a leading astral character: removes the whole code point', () => {
+        const content = caretInFirstBlock(bootMuya('\u{1F642}abc\n'), 2);
+        const event = pressBackspace(content);
+
+        expect(content.text).toBe('abc');
         expect(content.getCursor()!.start.offset).toBe(0);
         expect(event.defaultPrevented).toBe(true);
     });

--- a/packages/muya/src/block/base/__tests__/graphemeDelete.spec.ts
+++ b/packages/muya/src/block/base/__tests__/graphemeDelete.spec.ts
@@ -1,0 +1,234 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+
+// Coverage for deleting emoji as whole characters (#4926).
+//
+// A collapsed caret can end up *inside* a character: pasting, and Muya's own
+// offset arithmetic, can both park it between the UTF-16 code units of an
+// emoji. Deleting from there removed a single code unit, and that unit could be
+// half of a surrogate pair — a lone surrogate that `ot-text-unicode` cannot
+// encode, which crashed the renderer. Even when the delete did not throw, it
+// took out only a fraction of what the user sees as one character.
+//
+// The contract pinned down here: whatever a caret sits inside, one Backspace or
+// Delete removes that whole grapheme cluster (UAX #29) and nothing else.
+//
+// Fixtures, with the shape that makes them interesting:
+//   🙂          1 code point  / 2 code units  (one surrogate pair)
+//   👍🏽          2 code points / 4 code units  (base + skin tone modifier)
+//   🇨🇳          2 code points / 4 code units  (two regional indicators)
+//   1️⃣          3 code points / 3 code units  (digit + VS16 + enclosing keycap)
+//   e + U+0301    2 code points / 2 code units  (base + combining acute)
+//   👨‍👩‍👧          5 code points / 8 code units  (ZWJ sequence)
+const FAMILY = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}';
+const SKIN_TONE = '\u{1F44D}\u{1F3FD}';
+const FLAG = '\u{1F1E8}\u{1F1F3}';
+const KEYCAP = '1\uFE0F\u20E3';
+const COMBINING = 'e\u0301';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    // The DOM selection is document-global; a range left pointing into the
+    // just-removed host would corrupt the next test's `setCursor`.
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+// Rest a collapsed caret at `offset` (RAW markdown coordinates) inside the
+// first content block, the way a paste or an offset calculation can leave it.
+function caretInFirstBlock(muya: Muya, offset: number): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    content.setCursor(offset, offset, true);
+    return content;
+}
+
+// The full keydown path, which is where the cluster check runs.
+function pressKey(content: Format, key: 'Backspace' | 'Delete'): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key, cancelable: true });
+    content.keydownHandler(event);
+    return event;
+}
+
+// The handler on its own, with the cluster check bypassed.
+function pressBackspaceHandler(content: Format): Event {
+    const event = new Event('keydown', { cancelable: true });
+    content.backspaceHandler(event);
+    return event;
+}
+
+describe('grapheme cluster fixtures', () => {
+    it('are multi-code-point / multi-code-unit characters', () => {
+        // Guard the fixtures themselves: if these lengths ever change, the
+        // offsets the tests below use stop meaning anything.
+        expect(FAMILY.length).toBe(8);
+        expect(SKIN_TONE.length).toBe(4);
+        expect(FLAG.length).toBe(4);
+        expect(KEYCAP.length).toBe(3);
+        expect(COMBINING.length).toBe(2);
+    });
+});
+
+describe('caret inside a grapheme cluster — Backspace removes the whole character', () => {
+    it('between the halves of a ZWJ sequence\'s first code point', () => {
+        const content = caretInFirstBlock(bootMuya(`abc${FAMILY}\n`), 5);
+        const event = pressKey(content, 'Backspace');
+
+        // The whole 8-unit family emoji is gone — not the 2 units of `👨`, and
+        // not a lone surrogate left behind.
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('between the ZWJ joiner and the following code point', () => {
+        const content = caretInFirstBlock(bootMuya(`abc${FAMILY}\n`), 6);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('removes only the cluster under the caret, leaving its neighbours', () => {
+        const content = caretInFirstBlock(bootMuya(`a${FAMILY}b\n`), 5);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('ab');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('handles a skin tone modifier', () => {
+        const content = caretInFirstBlock(bootMuya(`x${SKIN_TONE}\n`), 2);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('x');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('handles a regional indicator flag', () => {
+        const content = caretInFirstBlock(bootMuya(`x${FLAG}\n`), 2);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('x');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('handles a keycap sequence', () => {
+        const content = caretInFirstBlock(bootMuya(`x${KEYCAP}\n`), 2);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('x');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('handles a combining mark', () => {
+        const content = caretInFirstBlock(bootMuya(`x${COMBINING}\n`), 2);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('x');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+});
+
+describe('caret inside a grapheme cluster — Delete removes the whole character', () => {
+    it('between the halves of a ZWJ sequence\'s first code point', () => {
+        const content = caretInFirstBlock(bootMuya(`abc${FAMILY}\n`), 5);
+        const event = pressKey(content, 'Delete');
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('inside a cluster that ends the text', () => {
+        const content = caretInFirstBlock(bootMuya(`a${FAMILY}\n`), 5);
+        const event = pressKey(content, 'Delete');
+
+        expect(content.text).toBe('a');
+        expect(content.getCursor()!.start.offset).toBe(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+});
+
+describe('caret on a cluster boundary — the default behaviour is left alone', () => {
+    it('before a ZWJ sequence defers instead of deleting it', () => {
+        const content = caretInFirstBlock(bootMuya(`abc${FAMILY}\n`), 3);
+        const event = pressKey(content, 'Backspace');
+
+        // Offset 3 is the cluster's own start: a boundary, so Muya does not own
+        // this delete. The browser's grapheme-aware Backspace removes `c`.
+        expect(content.text).toBe(`abc${FAMILY}`);
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('inside plain ASCII text defers', () => {
+        const content = caretInFirstBlock(bootMuya('hello\n'), 3);
+        const event = pressKey(content, 'Backspace');
+
+        expect(content.text).toBe('hello');
+        expect(event.defaultPrevented).toBe(false);
+    });
+});
+
+describe('inline-token trimming is cluster aware', () => {
+    it('trims a whole trailing ZWJ sequence from the token', () => {
+        const content = caretInFirstBlock(bootMuya(`abc${FAMILY}\n`), 11);
+        const event = pressBackspaceHandler(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(3);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('trims a whole leading ZWJ sequence from the token', () => {
+        const content = caretInFirstBlock(bootMuya(`${FAMILY}abc\n`), 8);
+        const event = pressBackspaceHandler(content);
+
+        expect(content.text).toBe('abc');
+        expect(content.getCursor()!.start.offset).toBe(0);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('still trims one marker char from an ASCII run', () => {
+        // The #113 behaviour must survive: `foo **strong**` loses one `*`.
+        const content = caretInFirstBlock(bootMuya('foo **strong**\n'), 14);
+        const event = pressBackspaceHandler(content);
+
+        expect(content.text).toBe('foo **strong*');
+        expect(event.defaultPrevented).toBe(true);
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -708,6 +708,32 @@ class Content extends TreeNode {
         return true;
     }
 
+    private _snapDeletionCursorToCodePointBoundary(event: KeyboardEvent) {
+        if (event.key !== EVENT_KEYS.Backspace && event.key !== EVENT_KEYS.Delete)
+            return;
+
+        const cursor = this.getCursor();
+        if (!cursor?.isCollapsed)
+            return;
+
+        const offset = cursor.start.offset;
+        const previous = this.text.charCodeAt(offset - 1);
+        const next = this.text.charCodeAt(offset);
+        const splitsSurrogatePair
+            = previous >= 0xD800
+                && previous <= 0xDBFF
+                && next >= 0xDC00
+                && next <= 0xDFFF;
+
+        // Native deletion at this invalid UTF-16 boundary leaves a lone
+        // surrogate that text-unicode cannot encode (#4926).
+        if (splitsSurrogatePair) {
+            const safeOffset
+                = event.key === EVENT_KEYS.Backspace ? offset + 1 : offset - 1;
+            this.setCursor(safeOffset, safeOffset);
+        }
+    }
+
     keydownHandler = (event: Event) => {
         if (!isKeyboardEvent(event))
             return;
@@ -717,6 +743,8 @@ class Content extends TreeNode {
 
         if (this._wrapSelectionWithAutoPair(event))
             return;
+
+        this._snapDeletionCursorToCodePointBoundary(event);
 
         switch (event.key) {
             case EVENT_KEYS.Backspace:

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -12,6 +12,7 @@ import Selection from '../../selection';
 import {
     adjustOffset,
     diffToTextOp,
+    graphemeClusterContaining,
     isCompositionEndEvent,
     isInputEvent,
     isKeyboardEvent,
@@ -842,6 +843,59 @@ class Content extends TreeNode {
         return true;
     }
 
+    // A collapsed caret can be parked *inside* a character: pasting, and Muya's
+    // own offset arithmetic, can both leave it between the UTF-16 code units of
+    // an emoji. A delete from there is not "remove one character" — the browser
+    // takes an arbitrary piece of the cluster, and that piece can be half of a
+    // surrogate pair, which is a lone surrogate `ot-text-unicode` cannot encode
+    // (#4926). Even when it does not crash, what remains is a fraction of what
+    // the user sees as one character.
+    //
+    // So handle those deletes here, on grapheme cluster boundaries (UAX #29):
+    // one whole character goes away, however many code points or code units it
+    // is made of (`👨‍👩‍👧` is 5 and 8 respectively). A caret that already sits on a
+    // cluster boundary is left to the regular handlers, which keeps the common
+    // case on the browser's own — grapheme aware — deletion path.
+    private _deleteGraphemeClusterContainingCaret(event: KeyboardEvent) {
+        const isBackspace = event.key === EVENT_KEYS.Backspace;
+        if (!isBackspace && event.key !== EVENT_KEYS.Delete)
+            return false;
+
+        // An IME owns the keys while it composes (the Backspace / Delete cases
+        // below carry the same guard): the composing text is not in `this.text`
+        // yet, so there is no cluster here to delete.
+        if (this.isComposed)
+            return false;
+
+        const cursor = this.getCursor();
+        if (!cursor?.isCollapsed)
+            return false;
+
+        const { text } = this;
+        const { offset } = cursor.start;
+        // Cheap out for plain-text editing: a boundary between two ASCII code
+        // units can only fall inside a cluster for CR×LF, and Muya normalises
+        // line endings, so ASCII text never needs the segmentation below.
+        const previousUnit = text.charCodeAt(offset - 1);
+        const nextUnit = text.charCodeAt(offset);
+        if (previousUnit < 0x80 && nextUnit < 0x80 && previousUnit !== 0x0D)
+            return false;
+
+        const cluster = graphemeClusterContaining(text, offset);
+        if (!cluster)
+            return false;
+
+        event.preventDefault();
+        this.muya.editor.history.markInputBoundary(
+            isBackspace ? 'deleteContentBackward' : 'deleteContentForward',
+            null,
+        );
+        this.text = text.substring(0, cluster.start) + text.substring(cluster.end);
+        this.setCursor(cluster.start, cluster.start, true);
+
+        return true;
+    }
+
     keydownHandler = (event: Event) => {
         if (!isKeyboardEvent(event))
             return;
@@ -850,6 +904,9 @@ class Content extends TreeNode {
             return;
 
         if (this._wrapSelectionWithAutoPair(event))
+            return;
+
+        if (this._deleteGraphemeClusterContainingCaret(event))
             return;
 
         switch (event.key) {

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -41,6 +41,23 @@ interface IOffsetWithDelta extends IOffset {
 
 const debug = logger('block.format:');
 
+function firstCodePointLength(text: string) {
+    const codePoint = text.codePointAt(0);
+    return codePoint !== undefined && codePoint > 0xFFFF ? 2 : 1;
+}
+
+function lastCodePointLength(text: string) {
+    const last = text.length - 1;
+    const lastUnit = text.charCodeAt(last);
+    const previousUnit = text.charCodeAt(last - 1);
+    return lastUnit >= 0xDC00
+        && lastUnit <= 0xDFFF
+        && previousUnit >= 0xD800
+        && previousUnit <= 0xDBFF
+        ? 2
+        : 1;
+}
+
 function isEmojiToken(token: Token): token is CodeEmojiMathToken {
     return token.type === 'emoji';
 }
@@ -1321,7 +1338,7 @@ class Format extends Content {
         // `contenteditable=false` inline image; resolve the real offset from the
         // DOM so the scan can match the image token like any other caret.
         const offset = this._caretOffsetOnInlineImage() ?? start.offset;
-        const { needRender, imageToken, referenceImageToken }
+        const { needRender, imageToken, referenceImageToken, offsetDelta }
             = this._scanBackspaceTokens(tokens, offset);
 
         if (referenceImageToken) {
@@ -1337,8 +1354,8 @@ class Format extends Content {
             event.preventDefault();
             this.text = generator(tokens);
 
-            start.offset--;
-            end.offset--;
+            start.offset -= offsetDelta;
+            end.offset -= offsetDelta;
             this.setCursor(start.offset, end.offset, true);
         }
 
@@ -1365,6 +1382,7 @@ class Format extends Content {
         needRender: boolean;
         imageToken: Token | null;
         referenceImageToken: Token | null;
+        offsetDelta: number;
     } {
         for (const token of tokens) {
             // An inline image followed by other content: the caret lands on the
@@ -1374,31 +1392,33 @@ class Format extends Content {
                 = token.type === 'image'
                     || (token.type === 'html_tag' && token.tag === 'img');
             if (token.range.end === offset && isImageToken)
-                return { needRender: false, imageToken: token, referenceImageToken: null };
+                return { needRender: false, imageToken: token, referenceImageToken: null, offsetDelta: 0 };
 
             // A reference image (`![alt][ref]`) is editable marked text, so it has
             // no inline-image wrapper to select. Delete the whole token at once.
             if (token.range.end === offset && token.type === 'reference_image')
-                return { needRender: false, imageToken: null, referenceImageToken: token };
+                return { needRender: false, imageToken: null, referenceImageToken: token, offsetDelta: 0 };
 
             // handle delete the second marker(et:*、$) in inline syntax.(Firefox compatible)
             // Fix: https://github.com/marktext/muya/issues/113
             // for example: foo **strong**|
             if (token.range.end === offset) {
-                token.raw = token.raw.substring(0, token.raw.length - 1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+                const removedLength = lastCodePointLength(token.raw);
+                token.raw = token.raw.substring(0, token.raw.length - removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
 
-            // If preToken is a syntax token, the the cursor is at offset 1, need to set the cursor manually.(Firefox compatible)
-            // // Fix: https://github.com/marktext/muya/issues/113
-            // for example: foo **strong**w|
-            if (token.range.start + 1 === offset) {
-                token.raw = token.raw.substring(1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+            // When the caret is just after a token's first code point, remove
+            // that code point and place the cursor manually (Firefox parity).
+            // Fix: https://github.com/marktext/muya/issues/113
+            const removedLength = firstCodePointLength(token.raw);
+            if (token.range.start + removedLength === offset) {
+                token.raw = token.raw.substring(removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
         }
 
-        return { needRender: false, imageToken: null, referenceImageToken: null };
+        return { needRender: false, imageToken: null, referenceImageToken: null, offsetDelta: 0 };
     }
 
     // Resolve the real caret offset when the collapsed caret is parked on a

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -27,7 +27,7 @@ import { generator, tokenizer } from '../../inlineRenderer/lexer';
 import Selection, { getCursorReference } from '../../selection';
 import { getTextContent } from '../../selection/dom';
 import { isListItemState } from '../../state/types';
-import { conflict, escapeHTML, isHTMLElement, isMouseEvent } from '../../utils';
+import { conflict, escapeHTML, firstGraphemeLength, isHTMLElement, isMouseEvent, lastGraphemeLength } from '../../utils';
 import { correctImageSrc, encodeImageSrc, getImageInfo } from '../../utils/image';
 import logger from '../../utils/logger';
 
@@ -1331,7 +1331,7 @@ class Format extends Content {
         // `contenteditable=false` inline image; resolve the real offset from the
         // DOM so the scan can match the image token like any other caret.
         const offset = this._caretOffsetOnInlineImage() ?? start.offset;
-        const { needRender, imageToken, referenceImageToken }
+        const { needRender, imageToken, referenceImageToken, offsetDelta }
             = this._scanBackspaceTokens(tokens, offset);
 
         if (referenceImageToken) {
@@ -1347,8 +1347,8 @@ class Format extends Content {
             event.preventDefault();
             this.text = generator(tokens);
 
-            start.offset--;
-            end.offset--;
+            start.offset -= offsetDelta;
+            end.offset -= offsetDelta;
             this.setCursor(start.offset, end.offset, true);
         }
 
@@ -1375,6 +1375,7 @@ class Format extends Content {
         needRender: boolean;
         imageToken: Token | null;
         referenceImageToken: Token | null;
+        offsetDelta: number;
     } {
         for (const token of tokens) {
             // An inline image followed by other content: the caret lands on the
@@ -1384,31 +1385,36 @@ class Format extends Content {
                 = token.type === 'image'
                     || (token.type === 'html_tag' && token.tag === 'img');
             if (token.range.end === offset && isImageToken)
-                return { needRender: false, imageToken: token, referenceImageToken: null };
+                return { needRender: false, imageToken: token, referenceImageToken: null, offsetDelta: 0 };
 
             // A reference image (`![alt][ref]`) is editable marked text, so it has
             // no inline-image wrapper to select. Delete the whole token at once.
             if (token.range.end === offset && token.type === 'reference_image')
-                return { needRender: false, imageToken: null, referenceImageToken: token };
+                return { needRender: false, imageToken: null, referenceImageToken: token, offsetDelta: 0 };
 
             // handle delete the second marker(et:*、$) in inline syntax.(Firefox compatible)
             // Fix: https://github.com/marktext/muya/issues/113
             // for example: foo **strong**|
             if (token.range.end === offset) {
-                token.raw = token.raw.substring(0, token.raw.length - 1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+                // Remove a whole trailing character — a grapheme cluster, so an
+                // emoji is deleted in one piece instead of losing one code unit
+                // (or one code point) of it (#4926).
+                const removedLength = lastGraphemeLength(token.raw);
+                token.raw = token.raw.substring(0, token.raw.length - removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
 
-            // If preToken is a syntax token, the the cursor is at offset 1, need to set the cursor manually.(Firefox compatible)
-            // // Fix: https://github.com/marktext/muya/issues/113
-            // for example: foo **strong**w|
-            if (token.range.start + 1 === offset) {
-                token.raw = token.raw.substring(1);
-                return { needRender: true, imageToken: null, referenceImageToken: null };
+            // When the caret is just after a token's first character, remove
+            // that character and place the cursor manually (Firefox parity).
+            // Fix: https://github.com/marktext/muya/issues/113
+            const removedLength = firstGraphemeLength(token.raw);
+            if (token.range.start + removedLength === offset) {
+                token.raw = token.raw.substring(removedLength);
+                return { needRender: true, imageToken: null, referenceImageToken: null, offsetDelta: removedLength };
             }
         }
 
-        return { needRender: false, imageToken: null, referenceImageToken: null };
+        return { needRender: false, imageToken: null, referenceImageToken: null, offsetDelta: 0 };
     }
 
     // Resolve the real caret offset when the collapsed caret is parked on a

--- a/packages/muya/src/types/global.d.ts
+++ b/packages/muya/src/types/global.d.ts
@@ -20,9 +20,9 @@ declare global {
     }
 
     // `Intl.Segmenter` (Stage 4, ES2022) is not in the ES2020 TS lib the
-    // package targets. Declare the minimal surface we use so `visibleLength`
-    // can call it without an `as any` escape hatch. The examples app
-    // polyfills it when the runtime engine lacks support.
+    // package targets. Declare the minimal surface the grapheme cluster helpers
+    // in `utils` use, so they can call it without an `as any` escape hatch. The
+    // examples app polyfills it when the runtime engine lacks support.
     namespace Intl {
         interface ISegmenterOptions {
             granularity?: 'grapheme' | 'word' | 'sentence';

--- a/packages/muya/src/utils/__tests__/diffToTextOp.spec.ts
+++ b/packages/muya/src/utils/__tests__/diffToTextOp.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import diff from 'fast-diff';
+import { type as textType } from 'ot-text-unicode';
+import { describe, expect, it } from 'vitest';
+import { diffToTextOp } from '../index';
+
+// `diffToTextOp` turns a text diff into an `ot-text-unicode` operation. That
+// type counts its positions in **code points**, so a run of unchanged text has
+// to be measured the same way. Measuring it in grapheme clusters (as this used
+// to) drifts on every character that is more than one code point, and the
+// resulting op then edits the wrong offset — the JSON state silently diverges
+// from the text the user is looking at, which is the corruption behind the
+// #4926 family of emoji crashes.
+//
+// The invariant asserted below is the only one that matters: replaying the op
+// against the document must produce exactly the text the editor now shows.
+const FAMILY = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}';
+const SKIN_TONE = '\u{1F44D}\u{1F3FD}';
+const FLAG = '\u{1F1E8}\u{1F1F3}';
+const KEYCAP = '1\uFE0F\u20E3';
+const COMBINING = 'e\u0301';
+const SMILE = '\u{1F642}';
+
+function apply(from: string, to: string): string {
+    return textType.apply(from, diffToTextOp(diff(from, to)) as never);
+}
+
+describe('diffToTextOp — the op replays the edit exactly', () => {
+    const cases: Array<[name: string, from: string, to: string]> = [
+        ['delete', 'abc', 'ab'],
+        ['insert', 'abc', 'abcd'],
+        ['replace', 'abc', 'axc'],
+        ['multi-edit', 'hello world', 'hello brave world'],
+        ['insert a ZWJ sequence', 'abc', `abc${FAMILY}`],
+        ['delete a ZWJ sequence', `abc${FAMILY}`, 'abc'],
+        ['delete after a ZWJ sequence', `${FAMILY}abc`, FAMILY],
+        ['insert after a ZWJ sequence', `${FAMILY}abc`, `${FAMILY}abcd`],
+        ['edit between an emoji and a ZWJ sequence', `${SMILE}${FAMILY}y`, `${SMILE}${FAMILY}`],
+        ['edit between two ZWJ sequences', `${FAMILY}${FAMILY}!`, `${FAMILY}${FAMILY}`],
+        ['a skin tone modifier', `${SKIN_TONE}ok`, SKIN_TONE],
+        ['a regional indicator flag', `${FLAG}${KEYCAP}x`, `${FLAG}${KEYCAP}`],
+        ['a combining mark', `x${COMBINING}`, 'x'],
+        ['mixed clusters', `a${SMILE}b${FAMILY}c`, `a${FAMILY}c`],
+    ];
+
+    for (const [name, from, to] of cases) {
+        it(name, () => {
+            expect(apply(from, to)).toBe(to);
+        });
+    }
+});
+
+describe('diffToTextOp — position units', () => {
+    it('counts a skipped run in code points, not grapheme clusters', () => {
+        // `👨‍👩‍👧` is ONE grapheme cluster but FIVE code points; the op has to
+        // skip five, or the delete lands inside the emoji.
+        expect(diffToTextOp(diff(`${FAMILY}y`, FAMILY))).toEqual([5, { d: 'y' }]);
+    });
+
+    it('keeps ASCII skips unchanged', () => {
+        expect(diffToTextOp(diff('abcy', 'abc'))).toEqual([3, { d: 'y' }]);
+    });
+
+    it('counts an astral character as one code point', () => {
+        expect(diffToTextOp(diff(`${SMILE}y`, SMILE))).toEqual([1, { d: 'y' }]);
+    });
+});

--- a/packages/muya/src/utils/index.ts
+++ b/packages/muya/src/utils/index.ts
@@ -268,8 +268,111 @@ export function getParagraphReference(ele: HTMLElement, id: string) {
     };
 }
 
-function visibleLength(str: string) {
-    return [...new Intl.Segmenter().segment(str)].length;
+// `ot-text-unicode` counts its positions in Unicode code points: both of the
+// offsets it walks a string by advance one or two UTF-16 code units, depending
+// on whether the current unit starts a surrogate pair (`uniToStrPos` /
+// `strPosToUni`). A skipped run of unchanged text therefore has to be measured
+// in code points as well. Measuring it in grapheme clusters drifts as soon as a
+// character is more than one code point — `👨‍👩‍👧` is one cluster but five code
+// points — and the op then edits the wrong offsets, silently desyncing the JSON
+// state from the document (the corruption behind the #4926 family of crashes).
+function codePointLength(str: string) {
+    let length = 0;
+    for (let i = 0; i < str.length; i++) {
+        const code = str.charCodeAt(i);
+        if (code >= 0xD800 && code <= 0xDFFF)
+            i++; // Count a surrogate pair as the single code point it encodes.
+
+        length++;
+    }
+
+    return length;
+}
+
+// ---------------------------------------------------------------------------
+// Extended grapheme clusters (UAX #29).
+//
+// One "character" from the user's point of view can be several code points
+// (`👨‍👩‍👧` is 5) and several UTF-16 code units (8). Anything that moves over or
+// deletes "one character" therefore has to work on grapheme cluster boundaries
+// rather than on code units or code points — otherwise it can stop inside a
+// cluster and leave half of it behind. `Intl.Segmenter` applies the same UAX
+// #29 segmentation the browser uses for its own caret movement and for the
+// deletion commands, so the editor stays consistent with it.
+// ---------------------------------------------------------------------------
+
+export interface IGraphemeCluster {
+    /** Offset of the cluster's first UTF-16 code unit. */
+    start: number;
+    /** Offset just past the cluster's last UTF-16 code unit. */
+    end: number;
+}
+
+let graphemeSegmenter: Intl.Segmenter | null | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | null {
+    if (graphemeSegmenter === undefined) {
+        graphemeSegmenter
+            = typeof Intl.Segmenter === 'function'
+                ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+                : null;
+    }
+
+    return graphemeSegmenter;
+}
+
+// The grapheme clusters of `text`, as `[start, end)` code-unit ranges. Engines
+// without `Intl.Segmenter` degrade to code points (surrogate-pair aware), which
+// is the narrowest unit the delete handlers can then rely on.
+function* graphemeClusters(text: string): Generator<IGraphemeCluster> {
+    const segmenter = getGraphemeSegmenter();
+    if (segmenter) {
+        for (const { segment, index } of segmenter.segment(text))
+            yield { start: index, end: index + segment.length };
+
+        return;
+    }
+
+    for (let i = 0; i < text.length;) {
+        const end = i + (text.codePointAt(i)! > 0xFFFF ? 2 : 1);
+        yield { start: i, end };
+        i = end;
+    }
+}
+
+// The cluster strictly containing `offset`, or `null` when `offset` already sits
+// on a cluster boundary. Callers use this to detect a caret parked *inside* a
+// character, which is never a valid place to delete from (#4926).
+export function graphemeClusterContaining(
+    text: string,
+    offset: number,
+): IGraphemeCluster | null {
+    if (offset <= 0 || offset >= text.length)
+        return null;
+
+    for (const cluster of graphemeClusters(text)) {
+        if (offset < cluster.end)
+            return cluster.start < offset ? cluster : null;
+    }
+
+    return null;
+}
+
+// Length in UTF-16 code units of the first grapheme cluster of `text`, so
+// callers can advance one whole character instead of one code unit.
+export function firstGraphemeLength(text: string): number {
+    const [first] = graphemeClusters(text);
+
+    return first ? first.end - first.start : 0;
+}
+
+// Length in UTF-16 code units of the last grapheme cluster of `text`.
+export function lastGraphemeLength(text: string): number {
+    let length = 0;
+    for (const cluster of graphemeClusters(text))
+        length = cluster.end - cluster.start;
+
+    return length;
 }
 
 export type TDiff = (string | number | { d: string });
@@ -288,7 +391,7 @@ export function diffToTextOp(diffs: Diff[]) {
                 break;
 
             case 0:
-                op.push(visibleLength(diff[1]));
+                op.push(codePointLength(diff[1]));
                 break;
 
             case 1:


### PR DESCRIPTION
Closes #4926
Related to #4892

## Summary

Emoji and other astral characters are stored as UTF-16 surrogate pairs (a high code unit followed by a low one). When a collapsed caret sits **between** those two units and the user presses Backspace or Delete, the editor could delete a single code unit and leave a **lone surrogate** in the document. `ot-text-unicode` cannot encode a lone surrogate, so a subsequent operation throws `Invalid offset - splits unicode bytes` and crashes the renderer.

**#4926** is reproduced and fixed here — the error is thrown while applying the text operation (`JSONState._flushOperationCache` → `apply` → `strPosToUni`).

A second, related path could also split a pair: the inline-token Backspace handler (`_scanBackspaceTokens`) trimmed one UTF-16 code unit at a time, so deleting a leading or trailing emoji from a token left half of its surrogate pair behind.

### Changes

- **Snap the caret to a code-point boundary before deletion** (`packages/muya/src/block/base/content.ts`) — when a collapsed caret would split a surrogate pair, it is moved to the adjacent valid boundary before the delete runs (Backspace snaps past the pair, Delete snaps before it), so the whole emoji is removed as a single code point.
- **Delete inline-token characters by whole code point** (`packages/muya/src/block/base/format.ts`) — `_scanBackspaceTokens` now removes a complete leading/trailing code point instead of one code unit, and reports the removed length so the cursor offset is adjusted to match.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [x] Manually tested on: Windows
- [x] Muya unit tests, #4926 Electron E2E, type checks, targeted lint, and the Electron production build pass

New automated coverage:

- **Muya unit tests** — deleting a trailing (`abc🙂`) and a leading (`🙂abc`) astral emoji removes the whole code point and leaves the cursor at the correct offset.
- **Electron E2E (real clipboard paste)** — Backspace and Delete inside a pasted emoji, plus a trailing emoji, asserting the exact resulting text and that a follow-up edit still applies cleanly (which catches deferred corruption).

## Notes for reviewers [optional]

- **#4892 is likely the same bug, but unconfirmed.** It reports the identical `Invalid offset - splits unicode bytes` error through the history/inversion path (`makeInvertible` → `mapOp` → `strPosToUni`) — the same lone-surrogate failure as #4926 — so this fix very likely resolves it. However, #4892 has no reproduction steps or input, so a different entry point producing the invalid Unicode cannot be ruled out. It is referenced here rather than auto-closed, and can be verified and closed separately.
- The full local Muya run has a pre-existing timeout in the unrelated `tableChessboard` dynamic-import test; all other test files pass.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
