### PR TITLE
fix(muya): escape HTML in image attribute values (CWE-79)

### DIFF
--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -27,7 +27,7 @@ import { generator, tokenizer } from '../../inlineRenderer/lexer';
 import Selection, { getCursorReference } from '../../selection';
 import { getTextContent } from '../../selection/dom';
 import { isListItemState } from '../../state/types';
-import { conflict, isHTMLElement, isMouseEvent } from '../../utils';
+import { conflict, escapeHTML, isHTMLElement, isMouseEvent } from '../../utils';
 import { correctImageSrc, encodeImageSrc, getImageInfo } from '../../utils/image';
 import logger from '../../utils/logger';
 
@@ -390,7 +390,7 @@ class Format extends Content {
                 if (value && attr === 'src')
                     value = correctImageSrc(value);
 
-                imageText += `${attr}="${value}" `;
+                imageText += `${attr}="${escapeHTML(String(value))}" `;
             }
             imageText = imageText.trim();
             imageText += ' />';
@@ -421,7 +421,7 @@ class Format extends Content {
             if (value && attr === 'src')
                 value = correctImageSrc(value);
 
-            imageText += `${attr}="${value}" `;
+            imageText += `${attr}="${escapeHTML(String(value))}" `;
         }
         imageText = imageText.trim();
         imageText += ' />';

--- a/packages/muyajs/lib/contentState/imageCtrl.js
+++ b/packages/muyajs/lib/contentState/imageCtrl.js
@@ -1,5 +1,6 @@
 import { URL_REG, DATA_URL_REG } from '../config'
 import { correctImageSrc } from '../utils/getImageInfo'
+import { escapeHTML } from '../utils'
 
 // Browser-friendly replacement for Node's `url.fileURLToPath`. Renderer is
 // sandboxed so we can't reach Node's `url` module.
@@ -133,7 +134,7 @@ const imageCtrl = (ContentState) => {
       if (value && attr === 'src') {
         value = correctImageSrc(value)
       }
-      imageText += `${attr}="${value}" `
+      imageText += `${attr}="${escapeHTML(String(value))}" `
     }
     imageText = imageText.trim()
     imageText += '>'
@@ -179,7 +180,7 @@ const imageCtrl = (ContentState) => {
         if (value && attr === 'src') {
           value = correctImageSrc(value)
         }
-        imageText += `${attr}="${value}" `
+        imageText += `${attr}="${escapeHTML(String(value))}" `
       }
       imageText = imageText.trim()
       imageText += '>'


### PR DESCRIPTION
## Summary

This PR fixes a stored XSS vulnerability (CWE-79) in Muya's image tag construction. Image attribute values (`alt`, `title`, `src`, etc.) are concatenated into an HTML string without escaping, so a value containing a `"` can break out of the attribute and inject arbitrary attributes — including event handlers like `onerror` / `onload` — that execute inside the editor's renderer.

Reopening the discussion from #4206 with a clean, minimal, rebased diff (the previous PR was closed for merge conflicts). The fix now uses the existing `escapeHTML` helper as suggested in the earlier review.

## Vulnerability

- **CWE-79** — Improper Neutralization of Input During Web Page Generation
- **Affected files / functions:**
  - `packages/muya/src/block/base/format.ts` — `insertImage` (~L390) and `updateImage` (~L421)
  - `packages/muyajs/lib/contentState/imageCtrl.js` — two attribute-serialization loops (~L133, ~L179) in the legacy renderer path
- **Sink:** all four call sites build `imageText += \`${attr}="${value}" \`` with no escaping.
- **Source:** attribute values originate from image-editing UI input or from parsed markdown/HTML tokens in an opened document, so a crafted `.md` file (or paste) supplies attacker-controlled values.
- **Trigger:** opening a malicious markdown file whose image tag contains a value like `x" onerror="…`. Muya re-serializes the token via the above sinks, producing `<img alt="x" onerror="…" …>` which the editor then renders in its inline-HTML pipeline. No user authentication is required — for a markdown editor, "opens a file someone sent me" is a realistic threat.

## Fix

Wrap every value with the existing `escapeHTML` utility (already exported from `packages/muya/src/utils` and `packages/muyajs/lib/utils`) before interpolating it into the attribute string. `String(value)` guards against non-string attribute values before escaping.

Diff is 6 lines changed across 2 files (plus one import per file). No behavior change for legitimate content — `escapeHTML` only rewrites `&`, `<`, `>`, `"`, and `'`, which are already invalid unescaped inside a double-quoted attribute.

## Proof of Concept

Create `poc.md` with:

```markdown
<img src="nonexistent.png" alt='x" onerror="alert(document.title)' />
```

**Before the fix:** opening `poc.md` in MarkText serializes the image as
`<img src="nonexistent.png" alt="x" onerror="alert(document.title)" />`
and the `onerror` handler fires when the image fails to load, proving arbitrary JS execution inside the renderer.

**After the fix:** the same file serializes to
`<img src="nonexistent.png" alt="x&quot; onerror=&quot;alert(document.title)" />`
— the payload is inert and rendered as literal text inside the `alt` attribute.

You can verify the escape directly:

```js
const { escapeHTML } = require('./packages/muya/src/utils');
console.log(`alt="${escapeHTML('x" onerror="alert(1)')}"`);
// alt="x&quot; onerror=&quot;alert(1)"
```

## Security analysis

The Electron renderer runs with `contextIsolation: true`, `sandbox: true`, and `nodeIntegration: false`, which prevents this XSS from directly achieving RCE via Node APIs. However, it still allows:

- reading and exfiltrating the currently-open document contents,
- interacting with any IPC channels the preload script exposes (file dialogs, recent files, settings),
- persisting the payload — the crafted attribute round-trips through save, so re-opening keeps the vulnerability live (stored XSS).

For a desktop markdown editor whose primary use case is opening files from other people, the "open a `.md` you were sent" precondition is normal user behavior, not a high bar.

## Adversarial review

Before submitting we tried to disprove this: we checked whether Muya's tokenizer already strips dangerous attributes, whether a downstream sanitizer runs before the string reaches the DOM, and whether the renderer's CSP would block the `onerror` handler. It doesn't — the image attributes are re-emitted verbatim into the editor's HTML, there is no CSP on the editor surface that blocks inline event handlers, and `runSanitize` is only invoked on paste/export paths, not on the image-tag round-trip. The `contextIsolation`/`sandbox` flags meaningfully limit blast radius (no RCE) but do not prevent the XSS itself.

## Test plan

- [x] Manually tested on: macOS. Opened a `poc.md` containing the payload above, confirmed `onerror` fires before the fix and does not fire after.
- [x] Verified `escapeHTML` is the same helper the codebase uses elsewhere for HTML escaping (`packages/muya/src/utils/index.ts:146`, `packages/muyajs/lib/utils/index.js:308`).
- [x] Diff is 2 files / 6 changed lines — no unrelated changes.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)