### PR TITLE
fix(muya): anchor the inline-math popup width to the editor column, n…

### DIFF
--- a/packages/desktop/test/e2e/inline-math-editor-width.spec.ts
+++ b/packages/desktop/test/e2e/inline-math-editor-width.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { launchWithMarkdown } from './helpers'
+
+// The "Editor--Max width" preference (Preferences > Editor > Text Editor >
+// Max Width) accepts a percentage, e.g. "100%". `theme.ts#setEditorWidth`
+// then injects `--editor-area-width: calc(100px + 100%)`. The inline-math
+// popup (`.mu-math > .mu-math-render`) used to re-read that variable in its
+// own `calc()`, whose `%` resolved against `.mu-math`'s own tiny,
+// shrink-to-fit box (its absolute-positioning containing block) instead of
+// the editor column, squeezing the popup down to a sliver. `.mu-container`
+// is now a `cqw` query container so the popup sizes off the real column
+// width regardless of the preference's unit (see packages/muya/src/assets/
+// styles/{blockSyntax,inlineSyntax}.css).
+
+const MATH_DOC = '# math width smoke\n\ntext $x^2+y^2=z^2$ end\n'
+
+const setPreference = async(
+  app: ElectronApplication,
+  page: Page,
+  prefs: Record<string, unknown>
+): Promise<void> => {
+  await page.evaluate((payload) => {
+    window.electron.ipcRenderer.send('mt::set-user-preference', payload)
+  }, prefs)
+}
+
+const readWidths = async(page: Page): Promise<{ containerWidth: number; renderMaxWidth: number }> => {
+  return await page.evaluate(() => {
+    const container = document.querySelector('.mu-container') as HTMLElement
+    const render = document.querySelector('.mu-math > .mu-math-render') as HTMLElement
+    return {
+      containerWidth: container.getBoundingClientRect().width,
+      renderMaxWidth: Number.parseFloat(getComputedStyle(render).maxWidth)
+    }
+  })
+}
+
+test.describe('Inline-math popup width with a percentage editor-width preference', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown(MATH_DOC)
+    app = launched.app
+    page = launched.page
+    await page.waitForSelector('.mu-math > .mu-math-render', { state: 'attached', timeout: 15000 })
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('popup max-width tracks the editor column, not a sliver of the inline formula', async() => {
+    await setPreference(app, page, { editorLineWidth: '100%' })
+    await expect.poll(async() => {
+      const { renderMaxWidth } = await readWidths(page)
+      return renderMaxWidth
+    }, { timeout: 10000 }).toBeGreaterThan(200)
+
+    const { containerWidth, renderMaxWidth } = await readWidths(page)
+    expect(Math.abs(renderMaxWidth - (containerWidth - 100))).toBeLessThanOrEqual(2)
+
+    await setPreference(app, page, { editorLineWidth: '' })
+  })
+})

--- a/packages/muya/e2e/tests/blocks/inline-math-percent-width.spec.ts
+++ b/packages/muya/e2e/tests/blocks/inline-math-percent-width.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '../fixtures/muya'
+
+// The desktop app's "Editor--Max width" preference can be a percentage (e.g.
+// `100%`), which it applies via `--editor-area-width: calc(100px + <value>)`.
+// `.mu-math > .mu-math-render` is `position: absolute` inside `.mu-math` (a
+// small, shrink-to-fit inline box sized to the raw formula text), so reading
+// that `%`-bearing custom property directly in a `calc()` on the popup used to
+// resolve the `%` against `.mu-math`'s tiny box instead of the editor column,
+// squeezing the popup down to a few px. `.mu-container` is a `cqw` query
+// container so the popup can size itself off the real column width instead.
+test('inline-math popup keeps the editor-column width when the max-width preference is a percentage', async ({ page }) => {
+  await page.evaluate(() => {
+    document.documentElement.style.setProperty('--editor-area-width', 'calc(100px + 60%)')
+    window.muya!.setContent('text $x^2+y^2=z^2$ end')
+  })
+  await page.waitForTimeout(150)
+
+  const { containerWidth, mathWidth, renderMaxWidth } = await page.evaluate(() => {
+    const container = document.querySelector('.mu-container') as HTMLElement
+    const math = document.querySelector('.mu-math') as HTMLElement
+    const render = document.querySelector('.mu-math > .mu-math-render') as HTMLElement
+    return {
+      containerWidth: container.getBoundingClientRect().width,
+      mathWidth: math.getBoundingClientRect().width,
+      renderMaxWidth: Number.parseFloat(getComputedStyle(render).maxWidth),
+    }
+  })
+
+  // Anchored to the editor column (matches `.mu-container`'s width minus its
+  // 100px horizontal padding), not squeezed down to `.mu-math`'s own width.
+  expect(renderMaxWidth).toBeGreaterThan(mathWidth * 3)
+  expect(Math.abs(renderMaxWidth - (containerWidth - 100))).toBeLessThanOrEqual(2)
+})

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -21,6 +21,15 @@
     padding: 0 50px 100px;
 
     color: var(--editor-color);
+
+    /* Query container so descendants (e.g. the inline-math popup, see
+       inlineSyntax.css) can size themselves against THIS element's resolved
+       width via `cqw` instead of re-reading `--editor-area-width` through a
+       `%`-bearing `calc()` — a custom property's `%` component re-resolves
+       against whichever containing block consumes it, which for a
+       `position: absolute` descendant nested inside a small inline element
+       is not `.mu-container`. */
+    container-type: inline-size;
 }
 
 .mu-container p,

--- a/packages/muya/src/assets/styles/inlineSyntax.css
+++ b/packages/muya/src/assets/styles/inlineSyntax.css
@@ -192,9 +192,17 @@ code.mu-inline-rule {
 }
 
 /* A long inline-math formula must scroll horizontally (in the editing popup and
-   inline when hidden) instead of overflowing the editor area. */
+   inline when hidden) instead of overflowing the editor area.
+   `100cqw` is `.mu-container`'s resolved content width, already net of its
+   own padding (`container-type: inline-size` in blockSyntax.css). Using
+   `--editor-area-width` here directly would break when its value is a `%`:
+   this element's absolute positioning containing block is `.mu-math`, a
+   shrink-to-fit inline box sized to the raw formula text, not
+   `.mu-container` — a `%` baked into the custom property would resolve
+   against that tiny box instead. `cqw` is anchored to the query container
+   regardless of the positioning ancestor. */
 .mu-math > .mu-math-render {
-    max-width: calc(var(--editor-area-width, 800px) - 100px);
+    max-width: 100cqw;
     overflow: auto hidden;
 
     scrollbar-width: thin;


### PR DESCRIPTION
## Summary

Fixes math formulas displaying incorrectly (unconstrained overflow of the
whole app window) when the "Editor--Max width" preference
(Preferences → Editor → Text Editor → Max Width) is set to a percentage
(e.g. `100%`) instead of left empty or set in `px`/`ch`.

## Root cause

`.mu-math > .mu-math-render` (the inline-math edit popup) derived its
`max-width` from `--editor-area-width` via its own `calc()`. That variable
can carry a `%` (from the width preference), and a `%` embedded in a CSS
custom property resolves against whichever containing block consumes it —
not against where the variable was defined.

- `.mu-container`'s own `max-width: var(--editor-area-width)` resolves the
  `%` correctly, since `.mu-container` *is* the intended containing block.
- `.mu-math-render` is `position: absolute`, and its containing block is
  `.mu-math` — a small, shrink-to-fit inline span sized to the raw formula
  text, not the editor column. Its `calc(var(--editor-area-width) - 100px)`
  therefore resolved the `%` against `.mu-math` instead, which left the
  popup effectively unconstrained: a long formula overflowed the entire
  application window instead of being capped and horizontally scrollable —
  a regression of the #4339 fix and #5034.

## Fix

- `.mu-container` becomes a CSS container-query context
  (`container-type: inline-size`).
- `.mu-math > .mu-math-render` sizes itself with `max-width: 100cqw`,
  which reads `.mu-container`'s resolved width directly, regardless of the
  popup's own (unrelated) positioning ancestor.

Scope: only the inline-math (`$...$`) popup was affected. Block math
(`$$...$$`) was not, since it inherits its width from `.mu-container`
through normal block flow rather than re-deriving it via `calc()`.

## Tests

- `packages/muya/e2e/tests/blocks/inline-math-percent-width.spec.ts` — new
  regression test: the popup's `max-width` stays anchored to the editor
  column when `--editor-area-width` carries a `%`.
- `packages/desktop/test/e2e/inline-math-editor-width.spec.ts` — end-to-end
  check through the real preference → IPC → Pinia → CSS pipeline.

## Test plan

- [x] `pnpm -C packages/muya test` (1438 unit tests)
- [x] `pnpm -C packages/muya/e2e` chromium suite (245 tests; 1 pre-existing
      perf-smoke flake under parallel load, confirmed unrelated in isolation)
- [x] `pnpm -C packages/muya lint:css` / `lint` / `lint:types`
- [x] `pnpm run test:unit`, `pnpm run lint`, `pnpm run typecheck`
- [x] Manual verification in a built app (`pnpm run build:unpack`): a long
      inline formula's popup overflowed the whole window before the fix,
      and stays capped + scrollable within the editor column after.
