### PR TITLE
fix(muya): app freezes (must force-kill) on files with large tables - avoid full-table DOM rebuild on every interaction

### DIFF
--- a/packages/muyajs/lib/contentState/inputCtrl.js
+++ b/packages/muyajs/lib/contentState/inputCtrl.js
@@ -365,6 +365,22 @@ const inputCtrl = (ContentState) => {
       }
     }
 
+    // PERF: an inline edit inside a table cell only affects that cell's own
+    // content. Going through `partialRender` would re-render the whole
+    // outermost block -- for a table that means rebuilding every single cell
+    // on each keystroke, which freezes the editor on large tables. When the
+    // edit is contained in one cell and no block-structure change happened,
+    // patch just the edited cell.
+    if (
+      block.functionType === 'cellContent' &&
+      !inlineUpdatedBlock &&
+      !needRenderAll &&
+      oldStart.key === oldEnd.key &&
+      (checkMarkedUpdate || needRender)
+    ) {
+      return this.singleRender(block)
+    }
+
     if (checkMarkedUpdate || inlineUpdatedBlock || needRender) {
       return needRenderAll ? this.render() : this.partialRender()
     }

--- a/packages/muyajs/lib/parser/render/index.js
+++ b/packages/muyajs/lib/parser/render/index.js
@@ -192,12 +192,92 @@ class StateRender {
     this.codeCache.clear()
   }
 
+  /**
+   * Try to update the given outermost blocks in place with snabbdom.
+   *
+   * The legacy path below serializes the whole render range to an HTML
+   * string and rebuilds the DOM from scratch. For big single blocks -- most
+   * notably tables with hundreds or thousands of rows -- that means every
+   * click, arrow key or keystroke rebuilds (and re-lays-out) the entire
+   * table, which freezes the UI (#large-table-freeze). When the block
+   * structure is unchanged (the common case: cursor moves and inline edits),
+   * we can diff each block against its existing DOM node instead, which only
+   * touches the nodes that actually changed.
+   *
+   * Returns `true` when the in-place patch was applied, `false` when the
+   * DOM does not match the block sequence (structural change) and the
+   * caller must fall back to the rebuild path.
+   */
+  patchPartialBlocks(blocks, activeBlocks, matches, t) {
+    if (blocks.length === 0) {
+      return false
+    }
+    const firstDom = document.querySelector(`#${blocks[0].key}`)
+    if (!firstDom) {
+      return false
+    }
+    // The DOM sibling sequence must match the block sequence exactly,
+    // including both boundaries, otherwise blocks were added/removed and we
+    // cannot patch in place.
+    const preKey = blocks[0].preSibling || null
+    const preDom = firstDom.previousElementSibling
+    if (preKey !== (preDom ? preDom.id : null)) {
+      return false
+    }
+    const doms = []
+    let dom = firstDom
+    for (const block of blocks) {
+      if (!dom || dom.id !== block.key) {
+        return false
+      }
+      doms.push(dom)
+      dom = dom.nextElementSibling
+    }
+    const nextKey = blocks[blocks.length - 1].nextSibling || null
+    if (nextKey !== (dom ? dom.id : null)) {
+      return false
+    }
+
+    blocks.forEach((block, i) => {
+      const newVnode = this.renderBlock(null, block, activeBlocks, matches, false, t)
+      patch(toVNode(doms[i]), newVnode)
+    })
+
+    return true
+  }
+
   // Only render the blocks which you updated
   partialRender(blocks, activeBlocks, matches, startKey, endKey) {
     const cursorOutMostBlock = activeBlocks[activeBlocks.length - 1]
     // If cursor is not in render blocks, need to render cursor block independently
     const needRenderCursorBlock = blocks.indexOf(cursorOutMostBlock) === -1
     const t = this.muya.options.t || ((key) => key) // Get the translation function, falling back to returning the key itself if absent
+
+    if (this.patchPartialBlocks(blocks, activeBlocks, matches, t)) {
+      // Render cursor block independently
+      if (needRenderCursorBlock) {
+        const { key } = cursorOutMostBlock
+        const cursorDom = document.querySelector(`#${key}`)
+        if (cursorDom) {
+          const oldCursorVnode = toVNode(cursorDom)
+          const newCursorVnode = this.renderBlock(
+            null,
+            cursorOutMostBlock,
+            activeBlocks,
+            matches,
+            false,
+            t
+          )
+          patch(oldCursorVnode, newCursorVnode)
+        }
+      }
+
+      this.renderMermaid()
+      this.renderDiagram()
+      this.codeCache.clear()
+      return
+    }
+
     const newVnode = h(
       'section',
       blocks.map((block) => this.renderBlock(null, block, activeBlocks, matches, false, t))


### PR DESCRIPTION
## TL;DR

Opening a markdown file that contains a **large GFM table** (real-world file: **1,245 rows × 5 columns, ~90 KB**) makes MarkText 0.19.x effectively freeze — the window stops responding and the app has to be force-killed. The root cause is that the legacy `@marktext/muyajs` engine rebuilds the **entire table DOM from an HTML string on every click, arrow-key move and keystroke** inside the table. This PR adds a conservative in-place snabbdom patch fast path to `StateRender.partialRender()` and a single-cell render shortcut to `inputCtrl`, reducing the per-interaction main-thread block from **~800 ms + full re-layout of 6,215 cells** to **~10–300 ms with no re-layout**, measured on the real app.

---

## 1. Reproduction

Any markdown file with a very large pipe table reproduces it. Generator:

```js
// gen-table.js — node gen-table.js > big-table.md
const rows = ['# Big table', '', '| # | name | count | type | description |', '|---:|---|---:|:---:|---|']
for (let i = 1; i <= 1245; i++) {
  rows.push(`| ${i} | \`item-${i}\` | ${Math.floor(Math.random() * 10000).toLocaleString()} | User | 日本語の説明テキスト ${i} |`)
}
console.log(rows.join('\n'))
```

Steps: open the file in MarkText 0.19.1 → move the mouse over the table / click a cell / press an arrow key / type a character. Each interaction blocks the renderer main thread for ~0.8 s and forces a full table re-layout; a handful of queued mouse events produce a multi-second hang, which users experience as a hard freeze ("have to force-kill").

The initial *parse and first render* of the file are **not** the problem (~0.5 s once): the freeze is driven entirely by the per-interaction re-render.

## 2. Investigation

Everything below was measured against the **shipped app** (MarkText 0.19.1 on Windows 11, Electron renderer) driven over the Chrome DevTools Protocol (`--remote-debugging-port`), plus jsdom micro-benchmarks against `packages/muyajs` from this repo.

- Block lexing (`Lexer.lex`) of the whole file: **5 ms** — fine.
- Inline tokenizer over all 6,215 cells: **29 ms** total — fine.
- `Muya` init + first full render (jsdom): **~570 ms** once — acceptable.
- **Every subsequent interaction inside the table** goes through `ContentState.partialRender()`. Main-thread block per real click, captured in the running app with `new PerformanceObserver(...).observe({ entryTypes: ['longtask'] })` while dispatching real clicks via CDP `Input.dispatchMouseEvent`:

  ```
  longtasks per click (before): [797, 821, 772, 805, 814, 764] ms
  CDP Input.insertText (typing one char): ~808 ms
  ```

### Root cause (code path)

`ContentState.partialRender()` computes a render range of **outermost** blocks around the cursor (`setNextRenderRange()` → `[startOutMostBlock.preSibling, endOutMostBlock.nextSibling]`). For a table, the outermost block containing the cursor is the whole `figure` — i.e. the **entire table** is always inside the range.

`StateRender.partialRender()` (`packages/muyajs/lib/parser/render/index.js`) then:

```js
const newVnode = h('section', blocks.map(block => this.renderBlock(...)))
const html = toHTML(newVnode).replace(...)          // 1) serialize ENTIRE table to an HTML string (snabbdom-to-html)
...
firstOldDom.insertAdjacentHTML('beforebegin', html) // 2) build all 6,215 cells' DOM from scratch
Array.from(needToRemoved).forEach(dom => dom.remove()) // 3) throw away the old DOM
```

So a click that only needs to move an `ag-active` class and two drag bars pays for: full vnode build + full HTML serialization + full DOM construction + destruction of the old subtree + **a full layout/style pass over every cell**. This runs on *every* `clickCtrl`/`arrowCtrl`/`inputCtrl` interaction inside the table.

(Confirmed the freeze is not in parsing, history, `ExportMarkdown`, word count, or the marked block/inline rules — all sub-10 ms on this file.)

## 3. The fix

Two independent, structure-preserving changes in `packages/muyajs`, both falling back to the existing code path whenever their preconditions do not hold.

### 3.1 `StateRender.patchPartialBlocks()` — in-place snabbdom diff fast path

Before using the HTML-rebuild path, `partialRender()` now checks whether the **DOM sibling sequence still matches the block sequence exactly**:

- `#blocks[0].key` exists in the DOM;
- its `previousElementSibling` id equals `blocks[0].preSibling` (left boundary intact);
- walking `nextElementSibling`, every DOM id matches the corresponding `block.key` one-to-one;
- the element after the last block matches `blocks[last].nextSibling` (right boundary intact).

If all of that holds, no blocks were added/removed/merged — the common case for clicks, cursor moves, selection changes and inline edits — and each outermost block is diffed **in place**:

```js
blocks.forEach((block, i) => {
  const newVnode = this.renderBlock(null, block, activeBlocks, matches, false, t)
  patch(toVNode(doms[i]), newVnode)
})
```

Only the nodes that actually changed (active-class chain, table tools row, drag bars, the edited cell) are touched, so the browser re-lays-out almost nothing. `patch(toVNode(dom), vnode)` is the exact pattern `render()` and `singleRender()` already use, and because it reads the *live* DOM it stays correct in the presence of muyajs's direct DOM mutations (e.g. `setSelectedCellsStyle`, drag transforms).

If **any** check fails (block split/merge/insert/delete, stale DOM), the method returns `false` and the original serialize-and-rebuild path runs unchanged — including its `needRenderCursorBlock` handling, which the fast path replicates.

### 3.2 `inputCtrl.inputHandler()` — single-cell render for cell edits

An inline edit confined to one table cell now renders only that cell:

```js
if (
  block.functionType === 'cellContent' &&
  !inlineUpdatedBlock &&        // no block-type conversion
  !needRenderAll &&
  oldStart.key === oldEnd.key && // previous selection did not span blocks (no removeBlocks happened)
  (checkMarkedUpdate || needRender)
) {
  return this.singleRender(block)
}
```

`singleRender(block)` patches `span#<key>` only — inline-syntax re-tokenization inside the cell (e.g. typing `**bold**`) still works because the cell is re-tokenized from `block.text`.

## 4. Results

Same 1,245-row file, MarkText 0.19.1 on Windows, patched bundle in a copy of the installed app, real input over CDP, main-thread block per interaction via `PerformanceObserver('longtask')`:

| Interaction | Before | After |
|---|---:|---:|
| Click into a cell | 770–820 ms + full table re-layout | 497 ms first (cold JIT/cache), then **86–296 ms**, no re-layout |
| Typing in a cell (`Input.insertText`) | ~810 ms | **~46 ms** |
| jsdom micro-bench: `partialRender` after a cell text edit | 621 ms | **13 ms** (single-cell path) |
| jsdom micro-bench: `partialRender` on cursor move (whole-range patch) | 478 ms | ~200–270 ms JS-only, zero DOM rebuild |

The remaining click cost is dominated by `toVNode()` over the large existing subtree (~130 ms) plus vnode build + diff; crucially it no longer destroys/rebuilds DOM, so there is no follow-up layout storm and no compounding freeze when events queue up.

## 5. Correctness verification

On the patched real app (CDP-driven):

- table renders identically: 1,244 `<tr>` / 6,215 `<td>`;
- clicking a cell activates it: 6 elements in the `ag-active` chain, table tools row present (`.ag-tool-table` ×1), drag bars present (`.ag-drag-handler` ×2, left + bottom);
- real `Input.insertText` lands in the clicked cell and the cell content updates correctly;
- markdown round-trip (`getMarkdown()`) unchanged in the jsdom harness after click/edit cycles;
- structural operations still work because any key-sequence mismatch falls back to the legacy rebuild path.

## 6. Scope / what this does NOT touch

- **muya v2 (`@muyajs/core`)** — the new engine used by the desktop editor on `master` renders table cells individually (`TableCellContent.update()` → `inlineRenderer.patch(this, ...)`) and does not have this problem. No changes there.
- No changes to the markdown parser, the exporter, or any structural editing path — the fallback preserves the exact previous behavior whenever block structure changes.
- The `render()` full-render path is untouched.

## 7. Why this matters

Large generated tables (API dumps, rankings, data exports) are a common real-world markdown payload. Right now such a file turns MarkText 0.19.x into a force-kill situation; with this change the same file opens and edits smoothly on the shipped legacy engine, which should benefit any future 0.19.x patch release.
