### PR TITLE
fix(muya): preserve cursor on IME composition backspace(#4956)

### DIFF
--- a/packages/muya/src/block/base/__tests__/imeBackspaceComposition.spec.ts
+++ b/packages/muya/src/block/base/__tests__/imeBackspaceComposition.spec.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+// Pressing Backspace/Delete while an IME composition is active (e.g. deleting
+// pre-commit pinyin characters inside an HTML block's closing tag) must reach
+// the IME, not run the editor's backspaceHandler/deleteHandler. keydownHandler
+// already guards Enter, the arrow keys and Tab with `!isComposed`; Backspace
+// and Delete were missing the same guard, so CodeBlockContent.backspaceHandler
+// ran mid-composition against a stale `this.text` and dislocated the cursor
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion) {
+        window.MUYA_VERSION = originalVersion as string;
+    }
+    else {
+        delete (window as Partial<Window>).MUYA_VERSION;
+    }
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function press(content: Format, key: string): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    content.keydownHandler(event);
+    return event;
+}
+
+describe('backspace/delete during IME composition', () => {
+    it('does not run backspaceHandler while composing — Backspace is left to the IME', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(5, 5);
+        content.composeHandler(new Event('compositionstart'));
+        const backspaceHandler = vi.spyOn(content, 'backspaceHandler');
+
+        const event = press(content, 'Backspace');
+
+        expect(backspaceHandler).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+        expect(content.text).toBe('hello');
+    });
+
+    it('does not run deleteHandler while composing — Delete is left to the IME', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 0);
+        content.composeHandler(new Event('compositionstart'));
+        const deleteHandler = vi.spyOn(content, 'deleteHandler');
+
+        const event = press(content, 'Delete');
+
+        expect(deleteHandler).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+        expect(content.text).toBe('hello');
+    });
+
+    it('runs backspaceHandler normally when not composing', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(5, 5);
+        const backspaceHandler = vi.spyOn(content, 'backspaceHandler');
+
+        press(content, 'Backspace');
+
+        expect(backspaceHandler).toHaveBeenCalled();
+    });
+
+    it('runs deleteHandler normally when not composing', () => {
+        const muya = bootMuya('hello\n');
+        const content = firstBlock(muya);
+        content.setCursor(0, 0);
+        const deleteHandler = vi.spyOn(content, 'deleteHandler');
+
+        press(content, 'Delete');
+
+        expect(deleteHandler).toHaveBeenCalled();
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -720,11 +720,15 @@ class Content extends TreeNode {
 
         switch (event.key) {
             case EVENT_KEYS.Backspace:
-                this.backspaceHandler(event);
+                if (!this.isComposed)
+                    this.backspaceHandler(event);
+
                 break;
 
             case EVENT_KEYS.Delete:
-                this.deleteHandler(event);
+                if (!this.isComposed)
+                    this.deleteHandler(event);
+
                 break;
 
             case EVENT_KEYS.Enter:


### PR DESCRIPTION
<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes https://github.com/marktext/marktext/issues/4956

## Summary
Why: During IME composition, Backspace/Delete triggered the editor's backspaceHandler/deleteHandler instead of the IME. Since composition text isn't in this.text yet, the handler ran on a stale snapshot, dislocating the cursor.

Fix: Added if (!this.isComposed) guard in keydownHandler for Backspace/Delete, matching the existing guard for Enter/arrows/Tab.

Changes:
content.ts: guard the two keys during composition.
imeBackspaceComposition.spec.ts: new test (4 cases) covering composing vs. non-composing Backspace/Delete.
<!-- A concise description of what this PR does and why -->

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [ ] Manually tested on: <!-- macOS / Windows / Linux -->

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
