### PR TITLE
fix: check Linux system deps before native rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# MarkText — development setup & build
+# Usage:
+#   make deps      Install system dependencies (requires sudo)
+#   make install   Install node modules + rebuild native deps
+#   make dev       Start in development mode
+#   make build     Build for Linux
+#   make clean     Clean build artifacts
+
+SHELL := /bin/bash
+
+# System packages required for native-keymap and other native modules (Linux)
+LINUX_DEPS := libx11-dev libxkbfile-dev libsecret-1-dev pkg-config build-essential python3
+
+.PHONY: help deps install dev build clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+deps: ## Install system dependencies (requires sudo)
+	sudo apt-get update && sudo apt-get install -y $(LINUX_DEPS)
+
+install: ## Install node modules and rebuild native deps
+	pnpm install
+
+dev: ## Start MarkText in development mode
+	pnpm dev
+
+build: ## Build MarkText for Linux
+	pnpm build:linux
+
+clean: ## Clean build artifacts
+	rm -rf packages/desktop/dist packages/desktop/build
+	pnpm --filter marktext exec -- rm -rf dist build

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -24,9 +24,30 @@
 const { execSync } = require('child_process')
 const path = require('path')
 const fs = require('fs')
+const os = require('os')
 
 const repoRoot = path.join(__dirname, '..')
 const desktopRoot = path.join(repoRoot, 'packages', 'desktop')
+
+// ── 0. Verify system dependencies (Linux only) ─────────────────────────────
+if (os.platform() === 'linux') {
+  const requiredPkgs = ['libx11-dev', 'libxkbfile-dev', 'libsecret-1-dev', 'pkg-config']
+  const missing = requiredPkgs.filter((pkg) => {
+    try {
+      execSync(`dpkg -s ${pkg}`, { stdio: 'ignore' })
+      return false
+    } catch {
+      return true
+    }
+  })
+  if (missing.length > 0) {
+    console.error('\n\x1b[31m✖ Missing system dependencies:\x1b[0m', missing.join(', '))
+    console.error('\n  Install them with:\n')
+    console.error(`    sudo apt-get install -y ${missing.join(' ')}\n`)
+    console.error('  Then re-run: pnpm install\n')
+    process.exit(1)
+  }
+}
 
 function run(cmd, opts = {}) {
   const { cwd = repoRoot, env = {} } = opts
@@ -62,7 +83,6 @@ const electronInstall = path.join(desktopRoot, 'node_modules', 'electron', 'inst
 if (!fs.existsSync(electronInstall)) {
   console.error('electron/install.js not found — skipping Electron download')
 } else {
-  const os = require('os')
   const plat =
     process.env.ELECTRON_INSTALL_PLATFORM || process.env.npm_config_platform || os.platform()
   const platformBinary =

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -31,21 +31,57 @@ const desktopRoot = path.join(repoRoot, 'packages', 'desktop')
 
 // ── 0. Verify system dependencies (Linux only) ─────────────────────────────
 if (os.platform() === 'linux') {
-  const requiredPkgs = ['libx11-dev', 'libxkbfile-dev', 'libsecret-1-dev', 'pkg-config']
-  const missing = requiredPkgs.filter((pkg) => {
-    try {
-      execSync(`dpkg -s ${pkg}`, { stdio: 'ignore' })
-      return false
-    } catch {
-      return true
+  // Detect available package manager
+  const hasCmd = (cmd) => {
+    try { execSync(`command -v ${cmd}`, { stdio: 'ignore' }); return true } catch { return false }
+  }
+
+  const isDpkg = hasCmd('dpkg')
+  const isRpm = hasCmd('rpm')
+
+  if (isDpkg) {
+    const requiredPkgs = [
+      'libx11-dev', 'libxkbfile-dev', 'libsecret-1-dev',
+      'pkg-config', 'build-essential', 'python3'
+    ]
+    const missing = requiredPkgs.filter((pkg) => {
+      try {
+        execSync(`dpkg -s ${pkg}`, { stdio: 'ignore' })
+        return false
+      } catch {
+        return true
+      }
+    })
+    if (missing.length > 0) {
+      console.error('\n\x1b[31m✖ Missing system dependencies:\x1b[0m', missing.join(', '))
+      console.error('\n  Install them with:\n')
+      console.error(`    sudo apt-get install -y ${missing.join(' ')}\n`)
+      console.error('  Then re-run: pnpm install\n')
+      process.exit(1)
     }
-  })
-  if (missing.length > 0) {
-    console.error('\n\x1b[31m✖ Missing system dependencies:\x1b[0m', missing.join(', '))
-    console.error('\n  Install them with:\n')
-    console.error(`    sudo apt-get install -y ${missing.join(' ')}\n`)
-    console.error('  Then re-run: pnpm install\n')
-    process.exit(1)
+  } else if (isRpm) {
+    const requiredPkgs = [
+      'libX11-devel', 'libxkbfile-devel', 'libsecret-devel',
+      'pkg-config', 'gcc-c++', 'make', 'python3'
+    ]
+    const missing = requiredPkgs.filter((pkg) => {
+      try {
+        execSync(`rpm -q ${pkg}`, { stdio: 'ignore' })
+        return false
+      } catch {
+        return true
+      }
+    })
+    if (missing.length > 0) {
+      console.error('\n\x1b[31m✖ Missing system dependencies:\x1b[0m', missing.join(', '))
+      console.error('\n  Install them with:\n')
+      console.error(`    sudo dnf install -y ${missing.join(' ')}\n`)
+      console.error('  Then re-run: pnpm install\n')
+      process.exit(1)
+    }
+  } else {
+    console.warn('\n\x1b[33m⚠ Cannot verify system dependencies (no dpkg or rpm found).\x1b[0m')
+    console.warn('  Ensure these are installed: libx11-dev libxkbfile-dev libsecret-1-dev pkg-config build-essential python3\n')
   }
 }
 


### PR DESCRIPTION
Closes #5133

## Summary

`pnpm install` on Linux fails with a cryptic `node-gyp` error when system dependencies (`libx11-dev`, `libxkbfile-dev`, `libsecret-1-dev`) are missing. This PR adds a clear pre-flight check.

## Changes

- **`scripts/postinstall.ts`**: Added a Linux-only check (step 0) that verifies required system packages via `dpkg -s` before attempting the native rebuild. On failure, prints the exact `apt-get install` command needed.
- **`Makefile`**: Added for dev workflow convenience (`make deps`, `make install`, `make dev`, `make build`). Happy to discuss whether this belongs in the project.

## Testing

- Verified on Linux Mint 22.3 with Node v24.15.0 and pnpm 10.33.4
- Without deps: clear error message with install instructions
- With deps: postinstall completes successfully