### PR TITLE
feat(editor): add fixed/fluid editor width mode and configurable export content width

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -102,6 +102,12 @@
     "pattern": "^(?:$|[0-9]+(?:ch|px|%)$)",
     "default": ""
   },
+  "editorWidthMode": {
+    "description": "Editor--Width mode of the editor area: fixed centers a configured content column, fluid expands the content to fill the window width.",
+    "type": "string",
+    "enum": ["fixed", "fluid"],
+    "default": "fixed"
+  },
   "codeFontSize": {
     "description": "Editor--Font size in code Block, the range is 12 ~ 18",
     "type": "number",

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -111,7 +111,7 @@ import {
   zhTW,
   type ILocale
 } from '@muyajs/core'
-import { exportStyledHTML, type HeaderFooterPart } from '@/util/exportHtml'
+import { exportStyledHTML, exportWidthCss, type HeaderFooterPart } from '@/util/exportHtml'
 import { applyCursor, isIndexCursor } from '@/util/cursor'
 import EditorSearch from '../search/index.vue'
 import bus from '@/bus'
@@ -125,7 +125,7 @@ import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
 import { resolveTocHeadingElement } from '@/util/tocNavigation'
-import { addCommonStyle, setEditorWidth } from '@/util/theme'
+import { addCommonStyle, setEditorWidth, type EditorWidthMode } from '@/util/theme'
 import { usePreferencesStore } from '@/store/preferences'
 import { useEditorStore } from '@/store/editor'
 import { useProjectStore } from '@/store/project'
@@ -232,6 +232,7 @@ const {
   hideLinkPopup,
   autoCheck,
   editorLineWidth,
+  editorWidthMode,
   wrapCodeBlocks,
   imageInsertAction,
   imagePreferRelativeDirectory,
@@ -674,11 +675,11 @@ watch(hideQuickInsertHint, (value, oldValue) => {
   }
 })
 
-watch(editorLineWidth, (value, oldValue) => {
-  if (value !== oldValue) {
-    setEditorWidth(value)
-  }
-})
+const applyEditorWidth = () => {
+  setEditorWidth(editorLineWidth.value, editorWidthMode.value as EditorWidthMode)
+}
+watch(editorLineWidth, applyEditorWidth)
+watch(editorWidthMode, applyEditorWidth)
 
 watch(wrapCodeBlocks, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
@@ -1287,10 +1288,11 @@ const handleExport = async (options: unknown) => {
   switch (type) {
     case 'styledHtml': {
       try {
+        const widthCss = exportWidthCss(typeof opts.exportWidth === 'string' ? opts.exportWidth : '')
         const content = await exportStyledHTML(editor.value, markdown, {
           title: htmlTitle || '',
           printOptimization: false,
-          extraCss,
+          extraCss: extraCss + widthCss,
           toc: htmlToc,
           dir: props.textDirection
         })
@@ -1970,7 +1972,7 @@ onMounted(() => {
 
   document.addEventListener('keyup', keyup)
 
-  setEditorWidth(editorLineWidth.value)
+  setEditorWidth(editorLineWidth.value, editorWidthMode.value as EditorWidthMode)
 })
 
 onBeforeUnmount(() => {

--- a/packages/desktop/src/renderer/src/components/exportSettings/index.vue
+++ b/packages/desktop/src/renderer/src/components/exportSettings/index.vue
@@ -27,6 +27,14 @@
               :emit-time="0"
               :on-change="(value: unknown) => onSelectChange('htmlTitle', value)"
             />
+            <text-box
+              :description="t('exportSettings.page.contentWidth')"
+              :notes="t('exportSettings.page.contentWidthNotes')"
+              :input="exportWidth"
+              :regex-validator="/^(?:$|[0-9]+(?:px|%|ch)$)/"
+              :emit-time="0"
+              :on-change="(value: unknown) => onSelectChange('exportWidth', value)"
+            />
           </div>
 
           <!-- PDF/Print -->
@@ -307,6 +315,7 @@ const isPrintable = ref(true)
 const showExportSettingsDialog = ref(false)
 const activeName = ref('info')
 const htmlTitle = ref('')
+const exportWidth = ref('980px')
 const pageSize = ref('A4')
 const pageSizeWidth = ref(210)
 const pageSizeHeight = ref(297)
@@ -343,6 +352,7 @@ const tocIncludeTopHeading = ref(true)
 // is registered here; changes are saved to localStorage and restored on mount.
 const persistableSettings: Record<string, Ref<unknown>> = {
   htmlTitle,
+  exportWidth,
   pageSize,
   pageSizeWidth,
   pageSizeHeight,
@@ -442,6 +452,7 @@ const handleClicked = () => {
 
   if (!isPrintable.value) {
     options.htmlTitle = htmlTitle.value
+    options.exportWidth = exportWidth.value
   }
 
   if (fontSettingsOverwrite.value) {
@@ -488,6 +499,7 @@ const handleClicked = () => {
 const onSelectChange = (key: string, value: unknown) => {
   const state: Record<string, Ref<unknown>> = {
     htmlTitle,
+    exportWidth,
     pageSize,
     isLandscape,
     fontSettingsOverwrite,

--- a/packages/desktop/src/renderer/src/prefComponents/editor/config.ts
+++ b/packages/desktop/src/renderer/src/prefComponents/editor/config.ts
@@ -55,6 +55,17 @@ export const getTrimTrailingNewlineOptions = (): PrefSelectOption<number>[] => [
   }
 ]
 
+export const getWidthModeOptions = (): PrefSelectOption<string>[] => [
+  {
+    label: t('preferences.editor.textEditor.widthMode.fixed'),
+    value: 'fixed'
+  },
+  {
+    label: t('preferences.editor.textEditor.widthMode.fluid'),
+    value: 'fluid'
+  }
+]
+
 export const getTextDirectionOptions = (): PrefSelectOption<string>[] => [
   {
     label: t('preferences.editor.misc.textDirection.ltr'),

--- a/packages/desktop/src/renderer/src/prefComponents/editor/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/editor/index.vue
@@ -30,7 +30,14 @@
           :value="editorFontFamily"
           :on-change="(value) => onSelectChange('editorFontFamily', value)"
         />
+        <cur-select
+          :description="t('preferences.editor.textEditor.widthMode.label')"
+          :value="editorWidthMode"
+          :options="getWidthModeOptions()"
+          :on-change="(value) => onSelectChange('editorWidthMode', value)"
+        />
         <text-box
+          v-if="editorWidthMode !== 'fluid'"
           :description="t('preferences.editor.textEditor.maxWidth')"
           :notes="t('preferences.editor.textEditor.maxWidthNotes')"
           :input="editorLineWidth"
@@ -197,6 +204,7 @@ import {
   tabSizeOptions,
   getEndOfLineOptions,
   getTextDirectionOptions,
+  getWidthModeOptions,
   getTrimTrailingNewlineOptions,
   getDefaultEncodingOptions
 } from './config'
@@ -226,6 +234,7 @@ const {
   autoNormalizeLineEndings,
   wrapCodeBlocks,
   editorLineWidth,
+  editorWidthMode,
   defaultEncoding,
   autoGuessEncoding,
   trimTrailingNewline

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -48,6 +48,7 @@ export interface PreferencesState {
   trimUnnecessaryCodeBlockEmptyLines: boolean
   wrapCodeBlocks: boolean
   editorLineWidth: string
+  editorWidthMode: string
 
   // ----- Markdown editing -----
   autoPairBracket: boolean
@@ -165,6 +166,7 @@ export const usePreferencesStore = defineStore('preferences', {
     trimUnnecessaryCodeBlockEmptyLines: true,
     wrapCodeBlocks: false,
     editorLineWidth: '',
+    editorWidthMode: 'fixed',
 
     autoPairBracket: true,
     autoPairMarkdownSyntax: true,

--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -162,6 +162,15 @@ const rewriteAnchorHrefs = (html: string): string =>
     return resolved === href ? match : `${pre}${resolved}${post}`
   })
 
+// 守卫：内容宽度必须匹配白名单格式，杜绝任意 CSS 注入导出 <head>
+const EXPORT_WIDTH_RE = /^[0-9]+(?:px|%|ch)$/
+export const exportWidthCss = (value: string): string => {
+  if (value && EXPORT_WIDTH_RE.test(value)) {
+    return `.markdown-body{max-width:${value};}`
+  }
+  return ''
+}
+
 /**
  * Build a styled, standalone HTML document equivalent to legacy muyajs
  * `exportStyledHTML`. Renders markdown through the new engine, injects the TOC

--- a/packages/desktop/src/renderer/src/util/theme.ts
+++ b/packages/desktop/src/renderer/src/util/theme.ts
@@ -197,10 +197,15 @@ export const addThemeStyle = (theme: string): void => {
   }
 }
 
-export const setEditorWidth = (value: string): void => {
+export type EditorWidthMode = 'fixed' | 'fluid'
+
+export const setEditorWidth = (value: string, mode: EditorWidthMode = 'fixed'): void => {
   const EDITOR_WIDTH_STYLE_ID = 'editor-width'
   let result = ''
-  if (value && /^[0-9]+(?:ch|px|%)$/.test(value)) {
+  if (mode === 'fluid') {
+    // box-sizing: border-box 使 100% 已包含 .mu-container 的左右 padding。
+    result = ':root { --editorAreaWidth: 100%; --editor-area-width: 100%; }'
+  } else if (value && /^[0-9]+(?:ch|px|%)$/.test(value)) {
     // Add 100px for the container's horizontal padding. Set both the legacy
     // camelCase var (source mode) and the kebab-case var the active
     // @muyajs/core engine reads for `.mu-container` max-width (issue #4828).

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -273,7 +273,9 @@
       "pageMargin": "Seitenrand (mm):",
       "topBottom": "Oben/Unten:",
       "leftRight": "Links/Rechts:",
-      "widthHeight": "Breite/Höhe (mm):"
+      "widthHeight": "Breite/Höhe (mm):",
+      "contentWidth": "Inhaltsbreite",
+      "contentWidthNotes": "Maximale Breite des exportierten Inhalts. Leer verwendet den Standard 980px."
     },
     "showFrontMatter": "Front Matter anzeigen",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Zeilenhöhe",
         "fontFamily": "Schriftfamilie",
         "maxWidth": "Maximale Breite",
-        "maxWidthNotes": "Maximale Breite des Editor-Inhalts"
+        "maxWidthNotes": "Maximale Breite des Editor-Inhalts",
+        "widthMode": {
+          "label": "Breitenmodus",
+          "fixed": "Fest",
+          "fluid": "Fließend"
+        }
       },
       "codeBlock": {
         "title": "Code-Block",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -273,7 +273,9 @@
       "pageMargin": "Page margin in mm:",
       "topBottom": "Top/Bottom:",
       "leftRight": "Left/Right:",
-      "widthHeight": "Width/Height in mm:"
+      "widthHeight": "Width/Height in mm:",
+      "contentWidth": "Content width",
+      "contentWidthNotes": "Maximum width of the exported content. Empty uses the default 980px."
     },
     "showFrontMatter": "Show front matter",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Line height",
         "fontFamily": "Font family",
         "maxWidth": "Max width",
-        "maxWidthNotes": "Maximum width of editor content"
+        "maxWidthNotes": "Maximum width of editor content",
+        "widthMode": {
+          "label": "Width mode",
+          "fixed": "Fixed",
+          "fluid": "Fluid"
+        }
       },
       "codeBlock": {
         "title": "Code Block",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -273,7 +273,9 @@
       "pageMargin": "Margen de página en mm:",
       "topBottom": "Superior/Inferior:",
       "leftRight": "Izquierda/Derecha:",
-      "widthHeight": "Ancho/Alto en mm:"
+      "widthHeight": "Ancho/Alto en mm:",
+      "contentWidth": "Ancho del contenido",
+      "contentWidthNotes": "Ancho máximo del contenido exportado. Vacío usa el 980px predeterminado."
     },
     "showFrontMatter": "Mostrar metadatos",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Altura de línea",
         "fontFamily": "Familia de fuente",
         "maxWidth": "Ancho máximo",
-        "maxWidthNotes": "Ancho máximo del contenido del editor"
+        "maxWidthNotes": "Ancho máximo del contenido del editor",
+        "widthMode": {
+          "label": "Modo de ancho",
+          "fixed": "Fijo",
+          "fluid": "Fluido"
+        }
       },
       "codeBlock": {
         "title": "Bloque de Código",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -273,7 +273,9 @@
       "pageMargin": "Marge de page (mm) :",
       "topBottom": "Haut/Bas :",
       "leftRight": "Gauche/Droite :",
-      "widthHeight": "Largeur/Hauteur (mm) :"
+      "widthHeight": "Largeur/Hauteur (mm) :",
+      "contentWidth": "Largeur du contenu",
+      "contentWidthNotes": "Largeur maximale du contenu exporté. Vide utilise 980px par défaut."
     },
     "showFrontMatter": "Afficher les métadonnées",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Hauteur de ligne",
         "fontFamily": "Famille de police",
         "maxWidth": "Largeur maximale",
-        "maxWidthNotes": "Largeur maximale du contenu de l'éditeur"
+        "maxWidthNotes": "Largeur maximale du contenu de l'éditeur",
+        "widthMode": {
+          "label": "Mode de largeur",
+          "fixed": "Fixe",
+          "fluid": "Fluide"
+        }
       },
       "codeBlock": {
         "title": "Bloc de code",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -273,7 +273,9 @@
       "pageMargin": "ページ余白 (mm):",
       "topBottom": "上/下:",
       "leftRight": "左/右:",
-      "widthHeight": "幅/高さ (mm):"
+      "widthHeight": "幅/高さ (mm):",
+      "contentWidth": "コンテンツ幅",
+      "contentWidthNotes": "エクスポートされたコンテンツの最大幅。空のデフォルトは980pxです。"
     },
     "showFrontMatter": "フロントマターを表示",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "行の高さ",
         "fontFamily": "フォントファミリー",
         "maxWidth": "最大幅",
-        "maxWidthNotes": "エディターコンテンツの最大幅"
+        "maxWidthNotes": "エディターコンテンツの最大幅",
+        "widthMode": {
+          "label": "幅のモード",
+          "fixed": "固定",
+          "fluid": "流動的"
+        }
       },
       "codeBlock": {
         "title": "コードブロック",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -273,7 +273,9 @@
       "pageMargin": "페이지 여백(mm):",
       "topBottom": "위/아래:",
       "leftRight": "왼쪽/오른쪽:",
-      "widthHeight": "너비/높이(mm):"
+      "widthHeight": "너비/높이(mm):",
+      "contentWidth": "컨텐츠 너비",
+      "contentWidthNotes": "내보낸 컨텐츠의 최대 너비입니다. 비어있으면 기본 980px를 사용합니다."
     },
     "showFrontMatter": "프론트 매터 보기",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "줄 높이",
         "fontFamily": "글꼴 패밀리",
         "maxWidth": "최대 너비",
-        "maxWidthNotes": "편집기 콘텐츠의 최대 너비"
+        "maxWidthNotes": "편집기 콘텐츠의 최대 너비",
+        "widthMode": {
+          "label": "너비 모드",
+          "fixed": "고정",
+          "fluid": "유동체"
+        }
       },
       "codeBlock": {
         "title": "코드 블록",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -273,7 +273,9 @@
       "pageMargin": "Margem da página em mm:",
       "topBottom": "Superior/Inferior:",
       "leftRight": "Esquerda/Direita:",
-      "widthHeight": "Largura/Altura em mm:"
+      "widthHeight": "Largura/Altura em mm:",
+      "contentWidth": "Largura do conteúdo",
+      "contentWidthNotes": "Largura máxima do conteúdo exportado. Vazio usa o padrão 980px."
     },
     "showFrontMatter": "Mostrar front matter",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Altura da linha",
         "fontFamily": "Família da fonte",
         "maxWidth": "Largura máxima",
-        "maxWidthNotes": "Largura máxima do conteúdo do editor"
+        "maxWidthNotes": "Largura máxima do conteúdo do editor",
+        "widthMode": {
+          "label": "Modo de largura",
+          "fixed": "Fixo",
+          "fluid": "Fluido"
+        }
       },
       "codeBlock": {
         "title": "Bloco de Código",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -273,7 +273,9 @@
       "pageMargin": "mm cinsinden sayfa kenar boşluğu:",
       "topBottom": "Üst/Alt:",
       "leftRight": "Sol/Sağ:",
-      "widthHeight": "mm cinsinden Genişlik/Yükseklik:"
+      "widthHeight": "mm cinsinden Genişlik/Yükseklik:",
+      "contentWidth": "İçerik genişliği",
+      "contentWidthNotes": "Dışa aktarılan içeriğin en fazla genişliği. Boş bırakıldığında varsayılan 980px kullanılır."
     },
     "showFrontMatter": "Ön bilgiyi göster",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "Satır yüksekliği",
         "fontFamily": "Yazı tipi ailesi",
         "maxWidth": "Maksimum genişlik",
-        "maxWidthNotes": "Düzenleyici içeriğinin maksimum genişliği"
+        "maxWidthNotes": "Düzenleyici içeriğinin maksimum genişliği",
+        "widthMode": {
+          "label": "Genişlik modu",
+          "fixed": "Sabit",
+          "fluid": "Akıcı"
+        }
       },
       "codeBlock": {
         "title": "Kod Bloğu",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -272,7 +272,9 @@
       "pageMargin": "页面边距（毫米）：",
       "topBottom": "上/下：",
       "leftRight": "左/右：",
-      "widthHeight": "宽度/高度（毫米）："
+      "widthHeight": "宽度/高度（毫米）：",
+      "contentWidth": "内容宽度",
+      "contentWidthNotes": "导出内容的最大宽度。留空使用默认的 980px。"
     },
     "style": {
       "label": "样式",
@@ -510,7 +512,12 @@
         "lineHeight": "行高",
         "fontFamily": "字体系列",
         "maxWidth": "最大宽度",
-        "maxWidthNotes": "编辑器内容的最大宽度"
+        "maxWidthNotes": "编辑器内容的最大宽度",
+        "widthMode": {
+          "label": "宽度模式",
+          "fixed": "固定",
+          "fluid": "流式"
+        }
       },
       "codeBlock": {
         "title": "代码块",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -273,7 +273,9 @@
       "pageMargin": "頁面邊距（毫米）：",
       "topBottom": "上/下：",
       "leftRight": "左/右：",
-      "widthHeight": "寬度/高度（毫米）："
+      "widthHeight": "寬度/高度（毫米）：",
+      "contentWidth": "內容寬度",
+      "contentWidthNotes": "匯出內容的最大寬度。留空使用預設 980px。"
     },
     "showFrontMatter": "顯示前置資料",
     "style": {
@@ -510,7 +512,12 @@
         "lineHeight": "行高",
         "fontFamily": "字型系列",
         "maxWidth": "最大寬度",
-        "maxWidthNotes": "編輯器內容的最大寬度"
+        "maxWidthNotes": "編輯器內容的最大寬度",
+        "widthMode": {
+          "label": "寬度模式",
+          "fixed": "固定",
+          "fluid": "流動"
+        }
       },
       "codeBlock": {
         "title": "程式碼區塊",

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -25,6 +25,7 @@
   "trimUnnecessaryCodeBlockEmptyLines": true,
   "wrapCodeBlocks": false,
   "editorLineWidth": "",
+  "editorWidthMode": "fixed",
 
   "autoPairBracket": true,
   "autoPairMarkdownSyntax": true,

--- a/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
+++ b/packages/desktop/test/unit/specs/editor-theme-style.spec.ts
@@ -123,5 +123,17 @@ describe('theme.ts style injection helpers', () => {
       // the invalid final call cleared the previously valid override
       expect(styleHtml(WIDTH_STYLE_ID)).toBe('')
     })
+
+    it('fluid mode writes a 100% width override (no calc padding offset)', () => {
+      setEditorWidth('', 'fluid')
+      expect(styleHtml(WIDTH_STYLE_ID)).toBe(
+        ':root { --editorAreaWidth: 100%; --editor-area-width: 100%; }'
+      )
+    })
+
+    it('fixed mode (explicit) matches the default calc() behaviour', () => {
+      setEditorWidth('800px', 'fixed')
+      expect(styleHtml(WIDTH_STYLE_ID)).toContain('--editor-area-width: calc(100px + 800px);')
+    })
   })
 })

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -30,7 +30,7 @@ vi.hoisted(() => {
   w.window.DIRNAME = '/docs'
 })
 
-import { exportStyledHTML } from '@/util/exportHtml'
+import { exportStyledHTML, exportWidthCss } from '@/util/exportHtml'
 import { getHtmlToc, type TocEntry } from '@/util/pdf'
 
 // `exportStyledHTML(muya, markdown, options)` renders through the real
@@ -279,5 +279,23 @@ describe('exportStyledHTML — relative link paths (#1688)', () => {
 
     expect(out).toContain('href="#heading"')
     expect(out).not.toContain('file://')
+  })
+})
+
+describe('exportWidthCss + extra max-width injection (#5033)', () => {
+  it('maps a valid width to a .markdown-body max-width rule', () => {
+    expect(exportWidthCss('100%')).toBe('.markdown-body{max-width:100%;}')
+    expect(exportWidthCss('900px')).toBe('.markdown-body{max-width:900px;}')
+  })
+
+  it('rejects empty and invalid values (defensive CSS-injection guard)', () => {
+    expect(exportWidthCss('')).toBe('')
+    expect(exportWidthCss('abc')).toBe('')
+    expect(exportWidthCss('10em')).toBe('')
+  })
+
+  it('injects the override into the exported HTML via extraCss', async() => {
+    const out = await exportStyledHTML(NO_MUYA, '# Hi', { extraCss: exportWidthCss('100%') })
+    expect(out).toContain('.markdown-body{max-width:100%;}')
   })
 })


### PR DESCRIPTION
Closes #5033
Closes #5044

## Summary

Two related width customisation features:

1. **Editor width mode (fixed / fluid)** — new `editorWidthMode` preference (default `fixed`, fully backward compatible). In `fluid` mode the editor content stretches to fill the window width (`--editor-area-width: 100%`), instead of the previous behaviour where even `100%` overflowed because of the `calc(100px + value)` padding offset. In `fixed` mode the existing max-width input (ch/px/%) keeps working as before.

2. **Configurable exported HTML content width** — the export dialog's "Page" tab now has a "Content width" option (default `980px`, accepts px/%/ch). The value is validated against a whitelist and injected through the existing `extraCss` mechanism, so `100%` width is available for wide screens / large Mermaid diagrams. Print/PDF export keeps the fixed 980px layout (constrained by the paper size).

## Type of change

- [x] New feature (non-breaking, adds functionality)

## Test plan

- [x] New tests added — `setEditorWidth` fluid mode and `exportWidthCss` validation/injection cases
- [x] Manually tested on: macOS

## Notes for reviewers

- Fluid mode writes `--editor-area-width: 100%` directly (no `calc(100px + …)` offset) because `.mu-container` uses `box-sizing: border-box`, so 100% already includes its padding.
- Source-code mode reuses the same `--editorAreaWidth` variable, so it follows the width mode automatically with no extra changes.
- The `$`-as-text toggle from #5044 was intentionally left out of scope (independent math-parsing change).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
