### PR TITLE
fix: #5152 align TOC navigation with editor viewport

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -125,7 +125,7 @@ import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
 import { dataURLToFile } from '@/util/dataURLToFile'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
-import { resolveTocHeadingElement } from '@/util/tocNavigation'
+import { getTocHeadingScrollTop, resolveTocHeadingElement } from '@/util/tocNavigation'
 import { addCommonStyle, setEditorWidth } from '@/util/theme'
 import { usePreferencesStore } from '@/store/preferences'
 import { useEditorStore } from '@/store/editor'
@@ -1226,9 +1226,8 @@ const scrollToCords = (y: number) => {
   })
 }
 
-// Smoothly scroll the editor so `anchor` sits at the standard top offset.
-// Shared by the TOC, search-highlight, and any other "reveal this element"
-// caller so the getBoundingClientRect + animatedScrollTo math lives once.
+// Smoothly scroll the editor so `anchor` sits at the standard caret offset.
+// Shared by search highlights and non-heading in-document anchors.
 const scrollElementIntoView = (anchor: Element | null | undefined, duration = 300) => {
   const container = getScrollContainer()
   if (!container || !anchor) return
@@ -1249,7 +1248,9 @@ const scrollToHighlight = () => {
 const scrollToHeader = (slug: unknown) => {
   const container = getScrollContainer()
   if (!container) return
-  scrollElementIntoView(resolveTocHeadingElement(container, editorStore.listToc, slug))
+  const heading = resolveTocHeadingElement(container, editorStore.listToc, slug)
+  if (!heading) return
+  animatedScrollTo(container, getTocHeadingScrollTop(container, heading), 300)
 }
 
 // Scrolls to a non-heading in-document anchor target (e.g. a custom

--- a/packages/desktop/src/renderer/src/util/tocNavigation.ts
+++ b/packages/desktop/src/renderer/src/util/tocNavigation.ts
@@ -19,6 +19,9 @@
 export const TOP_LEVEL_HEADINGS_SELECTOR =
   '.mu-container > h1, .mu-container > h2, .mu-container > h3, .mu-container > h4, .mu-container > h5, .mu-container > h6'
 
+/** Clearance in CSS pixels between a revealed heading and the editor viewport. */
+export const TOC_HEADING_TOP_GAP = 24
+
 export const resolveTocHeadingElement = (
   container: Element,
   listToc: ReadonlyArray<{ slug?: unknown }>,
@@ -28,4 +31,16 @@ export const resolveTocHeadingElement = (
   if (index < 0) return null
   const headings = container.querySelectorAll(TOP_LEVEL_HEADINGS_SELECTOR)
   return headings[index] ?? null
+}
+
+/**
+ * Returns the scroll position that places a TOC heading below the editor's
+ * visible top edge. The editor can move down when window chrome such as the tab
+ * bar is shown, so the alignment is relative to the scroll container rather
+ * than a fixed window coordinate.
+ */
+export const getTocHeadingScrollTop = (container: HTMLElement, heading: Element): number => {
+  const containerTop = container.getBoundingClientRect().top
+  const headingTop = heading.getBoundingClientRect().top
+  return container.scrollTop + headingTop - containerTop - TOC_HEADING_TOP_GAP
 }

--- a/packages/desktop/test/e2e/anchor-link-scroll.spec.ts
+++ b/packages/desktop/test/e2e/anchor-link-scroll.spec.ts
@@ -123,17 +123,21 @@ test.describe('In-document anchor link click scrolls the editor (item 236)', () 
     // meaningful distance toward the off-screen heading.
     await expect.poll(() => scrollTop(page), { timeout: 8000 }).toBeGreaterThan(100)
 
-    // Settle to the final position, then assert the heading is parked near the
-    // top of the viewport (STANDAR_Y = 320 offset), proving the jump landed on
-    // the right element and not at some arbitrary scroll offset.
+    // Settle to the final position, then assert the heading is parked below the
+    // editor viewport's top edge, proving the jump landed on the right element
+    // and accounted for the surrounding window layout.
     await page.waitForTimeout(500)
-    const headingTop = await page.evaluate(() => {
+    const headingOffset = await page.evaluate(() => {
+      const container = document.querySelector('.editor-component')
       const heading = document.querySelector('.mu-container > h2')
-      return heading ? heading.getBoundingClientRect().top : null
+      if (!container || !heading) return null
+      return Math.round(
+        heading.getBoundingClientRect().top - container.getBoundingClientRect().top
+      )
     })
-    expect(headingTop).not.toBeNull()
-    expect(headingTop as number).toBeLessThan(500)
-    expect(headingTop as number).toBeGreaterThan(-200)
+    expect(headingOffset).not.toBeNull()
+    expect(headingOffset as number).toBeGreaterThanOrEqual(20)
+    expect(headingOffset as number).toBeLessThanOrEqual(28)
 
     await expectNoRendererErrors(app)
   })

--- a/packages/desktop/test/e2e/toc-scroll.spec.ts
+++ b/packages/desktop/test/e2e/toc-scroll.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test'
 import type { ElectronApplication, Page } from 'playwright'
-import { launchWithMarkdown, clickMenuById, waitForEditor } from './helpers'
+import {
+  launchWithMarkdown,
+  clickMenuById,
+  waitForEditor,
+  sendIpcToRenderer
+} from './helpers'
 
 // Build a long document with many top-level headings so the editor content
 // overflows its scroll container. Each heading title is unique so the sidebar
@@ -58,6 +63,17 @@ const isHeadingInViewport = (page: Page, index: number): Promise<boolean> =>
     return hRect.top >= cRect.top - 1 && hRect.top <= cRect.bottom
   }, index)
 
+const headingOffsetFromViewportTop = (page: Page, index: number): Promise<number | null> =>
+  page.evaluate((idx) => {
+    const container = document.querySelector('.editor-component') as HTMLElement | null
+    const sel = '.mu-container > h1, .mu-container > h2, .mu-container > h3, .mu-container > h4, .mu-container > h5, .mu-container > h6'
+    const target = document.querySelectorAll(sel)[idx]
+    if (!container || !target) return null
+    return Math.round(
+      target.getBoundingClientRect().top - container.getBoundingClientRect().top
+    )
+  }, index)
+
 // Locate a TOC tree node label by its EXACT text. Exact matching avoids the
 // substring trap where "Heading Number 1" also matches "Heading Number 18".
 const tocLabel = (page: Page, text: string) =>
@@ -90,6 +106,21 @@ test.describe('TOC sidebar click scrolls the live editor', () => {
     app = launched.app
     page = launched.page
     await waitForEditor(page)
+    // Keep two files open so the editor viewport starts below the visible tab
+    // bar. The TOC target must align to that viewport, not to the window.
+    await sendIpcToRenderer(app, 'mt::new-untitled-tab', true, '')
+    await page.waitForFunction(
+      () => document.querySelectorAll('.tabs-container > li').length >= 2,
+      null,
+      { timeout: 5000 }
+    )
+    await expect(page.locator('.editor-tabs')).toBeVisible()
+    await sendIpcToRenderer(app, 'mt::switch-tab-by-index', 0)
+    await page.waitForFunction(
+      (count) => document.querySelectorAll('.mu-container > h1').length >= count,
+      HEADING_COUNT,
+      { timeout: 10000 }
+    )
     // Open the sidebar and switch its right column to the ToC (el-tree).
     await showSidebar(app, page)
     await clickMenuById(app, 'tocMenuItem')
@@ -131,6 +162,10 @@ test.describe('TOC sidebar click scrolls the live editor', () => {
     await expect
       .poll(() => isHeadingInViewport(page, targetIndex), { timeout: 8000 })
       .toBe(true)
+    await expect
+      .poll(() => headingOffsetFromViewportTop(page, targetIndex), { timeout: 8000 })
+      .toBeGreaterThanOrEqual(20)
+    expect(await headingOffsetFromViewportTop(page, targetIndex)).toBeLessThanOrEqual(28)
   })
 
   test('clicking an earlier heading scrolls back up toward it', async() => {

--- a/packages/desktop/test/unit/specs/toc-navigation.spec.ts
+++ b/packages/desktop/test/unit/specs/toc-navigation.spec.ts
@@ -27,7 +27,11 @@ vi.mock('@/services/notification', () => ({
 }))
 
 import { useEditorStore } from '@/store/editor'
-import { resolveTocHeadingElement } from '@/util/tocNavigation'
+import {
+  getTocHeadingScrollTop,
+  resolveTocHeadingElement,
+  TOC_HEADING_TOP_GAP
+} from '@/util/tocNavigation'
 
 describe('useEditorStore UPDATE_TOC', () => {
   beforeEach(() => {
@@ -125,5 +129,34 @@ describe('resolveTocHeadingElement', () => {
     container.innerHTML = '<div class="mu-container"><h1>Only one</h1></div>'
     // listToc claims two headings but the DOM has one — guard against overrun.
     expect(resolveTocHeadingElement(container, listToc, 'uid-2')).toBeNull()
+  })
+})
+
+describe('getTocHeadingScrollTop', () => {
+  it('aligns the heading below the scroll container top edge', () => {
+    const container = document.createElement('div')
+    const heading = document.createElement('h2')
+    container.scrollTop = 900
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ top: 52 } as DOMRect)
+    vi.spyOn(heading, 'getBoundingClientRect').mockReturnValue({ top: 600 } as DOMRect)
+
+    expect(getTocHeadingScrollTop(container, heading)).toBe(
+      900 + 600 - 52 - TOC_HEADING_TOP_GAP
+    )
+  })
+
+  it('accounts for layout chrome that moves the editor viewport', () => {
+    const container = document.createElement('div')
+    const heading = document.createElement('h2')
+    container.scrollTop = 900
+    vi.spyOn(heading, 'getBoundingClientRect').mockReturnValue({ top: 600 } as DOMRect)
+    const containerRect = vi.spyOn(container, 'getBoundingClientRect')
+
+    containerRect.mockReturnValue({ top: 24 } as DOMRect)
+    const withoutTabs = getTocHeadingScrollTop(container, heading)
+    containerRect.mockReturnValue({ top: 52 } as DOMRect)
+    const withTabs = getTocHeadingScrollTop(container, heading)
+
+    expect(withTabs).toBe(withoutTabs - 28)
   })
 })


### PR DESCRIPTION
Closes #5152

## Summary

- Align TOC targets relative to the editor scroll container instead of a fixed window coordinate.
- Keep 24 CSS pixels of clearance between the revealed heading and the editor viewport.
- Cover the scroll calculation, a visible two-tab layout, repeated TOC navigation, and heading anchor links.

## Root cause

TOC navigation shared the fixed `STANDAR_Y` viewport coordinate used for caret-oriented scrolling. Window chrome such as the tab bar moves the editor viewport without changing that coordinate, so headings could either land far down the document or become obscured when the constant was reduced.

## User impact

Clicking a TOC entry now places the heading near the editor's visible top edge with consistent clearance across layouts, including windows with multiple tabs.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New unit and end-to-end regression tests added
- [x] Manually verified on macOS 26.5.2
- [x] `corepack pnpm run build`
- [x] `corepack pnpm run test:unit` — 50 files, 736 tests passed
- [x] `corepack pnpm -C packages/desktop exec playwright test test/e2e/toc-scroll.spec.ts test/e2e/anchor-link-scroll.spec.ts` — 6 tests passed
- [x] `corepack pnpm run typecheck`
- [x] `corepack pnpm run lint`

## Demonstration

With two documents open, clicking `Heading Number 18` keeps the full heading visible below the tab bar:

![TOC navigation with two visible tabs](https://raw.githubusercontent.com/foo-hao/marktext/pr-assets/pr-assets/toc-navigation-multiple-tabs.png)

## Notes for reviewers

The TOC uses a dedicated container-relative calculation. Search highlights and non-heading anchors continue using their existing caret-oriented reveal position.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
