### PR TITLE
fix(muya): size table columns to their content

### DIFF
--- a/packages/muya/e2e/tests/blocks/table-column-widths-4894.spec.ts
+++ b/packages/muya/e2e/tests/blocks/table-column-widths-4894.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+/**
+ * #4894 — table columns size to their content, like GitHub. A blanket
+ * `min-width: 10em` on every cell content inflated each column's minimum to
+ * ~160px: narrow columns (`#`, `Short`) wasted space while a long column was
+ * squashed into the remainder, so every table read as a rough equal split
+ * regardless of content. The floor is now 2em — just enough that an empty
+ * cell keeps a visible, clickable caret slot.
+ */
+
+const REPRO_MD = [
+    '| # | Short | Content |',
+    '| --- | --- | --- |',
+    '| 1 | Ok | A pretty long amount of content that should force this column '
+    + 'to render much wider than the first. Though in reality most of my '
+    + 'long-column\'s content will be squished in a narrow space. |',
+    '',
+].join('\n');
+
+test('columns follow their content width instead of an equal split (#4894)', async ({ page }) => {
+    await page.evaluate(md => window.muya!.setContent(md), REPRO_MD);
+    const table = page.locator(editor.table).first();
+    await expect(table).toBeVisible();
+
+    const widths = await table
+        .locator('tr')
+        .first()
+        .locator('td')
+        .evaluateAll(cells => cells.map(cell => cell.getBoundingClientRect().width));
+
+    expect(widths).toHaveLength(3);
+    const [hash, short, content] = widths;
+    // The narrow columns hug their content — well under the ~186px the old
+    // 10em floor rendered them at…
+    expect(hash).toBeLessThan(100);
+    expect(short).toBeLessThan(120);
+    // …and the long column takes the bulk of the table.
+    expect(content).toBeGreaterThan((hash + short) * 2);
+});
+
+test('an empty cell still offers a usable caret slot', async ({ page }) => {
+    await page.evaluate(
+        md => window.muya!.setContent(md),
+        '|  |  |\n| --- | --- |\n|  |  |\n',
+    );
+    const firstCell = page.locator(editor.table).first().locator('td').first();
+    await expect(firstCell).toBeVisible();
+
+    // The 2em floor plus cell padding keeps the empty cell a real click
+    // target rather than a zero-width sliver.
+    const { width } = (await firstCell.boundingBox())!;
+    expect(width).toBeGreaterThanOrEqual(40);
+
+    await firstCell.click();
+    await page.keyboard.type('hi');
+    await expect(firstCell).toContainText('hi');
+});

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -969,8 +969,13 @@ pre.mu-active.mu-fenced-code::after {
     content: attr(empty-hint);
 }
 
+/* Columns size to their content, like GitHub (#4894). The old blanket
+   `min-width: 10em` inflated every column's minimum to ~160px, wasting
+   space on narrow columns and squashing long ones into a sliver. Keep a
+   small floor only so an empty cell still gives the caret a visible,
+   clickable slot. */
 .mu-table-cell-content {
-    min-width: 10em;
+    min-width: 2em;
 }
 
 /* Footnote definition block — port of marktext's `figure[data-role='FOOTNOTE']`


### PR DESCRIPTION
Fixes #4894.

## The cause

The equal-ish split was never a deliberate layout: `.mu-table-cell-content` carried a blanket `min-width: 10em` (inherited verbatim from the TS-rewrite migration, #4314). With the table's `table-layout: auto`, that floor inflates every column's minimum content width to ~160px — narrow columns (`#`, `Short`) waste 10em regardless of content, and a long column gets squashed into whatever remains. The issue's repro measures **186 / 186 / 328 px** at a 700px editor width.

## The fix

Drop the floor to `2em`. Column widths become content-driven, exactly like GitHub's rendering in the issue: the same repro now measures **58 / 69 / 573 px** — narrow columns hug their content, the long column takes the bulk.

Why keep any floor at all: a truly empty cell would collapse to a zero-width sliver that is hard to click into. `2em` plus the existing cell padding keeps every empty cell a real caret target (a new empty 3-column table renders compact but fully editable — covered by the spec below).

On the "some might prefer the equal split" question from the issue thread: the old behavior was an accidental artifact of the floor, not a designed equal split, and the reporter's expectation (GitHub parity) is what `table-layout: auto` gives once the artifact is removed. If a configurable layout mode is ever wanted, it can build on this as the default.

## Verification

- New e2e spec (`blocks/table-column-widths-4894.spec.ts`, real Chromium): the repro's narrow columns render under 100/120px with the long column > 2× their sum (fails on the old CSS), and an empty cell stays a usable click-and-type target.
- Table interaction neighborhood unaffected: drag bar, column toolbar, row/column menu, cross-cell selection, and rect clipboard e2e all pass with the narrower cells (19/19).
- Full muya e2e (chromium): 244 passed; the two exceptions are this machine's known `math-and-diagrams` KaTeX click failure (identical on clean `develop`) and a `@perf` smoke that passes in isolation (49.8s, timing-sensitive under parallel load).
- Stylelint on the changed file: no new findings (the 5 pre-existing ones are identical on `develop`).
