### PR TITLE
feat(desktop): add "Reset Zoom" item to the Window menu

### DIFF
--- a/packages/desktop/src/common/commands/constants.ts
+++ b/packages/desktop/src/common/commands/constants.ts
@@ -105,6 +105,7 @@ const COMMANDS = Object.freeze({
   WINDOW_TOGGLE_ALWAYS_ON_TOP: 'window.toggle-always-on-top',
   WINDOW_TOGGLE_FULL_SCREEN: 'window.toggle-full-screen',
   WINDOW_ZOOM_IN: 'window.zoomIn',
+  WINDOW_ZOOM_RESET: 'window.resetZoom',
   WINDOW_ZOOM_OUT: 'window.zoomOut'
 } as const)
 

--- a/packages/desktop/src/main/keyboard/keybindingsDarwin.ts
+++ b/packages/desktop/src/main/keyboard/keybindingsDarwin.ts
@@ -86,6 +86,7 @@ const keybindings: Map<string, string> = new Map([
   ['window.minimize', 'Command+M'],
   ['window.toggle-always-on-top', ''],
   ['window.zoomIn', ''],
+  ['window.resetZoom', ''],
   ['window.zoomOut', ''],
   ['window.toggle-full-screen', 'Ctrl+Command+F'],
 

--- a/packages/desktop/src/main/keyboard/keybindingsLinux.ts
+++ b/packages/desktop/src/main/keyboard/keybindingsLinux.ts
@@ -90,6 +90,7 @@ const keybindings: Map<string, string> = new Map([
   ['window.minimize', 'Ctrl+M'],
   ['window.toggle-always-on-top', ''],
   ['window.zoomIn', ''],
+  ['window.resetZoom', ''],
   ['window.zoomOut', ''],
   ['window.toggle-full-screen', 'F11'],
 

--- a/packages/desktop/src/main/keyboard/keybindingsWindows.ts
+++ b/packages/desktop/src/main/keyboard/keybindingsWindows.ts
@@ -89,6 +89,7 @@ const keybindings: Map<string, string> = new Map([
   ['window.minimize', 'Ctrl+M'],
   ['window.toggle-always-on-top', ''],
   ['window.zoomIn', ''],
+  ['window.resetZoom', ''],
   ['window.zoomOut', ''],
   ['window.toggle-full-screen', 'F11'],
 

--- a/packages/desktop/src/main/menu/actions/window.ts
+++ b/packages/desktop/src/main/menu/actions/window.ts
@@ -1,7 +1,7 @@
 import { Menu, ipcMain, type BrowserWindow } from 'electron'
 import { isOsx } from '../../config'
 import { COMMANDS } from '../../commands'
-import { zoomIn, zoomOut } from '../../windows/utils'
+import { zoomIn, zoomOut, resetZoom } from '../../windows/utils'
 import type { CommandManager } from '../../commands'
 
 export const minimizeWindow = (win: BrowserWindow | null | undefined): void => {
@@ -33,5 +33,6 @@ export const loadWindowCommands = (commandManager: CommandManager): void => {
   commandManager.add(COMMANDS.WINDOW_TOGGLE_ALWAYS_ON_TOP, toggleAlwaysOnTop)
   commandManager.add(COMMANDS.WINDOW_TOGGLE_FULL_SCREEN, toggleFullScreen)
   commandManager.add(COMMANDS.WINDOW_ZOOM_IN, zoomIn)
+  commandManager.add(COMMANDS.WINDOW_ZOOM_RESET, resetZoom)
   commandManager.add(COMMANDS.WINDOW_ZOOM_OUT, zoomOut)
 }

--- a/packages/desktop/src/main/menu/templates/window.ts
+++ b/packages/desktop/src/main/menu/templates/window.ts
@@ -1,6 +1,6 @@
 import { Menu, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { minimizeWindow, toggleAlwaysOnTop, toggleFullScreen } from '../actions/window'
-import { zoomIn, zoomOut } from '../../windows/utils'
+import { zoomIn, zoomOut, resetZoom } from '../../windows/utils'
 import { isOsx } from '../../config'
 import { t } from '../../i18n'
 import type Keybindings from '../../keyboard/shortcutHandler'
@@ -38,6 +38,13 @@ export default function(keybindings: Keybindings): MenuItemConstructorOptions {
       accelerator: keybindings.getAccelerator('window.zoomOut') ?? undefined,
       click(_menuItem, browserWindow) {
         zoomOut(browserWindow as BrowserWindow | undefined)
+      }
+    },
+    {
+      label: t('menu.window.resetZoom'),
+      accelerator: keybindings.getAccelerator('window.resetZoom') ?? undefined,
+      click(_menuItem, browserWindow) {
+        resetZoom(browserWindow as BrowserWindow | undefined)
       }
     },
     {

--- a/packages/desktop/src/main/windows/utils.ts
+++ b/packages/desktop/src/main/windows/utils.ts
@@ -18,6 +18,13 @@ export const zoomOut = (win: BrowserWindow | null | undefined): void => {
   webContents.send('mt::window-zoom', Math.max(0.5, zoom - 0.125))
 }
 
+export const resetZoom = (win: BrowserWindow | null | undefined): void => {
+  if (!win) return
+  const { webContents } = win
+  // WORKAROUND: We need to set zoom on the browser window due to Electron#16018.
+  webContents.send('mt::window-zoom', 1.0)
+}
+
 export const centerWindowOptions = (
   options: BrowserWindowConstructorOptions & {
     width: number

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -80,6 +80,7 @@
       "minimize": "Minimieren",
       "zoomIn": "Vergrößern",
       "zoomOut": "Verkleinern",
+      "resetZoom": "Zoom zurücksetzen",
       "fullScreen": "Vollbild",
       "bringAllToFront": "Alle nach vorne bringen",
       "alwaysOnTop": "Immer im Vordergrund"

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -80,6 +80,7 @@
       "minimize": "Minimize",
       "zoomIn": "Zoom In",
       "zoomOut": "Zoom Out",
+      "resetZoom": "Reset Zoom",
       "fullScreen": "Full Screen",
       "bringAllToFront": "Bring All to Front",
       "alwaysOnTop": "Always on Top"

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -80,6 +80,7 @@
       "minimize": "Minimizar",
       "zoomIn": "Acercar",
       "zoomOut": "Alejar",
+      "resetZoom": "Restablecer zoom",
       "fullScreen": "Pantalla Completa",
       "bringAllToFront": "Traer al Frente",
       "alwaysOnTop": "Siempre Encima"

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -80,6 +80,7 @@
       "minimize": "Réduire",
       "zoomIn": "Agrandir",
       "zoomOut": "Réduire",
+      "resetZoom": "Réinitialiser le zoom",
       "fullScreen": "Plein écran",
       "bringAllToFront": "Tout amener au premier plan",
       "alwaysOnTop": "Toujours au premier plan"

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -80,6 +80,7 @@
       "minimize": "最小化",
       "zoomIn": "拡大",
       "zoomOut": "縮小",
+      "resetZoom": "ズームをリセット",
       "fullScreen": "フルスクリーン",
       "bringAllToFront": "すべてを前面に移動",
       "alwaysOnTop": "常に最前面に表示"

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -80,6 +80,7 @@
       "minimize": "최소화",
       "zoomIn": "확대",
       "zoomOut": "축소",
+      "resetZoom": "줌 초기화",
       "fullScreen": "전체 화면",
       "bringAllToFront": "모든 창 앞으로 가져오기",
       "alwaysOnTop": "항상 위에"

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -80,6 +80,7 @@
       "minimize": "Minimizar",
       "zoomIn": "Aumentar Zoom",
       "zoomOut": "Diminuir Zoom",
+      "resetZoom": "Redefinir Zoom",
       "fullScreen": "Tela Cheia",
       "bringAllToFront": "Trazer Todas para Frente",
       "alwaysOnTop": "Sempre no Topo"

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -80,6 +80,7 @@
       "minimize": "Simge Durumuna Küçült",
       "zoomIn": "Yakınlaştır",
       "zoomOut": "Uzaklaştır",
+      "resetZoom": "Yakınlaştırmayı Sıfırla",
       "fullScreen": "Tam Ekran",
       "bringAllToFront": "Tümünü Öne Getir",
       "alwaysOnTop": "Her Zaman Üstte"

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -80,6 +80,7 @@
       "minimize": "最小化",
       "zoomIn": "放大",
       "zoomOut": "缩小",
+      "resetZoom": "重置缩放",
       "fullScreen": "全屏",
       "bringAllToFront": "将所有窗口置于前台",
       "alwaysOnTop": "总是在最前面"

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -80,6 +80,7 @@
       "minimize": "最小化",
       "zoomIn": "放大",
       "zoomOut": "縮小",
+      "resetZoom": "重置縮放",
       "fullScreen": "全螢幕",
       "bringAllToFront": "將全部移到前面",
       "alwaysOnTop": "總是在最上層"


### PR DESCRIPTION
<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #5184

## Summary

<!-- A concise description of what this PR does and why -->

Add a **Reset Zoom** item to the Window menu, between "Zoom Out" and the separator.
It restores the window zoom factor to 1.0 by reusing the existing `mt::window-zoom`
IPC channel (same workaround as Zoom In/Out for Electron#16018), and is registered
as a `window.resetZoom` command so it can be rebound in preferences.

- New action: `resetZoom` in `src/main/windows/utils.ts`
- New command id: `WINDOW_ZOOM_RESET` (`window.resetZoom`) in `src/common/commands/constants.ts`
- Menu entry added in `src/main/menu/templates/window.ts` with i18n labels
  (`menu.window.resetZoom`) for all 10 locales



## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed) - not needed: follows the exact
      pattern of the existing Zoom In/Out menu items; behavior verified by typecheck
      and manual testing.
- [ ] Manually tested on: <!-- macOS / Windows / Linux -->

## Notes for reviewers [optional]

<!-- Design decisions, known limitations, or anything else reviewers should know -->

- No default accelerator is assigned. `Ctrl+0`/`Cmd+0` are already taken
  (`tabs.switchToTenth` on Win/Linux, `paragraph.paragraph` on macOS), so the
  keybinding ships empty like `window.zoomIn`/`window.zoomOut` and can be
  customized in preferences.
- Reset always targets 1.0, matching Electron's built-in `resetZoom` role behavior.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
