### PR TITLE
fix: preserve viewport when toggling task-list checkbox

### DIFF
--- a/packages/desktop/test/e2e/task-list-autocheck.spec.ts
+++ b/packages/desktop/test/e2e/task-list-autocheck.spec.ts
@@ -31,6 +31,11 @@ import {
 // proven nesting fixture from the unit parity spec.
 const NESTED_TASKS = '- [ ] parent\n\n  - [ ] child1\n  - [ ] child2\n'
 
+const SCROLLED_TASKS = `${Array.from(
+  { length: 80 },
+  (_, index) => `Paragraph before task ${index + 1}`
+).join('\n\n')}\n\n- [ ] review decision\n`
+
 const setAutoCheck = async(app: ElectronApplication, value: boolean): Promise<void> => {
   await sendIpcToRenderer(app, 'mt::user-preference', { autoCheck: value })
 }
@@ -127,5 +132,37 @@ test.describe('Checklist 32 — task list autoCheck cascade via a real checkbox 
     expect(md).toContain('- [x] parent')
 
     await expectNoRendererErrors(app)
+  })
+})
+
+test.describe('Task-list checkbox preserves the viewport', () => {
+  test('clicking a visible checkbox in a long document does not jump to the top', async() => {
+    const { app, page } = await launchWithMarkdown(SCROLLED_TASKS, {
+      suppressErrorDialog: true
+    })
+
+    try {
+      const checkbox = page.locator('.editor-component input[type=checkbox]')
+      await checkbox.scrollIntoViewIfNeeded()
+
+      const before = await page.evaluate(() => {
+        const editor = document.querySelector('.editor-component') as HTMLElement | null
+        return editor?.scrollTop ?? 0
+      })
+      expect(before).toBeGreaterThan(500)
+
+      await checkbox.click()
+      await expect(checkbox).toBeChecked()
+      await page.waitForTimeout(250)
+
+      const after = await page.evaluate(() => {
+        const editor = document.querySelector('.editor-component') as HTMLElement | null
+        return editor?.scrollTop ?? 0
+      })
+      expect(after).toBeGreaterThan(before - 100)
+      await expectNoRendererErrors(app)
+    } finally {
+      await app.close()
+    }
   })
 })

--- a/packages/muya/src/block/gfm/taskListCheckbox/index.ts
+++ b/packages/muya/src/block/gfm/taskListCheckbox/index.ts
@@ -174,6 +174,11 @@ class TaskListCheckbox extends TreeNode {
                 this._checked = checked;
                 this.update(checked, 'user');
             }
+
+            // The control is not editable, so clicking it does not move the
+            // text selection. Seat the caret in this item before the desktop's
+            // selection-follow scroll can reveal a stale off-screen cursor.
+            (this.parent as TaskListItem).firstContentInDescendant()?.setCursor(0, 0, true);
         };
 
         const eventIds = [


### PR DESCRIPTION
## Summary

- Keep the editor viewport stable when a visible task-list checkbox is toggled.
- Add an Electron E2E regression test using a long document.

## Problem

Task-list checkboxes are non-editable controls. Clicking one updated the checked state but did not move the text selection. If the editor selection was still in an off-screen block, desktop selection-follow behavior could reveal that stale cursor and scroll the document to the top.

## Fix

After applying the checkbox state, seat the caret in the clicked task item first text descendant before selection-follow scrolling can run.

## Reproduction and verification

A long document with the target checkbox near the bottom produced these runtime measurements:

- Before the fix: editor `scrollTop` changed from `8927` to `0`.
- After the fix: editor `scrollTop` remained `8927` after 350 ms and 1.85 s.
- The regression test fails when the implementation change is removed and passes when it is restored.

Checks run:

- `pnpm lint` — 0 errors; existing warnings only.
- `pnpm typecheck` — passed.
- Desktop unit tests — 734 passed.
- Muya unit tests — 1438 passed.
- CommonMark and GFM specs — 1347 passed.
- Muya build and circular-dependency check — passed.
- Targeted Electron viewport regression test — passed.
- Production desktop build — passed.
- Installed macOS app runtime probe — passed.

## Local baseline notes

- The complete task-list E2E file has one pre-existing timing failure in the autoCheck OFF serialization assertion; it also reproduces with this implementation change removed. The new viewport regression passes.
- Muya Chromium E2E on macOS completed with 237 passed and 7 unrelated existing or platform-sensitive failures in search and replace, formatting shortcuts, auto-pair, and IME coverage.