### PR TITLE
fix: #5130  keep Electron locale resources for all supported UI languages

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -48,8 +48,28 @@ extraResources:
       - '**/*'
       - '!locales/**/!(*.min).json'
 npmRebuild: false
-electronLanguages: # Avoid packaging all chromium locales since our app has in-built locales
+electronLanguages: # Keep Chromium/AppKit locales for the UI languages MarkText supports
+  # Values must cover both spellings: "xx-YY" .pak files on Windows/Linux and
+  # "xx_YY" .lproj bundles on macOS. Keeping them lets OS-provided strings
+  # (e.g. the macOS Window management items) localize on non-English systems;
+  # the in-built locales are still the source for the app's own UI.
   - en-US
+  - en
+  - de
+  - es
+  - fr
+  - ja
+  - ko
+  - nl
+  - pt-BR
+  - pt-PT
+  - pt_BR
+  - pt_PT
+  - tr
+  - zh-CN
+  - zh-TW
+  - zh_CN
+  - zh_TW
 
 asarUnpack:
   - resources/**


### PR DESCRIPTION
Fixes #5130

## Problem

`electron-builder.yml` prunes the packaged app to `electronLanguages: [en-US]`. On macOS this also removes the per-language `.lproj` declarations from the app bundle, so macOS treats MarkText as an English-only app and renders **system-provided** UI in English even when both the OS language and MarkText's own UI language are not English. Most visibly, the macOS Sequoia Window-management items injected into the Window menu (`Fill`, `Center`, `Enter Full Screen`, `Move & Resize`, `Full Screen Tile`, `Remove Window from Set`) stay in English. Dev builds are unaffected because they run inside the unpruned `Electron.app`.

## Change

Keep the Chromium/AppKit locales matching the ten languages MarkText ships translations for. Details:

- macOS bundle folders are spelled with underscores (`zh_CN.lproj`) while Windows/Linux `.pak` files use hyphens (`zh-CN.pak`); app-builder-lib matches them literally, so both spellings are listed for region-specific locales.
- The added weight is a handful of empty `.lproj` folders on macOS and ~16 small `.pak` files on Windows/Linux — the original goal of the pruning (not shipping all ~50 Chromium locales) is preserved.

## Demonstration

Same machine, macOS system language and app language both 简体中文.

Before (v0.19.1 DMG, `electronLanguages: [en-US]`) — MarkText's own items are Chinese, but the macOS-injected Window-management section is English (`Fill ⌃⌥F`, `Center ⌃⌥C`, `Enter Full Screen ⌥F`, `Move & Resize ▸`, `Full Screen Tile ▸`, `Remove Window from Set`):

<img width="1174" height="1064" alt="window-before-en" src="https://github.com/user-attachments/assets/16af3da8-7e93-4e84-b919-6d8d93867326" />


After (local build of develop with this change, fresh profile) — the injected section follows the system language as well (填充 / 居中 / 进入全屏幕 / 移动和调整大小 / 全屏幕平铺 / 从组合中移掉窗口):

<img width="1718" height="1232" alt="window-after-zh-cn" src="https://github.com/user-attachments/assets/f960edb8-3a97-4450-b21c-b1f303c86c48" />



## Testing

- Built the mac arm64 target locally with this change and verified `marktext.app/Contents/Resources` retains all 11 relevant `.lproj` folders (`en, de, es, fr, ja, ko, pt_BR, pt_PT, tr, zh_CN, zh_TW`) instead of just `en` — the after screenshot above is from that build.
- Note on the double spelling: app-builder-lib matches the wanted languages literally against on-disk names, and macOS uses underscores (`zh_CN.lproj`) while Windows/Linux use hyphens (`zh-CN.pak`), so region-specific locales need both spellings to take effect on every platform.