### PR TITLE
feat(markdown): make inline math configurable

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -267,6 +267,11 @@
     "type": "boolean",
     "default": false
   },
+  "inlineMath": {
+    "description": "Markdown--Render single-dollar inline math expressions.",
+    "type": "boolean",
+    "default": true
+  },
   "isHtmlEnabled": {
     "description": "Markdown-Enable HTML rendering",
     "type": "boolean",

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -219,6 +219,7 @@ const {
   frontmatterType,
   superSubScript,
   footnote,
+  inlineMath,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
   lineHeight,
@@ -653,6 +654,12 @@ watch(superSubScript, (value, oldValue) => {
 watch(footnote, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ footnote: value }, true)
+  }
+})
+
+watch(inlineMath, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ inlineMath: value }, true)
   }
 })
 
@@ -1749,6 +1756,7 @@ onMounted(() => {
     frontmatterType: frontmatterType.value,
     superSubScript: superSubScript.value,
     footnote: footnote.value,
+    inlineMath: inlineMath.value,
     disableHtml: !isHtmlEnabled.value,
     isGitlabCompatibilityEnabled: isGitlabCompatibilityEnabled.value,
     hideQuickInsertHint: hideQuickInsertHint.value,

--- a/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
@@ -63,6 +63,12 @@
           :on-change="(value) => onSelectChange('footnote', value)"
           more="https://pandoc.org/MANUAL.html#footnotes"
         />
+        <bool
+          :description="t('preferences.markdown.extensions.inlineMath')"
+          :notes="t('preferences.markdown.extensions.inlineMathNotes')"
+          :bool="inlineMath"
+          :on-change="(value) => onSelectChange('inlineMath', value)"
+        />
       </template>
     </compound>
 
@@ -159,6 +165,7 @@ const {
   frontmatterType,
   superSubScript,
   footnote,
+  inlineMath,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
   sequenceTheme,

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -77,6 +77,7 @@ export interface PreferencesState {
   frontmatterType: FrontmatterType | string
   superSubScript: boolean
   footnote: boolean
+  inlineMath: boolean
   isHtmlEnabled: boolean
   isGitlabCompatibilityEnabled: boolean
   sequenceTheme: SequenceTheme | string
@@ -193,6 +194,7 @@ export const usePreferencesStore = defineStore('preferences', {
     frontmatterType: '-',
     superSubScript: false,
     footnote: false,
+    inlineMath: true,
     isHtmlEnabled: true,
     isGitlabCompatibilityEnabled: false,
     sequenceTheme: 'hand',

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -43,6 +43,7 @@ export interface IUserPreferences {
   frontmatterType?: '-' | ';' | '+' | '{'
   superSubScript?: boolean
   footnote?: boolean
+  inlineMath?: boolean
   isHtmlEnabled?: boolean
   isGitlabCompatibilityEnabled?: boolean
   theme?: string

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -405,6 +405,7 @@
         "frontmatterType": "Der Frontmatter-Typ",
         "superSubScript": "Pandocs Markdown-Erweiterung für hoch- und tiefgestellte Zeichen aktivieren",
         "footnote": "Pandocs Markdown-Erweiterung für Fußnoten aktivieren",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "HTML-Rendering aktivieren",
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
         "sequenceTheme": "Sequenzdiagramm-Theme",
@@ -625,6 +626,8 @@
         "superSubScript": "Hoch-/Tiefgestellt",
         "footnote": "Fußnote",
         "footnoteNotes": "Fußnoten",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON-Klammer",
           "jsonSemicolon": "JSON-Semikolon",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -404,6 +404,7 @@
         "frontmatterType": "The frontmatter type",
         "superSubScript": "Enable pandoc's markdown extension superscript and subscript",
         "footnote": "Enable pandoc's markdown extension footnote",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "Enable HTML rendering",
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
         "sequenceTheme": "Sequence diagram theme",
@@ -625,6 +626,8 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Footnote",
         "footnoteNotes": "Footnote notes",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON with Braces",
           "jsonSemicolon": "JSON with Semicolon",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -405,6 +405,7 @@
         "frontmatterType": "El tipo de frontmatter",
         "superSubScript": "Habilitar extensión markdown de pandoc superíndice y subíndice",
         "footnote": "Habilitar extensión markdown de pandoc nota al pie",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "Habilitar renderizado HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
         "sequenceTheme": "Tema del diagrama de secuencia",
@@ -625,6 +626,8 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Nota al pie",
         "footnoteNotes": "Notas al pie",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON con Llaves",
           "jsonSemicolon": "JSON con Punto y Coma",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -405,6 +405,7 @@
         "frontmatterType": "Le type de frontmatter",
         "superSubScript": "Activer l'extension markdown de pandoc pour exposant et indice",
         "footnote": "Activer l'extension markdown de pandoc pour note de bas de page",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "Activer le rendu HTML",
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
         "sequenceTheme": "Thème du diagramme de séquence",
@@ -625,6 +626,8 @@
         "superSubScript": "Exposant/Indice",
         "footnote": "Note de bas de page",
         "footnoteNotes": "Notes de bas de page",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "Accolade JSON",
           "jsonSemicolon": "Point-virgule JSON",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -405,6 +405,7 @@
         "frontmatterType": "フロントマターのタイプ",
         "superSubScript": "Pandocのmarkdown拡張上付き文字と下付き文字を有効にする",
         "footnote": "Pandocのmarkdown拡張脚注を有効にする",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "HTMLレンダリングを有効にする",
         "isGitlabCompatibilityEnabled": "GitLab互換モードを有効にする",
         "sequenceTheme": "シーケンス図のテーマ",
@@ -625,6 +626,8 @@
         "superSubScript": "上付き/下付き文字",
         "footnote": "脚注",
         "footnoteNotes": "脚注",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON括弧",
           "jsonSemicolon": "JSONセミコロン",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -405,6 +405,7 @@
         "frontmatterType": "프론트매터 유형",
         "superSubScript": "Pandoc의 마크다운 확장 위첨자와 아래첨자 활성화",
         "footnote": "Pandoc의 마크다운 확장 각주 활성화",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "HTML 렌더링 활성화",
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
         "sequenceTheme": "시퀀스 다이어그램 테마",
@@ -625,6 +626,8 @@
         "superSubScript": "위/아래 첨자",
         "footnote": "각주",
         "footnoteNotes": "각주 노트",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "중괄호가 있는 JSON",
           "jsonSemicolon": "세미콜론이 있는 JSON",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -405,6 +405,7 @@
         "frontmatterType": "O tipo de frontmatter",
         "superSubScript": "Habilitar extensão markdown do pandoc para sobrescrito e subscrito",
         "footnote": "Habilitar extensão markdown do pandoc para nota de rodapé",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "Habilitar renderização HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
         "sequenceTheme": "Tema do diagrama de sequência",
@@ -625,6 +626,8 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Nota de rodapé",
         "footnoteNotes": "Notas de rodapé",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON com Chaves",
           "jsonSemicolon": "JSON com Ponto e Vírgula",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -404,6 +404,7 @@
         "frontmatterType": "Ön bilgi türü",
         "superSubScript": "Pandoc'un markdown uzantısı üst simge ve alt simgeyi etkinleştir",
         "footnote": "Pandoc'un markdown uzantısı dipnotu etkinleştir",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "HTML işlemeyi etkinleştir",
         "isGitlabCompatibilityEnabled": "GitLab uyumluluk modunu etkinleştir",
         "sequenceTheme": "Dizi diyagramı teması",
@@ -625,6 +626,8 @@
         "superSubScript": "Üst/Alt Simge",
         "footnote": "Dipnot",
         "footnoteNotes": "Dipnot notları",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "Süslü Parantezli JSON",
           "jsonSemicolon": "Noktalı Virgüllü JSON",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -405,6 +405,7 @@
         "frontmatterType": "前言类型",
         "superSubScript": "启用 Pandoc 的 Markdown 扩展上标和下标",
         "footnote": "启用 Pandoc 的 Markdown 扩展脚注",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "启用 HTML 渲染",
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
         "sequenceTheme": "序列图主题",
@@ -625,6 +626,8 @@
         "superSubScript": "上标/下标",
         "footnote": "脚注",
         "footnoteNotes": "脚注注释",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "带大括号的 JSON",
           "jsonSemicolon": "带分号的 JSON",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -405,6 +405,7 @@
         "frontmatterType": "前言類型",
         "superSubScript": "啟用 Pandoc 的 Markdown 擴充功能上標和下標",
         "footnote": "啟用 Pandoc 的 Markdown 擴充功能腳註",
+        "inlineMath": "Render single-dollar inline math expressions",
         "isHtmlEnabled": "啟用 HTML 轉譯",
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
         "sequenceTheme": "序列圖主題",
@@ -625,6 +626,8 @@
         "superSubScript": "上標/下標",
         "footnote": "腳註",
         "footnoteNotes": "腳註備註",
+        "inlineMath": "Inline math",
+        "inlineMathNotes": "Turn off for finance prose with unescaped dollar amounts",
         "frontmatterType": {
           "jsonBrace": "JSON 大括號",
           "jsonSemicolon": "JSON 分號",

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -52,6 +52,7 @@
   "frontmatterType": "-",
   "superSubScript": false,
   "footnote": false,
+  "inlineMath": true,
   "isHtmlEnabled": true,
   "isGitlabCompatibilityEnabled": false,
   "sequenceTheme": "hand",

--- a/packages/muya/src/__tests__/setOptions.spec.ts
+++ b/packages/muya/src/__tests__/setOptions.spec.ts
@@ -210,6 +210,41 @@ describe('muya render-affecting options', () => {
         expect(muya.domNode.querySelectorAll('sup').length).toBe(1);
     });
 
+    it('inlineMath:false renders currency-heavy prose literally', async () => {
+        const markdown = 'Revenue rose from $13B to $24B while $x+y$ stayed mathematical.\n';
+        const muya = bootMuyaWith(markdown, { inlineMath: false });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+        expect(muya.domNode.querySelectorAll('.mu-math').length).toBe(0);
+        expect(muya.domNode.textContent).toContain('$13B');
+        expect(muya.domNode.textContent).toContain('$24B');
+        expect(muya.domNode.textContent).toContain('$x+y$');
+        expect(muya.getMarkdown()).toBe(markdown);
+    });
+
+    it('inlineMath:true preserves the existing single-dollar math rendering', async () => {
+        const muya = bootMuyaWith('$x+y$\n', { inlineMath: true });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+        expect(muya.domNode.querySelectorAll('.mu-math').length).toBe(1);
+        expect(muya.getMarkdown()).toBe('$x+y$\n');
+    });
+
+    it('setOptions inlineMath with forceRender toggles inline math live', async () => {
+        const muya = bootMuyaWith('$x+y$\n', { inlineMath: true });
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('.mu-math').length).toBe(1);
+
+        muya.setOptions({ inlineMath: false }, true);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('.mu-math').length).toBe(0);
+        expect(muya.domNode.textContent).toContain('$x+y$');
+
+        muya.setOptions({ inlineMath: true }, true);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        expect(muya.domNode.querySelectorAll('.mu-math').length).toBe(1);
+    });
+
     it('frontmatterType:false drives the option onto muya.options', () => {
         const muya = bootMuyaWith('body\n', {});
         muya.setOptions({ frontmatterType: '+' });

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -1311,11 +1311,11 @@ class Format extends Content {
 
         // fix: #897 in marktext repo
         const { text } = this;
-        const { footnote, superSubScript } = this.muya.options;
+        const { footnote, superSubScript, inlineMath } = this.muya.options;
         const { labels } = this.inlineRenderer;
         const tokens = tokenizer(text, {
             labels,
-            options: { footnote, superSubScript },
+            options: { footnote, superSubScript, inlineMath },
         });
         // The caret offset is unreliable when it is parked on a
         // `contenteditable=false` inline image; resolve the real offset from the

--- a/packages/muya/src/clipboard/copyData.ts
+++ b/packages/muya/src/clipboard/copyData.ts
@@ -36,11 +36,12 @@ function buildHtmlOptions(options: Muya['options']) {
         footnote,
         frontMatter = true,
         math,
+        inlineMath,
         isGitlabCompatibilityEnabled,
         superSubScript,
     } = options;
 
-    return { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript };
+    return { footnote, frontMatter, math, inlineMath, isGitlabCompatibilityEnabled, superSubScript };
 }
 
 /**

--- a/packages/muya/src/clipboard/paste.ts
+++ b/packages/muya/src/clipboard/paste.ts
@@ -394,6 +394,7 @@ function applyParsedPaste(
     const {
         footnote,
         math,
+        inlineMath,
         isGitlabCompatibilityEnabled,
         trimUnnecessaryCodeBlockEmptyLines,
         frontMatter,
@@ -402,6 +403,7 @@ function applyParsedPaste(
     const states = new MarkdownToState({
         footnote,
         math,
+        inlineMath,
         isGitlabCompatibilityEnabled,
         trimUnnecessaryCodeBlockEmptyLines,
         frontMatter,

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -344,6 +344,9 @@ export const MUYA_DEFAULT_OPTIONS = {
     frontMatter: true, // Whether to support frontmatter.
     superSubScript: true,
     footnote: false,
+    // Keep inline math independently configurable so currency-heavy prose can
+    // use literal dollar signs while display-math blocks remain available.
+    inlineMath: true,
     // Whether math block is supported.
     math: true,
     isGitlabCompatibilityEnabled: true,

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -37,6 +37,7 @@ interface ILexState {
     top: boolean;
     superSubScript: boolean;
     footnote: boolean;
+    inlineMath: boolean;
 }
 
 function pushPending(state: ILexState) {
@@ -195,6 +196,9 @@ function tryChunks(state: ILexState): boolean {
     const chunks = ['inline_code', 'del', 'emoji', 'inline_math'] as const;
 
     for (const rule of chunks) {
+        if (rule === 'inline_math' && !state.inlineMath)
+            continue;
+
         const to = state.inlineRules[rule].exec(state.src);
         if (to && isLengthEven(to[3])) {
             if (rule === 'emoji') {
@@ -809,7 +813,7 @@ const INLINE_HANDLERS: ReadonlyArray<(state: ILexState) => boolean> = [
 ];
 
 function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: InlineRules, pos = 0, top: boolean, labels: Labels, options: ITokenizerFacOptions) {
-    const { superSubScript, footnote } = options;
+    const { superSubScript, footnote, inlineMath = true } = options;
     const state: ILexState = {
         originSrc: src,
         src,
@@ -823,6 +827,7 @@ function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: I
         top,
         superSubScript,
         footnote,
+        inlineMath,
     };
 
     if (beginRules && state.pos === 0)
@@ -858,6 +863,7 @@ export function tokenizer(src: string, {
     options = {
         superSubScript: true,
         footnote: false,
+        inlineMath: true,
     },
 }: ITokenizerOptions = {} as ITokenizerOptions) {
     const tokens = tokenizerFac(

--- a/packages/muya/src/inlineRenderer/types.ts
+++ b/packages/muya/src/inlineRenderer/types.ts
@@ -31,6 +31,7 @@ export type Rules = Record<string, RegExp>;
 export interface ITokenizerFacOptions {
     superSubScript: boolean;
     footnote: boolean;
+    inlineMath?: boolean;
 }
 
 export interface ITokenizerOptions {

--- a/packages/muya/src/state/__tests__/renderToStaticHTML.spec.ts
+++ b/packages/muya/src/state/__tests__/renderToStaticHTML.spec.ts
@@ -220,6 +220,18 @@ describe('renderToStaticHTML', () => {
             // KaTeX output contains class="katex" wrappers when math enabled.
             expect(html).toMatch(/katex|<math/i);
         });
+
+        it('can disable inline math without disabling display math', () => {
+            const markdown = 'Revenue moved from $13B to $24B.\n\n$$\nx^2\n$$';
+            const html = renderToStaticHTML(markdown, {
+                math: true,
+                inlineMath: false,
+            });
+
+            expect(html).toContain('$13B');
+            expect(html).toContain('$24B');
+            expect(html).toMatch(/katex|<math/i);
+        });
     });
 
     it('returns a string for empty input', () => {

--- a/packages/muya/src/state/getTOC.ts
+++ b/packages/muya/src/state/getTOC.ts
@@ -52,11 +52,11 @@ export function getTOC(muya: Muya): ITocItem[] {
         // instead of the raw source (#4811). Slugging the same plain text keeps
         // `githubSlug` in step with the anchor id the HTML export injects from
         // `heading.textContent` (state/markdownToHtml.ts).
-        const { superSubScript, footnote } = muya.options;
+        const { superSubScript, footnote, inlineMath } = muya.options;
         const content = tokensToPlainText(
             tokenizer(source, {
                 hasBeginRules: false,
-                options: { superSubScript, footnote },
+                options: { superSubScript, footnote, inlineMath },
             }),
         ).trim();
 

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -100,6 +100,7 @@ class JSONState {
             trimUnnecessaryCodeBlockEmptyLines,
             frontMatter,
             math,
+            inlineMath,
         } = this._muya.options;
 
         return new MarkdownToState({
@@ -108,6 +109,7 @@ class JSONState {
             trimUnnecessaryCodeBlockEmptyLines,
             frontMatter,
             math,
+            inlineMath,
         }).generate(markdown);
     }
 

--- a/packages/muya/src/state/markdownToHtml.ts
+++ b/packages/muya/src/state/markdownToHtml.ts
@@ -188,6 +188,7 @@ export class MarkdownToHtml {
             isGitlabCompatibilityEnabled:
         this._muya?.options?.isGitlabCompatibilityEnabled ?? true,
             math: this._muya?.options?.math ?? true,
+            inlineMath: this._muya?.options?.inlineMath ?? true,
         });
 
         // Post-process footnotes into the standard GFM / pandoc shape (inline

--- a/packages/muya/src/state/markdownToState.ts
+++ b/packages/muya/src/state/markdownToState.ts
@@ -19,6 +19,7 @@ const debug = logger('import markdown: ');
 interface IMarkdownToStateOptions {
     footnote: boolean;
     math: boolean;
+    inlineMath?: boolean;
     isGitlabCompatibilityEnabled: boolean;
     trimUnnecessaryCodeBlockEmptyLines: boolean;
     frontMatter: boolean;
@@ -27,6 +28,7 @@ interface IMarkdownToStateOptions {
 const DEFAULT_OPTIONS = {
     footnote: false,
     math: true,
+    inlineMath: true,
     isGitlabCompatibilityEnabled: true,
     trimUnnecessaryCodeBlockEmptyLines: false,
     frontMatter: true,
@@ -54,6 +56,7 @@ export class MarkdownToState {
         const {
             footnote = false,
             math = true,
+            inlineMath = true,
             isGitlabCompatibilityEnabled = true,
             trimUnnecessaryCodeBlockEmptyLines = false,
             frontMatter = true,
@@ -65,6 +68,7 @@ export class MarkdownToState {
         const tokens: TBlockToken[] = lexBlock(markdown, {
             footnote,
             math,
+            inlineMath,
             frontMatter,
             isGitlabCompatibilityEnabled,
         });

--- a/packages/muya/src/state/renderToStaticHTML.ts
+++ b/packages/muya/src/state/renderToStaticHTML.ts
@@ -6,6 +6,7 @@ import { transformFootnotes } from './transformFootnotes';
 export interface IRenderToStaticHTMLOptions {
     footnote?: boolean;
     math?: boolean;
+    inlineMath?: boolean;
     isGitlabCompatibilityEnabled?: boolean;
     superSubScript?: boolean;
     frontMatter?: boolean;
@@ -52,6 +53,7 @@ export function renderToStaticHTML(
     let html = getHighlightHtml(markdown, {
         footnote,
         math: options.math ?? true,
+        inlineMath: options.inlineMath ?? true,
         isGitlabCompatibilityEnabled: options.isGitlabCompatibilityEnabled ?? true,
         superSubScript: options.superSubScript ?? true,
         frontMatter: options.frontMatter ?? false,

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -31,6 +31,8 @@ export interface IMuyaOptions {
     spellcheckHideMarks: boolean;
     superSubScript: boolean;
     footnote: boolean;
+    /** Whether single-dollar inline math (`$...$`) is rendered. */
+    inlineMath: boolean;
     math: boolean;
     isGitlabCompatibilityEnabled: boolean;
     autoMoveCheckedToEnd: boolean;

--- a/packages/muya/src/utils/marked/extensions/math.ts
+++ b/packages/muya/src/utils/marked/extensions/math.ts
@@ -12,6 +12,7 @@ export interface IMathToken {
 interface IOptions {
     throwOnError?: boolean;
     useKatexRender?: boolean;
+    inlineMath?: boolean;
 }
 
 const inlineStartRule = /(\s|^)\${1,2}(?!\$)/;
@@ -22,16 +23,19 @@ const blockRule = /^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1[ \t]*(?:\n|$)/;
 const DEFAULT_OPTIONS = {
     throwOnError: false,
     useKatexRender: false,
+    inlineMath: true,
 };
 
 export default function (options: IOptions = {}) {
     const opts = Object.assign({}, DEFAULT_OPTIONS, options);
 
     return {
-        extensions: [
-            inlineKatex(createRenderer(opts, false)),
-            blockKatex(createRenderer(opts, true)),
-        ],
+        extensions: opts.inlineMath
+            ? [
+                    inlineKatex(createRenderer(opts, false)),
+                    blockKatex(createRenderer(opts, true)),
+                ]
+            : [blockKatex(createRenderer(opts, true))],
     };
 }
 

--- a/packages/muya/src/utils/marked/getClipboardHtml.ts
+++ b/packages/muya/src/utils/marked/getClipboardHtml.ts
@@ -12,7 +12,7 @@ import walkTokens from './walkTokens';
 
 export function getClipBoardHtml(src: string, options: ILexOption = {}) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
-    const { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
+    const { footnote, frontMatter, math, inlineMath, isGitlabCompatibilityEnabled, superSubScript }
         = options;
     let html = '';
 
@@ -35,6 +35,7 @@ export function getClipBoardHtml(src: string, options: ILexOption = {}) {
             mathExtension({
                 throwOnError: false,
                 useKatexRender: false,
+                inlineMath,
             }),
         );
     }

--- a/packages/muya/src/utils/marked/getHighlightHtml.ts
+++ b/packages/muya/src/utils/marked/getHighlightHtml.ts
@@ -37,7 +37,7 @@ function highlight(code: string, lang: string) {
 
 export function getHighlightHtml(src: string, options: ILexOption = {}) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
-    const { footnote, frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
+    const { footnote, frontMatter, math, inlineMath, isGitlabCompatibilityEnabled, superSubScript }
         = options;
 
     // Build a fresh Marked instance per call. `Marked.use({ walkTokens })`
@@ -62,6 +62,7 @@ export function getHighlightHtml(src: string, options: ILexOption = {}) {
             mathExtension({
                 throwOnError: false,
                 useKatexRender: true,
+                inlineMath,
             }),
         );
     }

--- a/packages/muya/src/utils/marked/lexBlock.ts
+++ b/packages/muya/src/utils/marked/lexBlock.ts
@@ -13,7 +13,7 @@ export function lexBlock(
     options: ILexOption = DEFAULT_OPTIONS,
 ): TLexedToken[] {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
-    const { math, frontMatter, footnote } = options;
+    const { math, inlineMath, frontMatter, footnote } = options;
     let tokens: (Token | IFrontmatterToken)[] = [];
 
     // Use a per-call Marked instance so extensions don't bleed across calls.
@@ -26,6 +26,7 @@ export function lexBlock(
             mathExtension({
                 throwOnError: false,
                 useKatexRender: false,
+                inlineMath,
             }),
         );
     }

--- a/packages/muya/src/utils/marked/options.ts
+++ b/packages/muya/src/utils/marked/options.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_OPTIONS = {
     footnote: false,
     math: true,
+    inlineMath: true,
     isGitlabCompatibilityEnabled: true,
     frontMatter: true,
     superSubScript: true,

--- a/packages/muya/src/utils/marked/types.ts
+++ b/packages/muya/src/utils/marked/types.ts
@@ -3,6 +3,7 @@ import type { MarkedToken, Tokens } from 'marked';
 export interface ILexOption {
     footnote?: boolean;
     math?: boolean;
+    inlineMath?: boolean;
     isGitlabCompatibilityEnabled?: boolean;
     frontMatter?: boolean;
     superSubScript?: boolean;


### PR DESCRIPTION
Related to #2002. Follow-up to #4231, which was closed unmerged before the TypeScript Muya migration.

## Summary

- Adds a default-on **Inline math** preference under Preferences → Markdown → Extensions.
- When disabled, single-dollar expressions remain literal text, so currency-heavy prose such as `$13B` and `$24B` is not interpreted as math.
- Display math remains enabled and unchanged.
- Applies the option consistently to live editing, Markdown import, clipboard HTML, TOC text, and static HTML/export rendering.

### Why keep inline and display math separate?

This directly addresses the design question raised on #4231. A document can legitimately contain both frequent currency amounts in prose and display equations. Disabling only single-dollar inline parsing removes the ambiguity without removing display math. The new preference defaults to `true`, so existing behavior and saved configurations remain backward compatible.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added.
- [x] Manually tested on macOS arm64.
- [x] `pnpm lint` — 0 errors (existing repository warnings only).
- [x] `pnpm typecheck`.
- [x] `pnpm test` under the CI Node version (22.21.1) — 734 tests passed.
- [x] `pnpm --filter @muyajs/core test` — 1,442 tests passed.
- [x] `pnpm build`.

Regression coverage verifies that:

- default `inlineMath: true` preserves existing rendering;
- `inlineMath: false` keeps currency and `$x+y$` literal;
- toggling the preference re-renders the document immediately;
- display math still renders when inline math is disabled.

## Notes for reviewers

Compared with #4231, this implementation targets the current TypeScript Muya pipeline and propagates the option through all current parsing/rendering entry points, with unit coverage at both the editor and static-rendering layers.

The implementation and tests were generated with OpenAI Codex under user direction, then run and validated locally on the clean PR branch. No theme or unrelated rendering changes are included.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.