### PR TITLE
fix: validate cliScript path before execFile in uploader IPC handler

### DIFF
--- a/packages/desktop/src/main/ipc/uploader.ts
+++ b/packages/desktop/src/main/ipc/uploader.ts
@@ -106,8 +106,19 @@ const uploadByPicgo = (localPath: string): Promise<string> =>
 
 const uploadByCli = (cliScript: string, localPath: string): Promise<string> =>
   new Promise((resolve, reject) => {
+    if (!cliScript) return reject(new Error('No CLI script specified'))
+    const resolved = path.resolve(cliScript)
+    const tmpPrefixes = [tmpdir(), '/tmp', '/var/tmp'].map((d) => path.resolve(d))
+    if (tmpPrefixes.some((t) => resolved === t || resolved.startsWith(t + path.sep))) {
+      return reject(new Error(`CLI script in temporary directory is not allowed: ${cliScript}`))
+    }
+    try {
+      fs.accessSync(resolved, fs.constants.X_OK)
+    } catch {
+      return reject(new Error(`CLI script not found or not executable: ${cliScript}`))
+    }
     execFile(
-      cliScript,
+      resolved,
       [localPath],
       { env: { ...process.env, PATH: buildPreferredPathEnv() } },
       (err, data) => {


### PR DESCRIPTION
Closes #5124 

## Summary

Reject empty paths, temp directory paths, and non-executable files to prevent write-then-execute attacks via the renderer.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [ ] New tests added (or explain why not needed)
- [x] Manually tested on: macOS

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
