### PR TITLE
feat: add 'Treat soft newlines as spaces' preference (#1849)

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -277,6 +277,11 @@
     "type": "boolean",
     "default": false
   },
+  "softNewlineAsSpace": {
+    "description": "Markdown--Treat soft newlines (two trailing spaces) as spaces instead of line breaks.",
+    "type": "boolean",
+    "default": false
+  },
   "sequenceTheme": {
     "description": "Markdown--Sequence diagram theme",
     "enum": ["hand", "simple"],

--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -276,6 +276,11 @@
     "type": "boolean",
     "default": false
   },
+  "softNewlineAsSpace": {
+    "description": "Markdown--Treat soft newlines (two trailing spaces) as spaces instead of line breaks.",
+    "type": "boolean",
+    "default": false
+  },
   "sequenceTheme": {
     "description": "Markdown--Sequence diagram theme",
     "enum": ["hand", "simple"],

--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -277,7 +277,7 @@
     "default": false
   },
   "softNewlineAsSpace": {
-    "description": "Markdown--Treat soft newlines (two trailing spaces) as spaces instead of line breaks.",
+    "description": "Markdown--Treat a soft line break (a single bare newline within a paragraph) as a space instead of a line break.",
     "type": "boolean",
     "default": false
   },

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -221,6 +221,7 @@ const {
   footnote,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
+  softNewlineAsSpace,
   lineHeight,
   fontSize,
   codeFontSize,
@@ -665,6 +666,12 @@ watch(isHtmlEnabled, (value, oldValue) => {
 watch(isGitlabCompatibilityEnabled, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ isGitlabCompatibilityEnabled: value }, true)
+  }
+})
+
+watch(softNewlineAsSpace, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ softNewlineAsSpace: value }, true)
   }
 })
 
@@ -1751,6 +1758,7 @@ onMounted(() => {
     footnote: footnote.value,
     disableHtml: !isHtmlEnabled.value,
     isGitlabCompatibilityEnabled: isGitlabCompatibilityEnabled.value,
+    softNewlineAsSpace: softNewlineAsSpace.value,
     hideQuickInsertHint: hideQuickInsertHint.value,
     hideLinkPopup: hideLinkPopup.value,
     autoCheck: autoCheck.value,

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -222,6 +222,7 @@ const {
   footnote,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
+  softNewlineAsSpace,
   lineHeight,
   fontSize,
   codeFontSize,
@@ -666,6 +667,12 @@ watch(isHtmlEnabled, (value, oldValue) => {
 watch(isGitlabCompatibilityEnabled, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ isGitlabCompatibilityEnabled: value }, true)
+  }
+})
+
+watch(softNewlineAsSpace, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ softNewlineAsSpace: value }, true)
   }
 })
 
@@ -1763,6 +1770,7 @@ onMounted(() => {
     footnote: footnote.value,
     disableHtml: !isHtmlEnabled.value,
     isGitlabCompatibilityEnabled: isGitlabCompatibilityEnabled.value,
+    softNewlineAsSpace: softNewlineAsSpace.value,
     hideQuickInsertHint: hideQuickInsertHint.value,
     hideLinkPopup: hideLinkPopup.value,
     autoCheck: autoCheck.value,

--- a/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
@@ -83,6 +83,11 @@
           :bool="isGitlabCompatibilityEnabled"
           :on-change="(value) => onSelectChange('isGitlabCompatibilityEnabled', value)"
         />
+        <bool
+          :description="t('preferences.markdown.compatibility.softNewlineAsSpace')"
+          :bool="softNewlineAsSpace"
+          :on-change="(value) => onSelectChange('softNewlineAsSpace', value)"
+        />
       </template>
     </compound>
 
@@ -161,6 +166,7 @@ const {
   footnote,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
+  softNewlineAsSpace,
   sequenceTheme,
   plantumlServer
 } = storeToRefs(preferenceStore)

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -79,6 +79,7 @@ export interface PreferencesState {
   footnote: boolean
   isHtmlEnabled: boolean
   isGitlabCompatibilityEnabled: boolean
+  softNewlineAsSpace: boolean
   sequenceTheme: SequenceTheme | string
   plantumlServer: string
 
@@ -195,6 +196,7 @@ export const usePreferencesStore = defineStore('preferences', {
     footnote: false,
     isHtmlEnabled: true,
     isGitlabCompatibilityEnabled: false,
+    softNewlineAsSpace: false,
     sequenceTheme: 'hand',
     plantumlServer: 'https://www.plantuml.com/plantuml',
 

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -45,6 +45,7 @@ export interface IUserPreferences {
   footnote?: boolean
   isHtmlEnabled?: boolean
   isGitlabCompatibilityEnabled?: boolean
+  softNewlineAsSpace?: boolean
   theme?: string
   spellcheckerEnabled?: boolean
   spellcheckerNoUnderline?: boolean

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "GitLab-Kompatibilität aktivieren",
         "enableHtml": "HTML-Unterstützung aktivieren",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Kompatibilität"
       },
       "lists": {

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -411,6 +411,7 @@
         "footnote": "Pandocs Markdown-Erweiterung für Fußnoten aktivieren",
         "isHtmlEnabled": "HTML-Rendering aktivieren",
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
+        "softNewlineAsSpace": "Weiche Zeilenumbrüche als Leerzeichen behandeln",
         "sequenceTheme": "Sequenzdiagramm-Theme",
         "plantumlServer": "PlantUML-Server-URL",
         "theme": "Das in MarkText verwendete Theme auswählen",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "GitLab-Kompatibilität aktivieren",
         "enableHtml": "HTML-Unterstützung aktivieren",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "Weiche Zeilenumbrüche als Leerzeichen behandeln",
         "title": "Kompatibilität"
       },
       "lists": {

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "GitLab-Kompatibilität aktivieren",
         "enableHtml": "HTML-Unterstützung aktivieren",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Kompatibilität"
       },
       "lists": {

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "Enable GitLab compatibility",
         "enableHtml": "Enable HTML support",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibility"
       },
       "lists": {

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -410,6 +410,7 @@
         "footnote": "Enable pandoc's markdown extension footnote",
         "isHtmlEnabled": "Enable HTML rendering",
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "sequenceTheme": "Sequence diagram theme",
         "plantumlServer": "PlantUML server URL",
         "theme": "Select the theme used in MarkText",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "Enable GitLab compatibility",
         "enableHtml": "Enable HTML support",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibility"
       },
       "lists": {

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidad con GitLab",
         "enableHtml": "Habilitar soporte HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilidad"
       },
       "lists": {

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidad con GitLab",
         "enableHtml": "Habilitar soporte HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilidad"
       },
       "lists": {

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -411,6 +411,7 @@
         "footnote": "Habilitar extensión markdown de pandoc nota al pie",
         "isHtmlEnabled": "Habilitar renderizado HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
+        "softNewlineAsSpace": "Tratar los saltos de línea suaves como espacios",
         "sequenceTheme": "Tema del diagrama de secuencia",
         "plantumlServer": "URL del servidor PlantUML",
         "theme": "Seleccionar el tema usado en MarkText",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidad con GitLab",
         "enableHtml": "Habilitar soporte HTML",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "Tratar los saltos de línea suaves como espacios",
         "title": "Compatibilidad"
       },
       "lists": {

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "Activer la compatibilité GitLab",
         "enableHtml": "Activer le support HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilité"
       },
       "lists": {

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -411,6 +411,7 @@
         "footnote": "Activer l'extension markdown de pandoc pour note de bas de page",
         "isHtmlEnabled": "Activer le rendu HTML",
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
+        "softNewlineAsSpace": "Traiter les sauts de ligne simples comme des espaces",
         "sequenceTheme": "Thème du diagramme de séquence",
         "plantumlServer": "URL du serveur PlantUML",
         "theme": "Sélectionner le thème utilisé dans MarkText",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "Activer la compatibilité GitLab",
         "enableHtml": "Activer le support HTML",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "Traiter les sauts de ligne simples comme des espaces",
         "title": "Compatibilité"
       },
       "lists": {

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "Activer la compatibilité GitLab",
         "enableHtml": "Activer le support HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilité"
       },
       "lists": {

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "GitLab互換性を有効",
         "enableHtml": "HTMLサポートを有効",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "互換性"
       },
       "lists": {

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -656,8 +656,9 @@
         "title": "その他"
       },
       "compatibility": {
-        "enableGitlab": "GitLab 互換性を有効",
-        "enableHtml": "HTML サポートを有効",
+        "enableGitlab": "GitLab互換性を有効",
+        "enableHtml": "HTMLサポートを有効",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "互換性"
       },
       "lists": {

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -411,6 +411,7 @@
         "footnote": "Pandoc の markdown 拡張脚注を有効にする",
         "isHtmlEnabled": "HTML レンダリングを有効にする",
         "isGitlabCompatibilityEnabled": "GitLab 互換モードを有効にする",
+        "softNewlineAsSpace": "ソフト改行をスペースとして扱う",
         "sequenceTheme": "シーケンス図のテーマ",
         "plantumlServer": "PlantUML サーバーの URL",
         "theme": "MarkText で使用するテーマの選択",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "GitLab互換性を有効",
         "enableHtml": "HTMLサポートを有効",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "ソフト改行をスペースとして扱う",
         "title": "互換性"
       },
       "lists": {

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "GitLab 호환성 활성화",
         "enableHtml": "HTML 지원 활성화",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "호환성"
       },
       "lists": {

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "GitLab 호환성 활성화",
         "enableHtml": "HTML 지원 활성화",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "호환성"
       },
       "lists": {

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -411,6 +411,7 @@
         "footnote": "Pandoc의 마크다운 확장 각주 활성화",
         "isHtmlEnabled": "HTML 렌더링 활성화",
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
+        "softNewlineAsSpace": "소프트 줄바꿈을 공백으로 처리",
         "sequenceTheme": "시퀀스 다이어그램 테마",
         "plantumlServer": "PlantUML 서버 URL",
         "theme": "MarkText에서 사용할 테마 선택",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "GitLab 호환성 활성화",
         "enableHtml": "HTML 지원 활성화",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "소프트 줄바꿈을 공백으로 처리",
         "title": "호환성"
       },
       "lists": {

--- a/packages/desktop/static/locales/nl.json
+++ b/packages/desktop/static/locales/nl.json
@@ -410,6 +410,7 @@
         "footnote": "Pandoc voetnoten inschakelen",
         "isHtmlEnabled": "HTML-weergave inschakelen",
         "isGitlabCompatibilityEnabled": "GitLab-compatibiliteitsmodus inschakelen",
+        "softNewlineAsSpace": "Zachte regeleinden als spaties behandelen",
         "sequenceTheme": "Sequentiediagram thema",
         "plantumlServer": "PlantUML server-URL",
         "theme": "Selecteer het thema voor MarkText",
@@ -658,6 +659,7 @@
       "compatibility": {
         "enableGitlab": "GitLab-compatibiliteit inschakelen",
         "enableHtml": "HTML-ondersteuning inschakelen",
+        "softNewlineAsSpace": "Zachte regeleinden als spaties behandelen",
         "title": "Compatibiliteit"
       },
       "lists": {

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidade GitLab",
         "enableHtml": "Habilitar suporte HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilidade"
       },
       "lists": {

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidade GitLab",
         "enableHtml": "Habilitar suporte HTML",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Compatibilidade"
       },
       "lists": {

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -411,6 +411,7 @@
         "footnote": "Habilitar extensão markdown do pandoc para nota de rodapé",
         "isHtmlEnabled": "Habilitar renderização HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
+        "softNewlineAsSpace": "Tratar quebras de linha suaves como espaços",
         "sequenceTheme": "Tema do diagrama de sequência",
         "plantumlServer": "URL do servidor PlantUML",
         "theme": "Selecionar o tema usado no MarkText",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "Habilitar compatibilidade GitLab",
         "enableHtml": "Habilitar suporte HTML",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "Tratar quebras de linha suaves como espaços",
         "title": "Compatibilidade"
       },
       "lists": {

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "GitLab uyumluluğunu etkinleştir",
         "enableHtml": "HTML desteğini etkinleştir",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Uyumluluk"
       },
       "lists": {

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -410,6 +410,7 @@
         "footnote": "Pandoc'un markdown uzantısı dipnotu etkinleştir",
         "isHtmlEnabled": "HTML işlemeyi etkinleştir",
         "isGitlabCompatibilityEnabled": "GitLab uyumluluk modunu etkinleştir",
+        "softNewlineAsSpace": "Yumuşak satır sonlarını boşluk olarak değerlendir",
         "sequenceTheme": "Dizi diyagramı teması",
         "theme": "MarkText'te kullanılan temayı seçin",
         "followSystemTheme": "Sistem Temasını Takip Et",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "GitLab uyumluluğunu etkinleştir",
         "enableHtml": "HTML desteğini etkinleştir",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "Yumuşak satır sonlarını boşluk olarak değerlendir",
         "title": "Uyumluluk"
       },
       "lists": {

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "GitLab uyumluluğunu etkinleştir",
         "enableHtml": "HTML desteğini etkinleştir",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "Uyumluluk"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "启用 GitLab 兼容性",
         "enableHtml": "启用 HTML 支持",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "兼容性"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -411,6 +411,7 @@
         "footnote": "启用 Pandoc 的 Markdown 扩展脚注",
         "isHtmlEnabled": "启用 HTML 渲染",
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
+        "softNewlineAsSpace": "将软换行符视为空格",
         "sequenceTheme": "序列图主题",
         "plantumlServer": "PlantUML 服务器 URL",
         "theme": "选择 MarkText 中使用的主题",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "启用 GitLab 兼容性",
         "enableHtml": "启用 HTML 支持",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "将软换行符视为空格",
         "title": "兼容性"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "启用 GitLab 兼容性",
         "enableHtml": "启用 HTML 支持",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "兼容性"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -653,6 +653,7 @@
       "compatibility": {
         "enableGitlab": "啟用 GitLab 相容性",
         "enableHtml": "啟用 HTML 支援",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "相容性"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -658,6 +658,7 @@
       "compatibility": {
         "enableGitlab": "啟用 GitLab 相容性",
         "enableHtml": "啟用 HTML 支援",
+        "softNewlineAsSpace": "Treat soft newlines as spaces",
         "title": "相容性"
       },
       "lists": {

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -411,6 +411,7 @@
         "footnote": "啟用 Pandoc 的 Markdown 擴充功能腳註",
         "isHtmlEnabled": "啟用 HTML 轉譯",
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
+        "softNewlineAsSpace": "將軟換行視為空格",
         "sequenceTheme": "序列圖主題",
         "plantumlServer": "PlantUML 伺服器 URL",
         "theme": "選擇 MarkText 中使用的主題",
@@ -658,7 +659,7 @@
       "compatibility": {
         "enableGitlab": "啟用 GitLab 相容性",
         "enableHtml": "啟用 HTML 支援",
-        "softNewlineAsSpace": "Treat soft newlines as spaces",
+        "softNewlineAsSpace": "將軟換行視為空格",
         "title": "相容性"
       },
       "lists": {

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -54,6 +54,7 @@
   "footnote": false,
   "isHtmlEnabled": true,
   "isGitlabCompatibilityEnabled": false,
+  "softNewlineAsSpace": false,
   "sequenceTheme": "hand",
   "plantumlServer": "https://www.plantuml.com/plantuml",
 

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -147,6 +147,13 @@ code.mu-inline-rule {
     display: block;
 }
 
+/* When softNewlineAsSpace is on, collapse the \n inside a soft break span
+   to a space. white-space: normal inside a pre-wrap block causes the inner
+   span to ignore the parent's pre-wrap, collapsing the newline to a space. */
+.mu-soft-newline-as-space {
+    white-space: normal;
+}
+
 .mu-hard-line-break-space::after {
     font-family: monospace;
 

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1522,9 +1522,10 @@ class Format extends Content {
 
         const { text: oldText } = this;
         const { start, end } = this.getCursor()!;
+        const breakChar = this.muya.options.softNewlineAsSpace ? '  \n' : '\n';
         this.text
-            = `${oldText.substring(0, start.offset)}\n${oldText.substring(end.offset)}`;
-        this.setCursor(start.offset + 1, end.offset + 1, true);
+            = `${oldText.substring(0, start.offset)}${breakChar}${oldText.substring(end.offset)}`;
+        this.setCursor(start.offset + breakChar.length, end.offset + breakChar.length, true);
     }
 
     override enterHandler(event: KeyboardEvent): void {

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1522,10 +1522,9 @@ class Format extends Content {
 
         const { text: oldText } = this;
         const { start, end } = this.getCursor()!;
-        const breakChar = this.muya.options.softNewlineAsSpace ? '  \n' : '\n';
         this.text
-            = `${oldText.substring(0, start.offset)}${breakChar}${oldText.substring(end.offset)}`;
-        this.setCursor(start.offset + breakChar.length, end.offset + breakChar.length, true);
+            = `${oldText.substring(0, start.offset)}\n${oldText.substring(end.offset)}`;
+        this.setCursor(start.offset + 1, end.offset + 1, true);
     }
 
     override enterHandler(event: KeyboardEvent): void {

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -162,6 +162,7 @@ export const CLASS_NAMES = genUpper2LowerKeyHash([
     'MU_RUBY_RENDER',
     'MU_SELECTED',
     'MU_SOFT_LINE_BREAK',
+    'MU_SOFT_NEWLINE_AS_SPACE',
     'MU_MATH_ERROR',
     'MU_MATH_MARKER',
     'MU_MATH_RENDER',

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -347,6 +347,8 @@ export const MUYA_DEFAULT_OPTIONS = {
     // Whether math block is supported.
     math: true,
     isGitlabCompatibilityEnabled: true,
+    // Render soft line breaks as spaces instead of visual newlines.
+    softNewlineAsSpace: false,
     // Move checked task list item to the end of task list.
     autoMoveCheckedToEnd: false,
     // Whether HTML rendering is disabled or not.

--- a/packages/muya/src/inlineRenderer/renderer/__tests__/softLineBreak.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/softLineBreak.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import type { SoftLineBreakToken } from '../../types';
+import type Renderer from '../index';
+import { describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../../../config';
+import { h } from '../../../utils/snabbdom';
+import softLineBreak from '../softLineBreak';
+
+function makeToken(overrides: Partial<SoftLineBreakToken> = {}): SoftLineBreakToken {
+    return {
+        type: 'soft_line_break',
+        raw: '\n',
+        lineBreak: '\n',
+        isAtEnd: false,
+        parent: [],
+        range: { start: 0, end: 1 },
+        ...overrides,
+    };
+}
+
+function asRenderer(obj: object): Renderer {
+    return obj as unknown as Renderer;
+}
+
+function getSelector(vnodes: ReturnType<typeof softLineBreak>): string {
+    return vnodes[0].sel as string;
+}
+
+function getContent(vnodes: ReturnType<typeof softLineBreak>): string {
+    const node = vnodes[0];
+    return typeof node.children === 'string'
+        ? node.children
+        : (node.text as string);
+}
+
+describe('softLineBreak renderer — softNewlineAsSpace', () => {
+    it('emits \\n content and MU_SOFT_LINE_BREAK class by default', () => {
+        const renderer = asRenderer({
+            muya: { options: { softNewlineAsSpace: false } },
+        });
+        const token = makeToken();
+        const out = softLineBreak.call(
+            renderer,
+            { h, token } as Parameters<typeof softLineBreak>[1],
+        );
+
+        expect(getSelector(out)).toBe(`span.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`);
+        expect(getContent(out)).toBe('\n');
+    });
+
+    it('emits \\n content (not a space) with MU_SOFT_NEWLINE_AS_SPACE class when option is on', () => {
+        const renderer = asRenderer({
+            muya: { options: { softNewlineAsSpace: true } },
+        });
+        const token = makeToken();
+        const out = softLineBreak.call(
+            renderer,
+            { h, token } as Parameters<typeof softLineBreak>[1],
+        );
+
+        expect(getSelector(out)).toContain(CLASS_NAMES.MU_SOFT_NEWLINE_AS_SPACE);
+        expect(getSelector(out)).toContain(CLASS_NAMES.MU_SOFT_LINE_BREAK);
+        expect(getContent(out)).toBe('\n');
+    });
+
+    it('does not add MU_LINE_END when softNewlineAsSpace is on, even if isAtEnd is true', () => {
+        const renderer = asRenderer({
+            muya: { options: { softNewlineAsSpace: true } },
+        });
+        const token = makeToken({ isAtEnd: true });
+        const out = softLineBreak.call(
+            renderer,
+            { h, token } as Parameters<typeof softLineBreak>[1],
+        );
+
+        expect(getSelector(out)).not.toContain(CLASS_NAMES.MU_LINE_END);
+        expect(getSelector(out)).toContain(CLASS_NAMES.MU_SOFT_NEWLINE_AS_SPACE);
+    });
+
+    it('adds MU_LINE_END when isAtEnd is true and softNewlineAsSpace is off', () => {
+        const renderer = asRenderer({
+            muya: { options: { softNewlineAsSpace: false } },
+        });
+        const token = makeToken({ isAtEnd: true });
+        const out = softLineBreak.call(
+            renderer,
+            { h, token } as Parameters<typeof softLineBreak>[1],
+        );
+
+        expect(getSelector(out)).toContain(CLASS_NAMES.MU_LINE_END);
+    });
+});

--- a/packages/muya/src/inlineRenderer/renderer/__tests__/softLineBreak.spec.ts
+++ b/packages/muya/src/inlineRenderer/renderer/__tests__/softLineBreak.spec.ts
@@ -42,7 +42,7 @@ describe('softLineBreak renderer — softNewlineAsSpace', () => {
         const token = makeToken();
         const out = softLineBreak.call(
             renderer,
-            { h, token } as Parameters<typeof softLineBreak>[1],
+            { h, token } as Parameters<typeof softLineBreak>[0],
         );
 
         expect(getSelector(out)).toBe(`span.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`);
@@ -56,7 +56,7 @@ describe('softLineBreak renderer — softNewlineAsSpace', () => {
         const token = makeToken();
         const out = softLineBreak.call(
             renderer,
-            { h, token } as Parameters<typeof softLineBreak>[1],
+            { h, token } as Parameters<typeof softLineBreak>[0],
         );
 
         expect(getSelector(out)).toContain(CLASS_NAMES.MU_SOFT_NEWLINE_AS_SPACE);
@@ -71,7 +71,7 @@ describe('softLineBreak renderer — softNewlineAsSpace', () => {
         const token = makeToken({ isAtEnd: true });
         const out = softLineBreak.call(
             renderer,
-            { h, token } as Parameters<typeof softLineBreak>[1],
+            { h, token } as Parameters<typeof softLineBreak>[0],
         );
 
         expect(getSelector(out)).not.toContain(CLASS_NAMES.MU_LINE_END);
@@ -85,7 +85,7 @@ describe('softLineBreak renderer — softNewlineAsSpace', () => {
         const token = makeToken({ isAtEnd: true });
         const out = softLineBreak.call(
             renderer,
-            { h, token } as Parameters<typeof softLineBreak>[1],
+            { h, token } as Parameters<typeof softLineBreak>[0],
         );
 
         expect(getSelector(out)).toContain(CLASS_NAMES.MU_LINE_END);

--- a/packages/muya/src/inlineRenderer/renderer/softLineBreak.ts
+++ b/packages/muya/src/inlineRenderer/renderer/softLineBreak.ts
@@ -6,11 +6,13 @@ export default function softLineBreak(
     this: Renderer,
     { h, token }: ISyntaxRenderOptions & { token: SoftLineBreakToken },
 ) {
-    const { isAtEnd } = token;
-    const content = this.muya.options.softNewlineAsSpace ? ' ' : token.lineBreak;
     let selector = `span.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`;
-    if (isAtEnd)
+    if (this.muya.options.softNewlineAsSpace) {
+        selector += `.${CLASS_NAMES.MU_SOFT_NEWLINE_AS_SPACE}`;
+    }
+    else if (token.isAtEnd) {
         selector += `.${CLASS_NAMES.MU_LINE_END}`;
+    }
 
-    return [h(selector, content)];
+    return [h(selector, token.lineBreak)];
 }

--- a/packages/muya/src/inlineRenderer/renderer/softLineBreak.ts
+++ b/packages/muya/src/inlineRenderer/renderer/softLineBreak.ts
@@ -6,10 +6,11 @@ export default function softLineBreak(
     this: Renderer,
     { h, token }: ISyntaxRenderOptions & { token: SoftLineBreakToken },
 ) {
-    const { lineBreak, isAtEnd } = token;
+    const { isAtEnd } = token;
+    const content = this.muya.options.softNewlineAsSpace ? ' ' : token.lineBreak;
     let selector = `span.${CLASS_NAMES.MU_SOFT_LINE_BREAK}`;
     if (isAtEnd)
         selector += `.${CLASS_NAMES.MU_LINE_END}`;
 
-    return [h(selector, lineBreak)];
+    return [h(selector, content)];
 }

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -113,6 +113,7 @@ const TOGGLEABLE_BLOCK_LABELS = new Set([
 // document must be re-parsed from markdown. See setOptions below.
 const PARSE_AFFECTING_OPTIONS = new Set<keyof IMuyaOptions>([
     'isGitlabCompatibilityEnabled',
+    'softNewlineAsSpace',
     'math',
     'footnote',
     'frontMatter',

--- a/packages/muya/src/muya.ts
+++ b/packages/muya/src/muya.ts
@@ -113,7 +113,6 @@ const TOGGLEABLE_BLOCK_LABELS = new Set([
 // document must be re-parsed from markdown. See setOptions below.
 const PARSE_AFFECTING_OPTIONS = new Set<keyof IMuyaOptions>([
     'isGitlabCompatibilityEnabled',
-    'softNewlineAsSpace',
     'math',
     'footnote',
     'frontMatter',

--- a/packages/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getHighlightHtml } from '../../utils/marked';
 
@@ -32,5 +34,25 @@ describe('#3676 — soft line breaks survive export as a conformant newline', ()
         // Sanity: the change only touches soft breaks; hard breaks are untouched.
         const html = getHighlightHtml('line one  \nline two', OPTS);
         expect(html).toMatch(/<br\s*\/?>/);
+    });
+});
+
+// When softNewlineAsSpace is on, the export stylesheet omits the `pre-wrap`
+// rules for `.markdown-body p` and tight `li` so bare `\n` collapses to a space.
+describe('softNewlineAsSpace export CSS conditional inclusion', () => {
+    it('omits the paragraph/tight-list pre-wrap rule from exportStyle', () => {
+        // Read the raw CSS and apply the same split logic as generate().
+        const cssPath = resolve(__dirname, '../../assets/styles/exportStyle.css');
+        const exportStyle = readFileSync(cssPath, 'utf8');
+        const [base] = exportStyle.split('/* Render soft line breaks');
+        // Simulating softNewlineAsSpace on: only the base part is included.
+
+        // The paragraph/tight-list pre-wrap rule should be gone.
+        expect(base).not.toMatch(
+            /\.markdown-body p,\s*\.markdown-body li:not\(:has\(> p\)\)\s*\{/,
+        );
+        // The code-block pre-wrap rule must remain.
+        expect(base).toContain('.markdown-body pre');
+        expect(base).toMatch(/white-space:\s*pre-wrap/);
     });
 });

--- a/packages/muya/src/state/__tests__/softBreakExportHtml.spec.ts
+++ b/packages/muya/src/state/__tests__/softBreakExportHtml.spec.ts
@@ -1,7 +1,8 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from 'vitest';
 import { getHighlightHtml } from '../../utils/marked';
+import { MarkdownToHtml } from '../markdownToHtml';
 
 // #3676 — a soft line break (Shift+Enter, serialized as a bare `\n` inside a
 // block) shows as a line break in the editor (`.mu-content` is pre-wrap) but
@@ -37,22 +38,45 @@ describe('#3676 — soft line breaks survive export as a conformant newline', ()
     });
 });
 
-// When softNewlineAsSpace is on, the export stylesheet omits the `pre-wrap`
-// rules for `.markdown-body p` and tight `li` so bare `\n` collapses to a space.
-describe('softNewlineAsSpace export CSS conditional inclusion', () => {
-    it('omits the paragraph/tight-list pre-wrap rule from exportStyle', () => {
-        // Read the raw CSS and apply the same split logic as generate().
-        const cssPath = resolve(__dirname, '../../assets/styles/exportStyle.css');
-        const exportStyle = readFileSync(cssPath, 'utf8');
-        const [base] = exportStyle.split('/* Render soft line breaks');
-        // Simulating softNewlineAsSpace on: only the base part is included.
+// When softNewlineAsSpace is on, the exported stylesheet must still carry every
+// export rule (table display, image alignment, task-list layout, nested-list
+// numbering, diagram layout) and only append a narrowly scoped override that
+// resets the paragraph / tight-list `white-space` to `normal` so a bare `\n`
+// collapses to a space (CommonMark default) instead of showing as a break.
+describe('softNewlineAsSpace export CSS', () => {
+    const muyaWith = (softNewlineAsSpace: boolean) =>
+        ({ options: { softNewlineAsSpace } }) as unknown as ConstructorParameters<
+            typeof MarkdownToHtml
+        >[1];
 
-        // The paragraph/tight-list pre-wrap rule should be gone.
-        expect(base).not.toMatch(
-            /\.markdown-body p,\s*\.markdown-body li:not\(:has\(> p\)\)\s*\{/,
+    const generate = (softNewlineAsSpace: boolean) =>
+        new MarkdownToHtml('line one\nline two', muyaWith(softNewlineAsSpace))
+            .generate({ inlineStyles: false });
+
+    it('appends a white-space:normal override when the option is on', async () => {
+        const html = await generate(true);
+        expect(html).toMatch(
+            /\.markdown-body p,\s*\.markdown-body li:not\(:has\(> p\)\)\s*\{\s*white-space:\s*normal;/,
         );
-        // The code-block pre-wrap rule must remain.
-        expect(base).toContain('.markdown-body pre');
-        expect(base).toMatch(/white-space:\s*pre-wrap/);
+    });
+
+    it('keeps every non-soft-break export rule when the option is on', async () => {
+        const html = await generate(true);
+        // Rules that live after the soft-break rule in exportStyle.css and must
+        // survive the override being appended.
+        expect(html).toContain('.markdown-body table {');
+        expect(html).toContain('.markdown-body img[data-align=\'right\'] {');
+        expect(html).toContain('.markdown-body li:has(input[type=\'checkbox\']) {');
+        expect(html).toContain('.markdown-body div.mermaid,');
+    });
+
+    it('does not append the override when the option is off', async () => {
+        const html = await generate(false);
+        expect(html).not.toMatch(
+            /\.markdown-body p,\s*\.markdown-body li:not\(:has\(> p\)\)\s*\{\s*white-space:\s*normal;/,
+        );
+        expect(html).toMatch(
+            /\.markdown-body p,\s*\.markdown-body li:not\(:has\(> p\)\)\s*\{\s*white-space:\s*pre-wrap;/,
+        );
     });
 });

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -260,6 +260,17 @@ export class MarkdownToHtml {
         // `extraCSS` may changed in the mean time.
         const { title = '', extraCSS = '', inlineStyles = true, dir } = options;
 
+        // When softNewlineAsSpace is off (default), include the pre-wrap rules
+        // so bare \n characters render as line breaks — matching the editor.
+        // When on, omit them so \n collapses to a space (CommonMark default).
+        const [exportStyleBase, exportStyleSoftBreak] = exportStyle.split(
+            '/* Render soft line breaks',
+        );
+        const exportStyleFinal
+            = this._muya?.options.softNewlineAsSpace
+                ? exportStyleBase
+                : `${exportStyleBase}/* Render soft line breaks${exportStyleSoftBreak}`;
+
         // Mirror the editor's text direction onto the exported document so RTL
         // documents export right-to-left (#4553). LTR is the HTML default, so it
         // stays implicit to keep existing exports byte-identical.
@@ -286,7 +297,7 @@ export class MarkdownToHtml {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${sanitize(title, EXPORT_DOMPURIFY_CONFIG, true)}</title>
 ${baseStyles}
-  <style>${exportStyle}</style>
+  <style>${exportStyleFinal}</style>
   <style>${extraCSS}</style>
 </head>
 <body>

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -27,6 +27,17 @@ const CDN_STYLESHEET_LINKS = `  <!-- https://cdnjs.com/libraries/github-markdown
   <!-- https://cdnjs.com/libraries/prism -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css" integrity="sha512-/mZ1FHPkg6EKcxo0fKXF51ak6Cr2ocgDi5ytaTBjsQZIH/RNs6GF6+oId/vPe3eJB836T36nXwVh/WBl/cWT4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />`;
 
+// Appended after `exportStyle` when `softNewlineAsSpace` is on. Same selector as
+// the soft-break rule in exportStyle.css, but placed later so it wins and resets
+// `white-space` to `normal`, collapsing a bare `\n` in a paragraph or tight list
+// item to a space (CommonMark's soft-break behaviour) instead of a line break.
+const SOFT_NEWLINE_AS_SPACE_OVERRIDE = `
+.markdown-body p,
+.markdown-body li:not(:has(> p)) {
+    white-space: normal;
+}
+`;
+
 export class MarkdownToHtml {
     private _exportContainer: HTMLDivElement | null = null;
 
@@ -260,16 +271,12 @@ export class MarkdownToHtml {
         // `extraCSS` may changed in the mean time.
         const { title = '', extraCSS = '', inlineStyles = true, dir } = options;
 
-        // When softNewlineAsSpace is off (default), include the pre-wrap rules
-        // so bare \n characters render as line breaks — matching the editor.
-        // When on, omit them so \n collapses to a space (CommonMark default).
-        const [exportStyleBase, exportStyleSoftBreak] = exportStyle.split(
-            '/* Render soft line breaks',
-        );
-        const exportStyleFinal
-            = this._muya?.options.softNewlineAsSpace
-                ? exportStyleBase
-                : `${exportStyleBase}/* Render soft line breaks${exportStyleSoftBreak}`;
+        // The full export stylesheet always ships; when softNewlineAsSpace is on
+        // a single later override collapses paragraph / tight-list soft breaks to
+        // spaces without disturbing any other export rule.
+        const exportStyleFinal = this._muya?.options.softNewlineAsSpace
+            ? exportStyle + SOFT_NEWLINE_AS_SPACE_OVERRIDE
+            : exportStyle;
 
         // Mirror the editor's text direction onto the exported document so RTL
         // documents export right-to-left (#4553). LTR is the HTML default, so it

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -33,6 +33,7 @@ export interface IMuyaOptions {
     footnote: boolean;
     math: boolean;
     isGitlabCompatibilityEnabled: boolean;
+    softNewlineAsSpace: boolean;
     autoMoveCheckedToEnd: boolean;
     disableHtml: boolean;
     locale: {

--- a/packages/website/content/docs/end-user/PREFERENCES.md
+++ b/packages/website/content/docs/end-user/PREFERENCES.md
@@ -63,6 +63,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | footnote                     | Boolean | `false` | Enable pandoc's footnote markdown extension.                                                                                         |
 | isHtmlEnabled                | Boolean | `true`  | Enable inline HTML rendering.                                                                                                        |
 | isGitlabCompatibilityEnabled | Boolean | `false` | Enable GitLab compatibility mode.                                                                                                    |
+| softNewlineAsSpace           | Boolean | `false` | Treat a soft line break (a single bare newline within a paragraph) as a space instead of a line break.                               |
 | sequenceTheme                | String  | `hand`  | Theme for [js-sequence-diagrams](https://bramp.github.io/js-sequence-diagrams/): `hand` or `simple`.                                 |
 
 #### Theme


### PR DESCRIPTION
## Summary

Adds a new preference toggle **"Treat soft newlines as spaces"** under Preferences > Markdown > Compatibility. When enabled, single linebreaks within paragraphs (soft line breaks) render as spaces instead of visual line breaks, supporting [SemBr](https://sembr.org)-style writing where each sentence is on its own line but should render as a flowing paragraph.

This is my first contribution to MarkText — I'm very open to feedback about the implementation approach, code style, or anything else. Happy to make any changes the maintainers see fit.

References #1849

## Changes

- Added `softNewlineAsSpace` to `PreferencesState`, `IMuyaOptions`, and `MUYA_DEFAULT_OPTIONS` (default: `false`)
- Added a boolean toggle in the Compatibility section of the Markdown preferences UI
- Wired the setting through the editor component (refs, watcher, Muya init)
- Modified the inline renderer's soft line break handler to emit a space instead of `\n` when enabled
- Added the option to `PARSE_AFFECTING_OPTIONS` so toggling triggers a full re-parse

## Why default off?

I recognize that making this behavior global (as discussed in #1849) needs more community input. By adding it as an opt-in setting that defaults to off, people can test the feature and turn it on if they wish, which helps continue the discussion of whether this should eventually become the default.

## Screenshots

### Source Code Mode
<img width="786" height="291" alt="source code mode" src="https://github.com/user-attachments/assets/d8c43b60-4fcc-4b4f-9a10-796785950bba" />

### Current default

<img width="724" height="300" alt="default render" src="https://github.com/user-attachments/assets/f3321443-dbba-41f0-85d5-686959e750ae" />

### Showing the preference and rendering with it checked
<img width="993" height="678" alt="with new preference enabled" src="https://github.com/user-attachments/assets/3c03f96b-5ee3-4b26-a7fc-e55701bb5fcb" />
