### PR TITLE
fix(ui): sync quick insert highlight with input method

### DIFF
--- a/packages/muya/e2e/tests/ui/slash-menu.spec.ts
+++ b/packages/muya/e2e/tests/ui/slash-menu.spec.ts
@@ -29,6 +29,44 @@ test.describe('slash quick-insert menu', () => {
         await expect(page.locator(editor.atxHeading).first()).toBeVisible();
     });
 
+    test('highlight follows the active mouse or keyboard input', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.type('/');
+
+        const menu = page.locator(floats.quickInsert);
+        const heading1 = page.locator(quickInsertItem('atx-heading 1'));
+        await heading1.hover();
+
+        const pointerBackgrounds = await page.evaluate(() => {
+            const paragraph = document.querySelector<HTMLElement>('[data-label="paragraph"]');
+            const heading1 = document.querySelector<HTMLElement>('[data-label="atx-heading 1"]');
+            return {
+                paragraph: paragraph && getComputedStyle(paragraph).backgroundColor,
+                heading1: heading1 && getComputedStyle(heading1).backgroundColor,
+            };
+        });
+        expect(pointerBackgrounds.heading1).not.toBe(pointerBackgrounds.paragraph);
+
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('ArrowDown');
+
+        await expect(menu).toHaveClass(/mu-keyboard-navigation/);
+        await expect(page.locator(quickInsertItem('atx-heading 3'))).toHaveClass(/active/);
+        const keyboardBackgrounds = await page.evaluate(() => {
+            const heading1 = document.querySelector<HTMLElement>('[data-label="atx-heading 1"]');
+            const heading3 = document.querySelector<HTMLElement>('[data-label="atx-heading 3"]');
+            return {
+                heading1: heading1 && getComputedStyle(heading1).backgroundColor,
+                heading3: heading3 && getComputedStyle(heading3).backgroundColor,
+            };
+        });
+        expect(keyboardBackgrounds.heading3).not.toBe(keyboardBackgrounds.heading1);
+
+        await page.keyboard.press('Enter');
+        await expect(page.locator('h3.mu-atx-heading').first()).toBeVisible();
+    });
+
     // EXTEND item 1a — Enter-select inserts a block (keyboard, not click).
     // Typing `/` then narrowing with `quote` filters the menu so `block-quote`
     // becomes the active item (fuse top match); BaseScrollFloat's keydown

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.css
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.css
@@ -39,7 +39,11 @@
     background-color: var(--float-hover-color);
 }
 
-.mu-quick-insert:hover .active {
+.mu-quick-insert:not(.mu-keyboard-navigation):hover .active:not(:hover) {
+    background: transparent;
+}
+
+.mu-quick-insert.mu-keyboard-navigation div.item:hover:not(.active) {
     background: transparent;
 }
 

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
@@ -112,6 +112,31 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
         };
 
         eventCenter.attachDOMEvent(domNode, 'keydown', handleKeydown);
+        eventCenter.attachDOMEvent(this.container!, 'mousemove', (event: Event) => {
+            this.container!.classList.remove('mu-keyboard-navigation');
+            if (!(event.target instanceof Element))
+                return;
+
+            const itemElement = event.target.closest<HTMLElement>('.item');
+            if (!itemElement || !this.container!.contains(itemElement))
+                return;
+
+            const item = this.renderArray.find(({ label }) => {
+                return label === itemElement.dataset.label;
+            });
+            if (item && item !== this.activeItem)
+                this.activeItem = item;
+        });
+    }
+
+    override step(direction: 'previous' | 'next') {
+        this.container!.classList.add('mu-keyboard-navigation');
+        super.step(direction);
+    }
+
+    override hide() {
+        this.container!.classList.remove('mu-keyboard-navigation');
+        super.hide();
     }
 
     render() {


### PR DESCRIPTION
## Summary

Fixes inconsistent highlighting in the Quick Insert menu when switching between mouse and keyboard navigation.

Previously, hovering one item while navigating with the arrow keys could make the hovered item appear selected even though Enter executed a different internally active item.

Closes #5175

## Changes

- Switch the menu into keyboard-navigation styling when arrow-key navigation starts.
- Return control to mouse highlighting on actual pointer movement and synchronize the active item with the hovered item.
- Clear the input-mode styling when the menu closes.
- Add an end-to-end regression test covering mouse hover, keyboard navigation, the visible highlight, and the heading inserted by Enter.

## Expected behavior

- Mouse movement highlights and activates the item under the pointer.
- Arrow-key navigation keeps the keyboard-active item highlighted, even when the pointer remains over another item.
- Enter executes the item that is visibly highlighted.

## Testing

- `pnpm --filter @muyajs/core lint` (passes with existing warnings)
- `pnpm --filter @muyajs/core lint:types`
- `pnpm exec stylelint packages/muya/src/ui/paragraphQuickInsertMenu/index.css`
- `pnpm --filter @muyajs/core test` (1,438 tests passed)
- `pnpm --filter @muyajs/core check-circular`
- `pnpm --filter muya-e2e exec playwright test tests/ui/slash-menu.spec.ts --project=chromium --workers=1` (8 tests passed)

The full CSS lint command still reports an unrelated, pre-existing `no-descending-specificity` error in `src/assets/styles/blockSyntax.css:945`; the changed stylesheet passes targeted Stylelint.
