### PR TITLE
fix: #5129 detect system language on first start

### DIFF
--- a/packages/desktop/src/common/i18n.ts
+++ b/packages/desktop/src/common/i18n.ts
@@ -97,6 +97,35 @@ function isLanguageSupported(language: string): boolean {
   return (SUPPORTED_LANGUAGES as readonly string[]).includes(language)
 }
 
+/**
+ * Maps a system locale (e.g. `zh`, `zh-HK`, `pt-PT`) to a supported language
+ * code: exact match first, then any supported language with the same primary
+ * subtag. Returns null when nothing matches, including for an empty locale —
+ * `app.getLocale()` returns an empty string before the app is ready, and an
+ * empty primary subtag would otherwise match every entry.
+ */
+function matchSupportedLanguage(locale: string): string | null {
+  if (!locale) {
+    return null
+  }
+  if (isLanguageSupported(locale)) {
+    return locale
+  }
+  const primarySubtag = locale.split('-')[0]!.toLowerCase()
+
+  // The zh family splits by script rather than region: traditional characters
+  // are used in TW, HK and MO (zh-Hant), everything else is simplified.
+  if (primarySubtag === 'zh') {
+    const secondSubtag = (locale.split('-')[1] ?? '').toLowerCase()
+    return ['tw', 'hk', 'mo', 'hant'].includes(secondSubtag) ? 'zh-TW' : 'zh-CN'
+  }
+
+  return (
+    getSupportedLanguages().find(lang => lang.split('-')[0]!.toLowerCase() === primarySubtag) ??
+    null
+  )
+}
+
 function clearCache(): void {
   translationsCache = {}
 }
@@ -109,6 +138,7 @@ export {
   getTranslation,
   getSupportedLanguages,
   isLanguageSupported,
+  matchSupportedLanguage,
   clearCache,
   getAllTranslations,
   loadTranslations

--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -21,6 +21,7 @@ import { WindowType } from '../windows/base'
 import EditorWindow from '../windows/editor'
 import SettingWindow from '../windows/setting'
 import { setLanguage } from '../i18n'
+import { matchSupportedLanguage } from 'common/i18n'
 import { getNativeThemeSource, isDarkApplicationTheme } from './nativeTheme'
 import type Accessor from './accessor'
 import type WindowManager from './windowManager'
@@ -56,8 +57,6 @@ class App {
     // this.launchScreenshotWin = null // The window which call the screenshot.
     // this.shortcutCapture = null
 
-    // Initialize main process language
-    this._initializeLanguage()
     this._listenForIpcMain()
     // Initialize theme listener
     this._themeListenerRegistered = false
@@ -144,70 +143,24 @@ class App {
   }
 
   /**
-   * Initialize main process language from preferences
+   * Initialize the main process language from preferences, detecting the
+   * system language on first start. Must run after the app is ready —
+   * `app.getLocale()` returns an empty string before the ready event — and
+   * before the first window is created so menus and the renderer start in
+   * the right language.
    */
-  private async _initializeLanguage(): Promise<void> {
+  private _initializeLanguage(): void {
     try {
       let currentLanguage = this._accessor.preferences.getItem<string>('language')
 
-      // If no language is set, auto-detect based on the system language
+      // If no language is set (first start), auto-detect from the system language
       if (!currentLanguage) {
-        const systemLanguage = app.getLocale()
-        log.info(`System language detected: ${systemLanguage}`)
-
-        // Supported language list (based on languages actually supported by the project)
-        const supportedLanguages = [
-          'en',
-          'zh-CN',
-          'zh-TW',
-          'ja',
-          'ko',
-          'fr',
-          'de',
-          'es',
-          'nl',
-          'pt',
-          'ru'
-        ]
-
-        // Language mapping: system language code -> application language code
-        const languageMap: Record<string, string> = {
-          'zh-CN': 'zh-CN',
-          'zh-TW': 'zh-TW',
-          'zh-HK': 'zh-TW',
-          zh: 'zh-CN',
-          en: 'en',
-          'en-US': 'en',
-          'en-GB': 'en',
-          ja: 'ja',
-          'ja-JP': 'ja',
-          ko: 'ko',
-          'ko-KR': 'ko',
-          fr: 'fr',
-          'fr-FR': 'fr',
-          de: 'de',
-          'de-DE': 'de',
-          es: 'es',
-          'es-ES': 'es',
-          nl: 'nl',
-          'nl-NL': 'nl',
-          'nl-BE': 'nl',
-          pt: 'pt',
-          'pt-BR': 'pt',
-          ru: 'ru',
-          'ru-RU': 'ru'
-        }
-
-        currentLanguage = languageMap[systemLanguage] || 'en'
-
-        // If the detected language is not in the supported list, use English
-        if (!supportedLanguages.includes(currentLanguage)) {
-          currentLanguage = 'en'
-        }
-
-        // Save the detected language setting
+        const systemLocale = app.getLocale()
+        currentLanguage = matchSupportedLanguage(systemLocale) ?? 'en'
         this._accessor.preferences.setItem('language', currentLanguage)
-        log.info(`Auto-detected and set language to: ${currentLanguage}`)
+        log.info(
+          `Auto-detected and set language to: ${currentLanguage} (system locale: ${systemLocale})`
+        )
       }
 
       setLanguage(currentLanguage)
@@ -231,16 +184,13 @@ class App {
     const { _args: args, _openFilesCache } = this
     const { preferences, editorBufferStore } = this._accessor
 
-    // Initialize language settings
-    const { startUpAction, defaultDirectoryToOpen, theme, language } = preferences.getAll()
+    // Initialize language settings (detects the system language on first start)
+    this._initializeLanguage()
+    const { startUpAction, defaultDirectoryToOpen, theme } = preferences.getAll()
     const followSystemTheme = preferences.getItem<boolean>('followSystemTheme')
     const lastOpenedFolder = preferences.getItem<string>('lastOpenedFolder')
     const lightModeTheme = preferences.getItem<string>('lightModeTheme')
     const darkModeTheme = preferences.getItem<string>('darkModeTheme')
-
-    if (language) {
-      setLanguage(language)
-    }
 
     if (args._.length) {
       for (const pathname of args._) {

--- a/packages/desktop/src/main/preferences/index.ts
+++ b/packages/desktop/src/main/preferences/index.ts
@@ -1,12 +1,11 @@
 import fs from 'fs'
 import path from 'path'
 import Store, { type Schema } from 'electron-store'
-import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
+import { BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import log from 'electron-log'
 import { isWindows } from '../config'
 import { hasSameKeys } from '../utils'
 import { onInternalChannel } from '../utils/internalIpc'
-import { getSupportedLanguages, isLanguageSupported } from 'common/i18n'
 import { TypedEmitter } from '@shared/types/typedEmitter'
 import type { IUserPreferences } from '@shared/types/preferences'
 import schema from './schema.json'
@@ -71,12 +70,13 @@ class Preference extends TypedEmitter<PreferenceEvents> {
         defaultSettings!.theme = 'dark'
       }
 
-      // Set system language on first application start
+      // First start: leave `language` unset so it can be detected from the
+      // system language once the app is ready. `app.getLocale()` returns an
+      // empty string before the ready event, so detecting here would always
+      // fall back to English. The key stays in preference.json, so the
+      // hasSameKeys cleanup below keeps treating it as a known setting.
       if (!this.hasPreferencesFile) {
-        const systemLanguage = this._getSystemLanguage()
-        if (systemLanguage) {
-          defaultSettings!.language = systemLanguage
-        }
+        delete defaultSettings!.language
       }
     } catch (err) {
       log.error(err)
@@ -190,42 +190,6 @@ class Preference extends TypedEmitter<PreferenceEvents> {
     onInternalChannel('set-user-preference', (settings: Record<string, unknown>) => {
       this.setItems(settings)
     })
-  }
-
-  /**
-   * Gets the system language, or null if it's not in the supported list
-   * @returns Supported system language code or null
-   */
-  _getSystemLanguage(): string | null {
-    try {
-      // Get the system language
-      const systemLocale = app.getLocale()
-      log.info(`System locale detected: ${systemLocale}`)
-
-      // Get the list of supported languages
-      const supportedLanguages = getSupportedLanguages()
-
-      // Directly match the full language code (e.g. zh-CN)
-      if (isLanguageSupported(systemLocale)) {
-        log.info(`Using system language: ${systemLocale}`)
-        return systemLocale
-      }
-
-      // Attempt to match the primary part of the language (e.g. zh)
-      const primaryLanguage = systemLocale.split('-')[0]!
-      const matchedLanguage = supportedLanguages.find((lang) => lang.startsWith(primaryLanguage))
-
-      if (matchedLanguage) {
-        log.info(`Using matched language: ${matchedLanguage} for system locale: ${systemLocale}`)
-        return matchedLanguage
-      }
-
-      log.info(`System language ${systemLocale} not supported, will use default language`)
-      return null
-    } catch (error) {
-      log.error('Error detecting system language:', error)
-      return null
-    }
   }
 }
 

--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -67,9 +67,8 @@
     "type": "string"
   },
   "language": {
-    "description": "General--The language MarkText uses.",
-    "type": "string",
-    "default": "en"
+    "description": "General--The language MarkText uses. No default on purpose: the language is auto-detected from the system locale on first start (after app ready), so a schema default would always win over detection.",
+    "type": "string"
   },
   "editorFontFamily": {
     "description": "Editor--editor font family",

--- a/packages/desktop/test/unit/specs/i18n.spec.ts
+++ b/packages/desktop/test/unit/specs/i18n.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest'
+import { matchSupportedLanguage } from '../../../src/common/i18n'
 
 interface MockI18nUtils {
   loadTranslations: Mock
@@ -7,6 +8,44 @@ interface MockI18nUtils {
 // Window.i18nUtils is required in the runtime contextBridge typing, but in
 // this unit test we install a mock with `vi.fn` and remove it between specs.
 const win = window as unknown as { i18nUtils?: MockI18nUtils }
+
+// The main process resolves the system locale to a supported UI language via
+// matchSupportedLanguage on first start (after app ready — `app.getLocale()`
+// is empty before that, see src/main/app/index.ts).
+describe('common/i18n matchSupportedLanguage', () => {
+  it('returns the locale itself when exactly supported', () => {
+    expect(matchSupportedLanguage('zh-CN')).toBe('zh-CN')
+    expect(matchSupportedLanguage('en')).toBe('en')
+    expect(matchSupportedLanguage('zh-TW')).toBe('zh-TW')
+  })
+
+  it('returns null for an empty locale (app.getLocale() before ready)', () => {
+    expect(matchSupportedLanguage('')).toBeNull()
+  })
+
+  it('falls back to the primary subtag for unsupported regions', () => {
+    expect(matchSupportedLanguage('pt-PT')).toBe('pt')
+    expect(matchSupportedLanguage('en-GB')).toBe('en')
+    expect(matchSupportedLanguage('ja-JP')).toBe('ja')
+    expect(matchSupportedLanguage('de-AT')).toBe('de')
+  })
+
+  it('splits the zh family by script: TW/HK/MO use traditional characters', () => {
+    expect(matchSupportedLanguage('zh')).toBe('zh-CN')
+    expect(matchSupportedLanguage('zh-SG')).toBe('zh-CN')
+    expect(matchSupportedLanguage('zh-Hans')).toBe('zh-CN')
+    expect(matchSupportedLanguage('zh-HK')).toBe('zh-TW')
+    expect(matchSupportedLanguage('zh-MO')).toBe('zh-TW')
+    expect(matchSupportedLanguage('zh-Hant')).toBe('zh-TW')
+    expect(matchSupportedLanguage('zh-Hant-TW')).toBe('zh-TW')
+  })
+
+  it('returns null for languages without a supported translation', () => {
+    expect(matchSupportedLanguage('ru-RU')).toBeNull()
+    expect(matchSupportedLanguage('it')).toBeNull()
+    expect(matchSupportedLanguage('xx-YY')).toBeNull()
+  })
+})
 
 describe('renderer i18n language loading', () => {
   beforeEach(() => {


### PR DESCRIPTION
Fixes #5129.

## Problem

On a fresh profile MarkText always starts in English, even when the system locale is a supported non-English language (e.g. zh-CN). Two independent causes, details in the issue:

1. **Detection runs before the app is ready.** `Preference#init()` called `app.getLocale()` during bootstrap; before `ready` it returns `''`, whose empty primary subtag matches the first supported language (`en`), and that value is persisted — permanently disabling any later detection.
2. **A schema default made "unset" impossible.** `schema.json` declared `"language": {"default": "en"}` and electron-store validates with ajv `useDefaults: true`, so every `store.set()` injected `language: 'en'` even when the key was intentionally omitted. The `if (!currentLanguage)` fallback in `app/index.ts` was dead code.

## Changes

- Detect the system language once, at the beginning of the `ready` handler (`src/main/app/index.ts`) — after `app.getLocale()` is meaningful, and before the first window/menus are created, so menus and renderer start in the right language. On first start the detected language is persisted; afterwards the stored preference wins.
- Stop persisting a language during first-start bootstrap (`src/main/preferences/index.ts`); remove the now-unused pre-ready detection helper.
- Drop the `language` schema default (`src/main/preferences/schema.json`) so "not set yet" is representable.
- Consolidate locale matching into `matchSupportedLanguage()` in `src/common/i18n.ts`: exact match, then primary subtag; the `zh` family splits by script so `zh-HK`/`zh-MO`/`zh-Hant*` resolve to `zh-TW`. Empty locale returns `null` (guards the pre-ready case).
- Remove the duplicated hardcoded language table in `app/index.ts` that also listed `ru`, for which no translation exists (`ru-RU` now falls back to `en` instead of persisting a bogus `ru`).
- Unit tests for `matchSupportedLanguage` in `test/unit/specs/i18n.spec.ts` (empty locale, exact/primary-subtag match, zh script split, unsupported languages).

## Demonstration

First start on a zh-CN system, same machine, fresh profile both times.

**Before** (develop @ e52106f) — UI in English:

```
System locale detected:
Using matched language: en for system locale:
Main process language initialized to: en
```
<img width="2920" height="1738" alt="before-en" src="https://github.com/user-attachments/assets/52d5798d-cca4-4c57-b2ce-1f7d06624b11" />


**After** (this PR) — UI in Simplified Chinese:

```
Auto-detected and set language to: zh-CN (system locale: zh-CN)
Main process language initialized to: zh-CN
```
<img width="2936" height="1748" alt="after-zh-cn" src="https://github.com/user-attachments/assets/e653adf9-5b8a-4874-a189-f1689632a5fe" />

## Testing

- `pnpm -C packages/desktop exec vitest run test/unit/specs/i18n.spec.ts` — 9/9 pass
- `pnpm run lint`, `pnpm run typecheck` — clean
- Manual: fresh-profile first start on zh-CN → Chinese UI; second start keeps zh-CN without re-detection; manual language switching via preferences unaffected.
