### PR TITLE
docs(muya): document picker registration

### DIFF
--- a/packages/muya/README.md
+++ b/packages/muya/README.md
@@ -36,6 +36,7 @@ import {
     EmojiSelector,
     FootnoteTool,
     ImageEditTool,
+    ImagePathPicker,
     ImageResizeBar,
     ImageToolBar,
     InlineFormatToolbar,
@@ -45,6 +46,7 @@ import {
     ParagraphFrontMenu,
     ParagraphQuickInsertMenu,
     PreviewToolBar,
+    TableChessboard,
     TableColumnToolbar,
     TableDragBar,
     TableRowColumMenu,
@@ -59,8 +61,11 @@ Muya.use(FootnoteTool);
 Muya.use(InlineFormatToolbar);
 Muya.use(ImageToolBar);
 Muya.use(ImageResizeBar);
+Muya.use(ImagePathPicker);
 Muya.use(ImageEditTool, {
     imagePathPicker: async () => '/path/to/image.png',
+    imagePathAutoComplete: async (src) =>
+        src ? [{ text: 'image.png', type: 'file' }] : [],
     imageAction: async () => 'https://example.com/uploaded.png',
 });
 Muya.use(CodeBlockLanguageSelector);
@@ -74,6 +79,7 @@ Muya.use(LinkTools, {
 Muya.use(ParagraphFrontButton);
 Muya.use(ParagraphFrontMenu);
 Muya.use(ParagraphQuickInsertMenu);
+Muya.use(TableChessboard);
 Muya.use(TableColumnToolbar);
 Muya.use(TableDragBar);
 Muya.use(TableRowColumMenu);
@@ -142,11 +148,13 @@ Plugins are floating tools/menus that you opt into with `Muya.use(Plugin, option
 | `InlineFormatToolbar` | Bold / italic / link / etc. toolbar that follows the selection. |
 | `EmojiSelector` | `:` trigger emoji picker. |
 | `CodeBlockLanguageSelector` | Language picker inside fenced code blocks. |
-| `ImageToolBar`, `ImageResizeBar`, `ImageEditTool` | Image-related affordances; `ImageEditTool` accepts `imagePathPicker` and `imageAction` callbacks for upload flows. |
+| `ImageToolBar`, `ImageResizeBar`, `ImageEditTool` | Image-related affordances; `ImageEditTool` accepts `imagePathPicker`, `imagePathAutoComplete`, and `imageAction` callbacks for host-provided file and upload flows. |
+| `ImagePathPicker` | Floating autocomplete results for `ImageEditTool`; register it when providing `imagePathAutoComplete`. |
 | `LinkTools` | Hover toolbar over native `<a>`, markdown links, and reference links. Takes a `jumpClick` callback to control jump-out behavior. |
 | `FootnoteTool` | Floating popover for editing footnote definitions; requires the `footnote: true` editor option. |
 | `ParagraphFrontButton`, `ParagraphFrontMenu` | The handle and menu that appear to the left of the active block. |
 | `ParagraphQuickInsertMenu` | The `/` slash-command menu for inserting blocks. |
+| `TableChessboard` | Grid picker used by the table quick-insert action. |
 | `TableColumnToolbar`, `TableDragBar`, `TableRowColumMenu` | Table editing affordances. |
 | `PreviewToolBar` | Tools shown over previewable blocks (math, Mermaid, etc.). |
 

--- a/packages/muya/src/__tests__/readmePluginDocs.spec.ts
+++ b/packages/muya/src/__tests__/readmePluginDocs.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const quickStart = readme.match(/## Quick start[\s\S]*?## API at a glance/)?.[0] ?? '';
+const pluginTable = readme.match(/## Bundled UI plugins[\s\S]*?## Architecture/)?.[0] ?? '';
+
+describe('readme plugin registration', () => {
+    it('registers the pickers required by the documented image and table flows', () => {
+        expect(quickStart).toContain('Muya.use(ImagePathPicker);');
+        expect(quickStart).toContain('imagePathAutoComplete:');
+        expect(quickStart).toContain('Muya.use(TableChessboard);');
+        expect(pluginTable).toContain('| `ImagePathPicker` |');
+        expect(pluginTable).toContain('| `TableChessboard` |');
+    });
+});


### PR DESCRIPTION
Refs #375

## Summary

- document the current `ImagePathPicker` and `TableChessboard` registration surface in the Muya Quick start
- show the host-provided `imagePathAutoComplete` hook and describe both picker plugins
- add focused coverage so the README stays aligned with the exported picker APIs

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Documentation update

## Test plan

- [x] New tests added (README registration regression coverage)
- [x] Targeted picker and README tests: 3 files, 12 tests
- [x] Full `@muyajs/core` suite: 213 files, 1439 tests
- [x] Package lint and type check
- [x] Package build and formatting checks
- [x] `git diff --check`
- [ ] Manually tested on: not applicable; this documents existing exported APIs and does not change runtime UI

## Notes for reviewers

This documents the picker surface already exported and used by the current `@muyajs/core` implementation. It does not introduce or claim to complete a broader third-party plugin architecture. No screenshot is included because the runtime UI is unchanged.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#375: What do you want to do with plugins?](https://oss.issuehunt.io/repos/110446844/issues/375)
---
</details>
<!-- /Issuehunt content-->