### PR TITLE
fix: #5001 persist pasted bitmap images to the assets folder per preferences

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -862,6 +862,21 @@ const imagePathAutoComplete = async (src: string) => {
   })
 }
 
+// Convert a `data:` URL (e.g. a screenshot pasted from the clipboard bitmap)
+// back into a `File` so `imageAction` routes it through the copy-to-folder /
+// upload flows. Returns null when the payload is not a base64 image data URL.
+const dataURLToFile = (dataUrl: string): File | null => {
+  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(dataUrl)
+  if (!match) return null
+  const mime = match[1]
+  const ext =
+    mime === 'image/svg+xml' ? 'svg' : mime.split('/')[1]?.replace('jpeg', 'jpg') ?? 'png'
+  const binary = atob(match[2])
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new File([bytes], `image.${ext}`, { type: mime })
+}
+
 const imageAction = async (
   image: string | File,
   id: string | null,
@@ -870,6 +885,16 @@ const imageAction = async (
   // TODO(Refactor): Refactor this method.
   if (!currentFile.value) return ''
   const { filename, pathname: currentPathname } = currentFile.value
+
+  // A pasted screenshot / bitmap clipboard comes in as a `data:` URL string
+  // rather than a file path. `moveImageToFolder` and `uploadImage` treat any
+  // string as a local path, which would silently keep the base64 inline — so
+  // normalize it back into a `File` up front and let the branches below handle
+  // it as binary.
+  if (typeof image === 'string' && image.startsWith('data:')) {
+    const file = dataURLToFile(image)
+    if (file) image = file
+  }
 
   // Figure out the current working directory.
   // Save an image relative to the file, otherwise use the project root when available.

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -123,6 +123,7 @@ import { SpellChecker } from '@/spellchecker'
 import { isOsx, animatedScrollTo } from '@/util'
 import { moveImageToFolder, uploadImage } from '@/util/fileSystem'
 import { guessClipboardFilePath } from '@/util/clipboard'
+import { dataURLToFile } from '@/util/dataURLToFile'
 import { getCssForOptions, getHtmlToc, type PdfCssOptions, type HtmlTocOptions } from '@/util/pdf'
 import { resolveTocHeadingElement } from '@/util/tocNavigation'
 import { addCommonStyle, setEditorWidth } from '@/util/theme'
@@ -860,21 +861,6 @@ const imagePathAutoComplete = async (src: string) => {
     const iconClass = f.type === 'directory' ? 'icon-folder' : 'icon-image'
     return Object.assign(f, { iconClass, text: f.file + (f.type === 'directory' ? '/' : '') })
   })
-}
-
-// Convert a `data:` URL (e.g. a screenshot pasted from the clipboard bitmap)
-// back into a `File` so `imageAction` routes it through the copy-to-folder /
-// upload flows. Returns null when the payload is not a base64 image data URL.
-const dataURLToFile = (dataUrl: string): File | null => {
-  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(dataUrl)
-  if (!match) return null
-  const mime = match[1]
-  const ext =
-    mime === 'image/svg+xml' ? 'svg' : mime.split('/')[1]?.replace('jpeg', 'jpg') ?? 'png'
-  const binary = atob(match[2])
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-  return new File([bytes], `image.${ext}`, { type: mime })
 }
 
 const imageAction = async (

--- a/packages/desktop/src/renderer/src/util/dataURLToFile.ts
+++ b/packages/desktop/src/renderer/src/util/dataURLToFile.ts
@@ -1,0 +1,14 @@
+// Convert a `data:` URL (e.g. a screenshot pasted from the clipboard bitmap)
+// back into a `File` so `imageAction` routes it through the copy-to-folder /
+// upload flows. Returns null when the payload is not a base64 image data URL.
+export function dataURLToFile(dataUrl: string): File | null {
+  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(dataUrl)
+  if (!match) return null
+  const mime = match[1]
+  const ext =
+    mime === 'image/svg+xml' ? 'svg' : mime.split('/')[1]?.replace('jpeg', 'jpg') ?? 'png'
+  const binary = atob(match[2])
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new File([bytes], `image.${ext}`, { type: mime })
+}

--- a/packages/desktop/src/renderer/src/util/fileSystem.ts
+++ b/packages/desktop/src/renderer/src/util/fileSystem.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs'
-
 export type FileCreateType = 'file' | 'directory'
 export type PasteType = 'cut' | 'copy'
 export type HashType = 'sha1' | 'sha256' | 'sha512'
@@ -93,15 +91,16 @@ export const moveImageToFolder = async(
     }
   } else {
     const file = image as File
-    const imagePath = window.path.join(
-      outputDir,
-      `${dayjs().format('YYYY-MM-DD-HH-mm-ss')}-${file.name}`
-    )
-
     const buffer = new Uint8Array(await file.arrayBuffer())
-    await window.fileUtils.writeFile(imagePath, buffer)
+    // Name the persisted file by the SHA-1 hash of its bytes (same dedup scheme
+    // as the string-path branch above) so pasting the same bitmap twice reuses
+    // one file instead of accumulating timestamped copies.
+    const ext = window.path.extname(file.name)
+    const hash = await getHash(buffer, 'binary', 'sha1')
+    const hashFilePath = window.path.join(outputDir, `${hash}${ext}`)
+    await window.fileUtils.writeFile(hashFilePath, buffer)
 
-    return toResult(imagePath)
+    return toResult(hashFilePath)
   }
 }
 

--- a/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
+++ b/packages/desktop/test/unit/specs/move-image-to-folder.spec.ts
@@ -98,13 +98,16 @@ describe('moveImageToFolder relative-directory persistence', () => {
     // No copy for a binary File — it is written, not copied.
     expect(copy).not.toHaveBeenCalled()
     expect(writeFile).toHaveBeenCalledTimes(1)
-    // The written destination is inside the assets dir...
-    expect((writeFile.mock.calls[0] as unknown[])[0] as string).toMatch(/pasted\.png$/)
+    // The written destination is inside the assets dir, named by the SHA-1 of
+    // its bytes (the same dedup scheme as the string-path branch)...
+    expect((writeFile.mock.calls[0] as unknown[])[0] as string).toMatch(
+      /e809c5d1cea47b45e34701d23f608a9a58034dc9\.png$/
+    )
     expect(((writeFile.mock.calls[0] as unknown[])[0] as string).startsWith(assetsDir)).toBe(true)
     // ...and the inserted reference is the portable relative path.
     expect(path.isAbsolute(result)).toBe(false)
     expect(result.startsWith('assets/')).toBe(true)
-    expect(result.endsWith('pasted.png')).toBe(true)
+    expect(result.endsWith('e809c5d1cea47b45e34701d23f608a9a58034dc9.png')).toBe(true)
   })
 
   it('a string local path already inside outputDir is returned verbatim when isRelative is false (path-action string passthrough analog)', async() => {


### PR DESCRIPTION
Closes #5001

## Summary

Pasting a screenshot (e.g. from a chat/capture tool) or a right-click "Copy image" from a browser inserted an inline base64 `data:` URL instead of following the user's "copy to folder" preference (`imageInsertAction = 'folder'`). The image was never written to the assets folder.

### Root cause

The engine routes bitmap-only clipboard content to the desktop `imageAction` as a `data:` URL string (per the `IImageActionState` contract). The desktop `imageAction` (`editor.vue`) treated every string as a local file path, so `moveImageToFolder` resolved the `data:` URL as a path, failed the `isImageFile` check, and returned it unchanged — the base64 stayed inline.

### Fix

1. `editor.vue`: detect a `data:` URL in `imageAction` and convert it back into a `File` via the new `dataURLToFile` helper, so the existing copy-to-folder / upload branches handle it as binary.
2. `fileSystem.ts`: name persisted bitmap `File`s by the SHA-1 of their bytes (same dedup scheme as the string-path branch) instead of a timestamp, so pasting the same image twice reuses one file.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added: `move-image-to-folder.spec.ts` updated to assert content-hash naming for the binary `File` branch
- [x] Manually tested on: Windows

Steps:
1. Screenshot with a capture tool and paste (Ctrl+V) into the editor
2. Right-click "Copy image" on an image in a browser and paste
3. With "copy to folder" enabled, both are written to the assets folder with a content-hash name, and the markdown references the relative path

## Notes for reviewers

- The engine-side routing (paste → `imageAction`) is unchanged; this PR only fixes the desktop consumer.
- Naming change is limited to bitmap (File) inputs; local path pastes / drag-drops keep their existing path-hash naming.
