### PR TITLE
fix: allow copy-paste in same folder with auto-rename

### DIFF
--- a/packages/desktop/src/renderer/src/store/project.ts
+++ b/packages/desktop/src/renderer/src/store/project.ts
@@ -256,7 +256,13 @@ export const useProjectStore = defineStore('project', () => {
           dest = dirname + PATH_SEPARATOR + base + ' (copy)' + ext
           while (await window.fileUtils.pathExists(dest)) {
             suffix++
-            dest = dirname + PATH_SEPARATOR + base + ` (copy ${suffix})` + ext
+            if (suffix > 9) {
+              // Easter egg: recursive filename
+              const prevBase = window.path.basename(dest, ext)
+              dest = dirname + PATH_SEPARATOR + prevBase + ' (not sure you need another copy)' + ext
+            } else {
+              dest = dirname + PATH_SEPARATOR + base + ` (copy ${suffix})` + ext
+            }
           }
         }
 

--- a/packages/desktop/src/renderer/src/store/project.ts
+++ b/packages/desktop/src/renderer/src/store/project.ts
@@ -233,21 +233,34 @@ export const useProjectStore = defineStore('project', () => {
       const { pathname: src } = activeItem.value
       clipboard.value = { type: String(type), src }
     })
-    bus.on('SIDEBAR::paste', () => {
+    bus.on('SIDEBAR::paste', async() => {
       const cb = clipboard.value
       const { pathname, isDirectory } = activeItem.value
       const dirname = isDirectory ? pathname : window.path.dirname(pathname)
       if (cb && cb.src) {
-        cb.dest = dirname + PATH_SEPARATOR + window.path.basename(cb.src)
+        let dest = dirname + PATH_SEPARATOR + window.path.basename(cb.src)
 
-        if (window.path.normalize(cb.src) === window.path.normalize(cb.dest)) {
-          notice.notify({
-            title: 'Paste Forbidden',
-            type: 'warning',
-            message: 'Source and destination must not be the same.'
-          })
-          return
+        if (window.path.normalize(cb.src) === window.path.normalize(dest)) {
+          if (cb.type === 'cut') {
+            notice.notify({
+              title: 'Paste Forbidden',
+              type: 'warning',
+              message: 'Source and destination must not be the same.'
+            })
+            return
+          }
+          // Copy in same folder: generate unique name (e.g. "file (copy).md", "file (copy 2).md")
+          const ext = window.path.extname(cb.src)
+          const base = window.path.basename(cb.src, ext)
+          let suffix = 1
+          dest = dirname + PATH_SEPARATOR + base + ' (copy)' + ext
+          while (await window.fileUtils.pathExists(dest)) {
+            suffix++
+            dest = dirname + PATH_SEPARATOR + base + ` (copy ${suffix})` + ext
+          }
         }
+
+        cb.dest = dest
 
         paste(cb as PasteOptions)
           .then(() => {

--- a/packages/desktop/src/renderer/src/store/project.ts
+++ b/packages/desktop/src/renderer/src/store/project.ts
@@ -253,16 +253,19 @@ export const useProjectStore = defineStore('project', () => {
           const ext = window.path.extname(cb.src)
           const base = window.path.basename(cb.src, ext)
           let suffix = 1
+          const MAX_COPIES = 99
           dest = dirname + PATH_SEPARATOR + base + ' (copy)' + ext
           while (await window.fileUtils.pathExists(dest)) {
             suffix++
-            if (suffix > 9) {
-              // Easter egg: recursive filename
-              const prevBase = window.path.basename(dest, ext)
-              dest = dirname + PATH_SEPARATOR + prevBase + ' (not sure you need another copy)' + ext
-            } else {
-              dest = dirname + PATH_SEPARATOR + base + ` (copy ${suffix})` + ext
+            if (suffix > MAX_COPIES) {
+              notice.notify({
+                title: 'Too many copies',
+                type: 'warning',
+                message: `Maximum of ${MAX_COPIES} copies reached. Please clean up first.`
+              })
+              return
             }
+            dest = dirname + PATH_SEPARATOR + base + ` (copy ${suffix})` + ext
           }
         }
 


### PR DESCRIPTION
Closes #5138

## Problem

Copy-paste in the sidebar's same folder shows 'Source and destination must not be the same' — blocking a valid operation.

## Fix

When pasting a **copied** file into the same directory, generate a unique name:
- `file.md` → `file (copy).md`
- If exists: `file (copy 2).md`, etc.

**Cut**-paste in the same folder remains blocked (it's a no-op).

## Changes

- `packages/desktop/src/renderer/src/store/project.ts`: Make paste handler async, check `cb.type === 'cut'` before blocking, generate unique dest path using `pathExists()` loop.

## Testing

- Tested on Linux Mint 22.3 with MarkText develop branch