### PR TITLE
fix: keep loaded documents clean after normalization

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -323,6 +323,11 @@ const getSyntheticHistory = (id: string, baselineContent: string): SyntheticHist
 const resetSyntheticHistory = (id: string, baselineContent: string): void => {
   syntheticHistoryByTab.set(id, new SyntheticHistory(baselineContent))
 }
+const rebaselineSyntheticHistory = (id: string, baselineContent: string): IFileHistoryLike => {
+  const tracker = new SyntheticHistory(baselineContent)
+  syntheticHistoryByTab.set(id, tracker)
+  return tracker.build(baselineContent)
+}
 const makeSyntheticHistory = (id: string, content: string): IFileHistoryLike => {
   return getSyntheticHistory(id, content).build(content)
 }
@@ -1482,6 +1487,12 @@ const setMarkdownToEditor = (payload: unknown) => {
     // `json-change`, so seed the TOC explicitly (otherwise it stays empty until
     // the first edit, and a file switch keeps the previous file's TOC).
     editorStore.UPDATE_TOC(editor.value.getTOC())
+    // Opening a file may emit an initial normalization `json-change` before the
+    // load baseline is reseeded. Re-sync the store to the engine's loaded
+    // snapshot so an untouched file still closes cleanly (#5074).
+    if (id) {
+      markLoadedContentClean(id)
+    }
     // A freshly created/opened tab should be ready to type into.
     focusFreshEditor()
   }
@@ -1624,6 +1635,20 @@ const blurEditor = () => {
 
 const flushActiveEditor = () => {
   editor.value?.flush()
+}
+
+const markLoadedContentClean = (id: string): void => {
+  const ed = editor.value
+  if (!ed) return
+
+  const markdown = ed.getMarkdown()
+  editorStore.LISTEN_FOR_CONTENT_CHANGE({
+    id,
+    markdown,
+    history: rebaselineSyntheticHistory(id, markdown),
+    toc: ed.getTOC(),
+    blocks: ed.getState()
+  })
 }
 
 const focusEditor = () => {
@@ -1801,7 +1826,11 @@ onMounted(() => {
   // after the first edit — so the pristine content never maps to id 0 and
   // undoing back to the on-disk content can never read as clean again (PG15).
   if (currentFile.value?.id) {
-    getSyntheticHistory(currentFile.value.id, muya.getMarkdown())
+    if (currentFile.value.isSaved) {
+      markLoadedContentClean(currentFile.value.id)
+    } else {
+      getSyntheticHistory(currentFile.value.id, muya.getMarkdown())
+    }
   }
 
   const container = getScrollContainer()!

--- a/packages/desktop/test/unit/specs/source-mode-dirty.spec.ts
+++ b/packages/desktop/test/unit/specs/source-mode-dirty.spec.ts
@@ -82,4 +82,21 @@ describe('useEditorStore LISTEN_FOR_CONTENT_CHANGE — source-mode dirty trackin
 
     expect(tab.isSaved).toBe(true)
   })
+
+  it('can rebaseline a load-time normalized document back to clean (#5074)', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+    tab.isSaved = false
+    tab.markdown = 'hello\n'
+    tab.lastSavedHistoryId = 0
+    tab.history = { stack: [{ id: 1 }], lastEditIndex: 0, lastInitIndex: -1 } as never
+
+    store.LISTEN_FOR_CONTENT_CHANGE({
+      id: 'tab-1',
+      markdown: 'hello\n\n',
+      history: { stack: [{ id: 0 }], lastEditIndex: 0, lastInitIndex: -1 } as never
+    })
+
+    expect(tab.isSaved).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- After load-time markdown normalization, rebaseline editor history so an unmodified opened file stays clean.
- Prevents the save/don't-save prompt when closing a tab that was never edited.

Fixes #5074

## Test plan
- [ ] Open a markdown file, make no edits, close the tab — no save dialog.
- [ ] Edit then close — save dialog still appears.
- [x] Unit coverage in `source-mode-dirty.spec.ts` for load-time normalization rebaseline.
