### PR TITLE
fix(editor): preserve table cell text and add frontmatter disclosure

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -257,6 +257,11 @@
     "enum": ["-", "+", ";", "{"],
     "default": "-"
   },
+  "frontmatterDefaultCollapsed": {
+    "description": "Markdown--Whether properties are collapsed by default",
+    "type": "boolean",
+    "default": true
+  },
   "superSubScript": {
     "description": "Markdown-Enable pandoc's markdown extension superscript and subscript.",
     "type": "boolean",

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -217,6 +217,7 @@ const {
   tabSize,
   listIndentation,
   frontmatterType,
+  frontmatterDefaultCollapsed,
   superSubScript,
   footnote,
   isHtmlEnabled,
@@ -641,6 +642,12 @@ watch(listIndentation, (value, oldValue) => {
 watch(frontmatterType, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ frontmatterType: value })
+  }
+})
+
+watch(frontmatterDefaultCollapsed, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ frontmatterDefaultCollapsed: value }, true)
   }
 })
 
@@ -1747,6 +1754,7 @@ onMounted(() => {
     codeBlockLineNumbers: codeBlockLineNumbers.value,
     listIndentation: listIndentation.value,
     frontmatterType: frontmatterType.value,
+    frontmatterDefaultCollapsed: frontmatterDefaultCollapsed.value,
     superSubScript: superSubScript.value,
     footnote: footnote.value,
     disableHtml: !isHtmlEnabled.value,

--- a/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
@@ -51,6 +51,11 @@
           :on-change="(value) => onSelectChange('frontmatterType', value)"
         />
         <bool
+          :description="t('preferences.markdown.extensions.frontmatterDefaultCollapsed')"
+          :bool="frontmatterDefaultCollapsed"
+          :on-change="(value) => onSelectChange('frontmatterDefaultCollapsed', value)"
+        />
+        <bool
           :description="t('preferences.markdown.extensions.superSubScript')"
           :bool="superSubScript"
           :on-change="(value) => onSelectChange('superSubScript', value)"
@@ -157,6 +162,7 @@ const {
   preferHeadingStyle,
   listIndentation,
   frontmatterType,
+  frontmatterDefaultCollapsed,
   superSubScript,
   footnote,
   isHtmlEnabled,

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -75,6 +75,7 @@ export interface PreferencesState {
   tabSize: number
   listIndentation: number
   frontmatterType: FrontmatterType | string
+  frontmatterDefaultCollapsed: boolean
   superSubScript: boolean
   footnote: boolean
   isHtmlEnabled: boolean
@@ -191,6 +192,7 @@ export const usePreferencesStore = defineStore('preferences', {
     tabSize: 4,
     listIndentation: 1,
     frontmatterType: '-',
+    frontmatterDefaultCollapsed: true,
     superSubScript: false,
     footnote: false,
     isHtmlEnabled: true,

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -41,6 +41,7 @@ export interface IUserPreferences {
   tabSize?: number
   listIndentation?: number | string
   frontmatterType?: '-' | ';' | '+' | '{'
+  frontmatterDefaultCollapsed?: boolean
   superSubScript?: boolean
   footnote?: boolean
   isHtmlEnabled?: boolean

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -403,6 +403,7 @@
         "tabSize": "Tab durch x Leerzeichen ersetzen",
         "listIndentation": "Einrückung der Liste auswählen",
         "frontmatterType": "Der Frontmatter-Typ",
+        "frontmatterDefaultCollapsed": "Eigenschaften standardmäßig einklappen",
         "superSubScript": "Pandocs Markdown-Erweiterung für hoch- und tiefgestellte Zeichen aktivieren",
         "footnote": "Pandocs Markdown-Erweiterung für Fußnoten aktivieren",
         "isHtmlEnabled": "HTML-Rendering aktivieren",
@@ -625,6 +626,7 @@
         "superSubScript": "Hoch-/Tiefgestellt",
         "footnote": "Fußnote",
         "footnoteNotes": "Fußnoten",
+        "frontmatterDefaultCollapsed": "Eigenschaften standardmäßig einklappen",
         "frontmatterType": {
           "jsonBrace": "JSON-Klammer",
           "jsonSemicolon": "JSON-Semikolon",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -402,6 +402,7 @@
         "tabSize": "Replace the tab with x spaces",
         "listIndentation": "Select the indent of list",
         "frontmatterType": "The frontmatter type",
+        "frontmatterDefaultCollapsed": "Collapse properties by default",
         "superSubScript": "Enable pandoc's markdown extension superscript and subscript",
         "footnote": "Enable pandoc's markdown extension footnote",
         "isHtmlEnabled": "Enable HTML rendering",
@@ -625,6 +626,7 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Footnote",
         "footnoteNotes": "Footnote notes",
+        "frontmatterDefaultCollapsed": "Collapse properties by default",
         "frontmatterType": {
           "jsonBrace": "JSON with Braces",
           "jsonSemicolon": "JSON with Semicolon",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -403,6 +403,7 @@
         "tabSize": "Reemplazar la tabulación con x espacios",
         "listIndentation": "Seleccionar la sangría de lista",
         "frontmatterType": "El tipo de frontmatter",
+        "frontmatterDefaultCollapsed": "Contraer propiedades de forma predeterminada",
         "superSubScript": "Habilitar extensión markdown de pandoc superíndice y subíndice",
         "footnote": "Habilitar extensión markdown de pandoc nota al pie",
         "isHtmlEnabled": "Habilitar renderizado HTML",
@@ -625,6 +626,7 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Nota al pie",
         "footnoteNotes": "Notas al pie",
+        "frontmatterDefaultCollapsed": "Contraer propiedades de forma predeterminada",
         "frontmatterType": {
           "jsonBrace": "JSON con Llaves",
           "jsonSemicolon": "JSON con Punto y Coma",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -403,6 +403,7 @@
         "tabSize": "Remplacer la tabulation par x espaces",
         "listIndentation": "Sélectionner l'indentation de liste",
         "frontmatterType": "Le type de frontmatter",
+        "frontmatterDefaultCollapsed": "Réduire les propriétés par défaut",
         "superSubScript": "Activer l'extension markdown de pandoc pour exposant et indice",
         "footnote": "Activer l'extension markdown de pandoc pour note de bas de page",
         "isHtmlEnabled": "Activer le rendu HTML",
@@ -625,6 +626,7 @@
         "superSubScript": "Exposant/Indice",
         "footnote": "Note de bas de page",
         "footnoteNotes": "Notes de bas de page",
+        "frontmatterDefaultCollapsed": "Réduire les propriétés par défaut",
         "frontmatterType": {
           "jsonBrace": "Accolade JSON",
           "jsonSemicolon": "Point-virgule JSON",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -403,6 +403,7 @@
         "tabSize": "タブをx個のスペースに置き換える",
         "listIndentation": "リストのインデントを選択",
         "frontmatterType": "フロントマターのタイプ",
+        "frontmatterDefaultCollapsed": "プロパティをデフォルトで折りたたむ",
         "superSubScript": "Pandocのmarkdown拡張上付き文字と下付き文字を有効にする",
         "footnote": "Pandocのmarkdown拡張脚注を有効にする",
         "isHtmlEnabled": "HTMLレンダリングを有効にする",
@@ -625,6 +626,7 @@
         "superSubScript": "上付き/下付き文字",
         "footnote": "脚注",
         "footnoteNotes": "脚注",
+        "frontmatterDefaultCollapsed": "プロパティをデフォルトで折りたたむ",
         "frontmatterType": {
           "jsonBrace": "JSON括弧",
           "jsonSemicolon": "JSONセミコロン",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -403,6 +403,7 @@
         "tabSize": "탭을 x개의 공백으로 바꾸기",
         "listIndentation": "목록의 들여쓰기 선택",
         "frontmatterType": "프론트매터 유형",
+        "frontmatterDefaultCollapsed": "속성을 기본적으로 접기",
         "superSubScript": "Pandoc의 마크다운 확장 위첨자와 아래첨자 활성화",
         "footnote": "Pandoc의 마크다운 확장 각주 활성화",
         "isHtmlEnabled": "HTML 렌더링 활성화",
@@ -625,6 +626,7 @@
         "superSubScript": "위/아래 첨자",
         "footnote": "각주",
         "footnoteNotes": "각주 노트",
+        "frontmatterDefaultCollapsed": "속성을 기본적으로 접기",
         "frontmatterType": {
           "jsonBrace": "중괄호가 있는 JSON",
           "jsonSemicolon": "세미콜론이 있는 JSON",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -403,6 +403,7 @@
         "tabSize": "Substituir a tabulação com x espaços",
         "listIndentation": "Selecionar a indentação da lista",
         "frontmatterType": "O tipo de frontmatter",
+        "frontmatterDefaultCollapsed": "Recolher propriedades por padrão",
         "superSubScript": "Habilitar extensão markdown do pandoc para sobrescrito e subscrito",
         "footnote": "Habilitar extensão markdown do pandoc para nota de rodapé",
         "isHtmlEnabled": "Habilitar renderização HTML",
@@ -625,6 +626,7 @@
         "superSubScript": "Super/Sub script",
         "footnote": "Nota de rodapé",
         "footnoteNotes": "Notas de rodapé",
+        "frontmatterDefaultCollapsed": "Recolher propriedades por padrão",
         "frontmatterType": {
           "jsonBrace": "JSON com Chaves",
           "jsonSemicolon": "JSON com Ponto e Vírgula",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -402,6 +402,7 @@
         "tabSize": "Sekmeyi x boşlukla değiştir",
         "listIndentation": "Liste girintisini seçin",
         "frontmatterType": "Ön bilgi türü",
+        "frontmatterDefaultCollapsed": "Özellikleri varsayılan olarak daralt",
         "superSubScript": "Pandoc'un markdown uzantısı üst simge ve alt simgeyi etkinleştir",
         "footnote": "Pandoc'un markdown uzantısı dipnotu etkinleştir",
         "isHtmlEnabled": "HTML işlemeyi etkinleştir",
@@ -625,6 +626,7 @@
         "superSubScript": "Üst/Alt Simge",
         "footnote": "Dipnot",
         "footnoteNotes": "Dipnot notları",
+        "frontmatterDefaultCollapsed": "Özellikleri varsayılan olarak daralt",
         "frontmatterType": {
           "jsonBrace": "Süslü Parantezli JSON",
           "jsonSemicolon": "Noktalı Virgüllü JSON",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -403,6 +403,7 @@
         "tabSize": "用 x 个空格替换制表符",
         "listIndentation": "选择列表的缩进",
         "frontmatterType": "前言类型",
+        "frontmatterDefaultCollapsed": "默认折叠属性",
         "superSubScript": "启用 Pandoc 的 Markdown 扩展上标和下标",
         "footnote": "启用 Pandoc 的 Markdown 扩展脚注",
         "isHtmlEnabled": "启用 HTML 渲染",
@@ -625,6 +626,7 @@
         "superSubScript": "上标/下标",
         "footnote": "脚注",
         "footnoteNotes": "脚注注释",
+        "frontmatterDefaultCollapsed": "默认折叠属性",
         "frontmatterType": {
           "jsonBrace": "带大括号的 JSON",
           "jsonSemicolon": "带分号的 JSON",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -403,6 +403,7 @@
         "tabSize": "用 x 個空格替換製表符",
         "listIndentation": "選擇清單的縮排",
         "frontmatterType": "前言類型",
+        "frontmatterDefaultCollapsed": "預設折疊屬性",
         "superSubScript": "啟用 Pandoc 的 Markdown 擴充功能上標和下標",
         "footnote": "啟用 Pandoc 的 Markdown 擴充功能腳註",
         "isHtmlEnabled": "啟用 HTML 轉譯",
@@ -625,6 +626,7 @@
         "superSubScript": "上標/下標",
         "footnote": "腳註",
         "footnoteNotes": "腳註備註",
+        "frontmatterDefaultCollapsed": "預設折疊屬性",
         "frontmatterType": {
           "jsonBrace": "JSON 大括號",
           "jsonSemicolon": "JSON 分號",

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -50,6 +50,7 @@
   "tabSize": 4,
   "listIndentation": 1,
   "frontmatterType": "-",
+  "frontmatterDefaultCollapsed": true,
   "superSubScript": false,
   "footnote": false,
   "isHtmlEnabled": true,

--- a/packages/desktop/test/e2e/frontmatter-collapse.spec.ts
+++ b/packages/desktop/test/e2e/frontmatter-collapse.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import { expectNoRendererErrors, launchWithMarkdown } from './helpers'
+
+const FRONTMATTER_DOC = '---\ntitle: Example\nauthor: Tester\n---\n\nBody\n'
+const FRONTMATTER = '.editor-component .mu-frontmatter'
+
+const setPreference = async(page: Page, value: boolean): Promise<void> => {
+  await page.evaluate((frontmatterDefaultCollapsed) => {
+    window.electron.ipcRenderer.send('mt::set-user-preference', {
+      frontmatterDefaultCollapsed
+    })
+  }, value)
+}
+
+test.describe('frontmatter property disclosure preference', () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async() => {
+    const launched = await launchWithMarkdown(FRONTMATTER_DOC, {
+      suppressErrorDialog: true
+    })
+    app = launched.app
+    page = launched.page
+    await page.waitForSelector(FRONTMATTER, { state: 'attached', timeout: 15000 })
+  })
+
+  test.afterAll(async() => {
+    if (page) await setPreference(page, true)
+    if (app) await app.close()
+  })
+
+  test('starts collapsed and the Properties control expands it', async() => {
+    const frontmatter = page.locator(FRONTMATTER)
+    const toggle = frontmatter.locator('.mu-frontmatter-toggle')
+
+    await expect(frontmatter).toHaveClass(/mu-frontmatter-collapsed/)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(frontmatter.locator('.mu-code')).toBeHidden()
+
+    await toggle.click()
+    await expect(frontmatter).not.toHaveClass(/mu-frontmatter-collapsed/)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(frontmatter.locator('.mu-code')).toBeVisible()
+    await expectNoRendererErrors(app)
+  })
+
+  test('applies collapsed and expanded defaults live from preferences', async() => {
+    await setPreference(page, false)
+    await expect(page.locator(FRONTMATTER)).not.toHaveClass(/mu-frontmatter-collapsed/)
+    await expect(page.locator(`${FRONTMATTER} .mu-code`)).toBeVisible()
+
+    await setPreference(page, true)
+    await expect(page.locator(FRONTMATTER)).toHaveClass(/mu-frontmatter-collapsed/)
+    await expect(page.locator(`${FRONTMATTER} .mu-code`)).toBeHidden()
+
+    await setPreference(page, false)
+    await expect(page.locator(FRONTMATTER)).not.toHaveClass(/mu-frontmatter-collapsed/)
+    await expect(page.locator(`${FRONTMATTER} .mu-code`)).toBeVisible()
+    await expectNoRendererErrors(app)
+  })
+})

--- a/packages/desktop/test/unit/specs/frontmatter-collapse-preference.spec.ts
+++ b/packages/desktop/test/unit/specs/frontmatter-collapse-preference.spec.ts
@@ -1,0 +1,37 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import schema from '../../../src/main/preferences/schema.json'
+import defaultPreferences from '../../../static/preference.json'
+import { usePreferencesStore } from '@/store/preferences'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const markdownPreferencePath = resolve(here, '../../../src/renderer/src/prefComponents/markdown/index.vue')
+const editorPath = resolve(here, '../../../src/renderer/src/components/editorWithTabs/editor.vue')
+
+describe('frontmatter default collapse preference', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('defaults to collapsed in every preference source', () => {
+    const preferenceSchema = schema as Record<string, { default?: unknown }>
+    const defaults = defaultPreferences as Record<string, unknown>
+    const store = usePreferencesStore() as unknown as Record<string, unknown>
+
+    expect(preferenceSchema.frontmatterDefaultCollapsed?.default).toBe(true)
+    expect(defaults.frontmatterDefaultCollapsed).toBe(true)
+    expect(store.frontmatterDefaultCollapsed).toBe(true)
+  })
+
+  it('exposes the preference in Settings and passes it to Muya', () => {
+    const preferenceSource = readFileSync(markdownPreferencePath, 'utf8')
+    const editorSource = readFileSync(editorPath, 'utf8')
+
+    expect(preferenceSource).toContain("onSelectChange('frontmatterDefaultCollapsed'")
+    expect(editorSource).toContain('frontmatterDefaultCollapsed: frontmatterDefaultCollapsed.value')
+    expect(editorSource).toContain('watch(frontmatterDefaultCollapsed')
+  })
+})

--- a/packages/muya/e2e/tests/blocks/frontmatter.spec.ts
+++ b/packages/muya/e2e/tests/blocks/frontmatter.spec.ts
@@ -87,4 +87,55 @@ test.describe('frontmatter block', () => {
             expect(md).toContain(styleCase.expectedEnd);
         });
     }
+
+    test('defaults to collapsed and toggles without changing markdown', async ({ page }) => {
+        await page.evaluate(() => {
+            const state: TState[] = [{
+                name: 'frontmatter',
+                meta: { lang: 'yaml', style: '-' },
+                text: 'title: hi\nauthor: me',
+            }, {
+                name: 'paragraph',
+                text: 'body',
+            }];
+            window.muya!.setContent(state);
+        });
+
+        const fm = page.locator(editor.frontmatter);
+        const toggle = fm.locator('.mu-frontmatter-toggle');
+        const code = fm.locator('.mu-code');
+        const markdownBefore = await page.evaluate(() => window.muya!.getMarkdown());
+
+        await expect(fm).toHaveClass(/mu-frontmatter-collapsed/);
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+        await expect(toggle).toContainText('Properties');
+        await expect(code).toBeHidden();
+
+        await toggle.click();
+        await expect(fm).not.toHaveClass(/mu-frontmatter-collapsed/);
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+        await expect(code).toBeVisible();
+        await expect(code).toContainText('title: hi');
+        expect(await page.evaluate(() => window.muya!.getMarkdown())).toBe(markdownBefore);
+    });
+
+    test('supports expanded as the configured default', async ({ page }) => {
+        await page.evaluate(() => {
+            window.muya!.setOptions({ frontmatterDefaultCollapsed: false }, true);
+            const state: TState[] = [{
+                name: 'frontmatter',
+                meta: { lang: 'yaml', style: '-' },
+                text: 'title: expanded',
+            }, {
+                name: 'paragraph',
+                text: 'body',
+            }];
+            window.muya!.setContent(state);
+        });
+
+        const fm = page.locator(editor.frontmatter);
+        await expect(fm).not.toHaveClass(/mu-frontmatter-collapsed/);
+        await expect(fm.locator('.mu-frontmatter-toggle')).toHaveAttribute('aria-expanded', 'true');
+        await expect(fm.locator('.mu-code')).toBeVisible();
+    });
 });

--- a/packages/muya/e2e/tests/editing/table-cell-selection.spec.ts
+++ b/packages/muya/e2e/tests/editing/table-cell-selection.spec.ts
@@ -70,6 +70,35 @@ test.describe('cross-cell table selection', () => {
         }).toBe(4);
     });
 
+    test('keeps selected cell text painted above the selection tint', async ({ page }) => {
+        await seedTable(page);
+        await dragSelect(page, { row: 0, column: 1 }, { row: 2, column: 1 });
+        await expect.poll(() => selectedCount(page)).toBe(3);
+
+        const paintOrder = await page
+            .locator(`${editor.table} td.mu-table-cell-selected`)
+            .evaluateAll(cells => cells.map((cell) => {
+                const content = cell.querySelector('.mu-table-cell-content');
+                if (!content)
+                    return { text: '', overlayZ: 0, contentZ: 0 };
+
+                const overlayZ = Number.parseInt(getComputedStyle(cell, '::before').zIndex, 10) || 0;
+                const contentStyle = getComputedStyle(content);
+                const contentZ = contentStyle.position === 'static'
+                    ? 0
+                    : Number.parseInt(contentStyle.zIndex, 10) || 0;
+
+                return {
+                    text: content.textContent ?? '',
+                    overlayZ,
+                    contentZ,
+                };
+            }));
+
+        expect(paintOrder.map(item => item.text)).toEqual(['b1', 'b2', 'b3']);
+        expect(paintOrder.every(item => item.contentZ > item.overlayZ)).toBe(true);
+    });
+
     test('copy yields only the selected sub-rectangle as a GFM table', async ({ browserName, context, page }) => {
         test.skip(browserName !== 'chromium', 'clipboard read unreliable on Firefox/WebKit headless — BACKLOG Phase 3.');
         await context.grantPermissions(['clipboard-read', 'clipboard-write']);

--- a/packages/muya/src/__tests__/frontMatter.spec.ts
+++ b/packages/muya/src/__tests__/frontMatter.spec.ts
@@ -40,12 +40,21 @@ afterEach(() => {
         delete (window as Partial<Window>).MUYA_VERSION;
 });
 
-function bootMuya(markdown: string, frontmatterType?: string): Muya {
+function bootMuya(
+    markdown: string,
+    frontmatterType?: string,
+    frontmatterDefaultCollapsed?: boolean,
+): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
-    const options = { markdown } as ConstructorParameters<typeof Muya>[1] & { frontmatterType?: string };
+    const options = { markdown } as ConstructorParameters<typeof Muya>[1] & {
+        frontmatterType?: string;
+        frontmatterDefaultCollapsed?: boolean;
+    };
     if (frontmatterType !== undefined)
         options.frontmatterType = frontmatterType;
+    if (frontmatterDefaultCollapsed !== undefined)
+        options.frontmatterDefaultCollapsed = frontmatterDefaultCollapsed;
     const muya = new Muya(host, options);
     muya.init();
     bootedHosts.push(muya.domNode);
@@ -278,5 +287,50 @@ describe('front matter delimiter marker', () => {
         const pre = await insertFrontMatter('{');
         expect(pre.getAttribute('frontMatterStart')).toBe('{');
         expect(pre.getAttribute('frontMatterEnd')).toBe('}');
+    });
+});
+
+describe('front matter disclosure', () => {
+    const markdown = '---\ntitle: hi\nauthor: me\n---\n\nbody\n';
+
+    function frontmatterPre(muya: Muya): HTMLElement {
+        const block = muya.editor.scrollPage!.find(0) as unknown as Parent;
+        return block.domNode!;
+    }
+
+    it('defaults to collapsed while preserving the markdown content', () => {
+        const muya = bootMuya(markdown);
+        const pre = frontmatterPre(muya);
+        const toggle = pre.querySelector<HTMLButtonElement>('.mu-frontmatter-toggle');
+
+        expect(pre.classList.contains('mu-frontmatter-collapsed')).toBe(true);
+        expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+        expect(toggle?.textContent).toContain('Properties');
+        expect(muya.getMarkdown()).toBe(markdown);
+    });
+
+    it('supports an expanded default through the editor option', () => {
+        const muya = bootMuya(markdown, undefined, false);
+        const pre = frontmatterPre(muya);
+        const toggle = pre.querySelector<HTMLButtonElement>('.mu-frontmatter-toggle');
+
+        expect(pre.classList.contains('mu-frontmatter-collapsed')).toBe(false);
+        expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('toggles per block without changing document bytes', () => {
+        const muya = bootMuya(markdown);
+        const pre = frontmatterPre(muya);
+        const toggle = pre.querySelector<HTMLButtonElement>('.mu-frontmatter-toggle')!;
+
+        toggle.click();
+        expect(pre.classList.contains('mu-frontmatter-collapsed')).toBe(false);
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        expect(muya.getMarkdown()).toBe(markdown);
+
+        toggle.click();
+        expect(pre.classList.contains('mu-frontmatter-collapsed')).toBe(true);
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(muya.getMarkdown()).toBe(markdown);
     });
 });

--- a/packages/muya/src/assets/styles/blockSyntax.css
+++ b/packages/muya/src/assets/styles/blockSyntax.css
@@ -235,6 +235,62 @@
     font-family: inherit;
 }
 
+.mu-frontmatter-toggle {
+    display: flex;
+    gap: 0.65em;
+    align-items: center;
+    width: 100%;
+    padding: 0;
+
+    color: var(--editor-color);
+    font-weight: 600;
+    font-size: 1em;
+    font-family: var(--mu-font-family, sans-serif);
+    line-height: 1.4;
+    text-align: left;
+
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+}
+
+.mu-frontmatter-toggle::before {
+    width: 0.45em;
+    height: 0.45em;
+
+    border-right: 1.5px solid currentcolor;
+    border-bottom: 1.5px solid currentcolor;
+    transform: rotate(45deg);
+    transform-origin: center;
+
+    transition: transform 0.15s ease;
+
+    content: '';
+}
+
+.mu-frontmatter-toggle:focus-visible {
+    outline: 2px solid var(--theme-color);
+    outline-offset: 3px;
+}
+
+.mu-frontmatter > .mu-code {
+    display: block;
+    margin-top: 0.75em;
+}
+
+.mu-frontmatter.mu-frontmatter-collapsed > .mu-frontmatter-toggle::before {
+    transform: rotate(-45deg);
+}
+
+.mu-frontmatter.mu-frontmatter-collapsed > .mu-code {
+    display: none;
+}
+
+.mu-frontmatter.mu-frontmatter-collapsed::before,
+.mu-frontmatter.mu-frontmatter-collapsed::after {
+    content: none;
+}
+
 /* wrapCodeBlocks → `.mu-code-wrap`; wraps long lines (overrides prism's `pre`). */
 .mu-code-wrap .mu-code-block .mu-code {
     overflow: hidden;
@@ -971,6 +1027,11 @@ pre.mu-active.mu-fenced-code::after {
 
 .mu-table-cell-content {
     min-width: 10em;
+}
+
+.mu-table-inner tr td.mu-table-cell-selected > .mu-table-cell-content {
+    position: relative;
+    z-index: 2;
 }
 
 /* Footnote definition block — port of marktext's `figure[data-role='FOOTNOTE']`

--- a/packages/muya/src/block/extra/frontmatter/index.ts
+++ b/packages/muya/src/block/extra/frontmatter/index.ts
@@ -10,6 +10,8 @@ import Parent from '../../base/parent';
 import { ScrollPage } from '../../scrollPage';
 
 const debug = logger('frontmatter:');
+const COLLAPSED_CLASS = 'mu-frontmatter-collapsed';
+const TOGGLE_CLASS = 'mu-frontmatter-toggle';
 
 // The before/after focus markers mirror the delimiters `stateToMarkdown`
 // serializes for each front-matter type, so they reflect the real fences:
@@ -27,6 +29,8 @@ function delimiters(meta: IFrontmatterMeta): [string, string] {
 
 class Frontmatter extends Parent {
     public meta: IFrontmatterMeta;
+    private _collapsed: boolean;
+    private _toggleNode: HTMLButtonElement | null = null;
 
     static override blockName = 'frontmatter';
 
@@ -80,11 +84,40 @@ class Frontmatter extends Parent {
         super(muya);
         this.tagName = 'pre';
         this.meta = meta;
+        this._collapsed = muya.options.frontmatterDefaultCollapsed;
         this.classList = ['mu-frontmatter'];
         const [start, end] = delimiters(meta);
         this.attributes.frontMatterStart = start;
         this.attributes.frontMatterEnd = end;
         this.createDomNode();
+        this._createToggle();
+        this._setCollapsed(this._collapsed);
+    }
+
+    private _createToggle() {
+        const toggle = document.createElement('button');
+        const label = this.muya.i18n.t('Properties');
+
+        toggle.type = 'button';
+        toggle.className = TOGGLE_CLASS;
+        toggle.textContent = label;
+        toggle.title = label;
+        toggle.setAttribute('contenteditable', 'false');
+
+        toggle.addEventListener('mousedown', event => event.stopPropagation());
+        toggle.addEventListener('click', (event) => {
+            event.stopPropagation();
+            this._setCollapsed(!this._collapsed);
+        });
+
+        this.domNode!.appendChild(toggle);
+        this._toggleNode = toggle;
+    }
+
+    private _setCollapsed(collapsed: boolean) {
+        this._collapsed = collapsed;
+        this.domNode!.classList.toggle(COLLAPSED_CLASS, collapsed);
+        this._toggleNode?.setAttribute('aria-expanded', String(!collapsed));
     }
 
     queryBlock(path: TBlockPath) {

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -325,6 +325,7 @@ export const MUYA_DEFAULT_OPTIONS = {
     // bullet/list marker width + listIndentation, tab or Daring Fireball Markdown (4 spaces) --> list indentation
     listIndentation: 1,
     frontmatterType: '-',
+    frontmatterDefaultCollapsed: true,
     mermaidTheme: 'default', // dark / forest / default
     vegaTheme: 'latimes', // excel / ggplot2 / quartz / vox / fivethirtyeight / dark / latimes
     plantumlServer: 'https://www.plantuml.com/plantuml',

--- a/packages/muya/src/locales/de.ts
+++ b/packages/muya/src/locales/de.ts
@@ -16,6 +16,7 @@ export const de = {
         'Paragraph': 'Absatz',
         'Horizontal Line': 'Horizontale Linie',
         'Front Matter': 'Front Matter',
+        'Properties': 'Eigenschaften',
         'Heading 1': 'Überschrift 1',
         'Heading 2': 'Überschrift 2',
         'Heading 3': 'Überschrift 3',

--- a/packages/muya/src/locales/en.ts
+++ b/packages/muya/src/locales/en.ts
@@ -16,6 +16,7 @@ export const en = {
         'Paragraph': 'Paragraph',
         'Horizontal Line': 'Horizontal Line',
         'Front Matter': 'Front Matter',
+        'Properties': 'Properties',
         'Heading 1': 'Heading 1',
         'Heading 2': 'Heading 2',
         'Heading 3': 'Heading 3',

--- a/packages/muya/src/locales/es.ts
+++ b/packages/muya/src/locales/es.ts
@@ -16,6 +16,7 @@ export const es = {
         'Paragraph': 'Párrafo',
         'Horizontal Line': 'Línea horizontal',
         'Front Matter': 'Front Matter',
+        'Properties': 'Propiedades',
         'Heading 1': 'Encabezado 1',
         'Heading 2': 'Encabezado 2',
         'Heading 3': 'Encabezado 3',

--- a/packages/muya/src/locales/fr.ts
+++ b/packages/muya/src/locales/fr.ts
@@ -16,6 +16,7 @@ export const fr = {
         'Paragraph': 'Paragraphe',
         'Horizontal Line': 'Ligne horizontale',
         'Front Matter': 'Front Matter',
+        'Properties': 'Propriétés',
         'Heading 1': 'Titre 1',
         'Heading 2': 'Titre 2',
         'Heading 3': 'Titre 3',

--- a/packages/muya/src/locales/ja.ts
+++ b/packages/muya/src/locales/ja.ts
@@ -16,6 +16,7 @@ export const ja = {
         'Paragraph': '一般段落',
         'Horizontal Line': '水平分割線',
         'Front Matter': '上部情報ブロック',
+        'Properties': 'プロパティ',
         'Heading 1': 'タイトル 1',
         'Heading 2': 'タイトル 2',
         'Heading 3': 'タイトル 3',

--- a/packages/muya/src/locales/ko.ts
+++ b/packages/muya/src/locales/ko.ts
@@ -16,6 +16,7 @@ export const ko = {
         'Paragraph': '단락',
         'Horizontal Line': '수평선',
         'Front Matter': '머리말 블록',
+        'Properties': '속성',
         'Heading 1': '제목 1',
         'Heading 2': '제목 2',
         'Heading 3': '제목 3',

--- a/packages/muya/src/locales/pt.ts
+++ b/packages/muya/src/locales/pt.ts
@@ -16,6 +16,7 @@ export const pt = {
         'Paragraph': 'Parágrafo',
         'Horizontal Line': 'Linha horizontal',
         'Front Matter': 'Front Matter',
+        'Properties': 'Propriedades',
         'Heading 1': 'Título 1',
         'Heading 2': 'Título 2',
         'Heading 3': 'Título 3',

--- a/packages/muya/src/locales/tr.ts
+++ b/packages/muya/src/locales/tr.ts
@@ -16,6 +16,7 @@ export const tr = {
         'Paragraph': 'Paragraf',
         'Horizontal Line': 'Yatay Çizgi',
         'Front Matter': 'Ön Bilgi',
+        'Properties': 'Özellikler',
         'Heading 1': 'Başlık 1',
         'Heading 2': 'Başlık 2',
         'Heading 3': 'Başlık 3',

--- a/packages/muya/src/locales/zh-CN.ts
+++ b/packages/muya/src/locales/zh-CN.ts
@@ -16,6 +16,7 @@ export const zhCN = {
         'Paragraph': '普通段落',
         'Horizontal Line': '水平分割线',
         'Front Matter': '顶部信息块',
+        'Properties': '属性',
         'Heading 1': '标题 1',
         'Heading 2': '标题 2',
         'Heading 3': '标题 3',

--- a/packages/muya/src/locales/zh-TW.ts
+++ b/packages/muya/src/locales/zh-TW.ts
@@ -16,6 +16,7 @@ export const zhTW = {
         'Paragraph': '一般段落',
         'Horizontal Line': '水平分隔線',
         'Front Matter': '頂部資訊區塊',
+        'Properties': '屬性',
         'Heading 1': '標題 1',
         'Heading 2': '標題 2',
         'Heading 3': '標題 3',

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -20,6 +20,7 @@ export interface IMuyaOptions {
     listIndentation: number;
     frontMatter: boolean;
     frontmatterType: string; // '-' | '+' | ';' | '{';
+    frontmatterDefaultCollapsed: boolean;
     mermaidTheme: string;
     vegaTheme: string;
     plantumlServer: string;


### PR DESCRIPTION
Closes #5219
Closes #5220

## Summary

- Keep table cell contents visible above the rectangular selection tint.
- Add an accessible `Properties` disclosure for front matter blocks.
- Add a Markdown preference that controls whether properties are collapsed by default; the default is collapsed.
- Apply preference changes to open editors and localize the new labels.
- Add unit and end-to-end regression coverage for both behaviors.

## Problem

Selected table cells placed the selection overlay above the cell content, which made the selected values appear blank.

Large front matter blocks were always expanded, taking up substantial editor space. Users could not collapse an individual block or choose the initial state for newly rendered blocks.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Demonstration

The table regression test selects a rectangular range in Chromium and asserts that the cell text paints above the selection pseudo-element.

The front matter tests verify:

- the default collapsed state;
- per-block expand and collapse interaction;
- `aria-expanded` state;
- the expanded-default editor option;
- preference persistence and live propagation to open editors.

## Test plan

- [x] New tests added
- [x] Tested on macOS arm64 with unit tests, Chromium E2E tests, a desktop build, and packaged-app launch

Commands and results:

- `pnpm run lint` — passed with 0 errors (135 existing warnings)
- `pnpm -C packages/muya test` — 1,441 tests passed
- `pnpm -C packages/desktop test:unit` — 736 tests passed
- `pnpm -C packages/muya lint:types` — passed
- `pnpm -C packages/desktop typecheck` — passed
- `pnpm -C packages/muya/e2e exec playwright test tests/editing/table-cell-selection.spec.ts tests/blocks/frontmatter.spec.ts --project=chromium` — 10 tests passed
- `pnpm -C packages/desktop exec playwright test test/e2e/frontmatter-collapse.spec.ts` — 2 tests passed
- `pnpm -C packages/desktop build` — passed

## Notes for reviewers

The selection fix only adjusts paint order. The front matter behavior reuses the existing option/preference flow and adds no dependency. Existing documents and front matter source remain unchanged.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).