### PR TITLE
fix(desktop): restoreAll reopens every old session as its own window

### DIFF
--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -385,12 +385,9 @@ class App {
 
     const createWindow = (): void => {
       if (isRestorePathway) {
-        // We will restore based off the previous buffer, one window per buffer store file
-        const bufferStores = editorBufferStore.getAll()
-        const bufferStoreList = Object.values(bufferStores) as Array<{
-          id: string
-          filePath: string | null
-        }>
+        // We will restore based off the previous buffer, one window per distinct
+        // set of open documents
+        const bufferStoreList = editorBufferStore.getRestorableBufferStores()
         if (bufferStoreList.length === 0) {
           this._createEditorWindow()
           return

--- a/packages/desktop/src/main/app/windowManager.ts
+++ b/packages/desktop/src/main/app/windowManager.ts
@@ -329,6 +329,19 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
     const { id: windowId } = browserWindow
     const { _appMenu, _windows } = this
 
+    // Buffer cleanup belongs here rather than on the `mt::close-window` reply:
+    // every teardown path funnels through this method, so a window destroyed
+    // without the renderer round trip — `forceCloseById`, application quit, a
+    // renderer that never answers `mt::ask-for-close` — would otherwise leave
+    // its store behind forever. Must run before `remove()` so the editor window
+    // list still counts this window.
+    if (this.get(windowId)?.type === WindowType.EDITOR) {
+      this.editorBufferStore.handleClose(
+        (browserWindow as unknown as { restoreBufferId?: string }).restoreBufferId,
+        this.getWindowsByType('editor')
+      )
+    }
+
     // Free watchers used by this window
     this._watcher.unwatchByWindowId(windowId)
 
@@ -379,13 +392,7 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
 
     // Force close a BrowserWindow
     ipcMain.on('mt::close-window', (e) => {
-      const win = BrowserWindow.fromWebContents(e.sender)
-      // Before closing, update the buffer store if needed
-      this.editorBufferStore.handleClose(
-        (win as unknown as { restoreBufferId?: string })?.restoreBufferId,
-        this.getWindowsByType('editor')
-      )
-      this.forceClose(win)
+      this.forceClose(BrowserWindow.fromWebContents(e.sender))
     })
 
     ipcMain.on('mt::open-file', (e, filePath: string, options: Record<string, unknown>) => {

--- a/packages/desktop/src/main/editorBufferStore/index.ts
+++ b/packages/desktop/src/main/editorBufferStore/index.ts
@@ -15,7 +15,7 @@ interface BufferStoreEntry {
 }
 
 interface BufferStoreContent {
-  tabs: Array<{ isSaved: boolean; [key: string]: unknown }>
+  tabs: Array<{ isSaved: boolean; pathname?: string | null; [key: string]: unknown }>
   [key: string]: unknown
 }
 
@@ -66,6 +66,65 @@ class EditorBufferStore extends TypedEmitter<EditorBufferStoreEvents> {
     }
 
     return this.bufferStores
+  }
+
+  /**
+   * The buffer stores to restore on startup: at most one per distinct set of
+   * open documents, newest wins. Superseded stores are deleted.
+   *
+   * A window's restore identity is the set of documents it had open. Stores
+   * are only ever collected once every tab reports `isSaved`, so a document
+   * edited across many sessions without an explicit save leaves one store
+   * behind per session — and `restoreAll` then opens a window for each,
+   * growing without bound.
+   *
+   * Stores holding an untitled tab keep their own identity: their content
+   * exists nowhere else, so two untitled drafts must never collapse into one.
+   */
+  getRestorableBufferStores(): BufferStoreEntry[] {
+    const stores = this.getAllBufferStores()
+    const newestBySignature = new Map<string, { entry: BufferStoreEntry; mtimeMs: number }>()
+    const superseded: BufferStoreEntry[] = []
+
+    for (const id of Object.keys(stores)) {
+      const entry = stores[id]
+      let signature: string
+      let mtimeMs: number
+
+      try {
+        const buffer = this.readBufferStoreFile(entry.filePath)
+        const pathnames = buffer.tabs.map((tab) => tab.pathname)
+        signature = pathnames.every((pathname) => !!pathname)
+          ? JSON.stringify((pathnames as string[]).slice().sort())
+          : `untitled:${entry.id}`
+        mtimeMs = fs.statSync(entry.filePath).mtimeMs
+      } catch (e) {
+        console.error('Failed to inspect buffer store file while restoring', e)
+        continue
+      }
+
+      const incumbent = newestBySignature.get(signature)
+      if (!incumbent) {
+        newestBySignature.set(signature, { entry, mtimeMs })
+      } else if (mtimeMs > incumbent.mtimeMs) {
+        newestBySignature.set(signature, { entry, mtimeMs })
+        superseded.push(incumbent.entry)
+      } else {
+        superseded.push(entry)
+      }
+    }
+
+    for (const entry of superseded) {
+      try {
+        fs.unlinkSync(entry.filePath)
+        // `stores` is the live `this.bufferStores` map returned above.
+        delete stores[entry.id]
+      } catch (e) {
+        console.error('Failed to delete superseded buffer store file', e)
+      }
+    }
+
+    return [...newestBySignature.values()].map(({ entry }) => entry)
   }
 
   clearBufferStoresWithAllSaved(): void {

--- a/packages/desktop/test/unit/specs/buffer-store-restore-dedupe.spec.ts
+++ b/packages/desktop/test/unit/specs/buffer-store-restore-dedupe.spec.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, readdirSync, utimesSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The store registers ipcMain handlers in its constructor; stub electron so the
+// module imports without a real main process, then build instances off the
+// prototype so no handler registration happens.
+vi.mock('electron', () => ({}))
+
+const { default: EditorBufferStore } = await import('main_renderer/editorBufferStore')
+
+const dirs: string[] = []
+function tempDir(): string {
+  const d = mkdtempSync(path.join(tmpdir(), 'mt-buf-restore-'))
+  dirs.push(d)
+  return d
+}
+
+function makeStore(dir: string): InstanceType<typeof EditorBufferStore> {
+  const store = Object.create(EditorBufferStore.prototype) as InstanceType<typeof EditorBufferStore>
+  store.editorBufferStorePath = dir
+  store.bufferStores = null
+  return store
+}
+
+/** Write a buffer store whose mtime encodes recency: higher `age` is newer. */
+function writeStore(dir: string, id: string, pathnames: Array<string | null>, age: number): void {
+  const file = path.join(dir, `${id}_editor_buffer_store.json`)
+  writeFileSync(
+    file,
+    JSON.stringify({
+      tabs: pathnames.map((pathname, i) => ({ id: `mt-${i}`, pathname, isSaved: false }))
+    })
+  )
+  const t = new Date(2020, 0, 1 + age)
+  utimesSync(file, t, t)
+}
+
+function idsIn(dir: string): string[] {
+  return readdirSync(dir)
+    .map((name) => name.replace('_editor_buffer_store.json', ''))
+    .sort()
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+describe('EditorBufferStore.getRestorableBufferStores', () => {
+  it('collapses repeated snapshots of the same document to the newest one', () => {
+    const dir = tempDir()
+    writeStore(dir, 'old', ['/docs/a.md'], 1)
+    writeStore(dir, 'newest', ['/docs/a.md'], 3)
+    writeStore(dir, 'middle', ['/docs/a.md'], 2)
+
+    const restorable = makeStore(dir).getRestorableBufferStores()
+
+    expect(restorable.map((e) => e.id)).toEqual(['newest'])
+    // Superseded snapshots are removed so the directory cannot grow unbounded.
+    expect(idsIn(dir)).toEqual(['newest'])
+  })
+
+  it('keeps one window per distinct document', () => {
+    const dir = tempDir()
+    writeStore(dir, 'a', ['/docs/a.md'], 1)
+    writeStore(dir, 'b', ['/docs/b.md'], 1)
+
+    const restorable = makeStore(dir).getRestorableBufferStores()
+
+    expect(restorable.map((e) => e.id).sort()).toEqual(['a', 'b'])
+    expect(idsIn(dir)).toEqual(['a', 'b'])
+  })
+
+  it('treats tab sets as the restore identity regardless of tab order', () => {
+    const dir = tempDir()
+    writeStore(dir, 'first', ['/docs/a.md', '/docs/b.md'], 1)
+    writeStore(dir, 'reordered', ['/docs/b.md', '/docs/a.md'], 2)
+
+    const restorable = makeStore(dir).getRestorableBufferStores()
+
+    expect(restorable.map((e) => e.id)).toEqual(['reordered'])
+  })
+
+  it('never collapses untitled drafts, whose content exists nowhere else', () => {
+    const dir = tempDir()
+    writeStore(dir, 'draft1', [null], 1)
+    writeStore(dir, 'draft2', [null], 2)
+    writeStore(dir, 'mixed', ['/docs/a.md', null], 3)
+
+    const restorable = makeStore(dir).getRestorableBufferStores()
+
+    expect(restorable.map((e) => e.id).sort()).toEqual(['draft1', 'draft2', 'mixed'])
+    expect(idsIn(dir)).toEqual(['draft1', 'draft2', 'mixed'])
+  })
+
+  it('skips unreadable stores instead of aborting the restore', () => {
+    const dir = tempDir()
+    writeStore(dir, 'good', ['/docs/a.md'], 1)
+    writeFileSync(path.join(dir, 'broken_editor_buffer_store.json'), 'not json')
+
+    const restorable = makeStore(dir).getRestorableBufferStores()
+
+    expect(restorable.map((e) => e.id)).toEqual(['good'])
+    // A store we could not parse is left alone rather than deleted.
+    expect(idsIn(dir)).toEqual(['broken', 'good'])
+  })
+})


### PR DESCRIPTION
## Summary

Launching MarkText from a desktop launcher could open a pile of windows — one per leftover
buffer store — instead of restoring the previous session.

A buffer store is only collected once **every** tab in it reports `isSaved`. So editing a
file across several sessions without ever hitting save leaves one store behind per session,
and `restoreAll` opens a window for each. In my case: 34 stores covering 7 distinct files,
one file duplicated 12 times, so 34 windows on launch. The directory grows without bound
because nothing ever removes the stale duplicates.

Only the launcher pathway hits this — passing a file path on the command line skips the
restore branch entirely.

Two changes:

1. **Restore one window per distinct set of open documents, newest wins.**
   New `EditorBufferStore.getRestorableBufferStores()` keys each store by the *set* of
   pathnames its tabs hold (sorted, so tab order doesn't matter), keeps the store with the
   newest mtime for each key, and deletes the superseded ones so the folder stops growing.
   `App.createWindow` now calls it instead of iterating `getAll()`.

   Stores containing an untitled tab keep their own identity (`untitled:<id>`) and are never
   collapsed — an unsaved draft exists nowhere else on disk, so merging two of them would
   lose content.

   A store that fails to parse or stat is skipped, not deleted: it's excluded from the
   restore rather than aborting it, and left on disk rather than thrown away.

2. **Moved buffer cleanup from the `mt::close-window` handler into `forceClose()`.**
   Every window teardown path funnels through `forceClose`, but the cleanup only ran on the
   renderer's `mt::close-window` round trip. Windows destroyed any other way —
   `forceCloseById`, application quit, or a renderer that never answers `mt::ask-for-close` —
   never cleaned up their store, which is a large part of how the duplicates accumulated in
   the first place. The call sits before `remove()` so the editor-window list still counts
   the closing window.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added — `packages/desktop/test/unit/specs/buffer-store-restore-dedupe.spec.ts`,
      5 cases over `getRestorableBufferStores()`:
  - collapses repeated snapshots of the same document to the newest, deleting the rest
  - keeps one entry per distinct document
  - treats the tab set as the identity regardless of tab order
  - never collapses untitled drafts
  - skips an unparseable store instead of aborting, and leaves it on disk

  ```
  pnpm -C packages/desktop exec vitest run test/unit/specs/buffer-store-restore-dedupe.spec.ts
  Test Files  1 passed (1)
       Tests  5 passed (5)
  ```

- [x] Manually tested on: Linux — reproduced the 34-window launch, then confirmed a single
      restored window per document set after the fix, with the stale stores gone from the
      buffer-store directory.

## Notes for reviewers [optional]

- **Why mtime and not the store id.** Ids carry no ordering, so file mtime is the only
  recency signal available for picking a winner among duplicates. It's good enough here:
  the loser is a strictly older snapshot of the same document set.
- **Deletion happens during restore**, inside `getRestorableBufferStores()`. That's a
  side effect in something that reads like a getter, and I'd rather hear if you want it
  split into a separate sweep — I kept them together so the "which store won" decision and
  the "delete the losers" action can't drift apart.
- **Untitled tabs are deliberately never merged**, which means a session with an unsaved
  draft still restores as its own window. That's the conservative choice; the alternative
  risks silently dropping unsaved content.
- The `restoreBufferId` cast in `windowManager.ts` is pre-existing — the property is stashed
  on the `BrowserWindow` and isn't in Electron's types. I moved the call, not the cast.
