### PR TITLE
fix(desktop): flush pending edits before entering source code mode

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -818,6 +818,14 @@ watch(
     if (value && value !== oldValue) {
       if (editor.value) {
         editor.value.hideAllFloatTools()
+        // Flush the engine's queued rAF-batch ops into the tab before
+        // sourceCode.vue mounts and snapshots `currentFile.markdown` — an edit
+        // made in the same frame as the mode switch (e.g. a task-checkbox
+        // click) would otherwise be missing from the snapshot, and the swap
+        // back out of source mode cancels the scheduled flush, dropping the
+        // edit permanently. Same guard as saving (#3803) and tab switch
+        // (#2938).
+        editor.value.flush()
         // Compute the WYSIWYG caret as a source-markdown `{ line, ch }` index
         // cursor JUST-IN-TIME, only when entering source mode (Phase G — G7),
         // and write it to the tab before sourceCode.vue mounts (`flush: 'sync'`

--- a/packages/desktop/test/e2e/source-mode-flush.spec.ts
+++ b/packages/desktop/test/e2e/source-mode-flush.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  launchWithMarkdown,
+  waitForMenuReady,
+  getMarkdownContent,
+  expectNoRendererErrors
+} from './helpers'
+
+// Entering source mode must flush the engine's queued rAF-batch ops into the
+// tab first. An edit made in the same frame as the mode switch (here: a task
+// checkbox click) was missing from the CodeMirror snapshot, and switching back
+// out of source mode cancelled the scheduled flush — silently reverting the
+// edit. Same unflushed-edit class as saving (#3803) and tab switch (#2938).
+
+const NESTED_TASKS = '- [ ] parent\n\n  - [ ] child1\n  - [ ] child2\n'
+
+const checkboxCount = async(page: Page): Promise<number> => {
+  return await page.evaluate(
+    () => document.querySelectorAll('.editor-component input[type=checkbox]').length
+  )
+}
+
+test.describe('source mode entry flushes same-frame edits', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown(NESTED_TASKS, { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await waitForMenuReady(app)
+    await expect.poll(() => checkboxCount(page)).toBe(3)
+  })
+
+  test.afterAll(async() => {
+    await app.close()
+  })
+
+  test('a checkbox click immediately followed by source mode is not lost', async() => {
+    await page.click('.editor-component input[type=checkbox] >> nth=0')
+
+    // No settle wait: the very next thing the source view shows must already
+    // contain the toggle.
+    const md = await getMarkdownContent(page, app)
+    expect(md).toContain('- [x] parent')
+
+    // And the toggle survives the roundtrip back to WYSIWYG.
+    await page.waitForTimeout(300)
+    const after = await getMarkdownContent(page, app)
+    expect(after).toContain('- [x] parent')
+
+    await expectNoRendererErrors(app)
+  })
+})


### PR DESCRIPTION
Fixes #5102

### Problem

An edit made in the WYSIWYG editor in the same frame as switching to source code mode (deterministic repro: clicking a task-list checkbox, then immediately toggling **View → Source Code Mode**) is silently lost:

1. `@muyajs/core` queues the edit in its deferred rAF op batch (`JSONState`).
2. `sourceCode.vue` mounts and snapshots `currentFile.markdown` before that batch flushes, so CodeMirror opens on stale content.
3. Exiting source mode applies the stale snapshot back via `setContent`, which cancels the still-pending batch by design (#4658) — the edit is reverted permanently, with no undo entry.

This is the same unflushed-batch class as #3803 (dropped edit on save, fixed in #4859) and the tab-switch guard (#2938); source-mode entry was the remaining reader of `currentFile.markdown` without a flush.

It also explains a deterministic e2e failure on develop on macOS: `test/e2e/task-list-autocheck.spec.ts` › "with autoCheck OFF, clicking the parent changes only the parent" clicks a checkbox and immediately reads markdown through a source-mode round-trip, and fails 4/4 runs without this fix.

### Fix

Call `editor.value.flush()` in the existing `watch(sourceCode, …, { flush: 'sync' })` handler in `editorWithTabs/editor.vue` — the sync watcher that already prepares the tab (JIT cursor) before the `v-if`-gated `sourceCode.vue` mounts. The pending batch lands in the tab first, so the snapshot is always fresh.

### Tests

- New regression spec `test/e2e/source-mode-flush.spec.ts`: clicks a checkbox and immediately round-trips through source mode with no settle wait; asserts the toggle is present in the source view and survives the round-trip. Fails on develop, passes with the fix.
- `task-list-autocheck.spec.ts` (previously failing deterministically on macOS): now passes, including with `--repeat-each=2`.
- Full suites on macOS arm64: unit 734/734, e2e 216 passed / 4 skipped, `lint` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
