### PR TITLE
fix(desktop): allow saving directly to a drive root (#5150)

### DIFF
--- a/packages/desktop/src/main/filesystem/index.ts
+++ b/packages/desktop/src/main/filesystem/index.ts
@@ -35,7 +35,14 @@ export const writeFile = async(
 
   // write-file-atomic does not create parent directories; recreate a moved or
   // deleted folder first so an (auto)save into it still succeeds (#3509).
-  await ensureDir(path.dirname(pathname))
+  // Only do this when the parent does not already exist. On Windows fs.mkdir
+  // returns EPERM (not EEXIST) for an existing volume root (e.g. "E:\"), so for
+  // an existing parent — drive roots included — ensureDir would throw and block
+  // saving directly to a drive root instead of being a harmless no-op (#5150).
+  const dir = path.dirname(pathname)
+  if (!isDirectory(dir)) {
+    await ensureDir(dir)
+  }
 
   // Durable atomic save: write to a temp file in the target's directory, fsync
   // it, then rename it over the target. This survives an application crash AND


### PR DESCRIPTION
**Fixes #5150**

**Problem**

Saving a markdown file directly to a disk drive root (e.g. `E:\` or `D:\`) on Windows fails and blocks the save entirely, as reported in #5150.

**Root cause**

`writeFile()` in `packages/desktop/src/main/filesystem/index.ts` unconditionally called `ensureDir()` on the target's parent directory before writing. fs-extra's `ensureDir()` maps to `fs.mkdir(dir, { recursive: true })`. On Windows, `fs.mkdir()` throws `EPERM` (not the usual `EEXIST`) when the path is an existing volume root such as `E:\`. Node handles a filesystem-root path specially, so an existing parent — a drive root included — failed the save with:

```
EPERM: operation not permitted, mkdir 'E:\'
```

This is independent of the drive's ACL / write permission: even a writable drive root fails, because the error occurs at the `mkdir` step before any file write is attempted. That is why it reproduced on every drive root on Windows.

**Fix**

Only call `ensureDir()` when the parent directory does not already exist:

```ts
const dir = path.dirname(pathname)
if (!isDirectory(dir)) {
  await ensureDir(dir)
}
```

- An existing parent (drive roots included) is now a harmless no-op.
- The #3509 behaviour — recreating a moved/deleted parent folder on save, which is intentional and matches VS Code — is preserved, because `isDirectory()` returns `false` for a missing parent and `ensureDir()` still runs.
- `isDirectory()` uses `lstatSync` (does not follow symlinks), so symlinked parents still fall through to `ensureDir()`, keeping prior behaviour unchanged.

**Cross-platform safety**

The change is platform-neutral and only uses `lstatSync`. On macOS/Linux an existing parent directory is likewise a no-op (recursive `mkdir` on an existing directory succeeds silently), so the only behavioural change is skipping a redundant — and on Windows, failing — call on a drive root. Symlink and deleted-parent handling are unchanged.

**Verification**

- Reproduced the original failure with the exact fs-extra (11.3.5) and write-file-atomic (7.0.1) versions the desktop uses; confirmed `EPERM: operation not permitted, mkdir 'E:\'`.
- Confirmed the fix writes successfully to `E:\` directly, to an existing directory, to a recreated (deleted) parent, and to a normal new file.
- `pnpm typecheck` passes; the changed file is lint-clean.
- Existing `write-file-missing-dir.spec.ts` (#3509, 2 tests) still passes, confirming the recreate-missing-parent behaviour is unchanged.
