### PR TITLE
feat: #4940 add automatic reload preference

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -10,6 +10,11 @@
     "minimum": 1000,
     "default": 5000
   },
+  "autoReload": {
+    "description": "General--Automatically reload files changed on disk when there are no unsaved changes.",
+    "type": "boolean",
+    "default": false
+  },
   "titleBarStyle": {
     "description": "General--The title bar style (Windows and Linux system only).",
     "enum": ["custom", "native"],

--- a/packages/desktop/src/renderer/src/prefComponents/general/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/general/index.vue
@@ -4,7 +4,7 @@
     <compound>
       <template #head>
         <h6 class="title">
-          {{ t('preferences.general.autoSave.title') }}
+          {{ t('preferences.general.fileChanges.title') }}
         </h6>
       </template>
       <template #children>
@@ -21,6 +21,11 @@
           unit="ms"
           :step="100"
           :on-change="(value) => onSelectChange('autoSaveDelay', value)"
+        />
+        <bool
+          :description="t('preferences.general.autoReload.description')"
+          :bool="autoReload"
+          :on-change="(value) => onSelectChange('autoReload', value)"
         />
       </template>
     </compound>
@@ -209,6 +214,7 @@ const preferenceStore = usePreferencesStore()
 const {
   autoSave,
   autoSaveDelay,
+  autoReload,
   titleBarStyle,
   defaultDirectoryToOpen,
   openFilesInNewWindow,

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -1679,8 +1679,8 @@ export const useEditorStore = defineStore('editor', {
                 break
               }
 
-              const { autoSave } = preferencesStore
-              if (autoSave) {
+              const { autoReload, autoSave } = preferencesStore
+              if (autoReload || autoSave) {
                 if (autoSaveTimers.has(id)) {
                   const timer = autoSaveTimers.get(id)
                   if (timer) clearTimeout(timer)

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -23,6 +23,7 @@ export interface PreferencesState {
   // ----- General -----
   autoSave: boolean
   autoSaveDelay: number
+  autoReload: boolean
   titleBarStyle: TitleBarStyle | string
   openFilesInNewWindow: boolean
   openFolderInNewWindow: boolean
@@ -141,6 +142,7 @@ export const usePreferencesStore = defineStore('preferences', {
   state: (): PreferencesState => ({
     autoSave: false,
     autoSaveDelay: 5000,
+    autoReload: false,
     titleBarStyle: 'custom',
     openFilesInNewWindow: false,
     openFolderInNewWindow: false,

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -9,6 +9,7 @@
 export interface IUserPreferences {
   autoSave?: boolean
   autoSaveDelay?: number
+  autoReload?: boolean
   titleBarStyle?: 'custom' | 'native'
   openFilesInNewWindow?: boolean
   openFolderInNewWindow?: boolean

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -364,6 +364,7 @@
       "items": {
         "autoSave": "Automatically save the content being edited",
         "autoSaveDelay": "The time in ms after a change that the file is saved",
+        "autoReload": "Reload files changed on disk if they have no unsaved edits",
         "titleBarStyle": "The title bar style (Windows and Linux system only)",
         "openFilesInNewWindow": "Open files in a new window",
         "openFolderInNewWindow": "Open folder via menu in a new window",
@@ -435,10 +436,16 @@
     },
     "general": {
       "title": "General",
+      "fileChanges": {
+        "title": "File Changes"
+      },
       "autoSave": {
         "title": "Auto Save",
         "description": "Auto save",
         "delayDescription": "Auto save delay"
+      },
+      "autoReload": {
+        "description": "Reload files changed on disk if they have no unsaved edits"
       },
       "window": {
         "title": "Window",

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -1,6 +1,7 @@
 {
   "autoSave": false,
   "autoSaveDelay": 5000,
+  "autoReload": false,
   "titleBarStyle": "custom",
   "openFilesInNewWindow": false,
   "openFolderInNewWindow": false,

--- a/packages/desktop/test/e2e/external-reload-undo.spec.ts
+++ b/packages/desktop/test/e2e/external-reload-undo.spec.ts
@@ -50,10 +50,9 @@ test.describe('External disk reload — undo restores the pre-change document', 
     const { app, page, filePath } = await launchWithMarkdown('old content here\n')
     await waitForMenuReady(app)
 
-    // Auto-reload only applies silently when autoSave is on AND the tab is
-    // unmodified (a freshly-loaded tab is saved). Enable autoSave so the change
-    // applies without the manual "Reload" confirmation prompt.
-    await sendIpcToRenderer(app, 'mt::user-preference', { autoSave: true })
+    // A freshly loaded tab is clean, so auto reload can apply the external
+    // change without the manual confirmation prompt.
+    await sendIpcToRenderer(app, 'mt::user-preference', { autoReload: true })
     await page.waitForTimeout(100)
 
     await reportExternalChange(app, filePath, 'new content here\n')

--- a/packages/desktop/test/unit/specs/file-change-content-check.spec.ts
+++ b/packages/desktop/test/unit/specs/file-change-content-check.spec.ts
@@ -21,6 +21,7 @@ vi.mock('@/services/notification', () => ({
 vi.mock('@/store/bufferedState', () => ({ debouncedSendBufferedState: vi.fn() }))
 
 import { useEditorStore } from '@/store/editor'
+import { usePreferencesStore } from '@/store/preferences'
 
 // #1861: a watcher 'change' event fires even when only the file's mtime changed
 // (e.g. a git checkout that left the content byte-identical). The handler then
@@ -70,6 +71,36 @@ describe('useEditorStore LISTEN_FOR_FILE_CHANGE — content-identical change (#1
 
     fire(captureHandler(), 'hello world')
 
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    expect(tab.isSaved).toBe(false)
+  })
+
+  it('automatically reloads a clean tab when auto reload is enabled', () => {
+    const store = useEditorStore()
+    makeSavedTab(store)
+    usePreferencesStore().autoReload = true
+    const notifySpy = vi.spyOn(store, 'pushTabNotification').mockImplementation(() => {})
+    const loadSpy = vi.spyOn(store, 'loadChange').mockImplementation(() => {})
+    store.LISTEN_FOR_FILE_CHANGE()
+
+    fire(captureHandler(), 'hello world')
+
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('warns instead of discarding unsaved changes when auto reload is enabled', () => {
+    const store = useEditorStore()
+    const tab = makeSavedTab(store)
+    tab.isSaved = false
+    usePreferencesStore().autoReload = true
+    const notifySpy = vi.spyOn(store, 'pushTabNotification').mockImplementation(() => {})
+    const loadSpy = vi.spyOn(store, 'loadChange').mockImplementation(() => {})
+    store.LISTEN_FOR_FILE_CHANGE()
+
+    fire(captureHandler(), 'hello world')
+
+    expect(loadSpy).not.toHaveBeenCalled()
     expect(notifySpy).toHaveBeenCalledTimes(1)
     expect(tab.isSaved).toBe(false)
   })

--- a/packages/website/content/docs/end-user/PREFERENCES.md
+++ b/packages/website/content/docs/end-user/PREFERENCES.md
@@ -8,6 +8,7 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | ---------------------- | ------- | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | autoSave               | Boolean | `false`       | Automatically save the content being edited.                                                                               |
 | autoSaveDelay          | Number  | `5000`        | The delay in milliseconds after a change before a file is saved automatically. Minimum `1000`.                             |
+| autoReload             | Boolean | `false`       | Automatically reload files changed on disk when there are no unsaved changes.                                              |
 | titleBarStyle          | String  | `custom`      | The title bar style on Linux and Windows: `custom` or `native`.                                                            |
 | openFilesInNewWindow   | Boolean | `false`       | Open files in a new window.                                                                                                |
 | openFolderInNewWindow  | Boolean | `false`       | Open folder via menu in a new window.                                                                                      |


### PR DESCRIPTION
Closes #4940

## Summary

- Add a default-off **Auto Reload** preference under **General → File Changes**.
- Silently reload external disk changes only when the open tab has no unsaved edits.
- Keep the existing confirmation prompt for dirty tabs, so external content never overwrites unsaved work.
- Preserve the current auto-save behavior and document the new `autoReload` preference.

![Auto Reload preference enabled](https://raw.githubusercontent.com/cyppe/marktext/1e5aab0bfbf3013cf93b8c92310ca6f6773566c1/docs/pr-assets/auto-reload-setting.png)

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Documentation update

## Test plan

- [x] New tests added (or explain why not needed)
- [x] Manually tested on: Linux

Commands run:

- `pnpm run lint` (0 errors; existing repository warnings remain)
- `pnpm run typecheck`
- `pnpm -C packages/desktop exec vitest run`
- `pnpm -C packages/desktop exec playwright test test/e2e/external-reload-undo.spec.ts`
- `pnpm run build:unpack`

The Preferences UI was also exercised in Electron to verify that the new switch renders, defaults to off, and can be enabled.

## Notes for reviewers [optional]

`autoReload` defaults to `false` for backward compatibility. When enabled, only clean tabs reload automatically; tabs with unsaved edits continue to show the existing reload notification.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
