### PR TITLE
feat(muya): support TeX \( \) and \[ \] math delimiters

### DIFF
--- a/packages/desktop/src/main/preferences/schema.json
+++ b/packages/desktop/src/main/preferences/schema.json
@@ -267,6 +267,11 @@
     "type": "boolean",
     "default": false
   },
+  "mathDelimiter": {
+    "description": "Markdown--The delimiter used when inserting math formulas.",
+    "enum": ["dollar", "latex"],
+    "default": "dollar"
+  },
   "isHtmlEnabled": {
     "description": "Markdown-Enable HTML rendering",
     "type": "boolean",

--- a/packages/desktop/src/renderer/src/codeMirror/markdownMathMode.ts
+++ b/packages/desktop/src/renderer/src/codeMirror/markdownMathMode.ts
@@ -1,9 +1,10 @@
 // CodeMirror "markdown-math" — a GFM-flavoured Markdown mode that delegates
-// the contents of `$...$` (inline) and `$$...$$` (block) math spans to the
-// stex (LaTeX) mode. Without this wrapper the standard markdown mode highlights
-// `_` as emphasis delimiters even inside math, producing spurious italics for
-// subscript expressions like `$\text{F}_\text{A} = \text{F}_\text{B}$` in the
-// source view. See https://github.com/marktext/marktext/issues/4121.
+// the contents of `$...$` / `\(...\)` (inline) and `$$...$$` / `\[...\]`
+// (block) math spans to the stex (LaTeX) mode. Without this wrapper the
+// standard markdown mode highlights `_` as emphasis delimiters even inside
+// math, producing spurious italics for subscript expressions like
+// `$\text{F}_\text{A} = \text{F}_\text{B}$` in the source view.
+// See https://github.com/marktext/marktext/issues/4121.
 //
 // The outer mode is `gfm` to preserve the tables / autolinks / task lists
 // styling the previous `setMode(cm, 'markdown')` call resolved to via
@@ -46,8 +47,28 @@ const registerMarkdownMathMode = (CodeMirror: CodeMirrorLike): void => {
     // Block math (`$$…$$`) intentionally has no lookahead guard: a matching
     // closer typically lives on a later line, which CodeMirror's per-line
     // tokenizer cannot see from the opener.
+    //
+    // TeX delimiters are additive with `$` / `$$`: `\(...\)` is inline,
+    // `\[...\]` is display. They are registered before the dollar rules so a
+    // `\[` opener is not left to the GFM mode as an escaped `[`. String
+    // openers cannot see a preceding `\`, so a literal `\\[` may still
+    // highlight as math here — the parser itself rejects that case.
     return CodeMirror.multiplexingMode(
       gfmMode,
+      {
+        open: '\\[',
+        close: '\\]',
+        mode: stexMode,
+        delimStyle: 'formatting formatting-math formatting-math-block math-block',
+        innerStyle: 'math math-block'
+      },
+      {
+        open: '\\(',
+        close: '\\)',
+        mode: stexMode,
+        delimStyle: 'formatting formatting-math formatting-math-inline math-inline',
+        innerStyle: 'math math-inline'
+      },
       {
         open: '$$',
         close: '$$',

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -220,6 +220,7 @@ const {
   frontmatterType,
   superSubScript,
   footnote,
+  mathDelimiter,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
   lineHeight,
@@ -654,6 +655,12 @@ watch(superSubScript, (value, oldValue) => {
 watch(footnote, (value, oldValue) => {
   if (value !== oldValue && editor.value) {
     editor.value.setOptions({ footnote: value }, true)
+  }
+})
+
+watch(mathDelimiter, (value, oldValue) => {
+  if (value !== oldValue && editor.value) {
+    editor.value.setOptions({ mathDelimiter: value === 'latex' ? 'latex' : 'dollar' })
   }
 })
 
@@ -1760,6 +1767,7 @@ onMounted(() => {
     frontmatterType: frontmatterType.value,
     superSubScript: superSubScript.value,
     footnote: footnote.value,
+    mathDelimiter: mathDelimiter.value === 'latex' ? 'latex' : 'dollar',
     disableHtml: !isHtmlEnabled.value,
     isGitlabCompatibilityEnabled: isGitlabCompatibilityEnabled.value,
     hideQuickInsertHint: hideQuickInsertHint.value,

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/sourceCode.vue
@@ -368,9 +368,9 @@ onMounted(() => {
   // CodeMirror's line tree relies on object identity and must not be proxied by Vue.
   const codeMirrorInstance = markRaw(codeMirror(container, codeMirrorConfig))
 
-  // `markdown-math` wraps the standard Markdown mode and delegates `$...$` and
-  // `$$...$$` spans to stex so subscript underscores in math do not flip the
-  // outer mode into emphasis. See src/renderer/src/codeMirror/markdownMathMode.js.
+  // `markdown-math` wraps the standard Markdown mode and delegates `$...$`,
+  // `$$...$$`, `\(...\)`, and `\[...\]` spans to stex so subscript underscores
+  // in math do not flip the outer mode into emphasis. See markdownMathMode.ts.
   codeMirrorInstance.setOption('mode', 'markdown-math')
 
   codeMirrorInstance.on('contextmenu', (_cm: CMInstance, event: Event) => {

--- a/packages/desktop/src/renderer/src/prefComponents/markdown/config.ts
+++ b/packages/desktop/src/renderer/src/prefComponents/markdown/config.ts
@@ -94,3 +94,14 @@ export const getSequenceThemeOptions = (): PrefSelectOption<string>[] => [
     value: 'simple'
   }
 ]
+
+export const getMathDelimiterOptions = (): PrefSelectOption<string>[] => [
+  {
+    label: t('preferences.markdown.extensions.mathDelimiter.dollar'),
+    value: 'dollar'
+  },
+  {
+    label: t('preferences.markdown.extensions.mathDelimiter.latex'),
+    value: 'latex'
+  }
+]

--- a/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
+++ b/packages/desktop/src/renderer/src/prefComponents/markdown/index.vue
@@ -63,6 +63,13 @@
           :on-change="(value) => onSelectChange('footnote', value)"
           more="https://pandoc.org/MANUAL.html#footnotes"
         />
+        <cur-select
+          :description="t('preferences.markdown.extensions.mathDelimiter.title')"
+          :value="mathDelimiter"
+          :options="getMathDelimiterOptions()"
+          :on-change="(value) => onSelectChange('mathDelimiter', value)"
+          more="https://pandoc.org/MANUAL.html#extension-tex_math_single_backslash"
+        />
       </template>
     </compound>
 
@@ -142,7 +149,8 @@ import {
   getPreferHeadingStyleOptions,
   getListIndentationOptions,
   getFrontmatterTypeOptions,
-  getSequenceThemeOptions
+  getSequenceThemeOptions,
+  getMathDelimiterOptions
 } from './config'
 import { storeToRefs } from 'pinia'
 
@@ -159,6 +167,7 @@ const {
   frontmatterType,
   superSubScript,
   footnote,
+  mathDelimiter,
   isHtmlEnabled,
   isGitlabCompatibilityEnabled,
   sequenceTheme,

--- a/packages/desktop/src/renderer/src/store/preferences.ts
+++ b/packages/desktop/src/renderer/src/store/preferences.ts
@@ -14,6 +14,7 @@ export type OrderListDelimiter = '.' | ')'
 export type PreferHeadingStyle = 'atx' | 'setext'
 export type FrontmatterType = '-' | ';' | '{' | '+'
 export type SequenceTheme = 'hand' | 'simple'
+export type MathDelimiter = 'dollar' | 'latex'
 export type ImageInsertAction = 'folder' | 'path' | 'upload'
 export type ImageRelativeDirectoryBase = 'file' | 'root'
 export type FileSortBy = 'created' | 'modified' | 'title'
@@ -77,6 +78,7 @@ export interface PreferencesState {
   frontmatterType: FrontmatterType | string
   superSubScript: boolean
   footnote: boolean
+  mathDelimiter: MathDelimiter | string
   isHtmlEnabled: boolean
   isGitlabCompatibilityEnabled: boolean
   sequenceTheme: SequenceTheme | string
@@ -193,6 +195,7 @@ export const usePreferencesStore = defineStore('preferences', {
     frontmatterType: '-',
     superSubScript: false,
     footnote: false,
+    mathDelimiter: 'dollar',
     isHtmlEnabled: true,
     isGitlabCompatibilityEnabled: false,
     sequenceTheme: 'hand',

--- a/packages/desktop/src/shared/types/preferences.ts
+++ b/packages/desktop/src/shared/types/preferences.ts
@@ -43,6 +43,7 @@ export interface IUserPreferences {
   frontmatterType?: '-' | ';' | '+' | '{'
   superSubScript?: boolean
   footnote?: boolean
+  mathDelimiter?: 'dollar' | 'latex'
   isHtmlEnabled?: boolean
   isGitlabCompatibilityEnabled?: boolean
   theme?: string

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -408,6 +408,7 @@
         "frontmatterType": "Der Frontmatter-Typ",
         "superSubScript": "Pandocs Markdown-Erweiterung für hoch- und tiefgestellte Zeichen aktivieren",
         "footnote": "Pandocs Markdown-Erweiterung für Fußnoten aktivieren",
+        "mathDelimiter": "Das Trennzeichen beim Einfügen von mathematischen Formeln",
         "isHtmlEnabled": "HTML-Rendering aktivieren",
         "isGitlabCompatibilityEnabled": "GitLab-Kompatibilitätsmodus aktivieren",
         "sequenceTheme": "Sequenzdiagramm-Theme",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON-Klammer",
           "jsonSemicolon": "JSON-Semikolon",
           "title": "Front Matter Typ"
+        },
+        "mathDelimiter": {
+          "title": "Mathematik-Begrenzer",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -407,6 +407,7 @@
         "frontmatterType": "The frontmatter type",
         "superSubScript": "Enable pandoc's markdown extension superscript and subscript",
         "footnote": "Enable pandoc's markdown extension footnote",
+        "mathDelimiter": "The delimiter used when inserting math formulas",
         "isHtmlEnabled": "Enable HTML rendering",
         "isGitlabCompatibilityEnabled": "Enable GitLab compatibility mode",
         "sequenceTheme": "Sequence diagram theme",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON with Braces",
           "jsonSemicolon": "JSON with Semicolon",
           "title": "Frontmatter Type"
+        },
+        "mathDelimiter": {
+          "title": "Math delimiter",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -408,6 +408,7 @@
         "frontmatterType": "El tipo de frontmatter",
         "superSubScript": "Habilitar extensión markdown de pandoc superíndice y subíndice",
         "footnote": "Habilitar extensión markdown de pandoc nota al pie",
+        "mathDelimiter": "El delimitador usado al insertar fórmulas matemáticas",
         "isHtmlEnabled": "Habilitar renderizado HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidad GitLab",
         "sequenceTheme": "Tema del diagrama de secuencia",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON con Llaves",
           "jsonSemicolon": "JSON con Punto y Coma",
           "title": "Tipo de Metadatos"
+        },
+        "mathDelimiter": {
+          "title": "Delimitador de matemáticas",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -408,6 +408,7 @@
         "frontmatterType": "Le type de frontmatter",
         "superSubScript": "Activer l'extension markdown de pandoc pour exposant et indice",
         "footnote": "Activer l'extension markdown de pandoc pour note de bas de page",
+        "mathDelimiter": "Le délimiteur utilisé lors de l'insertion de formules mathématiques",
         "isHtmlEnabled": "Activer le rendu HTML",
         "isGitlabCompatibilityEnabled": "Activer le mode de compatibilité GitLab",
         "sequenceTheme": "Thème du diagramme de séquence",
@@ -633,6 +634,11 @@
           "jsonBrace": "Accolade JSON",
           "jsonSemicolon": "Point-virgule JSON",
           "title": "Type de métadonnées"
+        },
+        "mathDelimiter": {
+          "title": "Délimiteur mathématique",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -408,6 +408,7 @@
         "frontmatterType": "フロントマターのタイプ",
         "superSubScript": "Pandoc の markdown 拡張上付き文字と下付き文字を有効にする",
         "footnote": "Pandoc の markdown 拡張脚注を有効にする",
+        "mathDelimiter": "数式を挿入するときに使用する区切り文字",
         "isHtmlEnabled": "HTML レンダリングを有効にする",
         "isGitlabCompatibilityEnabled": "GitLab 互換モードを有効にする",
         "sequenceTheme": "シーケンス図のテーマ",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON 括弧",
           "jsonSemicolon": "JSON セミコロン",
           "title": "フロントマタータイプ"
+        },
+        "mathDelimiter": {
+          "title": "数式の区切り文字",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -408,6 +408,7 @@
         "frontmatterType": "프론트매터 유형",
         "superSubScript": "Pandoc의 마크다운 확장 위첨자와 아래첨자 활성화",
         "footnote": "Pandoc의 마크다운 확장 각주 활성화",
+        "mathDelimiter": "수식을 삽입할 때 사용하는 구분자",
         "isHtmlEnabled": "HTML 렌더링 활성화",
         "isGitlabCompatibilityEnabled": "GitLab 호환 모드 활성화",
         "sequenceTheme": "시퀀스 다이어그램 테마",
@@ -633,6 +634,11 @@
           "jsonBrace": "중괄호가 있는 JSON",
           "jsonSemicolon": "세미콜론이 있는 JSON",
           "title": "프론트매터 유형"
+        },
+        "mathDelimiter": {
+          "title": "수식 구분자",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/nl.json
+++ b/packages/desktop/static/locales/nl.json
@@ -407,6 +407,7 @@
         "frontmatterType": "Het type Front Matter",
         "superSubScript": "Pandoc superscript en subscript inschakelen",
         "footnote": "Pandoc voetnoten inschakelen",
+        "mathDelimiter": "De scheidingstekens bij het invoegen van formules",
         "isHtmlEnabled": "HTML-weergave inschakelen",
         "isGitlabCompatibilityEnabled": "GitLab-compatibiliteitsmodus inschakelen",
         "sequenceTheme": "Sequentiediagram thema",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON met accolades",
           "jsonSemicolon": "JSON met puntkomma",
           "title": "Front Matter-type"
+        },
+        "mathDelimiter": {
+          "title": "Scheidingstekens voor formules",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -408,6 +408,7 @@
         "frontmatterType": "O tipo de frontmatter",
         "superSubScript": "Habilitar extensão markdown do pandoc para sobrescrito e subscrito",
         "footnote": "Habilitar extensão markdown do pandoc para nota de rodapé",
+        "mathDelimiter": "O delimitador usado ao inserir fórmulas matemáticas",
         "isHtmlEnabled": "Habilitar renderização HTML",
         "isGitlabCompatibilityEnabled": "Habilitar modo de compatibilidade GitLab",
         "sequenceTheme": "Tema do diagrama de sequência",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON com Chaves",
           "jsonSemicolon": "JSON com Ponto e Vírgula",
           "title": "Tipo de Frontmatter"
+        },
+        "mathDelimiter": {
+          "title": "Delimitador de matemática",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -407,6 +407,7 @@
         "frontmatterType": "Ön bilgi türü",
         "superSubScript": "Pandoc'un markdown uzantısı üst simge ve alt simgeyi etkinleştir",
         "footnote": "Pandoc'un markdown uzantısı dipnotu etkinleştir",
+        "mathDelimiter": "Matematik formülleri eklerken kullanılan sınırlayıcı",
         "isHtmlEnabled": "HTML işlemeyi etkinleştir",
         "isGitlabCompatibilityEnabled": "GitLab uyumluluk modunu etkinleştir",
         "sequenceTheme": "Dizi diyagramı teması",
@@ -633,6 +634,11 @@
           "jsonBrace": "Süslü Parantezli JSON",
           "jsonSemicolon": "Noktalı Virgüllü JSON",
           "title": "Ön Bilgi Türü"
+        },
+        "mathDelimiter": {
+          "title": "Matematik sınırlayıcısı",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -408,6 +408,7 @@
         "frontmatterType": "前言类型",
         "superSubScript": "启用 Pandoc 的 Markdown 扩展上标和下标",
         "footnote": "启用 Pandoc 的 Markdown 扩展脚注",
+        "mathDelimiter": "插入数学公式时使用的分隔符",
         "isHtmlEnabled": "启用 HTML 渲染",
         "isGitlabCompatibilityEnabled": "启用 GitLab 兼容模式",
         "sequenceTheme": "序列图主题",
@@ -633,6 +634,11 @@
           "jsonBrace": "带大括号的 JSON",
           "jsonSemicolon": "带分号的 JSON",
           "title": "前置元数据类型"
+        },
+        "mathDelimiter": {
+          "title": "数学分隔符",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -408,6 +408,7 @@
         "frontmatterType": "前言類型",
         "superSubScript": "啟用 Pandoc 的 Markdown 擴充功能上標和下標",
         "footnote": "啟用 Pandoc 的 Markdown 擴充功能腳註",
+        "mathDelimiter": "插入數學公式時使用的分隔符",
         "isHtmlEnabled": "啟用 HTML 轉譯",
         "isGitlabCompatibilityEnabled": "啟用 GitLab 相容模式",
         "sequenceTheme": "序列圖主題",
@@ -633,6 +634,11 @@
           "jsonBrace": "JSON 大括號",
           "jsonSemicolon": "JSON 分號",
           "title": "前置資料類型"
+        },
+        "mathDelimiter": {
+          "title": "數學分隔符",
+          "dollar": "$ … $  ($$ … $$)",
+          "latex": "\\( … \\)  (\\[ … \\])"
         }
       },
       "diagrams": {

--- a/packages/desktop/static/preference.json
+++ b/packages/desktop/static/preference.json
@@ -52,6 +52,7 @@
   "frontmatterType": "-",
   "superSubScript": false,
   "footnote": false,
+  "mathDelimiter": "dollar",
   "isHtmlEnabled": true,
   "isGitlabCompatibilityEnabled": false,
   "sequenceTheme": "hand",

--- a/packages/muya/docs/jsonState.ts
+++ b/packages/muya/docs/jsonState.ts
@@ -167,7 +167,7 @@ const doc = [
         name: 'math-block',
         text: 'a \ne b',
         meta: {
-            mathStyle: '', // '' for `$$` and 'gitlab' for ```math
+            mathStyle: '', // '' for `$$`, 'gitlab' for ```math, 'latex' for `\[...\]`
         },
     },
     // Front Matter

--- a/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
+++ b/packages/muya/src/block/base/__tests__/formatCursor.spec.ts
@@ -35,8 +35,17 @@ interface IFormatProtoAddFormat {
     ) => void;
 }
 
-function applyAddFormat(text: string, start: number, end: number, type: string) {
-    const fakeThis = { text } as { text: string };
+function applyAddFormat(
+    text: string,
+    start: number,
+    end: number,
+    type: string,
+    mathDelimiter?: string,
+) {
+    const fakeThis = {
+        text,
+        muya: mathDelimiter ? { options: { mathDelimiter } } : undefined,
+    } as { text: string; muya?: { options: { mathDelimiter: string } } };
     const startOffset: IOffset = { offset: start };
     const endOffset: IOffset = { offset: end };
     (Format.prototype as unknown as IFormatProtoAddFormat)._addFormat.call(fakeThis, type, {
@@ -81,6 +90,13 @@ describe('format._addFormat caret/selection placement after wrapping', () => {
             expect(text).toBe('$abc$');
             expect(start).toBe(1);
             expect(end).toBe(4);
+        });
+
+        it('inline_math with mathDelimiter latex: "abc" -> "\\(abc\\)" with "abc" still selected (2..5)', () => {
+            const { text, start, end } = applyAddFormat('abc', 0, 3, 'inline_math', 'latex');
+            expect(text).toBe('\\(abc\\)');
+            expect(start).toBe(2);
+            expect(end).toBe(5);
         });
 
         it('mid-text selection: "hello world" select "world" -> "world" still selected', () => {

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -20,6 +20,7 @@ import {
     FORMAT_MARKER_MAP,
     FORMAT_TAG_MAP,
     FORMAT_TYPES,
+    mathInlineMarkers,
     PARAGRAPH_STATE,
     THEMATIC_BREAK_STATE,
 } from '../../config';
@@ -103,15 +104,19 @@ function getOffset(offset: number, token: Token) {
     switch (type) {
         case 'strong':
 
-        case 'del':
+        case 'del': {
+            return markeredOffset(dis, len, 2, 2);
+        }
 
         case 'em':
 
-        case 'inline_code':
+        case 'inline_code': {
+            return markeredOffset(dis, len, 1, 1);
+        }
 
         case 'inline_math': {
-            const markerLen = type === 'strong' || type === 'del' ? 2 : 1;
-            return markeredOffset(dis, len, markerLen, markerLen);
+            // `$…$` is 1; `\(...\)` / `\[...\]` are 2.
+            return markeredOffset(dis, len, token.marker.length, token.marker.length);
         }
 
         case 'html_tag': {
@@ -1699,15 +1704,31 @@ class Format extends Content {
         { start, end }: { start: IOffset; end: IOffset },
     ) {
         switch (type) {
+            case 'inline_math': {
+                const { open, close } = mathInlineMarkers(this.muya?.options?.mathDelimiter);
+                const oldText = this.text;
+                this.text
+                    = oldText.substring(0, start.offset)
+                        + open
+                        + oldText.substring(start.offset, end.offset)
+                        + close
+                        + oldText.substring(end.offset);
+                // Shift both offsets past the opening marker. A collapsed
+                // cursor stays between the markers (toggle-then-type lands
+                // INSIDE the format); a non-empty selection keeps the
+                // original text selected now that it sits inside the markers.
+                start.offset += open.length;
+                end.offset += open.length;
+                break;
+            }
+
             case 'em':
 
             case 'del':
 
             case 'inline_code':
 
-            case 'strong':
-
-            case 'inline_math': {
+            case 'strong': {
                 const MARKER = FORMAT_MARKER_MAP[type];
                 const oldText = this.text;
                 this.text

--- a/packages/muya/src/block/blockTransforms.ts
+++ b/packages/muya/src/block/blockTransforms.ts
@@ -1,6 +1,7 @@
 import type { Muya } from '../muya';
 import type { IFrontmatterMeta } from '../state/types';
 import type Parent from './base/parent';
+import { mathBlockStyle } from '../config';
 import emptyStates from '../config/emptyStates';
 import { getCursorReference } from '../selection';
 import { isParagraphState } from '../state/types';
@@ -98,6 +99,9 @@ function buildLeafBlock(label: TLeafReplacementLabel, muya: Muya, text: string) 
     const cloned = deepClone(emptyStates[label]);
     if (cloned.name === 'paragraph') {
         cloned.text = text;
+    }
+    else if (cloned.name === 'math-block') {
+        cloned.meta.mathStyle = mathBlockStyle(muya.options.mathDelimiter);
     }
     else if (cloned.name === 'block-quote') {
         const inner = cloned.children[0];

--- a/packages/muya/src/block/content/paragraphContent/__tests__/listMathEnterConvert.spec.ts
+++ b/packages/muya/src/block/content/paragraphContent/__tests__/listMathEnterConvert.spec.ts
@@ -55,7 +55,11 @@ function flush(): Promise<void> {
 
 // Drive `$$` + Enter on the list item's paragraph content and return the
 // resulting top-level document state (the order-list).
-async function enterDollarsInList(token: string): Promise<{ listChildren: number; itemBlockNames: string[] }> {
+async function enterDollarsInList(token: string): Promise<{
+    listChildren: number;
+    itemBlockNames: string[];
+    firstMathStyle?: string;
+}> {
     const muya = bootMuya('1. x\n');
     const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Content;
     content.text = token;
@@ -65,20 +69,36 @@ async function enterDollarsInList(token: string): Promise<{ listChildren: number
     content.enterHandler(keyEvent({ key: 'Enter' }));
     await flush();
 
-    const state = muya.getState() as Array<{ name: string; children?: Array<{ name: string; children?: Array<{ name: string }> }> }>;
+    const state = muya.getState() as Array<{ name: string; children?: Array<{ name: string; children?: Array<{ name: string; meta?: { mathStyle?: string } }> }> }>;
     const list = state[0];
     const items = list.children ?? [];
+    const children = items[0]?.children ?? [];
+    const math = children.find(c => c.name === 'math-block');
     return {
         listChildren: items.length,
-        itemBlockNames: (items[0]?.children ?? []).map(c => c.name),
+        itemBlockNames: children.map(c => c.name),
+        firstMathStyle: math?.meta?.mathStyle,
     };
 }
 
 describe('#2276 — `$$`/code-fence + Enter inside a list converts in place, no extra item', () => {
     it('`$$` converts the list item to a math block without adding a new list item', async () => {
-        const { listChildren, itemBlockNames } = await enterDollarsInList('$$');
+        const { listChildren, itemBlockNames, firstMathStyle } = await enterDollarsInList('$$');
         expect(listChildren).toBe(1); // no unwanted second list item
         expect(itemBlockNames).toContain('math-block');
+        expect(firstMathStyle).toBe('');
+    });
+
+    it('`\\[` converts the list item to a latex-styled math block without adding a new list item', async () => {
+        const { listChildren, itemBlockNames, firstMathStyle } = await enterDollarsInList('\\[');
+        expect(listChildren).toBe(1);
+        expect(itemBlockNames).toContain('math-block');
+        expect(firstMathStyle).toBe('latex');
+    });
+
+    it('`\\[ x` does not convert-on-enter (exact opener only, unlike $$)', async () => {
+        const { itemBlockNames } = await enterDollarsInList('\\[ x');
+        expect(itemBlockNames).not.toContain('math-block');
     });
 
     it('a code fence ```` ``` ```` converts in place without adding a new list item', async () => {

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -42,11 +42,14 @@ const debug = logger('paragraph:content');
 const HTML_BLOCK_REG = /^<([a-z\d-]+)(?=\s|>)[^<>]*>$/i;
 const CODE_BLOCK_REG = /(^ {0,3}`{3,})([^` ]*)/;
 const MATH_BLOCK_REG = /^\$\$/;
+// Exact `\[` only: unlike `$$`, a line that already has a formula (`\[ x`)
+// must not convert-on-enter and discard the rest of the text.
+const LATEX_DISPLAY_OPEN_REG = /^\\\[$/;
 // eslint-disable-next-line regexp/no-super-linear-backtracking
 const TABLE_BLOCK_REG = /^\|.*?(\\*)\|.*?(\\*)\|/;
 
 type BlockConversion
-    = | { kind: 'math' }
+    = | { kind: 'math'; mathStyle: string }
         | { kind: 'code'; lang: string }
         | { kind: 'table' }
         | { kind: 'html'; tagName: string };
@@ -57,7 +60,9 @@ type BlockConversion
 // can never drift between the two.
 function matchBlockConversion(text: string): BlockConversion | null {
     if (MATH_BLOCK_REG.test(text))
-        return { kind: 'math' };
+        return { kind: 'math', mathStyle: '' };
+    if (LATEX_DISPLAY_OPEN_REG.test(text))
+        return { kind: 'math', mathStyle: 'latex' };
 
     const codeBlockToken = text.match(CODE_BLOCK_REG);
     if (codeBlockToken)
@@ -267,7 +272,7 @@ class ParagraphContent extends Format {
                     name: 'math-block',
                     text: '',
                     meta: {
-                        mathStyle: '',
+                        mathStyle: match.mathStyle,
                     },
                 };
                 const mathBlock = ScrollPage.loadBlock('math-block').create(

--- a/packages/muya/src/config/emptyStates.ts
+++ b/packages/muya/src/config/emptyStates.ts
@@ -101,7 +101,7 @@ const emptyStates: IEmptyStates = {
         name: 'math-block',
         text: '',
         meta: {
-            mathStyle: '', // '' for `$$` and 'gitlab' for ```math
+            mathStyle: '', // '' for `$$`, 'gitlab' for ```math, 'latex' for `\[...\]`
         },
     },
     'html-block': {

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -39,6 +39,22 @@ export const FORMAT_MARKER_MAP: Record<string, string> = {
     inline_math: '$',
 };
 
+export type TMathDelimiter = 'dollar' | 'latex';
+
+// Markers for Format → Inline Math. `$…$` is the historical default;
+// `latex` writes `\(...\)` instead. Parsing always accepts both.
+export function mathInlineMarkers(delimiter?: string): { open: string; close: string } {
+    if (delimiter === 'latex')
+        return { open: '\\(', close: '\\)' };
+    return { open: '$', close: '$' };
+}
+
+// `mathStyle` for a newly inserted math-block. Existing blocks keep the
+// style they were saved with; this only applies to Format/Paragraph/quick-insert.
+export function mathBlockStyle(delimiter?: string): '' | 'latex' {
+    return delimiter === 'latex' ? 'latex' : '';
+}
+
 export const FORMAT_TAG_MAP: Record<string, ITag> = {
     u: {
         open: '<u>',
@@ -346,6 +362,8 @@ export const MUYA_DEFAULT_OPTIONS = {
     footnote: false,
     // Whether math block is supported.
     math: true,
+    // Delimiter written when inserting math from the UI. Parsing accepts both.
+    mathDelimiter: 'dollar' as const,
     isGitlabCompatibilityEnabled: true,
     // Move checked task list item to the end of task list.
     autoMoveCheckedToEnd: false,

--- a/packages/muya/src/inlineRenderer/__tests__/latexInlineMath.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/latexInlineMath.spec.ts
@@ -1,0 +1,49 @@
+import type { CodeEmojiMathToken } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../lexer';
+
+function mathToken(src: string): CodeEmojiMathToken | undefined {
+    return tokenizer(src).find(t => t.type === 'inline_math') as
+        | CodeEmojiMathToken
+        | undefined;
+}
+
+describe('inline lexer — TeX \\( \\) / \\[ \\] delimiters', () => {
+    it('tokenizes \\( ... \\) as inline_math', () => {
+        const token = mathToken('The formula \\(E = mc^2\\) is well known.');
+        expect(token?.content).toBe('E = mc^2');
+        expect(token?.marker).toBe('\\(');
+    });
+
+    it('keeps LaTeX backslashes inside \\( ... \\)', () => {
+        expect(mathToken('\\(x_i = \\frac{a_i}{b_i}\\)')?.content)
+            .toBe('x_i = \\frac{a_i}{b_i}');
+    });
+
+    it('tokenizes mid-paragraph \\[ ... \\] as inline_math with display marker', () => {
+        const token = mathToken('see \\[E = mc^2\\] here');
+        expect(token?.content).toBe('E = mc^2');
+        expect(token?.marker).toBe('\\[');
+    });
+
+    it('still tokenizes $...$ unchanged', () => {
+        expect(mathToken('$E = mc^2$')?.content).toBe('E = mc^2');
+        expect(mathToken('$E = mc^2$')?.marker).toBe('$');
+    });
+
+    it('does not treat inline code as math', () => {
+        const tokens = tokenizer('`\\[x\\]`');
+        expect(tokens.some(t => t.type === 'inline_math')).toBe(false);
+        expect(tokens.some(t => t.type === 'inline_code')).toBe(true);
+    });
+
+    it('leaves an unmatched \\[ as a CommonMark escape, not math', () => {
+        const tokens = tokenizer('\\[foo');
+        expect(tokens.some(t => t.type === 'inline_math')).toBe(false);
+    });
+
+    it('does not treat a literal backslash plus \\[ as math', () => {
+        const tokens = tokenizer('\\\\[x\\\\]');
+        expect(tokens.some(t => t.type === 'inline_math')).toBe(false);
+    });
+});

--- a/packages/muya/src/inlineRenderer/lexer.ts
+++ b/packages/muya/src/inlineRenderer/lexer.ts
@@ -7,6 +7,7 @@ import type {
 } from './types';
 import escapeCharactersMap from '../config/escapeCharacter';
 import { isLengthEven, union } from '../utils';
+import { matchLatexMath } from '../utils/matchLatexMath';
 import { beginRules, inlineRules, linkValidateRules, validateRules } from './rules';
 import {
     correctUrl,
@@ -113,6 +114,32 @@ function consumeBeginRules(state: ILexState, beginRules: BeginRules) {
         state.src = state.src.substring(def[0].length);
         state.pos = state.pos + def[0].length;
     }
+}
+
+function tryLatexMath(state: ILexState): boolean {
+    // Must run before tryBacklash: CommonMark treats `\(` / `\[` as escaped
+    // punctuation, so the generic backslash rule would steal the opener.
+    const latex = matchLatexMath(state.src);
+    if (!latex)
+        return false;
+
+    pushPending(state);
+    state.tokens.push({
+        type: 'inline_math',
+        raw: latex.raw,
+        range: {
+            start: state.pos,
+            end: state.pos + latex.raw.length,
+        },
+        marker: latex.open,
+        parent: state.tokens,
+        content: latex.text,
+        backlash: '',
+    });
+    state.src = state.src.substring(latex.raw.length);
+    state.pos = state.pos + latex.raw.length;
+
+    return true;
 }
 
 function tryBacklash(state: ILexState): boolean {
@@ -790,6 +817,7 @@ function tryTailHeader(state: ILexState): boolean {
 // The fixed, priority-ordered inline-rule handler list the tokenizer loop
 // iterates. This array order IS the rule-precedence contract.
 const INLINE_HANDLERS: ReadonlyArray<(state: ILexState) => boolean> = [
+    tryLatexMath,
     tryBacklash,
     tryStrongEm,
     tryChunks,

--- a/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
+++ b/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
@@ -23,20 +23,21 @@ export default function inlineMath(this: Renderer, {
 
     const { start, end } = token.range;
     const { marker } = token;
+    const markerLen = marker.length;
 
     const startMarker = this.highlight(
         h,
         block,
         start,
-        start + marker.length,
+        start + markerLen,
         token,
     );
-    const endMarker = this.highlight(h, block, end - marker.length, end, token);
+    const endMarker = this.highlight(h, block, end - markerLen, end, token);
     const content = this.highlight(
         h,
         block,
-        start + marker.length,
-        end - marker.length,
+        start + markerLen,
+        end - markerLen,
         token,
     );
 
@@ -44,8 +45,8 @@ export default function inlineMath(this: Renderer, {
 
     const { loadMathMap } = this;
 
-    const displayMode = false;
-    const key = `${math}_${type}`;
+    const displayMode = marker === '\\[';
+    const key = `${math}_${type}_${displayMode}`;
     let mathVnode = null;
     let previewSelector = `span.${CLASS_NAMES.MU_MATH_RENDER}`;
     // Inline math errors stay compact to keep the surrounding text baseline
@@ -86,8 +87,8 @@ export default function inlineMath(this: Renderer, {
                         ? { contenteditable: 'false', title: errorTitle }
                         : { contenteditable: 'false' },
                     dataset: {
-                        start: String(start + 1), // '$'.length
-                        end: String(end - 1), // '$'.length
+                        start: String(start + markerLen),
+                        end: String(end - markerLen),
                     },
                 },
                 mathVnode,

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -9,7 +9,7 @@ export const beginRules = {
     /^( {0,3}\[)([^\]]+?)(\\*)(\]: *)(<?)([^\s>]+)(>?)(?:( +)(["'(]?)([^\n"'()]+)\9)?( *)$/,
 
     // extra syntax (not belongs to GFM)
-    multiple_math: /^(\$\$)$/,
+    multiple_math: /^(\$\$|\\\[)$/,
 };
 
 export const endRules = {

--- a/packages/muya/src/state/__tests__/gitlabMath.spec.ts
+++ b/packages/muya/src/state/__tests__/gitlabMath.spec.ts
@@ -9,8 +9,9 @@ import ExportMarkdown from '../stateToMarkdown';
 //                into a `multiplemath` token with mathStyle='gitlab', but ONLY
 //                when BOTH `math` AND `isGitlabCompatibilityEnabled` are true.
 //   * serialize: state/stateToMarkdown.ts::_serializeMathBlock picks the fence
-//                purely from meta.mathStyle ('' → $$, 'gitlab' → ```math) — it
-//                does NOT re-read the option, so a block keeps its origin style.
+//                purely from meta.mathStyle ('' → $$, 'gitlab' → ```math,
+//                'latex' → `\[...\]`) — it does NOT re-read the option, so a
+//                block keeps its origin style.
 // The legacy engine (packages/muyajs) detected the same syntax with a dedicated
 // regex (`multiplemathGitlab` in parser/marked/blockRules.js). These specs lock
 // the state round-trip the renderer test (renderToStaticHTML.spec.ts) does not

--- a/packages/muya/src/state/__tests__/latexMath.spec.ts
+++ b/packages/muya/src/state/__tests__/latexMath.spec.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../markdownToState';
+import { renderToStaticHTML } from '../renderToStaticHTML';
+import ExportMarkdown from '../stateToMarkdown';
+
+// TeX delimiters `\(...\)` / `\[...\]` are additive with `$` / `$$`.
+// Block `\[...\]` is a first-class math-block whose mathStyle is 'latex'
+// so serialization writes `\[...\]` back, not `$$`.
+
+interface IBlock {
+    name: string;
+    text?: string;
+    meta?: { mathStyle?: string };
+}
+
+function parse(markdown: string, math = true): IBlock[] {
+    return new MarkdownToState({
+        footnote: false,
+        math,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    } as never).generate(markdown) as unknown as IBlock[];
+}
+
+function serialize(states: IBlock[]): string {
+    return new ExportMarkdown({ listIndentation: 1 } as never).generate(
+        states as never,
+    );
+}
+
+const USER_FORMULA = 'd_{\\text{fim a fim}} = N\\frac{L}{R}';
+const USER_BLOCK = `\\[
+${USER_FORMULA}
+\\]
+`;
+
+describe('latex math — parse', () => {
+    it('parses a multiline \\[ ... \\] block as math-block with mathStyle latex', () => {
+        const [block] = parse(USER_BLOCK);
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('latex');
+        expect(block.text).toBe(USER_FORMULA);
+    });
+
+    it('parses a single-line \\[ ... \\] that is the whole paragraph as a math block', () => {
+        const [block] = parse('\\[ E = mc^2 \\]\n');
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('latex');
+        expect(block.text).toBe('E = mc^2');
+    });
+
+    it('leaves \\[x\\] with trailing prose as a paragraph', () => {
+        const [block] = parse('\\[x\\] is not a block\n');
+        expect(block.name).toBe('paragraph');
+        expect(block.text).toContain('\\[x\\]');
+    });
+
+    it('parses a \\[ block after a preceding paragraph', () => {
+        const blocks = parse('Hello\n\n\\[\na\n\\]\n');
+        expect(blocks.map(b => b.name)).toEqual(['paragraph', 'math-block']);
+        expect(blocks[1]?.meta?.mathStyle).toBe('latex');
+        expect(blocks[1]?.text).toBe('a');
+    });
+
+    it('does not treat a 4-space-indented \\[ as a math block', () => {
+        const [block] = parse('    \\[x\\]\n');
+        expect(block.name).not.toBe('math-block');
+    });
+
+    it('does not parse \\[ ... \\] as math when math is off', () => {
+        const [block] = parse(USER_BLOCK, false);
+        expect(block.name).not.toBe('math-block');
+    });
+
+    it('does not parse a fenced code block containing \\[ ... \\] as math', () => {
+        const md = '```text\n\\[\nx = 1\n\\]\n```\n';
+        const [block] = parse(md);
+        expect(block.name).toBe('code-block');
+        expect(block.text).toContain('\\[');
+    });
+
+    it('still parses $$ as a dollar-style math block', () => {
+        const [block] = parse('$$\nE = mc^2\n$$\n');
+        expect(block.name).toBe('math-block');
+        expect(block.meta?.mathStyle).toBe('');
+        expect(block.text).toBe('E = mc^2');
+    });
+});
+
+describe('latex math — serialization', () => {
+    it('round-trips a latex-styled math block as \\[ ... \\], not $$', () => {
+        const states = parse(USER_BLOCK);
+        expect(serialize(states)).toBe(USER_BLOCK);
+    });
+
+    it('round-trips $$ unchanged next to a latex block', () => {
+        const md = `$$
+E = mc^2
+$$
+
+\\[
+a = b
+\\]
+`;
+        expect(serialize(parse(md))).toBe(md);
+    });
+
+    it('round-trips a paragraph that contains inline \\( ... \\)', () => {
+        const md = 'The formula \\(E = mc^2\\) is well known.\n';
+        expect(serialize(parse(md))).toBe(md);
+    });
+});
+
+describe('latex math — HTML export', () => {
+    it('renders a \\[ ... \\] block via KaTeX', () => {
+        const html = renderToStaticHTML(USER_BLOCK, { math: true });
+        expect(html).toMatch(/katex|<math/i);
+        expect(html).not.toContain('\\[');
+    });
+
+    it('renders inline \\( ... \\) via KaTeX', () => {
+        const html = renderToStaticHTML(
+            'The formula \\(E = mc^2\\) is well known.',
+            { math: true },
+        );
+        expect(html).toMatch(/katex|<math/i);
+        expect(html).not.toContain('\\(');
+    });
+
+    it('still renders $ and $$ via KaTeX', () => {
+        expect(renderToStaticHTML('$E = mc^2$', { math: true }))
+            .toMatch(/katex|<math/i);
+        expect(renderToStaticHTML('$$\nE = mc^2\n$$', { math: true }))
+            .toMatch(/katex|<math/i);
+    });
+
+    it('does not render \\[ ... \\] inside a fenced code block as math', () => {
+        const html = renderToStaticHTML('```text\n\\[\nx = 1\n\\]\n```\n', { math: true });
+        expect(html).not.toMatch(/katex|<math/i);
+        expect(html).toContain('\\[');
+    });
+
+    it('does not render inline-code \\[x\\] as math', () => {
+        const html = renderToStaticHTML('`\\[x\\]`', { math: true });
+        expect(html).not.toMatch(/katex|<math/i);
+    });
+});

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -42,6 +42,16 @@ function escapeText(str: string) {
     return str.replace(/(?<!\\)\|/g, '\\|');
 }
 
+// Origin of the block, not a parse-time rewrite of one delimiter into
+// another: '' → `$$`, gitlab → ```math, latex → `\[...\]`.
+function mathBlockFence(mathStyle: string): { open: string; close: string } {
+    if (mathStyle === 'gitlab')
+        return { open: '```math\n', close: '```\n' };
+    if (mathStyle === 'latex')
+        return { open: '\\[\n', close: '\\]\n' };
+    return { open: '$$\n', close: '$$\n' };
+}
+
 export interface IExportMarkdownOptions {
     listIndentation: number | string;
 }
@@ -405,12 +415,13 @@ export default class ExportMarkdown {
             meta: { mathStyle },
         } = state;
         const lines = text.split('\n');
-        result.push(indent + (mathStyle === '' ? '$$\n' : '```math\n'));
+        const { open, close } = mathBlockFence(mathStyle);
+        result.push(indent + open);
 
         for (const line of lines)
             result.push(`${indent}${line}\n`);
 
-        result.push(indent + (mathStyle === '' ? '$$\n' : '```\n'));
+        result.push(indent + close);
 
         return result.join('');
     }

--- a/packages/muya/src/state/types.ts
+++ b/packages/muya/src/state/types.ts
@@ -127,7 +127,7 @@ export interface ITaskListState {
 }
 
 export interface IMathMeta {
-    mathStyle: string; // "" | "gitlab";
+    mathStyle: string; // "" | "gitlab" | "latex";
 }
 
 export interface IMathBlockState {

--- a/packages/muya/src/types.ts
+++ b/packages/muya/src/types.ts
@@ -32,6 +32,12 @@ export interface IMuyaOptions {
     superSubScript: boolean;
     footnote: boolean;
     math: boolean;
+    /**
+     * Delimiter written when the user inserts math from the Format /
+     * Paragraph menus. `'dollar'` → `$…$` / `$$…$$` (default); `'latex'` →
+     * `\(...\)` / `\[…\]`. Parsing always accepts both.
+     */
+    mathDelimiter: 'dollar' | 'latex';
     isGitlabCompatibilityEnabled: boolean;
     autoMoveCheckedToEnd: boolean;
     disableHtml: boolean;

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -484,3 +484,39 @@ describe('replaceBlockByLabel — quick-insert frontmatter serializes the right 
         });
     });
 });
+
+describe('replaceBlockByLabel — math-block delimiter follows mathDelimiter option', () => {
+    it('defaults to dollar-style (empty mathStyle → $$)', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'math-block',
+            });
+            const math = captured.find(c => c.label === 'math-block')!;
+            expect(math.state.meta?.mathStyle).toBe('');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('writes latex mathStyle when mathDelimiter is latex', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            const muya = makeFakeMuya();
+            (muya.options as { mathDelimiter: string }).mathDelimiter = 'latex';
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya,
+                label: 'math-block',
+            });
+            const math = captured.find(c => c.label === 'math-block')!;
+            expect(math.state.meta?.mathStyle).toBe('latex');
+        }
+        finally {
+            restore();
+        }
+    });
+});

--- a/packages/muya/src/utils/__tests__/matchLatexMath.spec.ts
+++ b/packages/muya/src/utils/__tests__/matchLatexMath.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { matchLatexDisplayBlock, matchLatexMath } from '../matchLatexMath';
+
+describe('matchLatexMath — inline \\( ... \\)', () => {
+    it('matches a simple inline formula', () => {
+        const m = matchLatexMath('\\(E = mc^2\\)');
+        expect(m).toMatchObject({
+            text: 'E = mc^2',
+            kind: 'inline',
+            open: '\\(',
+            close: '\\)',
+        });
+    });
+
+    it('keeps LaTeX command backslashes inside the content', () => {
+        const m = matchLatexMath('\\(x_i = \\frac{a_i}{b_i}\\)');
+        expect(m?.text).toBe('x_i = \\frac{a_i}{b_i}');
+    });
+
+    it('does not treat \\\\( as an opener', () => {
+        expect(matchLatexMath('\\\\(x\\)')).toBeNull();
+    });
+
+    it('does not treat \\\\[ as an opener', () => {
+        expect(matchLatexMath('\\\\[x\\]')).toBeNull();
+    });
+
+    it('does not close on \\\\ ) (escaped backslash then paren)', () => {
+        expect(matchLatexMath('\\(x\\\\)')).toBeNull();
+    });
+
+    it('does not match an empty span', () => {
+        expect(matchLatexMath('\\(\\)')).toBeNull();
+    });
+});
+
+describe('matchLatexMath — inline \\[ ... \\]', () => {
+    it('matches display delimiters mid-string start', () => {
+        const m = matchLatexMath('\\[E = mc^2\\]');
+        expect(m).toMatchObject({
+            text: 'E = mc^2',
+            kind: 'display',
+            open: '\\[',
+            close: '\\]',
+        });
+    });
+});
+
+describe('matchLatexDisplayBlock', () => {
+    it('matches a multiline display formula including the trailing newline', () => {
+        const src = '\\[\nd_{\\text{fim a fim}} = N\\frac{L}{R}\n\\]\n';
+        const m = matchLatexDisplayBlock(src);
+        expect(m?.kind).toBe('display');
+        expect(m?.text).toBe('d_{\\text{fim a fim}} = N\\frac{L}{R}');
+        expect(m?.raw).toBe(src);
+    });
+
+    it('matches a single-line display formula that is the whole block', () => {
+        const m = matchLatexDisplayBlock('\\[ E = mc^2 \\]\n');
+        expect(m?.text).toBe('E = mc^2');
+    });
+
+    it('does not steal trailing prose on the same line', () => {
+        expect(matchLatexDisplayBlock('\\[x\\] is not a block\n')).toBeNull();
+    });
+
+    it('accepts up to three spaces of indent', () => {
+        const m = matchLatexDisplayBlock('   \\[x\\]\n');
+        expect(m?.text).toBe('x');
+    });
+});

--- a/packages/muya/src/utils/marked/extensions/math.ts
+++ b/packages/muya/src/utils/marked/extensions/math.ts
@@ -1,4 +1,5 @@
 import katex from 'katex';
+import { matchLatexDisplayBlock, matchLatexMath } from '../../matchLatexMath';
 import 'katex/dist/contrib/mhchem.mjs';
 
 export interface IMathToken {
@@ -6,7 +7,7 @@ export interface IMathToken {
     raw: string;
     text: string;
     displayMode: boolean;
-    mathStyle?: '' | 'gitlab';
+    mathStyle?: '' | 'gitlab' | 'latex';
 }
 
 interface IOptions {
@@ -18,6 +19,9 @@ const inlineStartRule = /(\s|^)\${1,2}(?!\$)/;
 const inlineRule
     = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:]|$)/;
 const blockRule = /^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1[ \t]*(?:\n|$)/;
+// `\[` / `\(` whose leading backslash is not itself escaped (`\\[` is a
+// literal backslash plus `[`, not a math opener).
+const latexInlineStartRule = /(?<!\\)\\(?:\(|\[)/;
 
 const DEFAULT_OPTIONS = {
     throwOnError: false,
@@ -47,10 +51,13 @@ function createRenderer(options: IOptions, newlineAfter: boolean) {
                 }) + (newlineAfter ? '\n' : '')
             );
         }
+        else if (type === 'inlineMath') {
+            if (mathStyle === 'latex')
+                return displayMode ? `\\[${text}\\]` : `\\(${text}\\)`;
+            return `$${text}$`;
+        }
         else {
-            return type === 'inlineMath'
-                ? `$${text}$`
-                : `<pre class="multiple-math" data-math-style="${mathStyle}">${text}</pre>\n`;
+            return `<pre class="multiple-math" data-math-style="${mathStyle}">${text}</pre>\n`;
         }
     };
 }
@@ -60,15 +67,7 @@ function inlineKatex(renderer: (token: IMathToken) => string) {
         name: 'inlineMath',
         level: 'inline' as const,
         start(src: string) {
-            const match = src.match(inlineStartRule);
-            if (!match)
-                return;
-
-            const index = (match.index || 0) + match[1].length;
-            const possibleKatex = src.substring(index);
-
-            if (inlineRule.test(possibleKatex))
-                return index;
+            return earliestInlineStart(src);
         },
         tokenizer(src: string) {
             const match = src.match(inlineRule);
@@ -80,9 +79,40 @@ function inlineKatex(renderer: (token: IMathToken) => string) {
                     displayMode: match[1].length === 2,
                 };
             }
+            const latex = matchLatexMath(src);
+            if (latex) {
+                return {
+                    type: 'inlineMath',
+                    raw: latex.raw,
+                    text: latex.text.trim(),
+                    displayMode: latex.kind === 'display',
+                    mathStyle: 'latex',
+                };
+            }
         },
         renderer,
     };
+}
+
+function earliestInlineStart(src: string): number | undefined {
+    const dollar = src.match(inlineStartRule);
+    let dollarIndex: number | undefined;
+    if (dollar) {
+        const index = (dollar.index || 0) + dollar[1].length;
+        if (inlineRule.test(src.substring(index)))
+            dollarIndex = index;
+    }
+
+    const latex = latexInlineStartRule.exec(src);
+    let latexIndex: number | undefined;
+    if (latex && matchLatexMath(src.substring(latex.index)))
+        latexIndex = latex.index;
+
+    if (dollarIndex === undefined)
+        return latexIndex;
+    if (latexIndex === undefined)
+        return dollarIndex;
+    return Math.min(dollarIndex, latexIndex);
 }
 
 function blockKatex(renderer: (token: IMathToken) => string) {
@@ -90,9 +120,19 @@ function blockKatex(renderer: (token: IMathToken) => string) {
         name: 'multiplemath',
         level: 'block' as const,
         start(src: string) {
-            return src.indexOf('\n$');
+            return earliestBlockStart(src);
         },
         tokenizer(src: string) {
+            const latex = matchLatexDisplayBlock(src);
+            if (latex) {
+                return {
+                    type: 'multiplemath',
+                    raw: latex.raw,
+                    text: latex.text,
+                    displayMode: true,
+                    mathStyle: 'latex',
+                };
+            }
             const match = src.match(blockRule);
             if (match) {
                 return {
@@ -106,4 +146,17 @@ function blockKatex(renderer: (token: IMathToken) => string) {
         },
         renderer,
     };
+}
+
+function earliestBlockStart(src: string): number | undefined {
+    if (matchLatexDisplayBlock(src) || blockRule.test(src))
+        return 0;
+
+    const dollar = src.indexOf('\n$');
+    const latex = src.search(/\n {0,3}\\\[/);
+    if (dollar < 0)
+        return latex < 0 ? undefined : latex;
+    if (latex < 0)
+        return dollar;
+    return Math.min(dollar, latex);
 }

--- a/packages/muya/src/utils/marked/types.ts
+++ b/packages/muya/src/utils/marked/types.ts
@@ -38,7 +38,7 @@ export interface IMultipleMathToken {
     raw: string;
     text: string;
     displayMode: boolean;
-    mathStyle: '' | 'gitlab';
+    mathStyle: '' | 'gitlab' | 'latex';
 }
 
 export interface IFrontmatterToken {

--- a/packages/muya/src/utils/matchLatexMath.ts
+++ b/packages/muya/src/utils/matchLatexMath.ts
@@ -1,0 +1,83 @@
+// TeX delimiters `\(...\)` (inline) and `\[...\]` (display). These are
+// first-class math spans — not a rewrite of `\[` into `$$` — so CommonMark's
+// backslash-escape of `[` / `(` must not consume the opener first.
+//
+// A closer is the two-char sequence `\)` / `\]` whose leading backslash is
+// not itself escaped: after any other `\` we skip the next character (so
+// `\\` is a literal backslash and `\\)` does not close).
+
+export type TLatexMathKind = 'inline' | 'display';
+
+export interface ILatexMathMatch {
+    raw: string;
+    text: string;
+    kind: TLatexMathKind;
+    open: '\\(' | '\\[';
+    close: '\\)' | '\\]';
+}
+
+export function matchLatexMath(src: string): ILatexMathMatch | null {
+    if (src.startsWith('\\('))
+        return scan(src, '\\(', '\\)', 'inline');
+    if (src.startsWith('\\['))
+        return scan(src, '\\[', '\\]', 'display');
+    return null;
+}
+
+// Block-level `\[...\]` only: the closer must be the last thing on the
+// line (optional trailing whitespace, then newline or EOF). `foo \[x\] bar`
+// stays a paragraph so the inline lexer can still render the span; a
+// dedicated block would swallow the trailing prose.
+export function matchLatexDisplayBlock(src: string): ILatexMathMatch | null {
+    const indentMatch = /^ {0,3}/.exec(src);
+    const indent = indentMatch ? indentMatch[0].length : 0;
+    if (!src.startsWith('\\[', indent))
+        return null;
+
+    const scanned = scan(src.slice(indent), '\\[', '\\]', 'display');
+    if (!scanned)
+        return null;
+
+    const after = src.slice(indent + scanned.raw.length);
+    const trail = /^[ \t]*(?:\n|$)/.exec(after);
+    if (!trail)
+        return null;
+
+    return {
+        raw: src.slice(0, indent + scanned.raw.length + trail[0].length),
+        text: scanned.text.trim(),
+        kind: 'display',
+        open: '\\[',
+        close: '\\]',
+    };
+}
+
+function scan(
+    src: string,
+    open: '\\(' | '\\[',
+    close: '\\)' | '\\]',
+    kind: TLatexMathKind,
+): ILatexMathMatch | null {
+    const closeChar = close[1];
+    let i = open.length;
+    while (i < src.length) {
+        if (src[i] === '\\') {
+            if (src[i + 1] === closeChar) {
+                const text = src.slice(open.length, i);
+                if (!text)
+                    return null;
+                return {
+                    raw: src.slice(0, i + 2),
+                    text,
+                    kind,
+                    open,
+                    close,
+                };
+            }
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    return null;
+}

--- a/packages/muya/src/utils/turndownService/index.ts
+++ b/packages/muya/src/utils/turndownService/index.ts
@@ -270,7 +270,14 @@ export function usePluginsAddRules(turndownService: TurndownService) {
                 && node.classList.contains('multiple-math')
             );
         },
-        replacement(content: string) {
+        replacement(content: string, node: Node) {
+            const style = node instanceof HTMLElement
+                ? node.getAttribute('data-math-style')
+                : '';
+            if (style === 'latex')
+                return `\\[\n${content}\n\\]`;
+            if (style === 'gitlab')
+                return `\`\`\`math\n${content}\n\`\`\``;
             return `$$\n${content}\n$$`;
         },
     });

--- a/packages/website/content/docs/end-user/MARKDOWN_SYNTAX.md
+++ b/packages/website/content/docs/end-user/MARKDOWN_SYNTAX.md
@@ -724,6 +724,23 @@ m=\frac{b_y-a_y}{b_x-a_x}
 $$
 ```
 
+### TeX delimiters
+
+MarkText also recognizes TeX delimiters — the same pairs [KaTeX auto-render](https://katex.org/docs/autorender.html) and Pandoc's [`tex_math_single_backslash`](https://pandoc.org/MANUAL.html#extension-tex_math_single_backslash) use:
+
+- Inline: <code>\( ... \)</code>
+- Display: <code>\[ ... \]</code>
+
+```markdown
+The Pythagorean theorem is \(a^2 + b^2 = c^2\).
+
+\[
+\int_0^1 x^2 \, dx
+\]
+```
+
+`$` / `$$` and the TeX pairs are both parsed. Which pair the Format and Paragraph menus **insert** is set under **Preferences → Markdown → Math delimiter**. Existing formulas keep the delimiters they were saved with.
+
 <br>
 
 ## Diagrams

--- a/packages/website/content/docs/end-user/PREFERENCES.md
+++ b/packages/website/content/docs/end-user/PREFERENCES.md
@@ -60,8 +60,9 @@ Preferences can be controlled and modified in the settings window or via the `pr
 | listIndentation              | Mixed   | `1`     | List indentation. Optional values: `dfm`, `tab`, or a number `1`–`4`.                                                                |
 | frontmatterType              | String  | `-`     | Frontmatter delimiter: `-` (YAML), `+` (TOML), `;` (JSON), or `{` (JSON).                                                            |
 | superSubScript               | Boolean | `false` | Enable pandoc's superscript/subscript markdown extension.                                                                            |
-| footnote                     | Boolean | `false` | Enable pandoc's footnote markdown extension.                                                                                         |
-| isHtmlEnabled                | Boolean | `true`  | Enable inline HTML rendering.                                                                                                        |
+| footnote                     | Boolean | `false`  | Enable pandoc's footnote markdown extension.                                                                                         |
+| mathDelimiter                | String  | `dollar` | Delimiter written when inserting math from the Format and Paragraph menus. Optional values: `dollar` (`$…$` / `$$…$$`), `latex` (`\(...\)` / `\[…\]`). Parsing always accepts both. |
+| isHtmlEnabled                | Boolean | `true`   | Enable inline HTML rendering.                                                                                                        |
 | isGitlabCompatibilityEnabled | Boolean | `false` | Enable GitLab compatibility mode.                                                                                                    |
 | sequenceTheme                | String  | `hand`  | Theme for [js-sequence-diagrams](https://bramp.github.io/js-sequence-diagrams/): `hand` or `simple`.                                 |
 


### PR DESCRIPTION
Related to #1188

## Summary

Markdown is how these notes actually live and move. A large share of that
corpus uses TeX delimiters `\(...\)` and `\[...\]` instead of `$` / `$$` —
Pandoc, KaTeX auto-render, academic exports, LLM output, and files that
travel through the same notes ecosystem as Obsidian and Zettlr.

MarkText already renders dollar math, so those documents open as CommonMark
escapes (`\[` → `[`) rather than formulas. That limitation is what motivated
this change: I have several Markdown files in the TeX spelling, and I wanted
them to render here the way they already do in the rest of that toolchain,
without converting everyone else's `$` / `$$` notes.

This PR adds the TeX pair **additively**. `$` / `$$` keep working. A `\[`
block is stored with `mathStyle: 'latex'` and writes `\[...\]` back, not
`$$`. A new **Markdown → Math delimiter** preference (`dollar` default |
`latex`) only affects what Format / Paragraph insert. Opening a file always
accepts both pairs.

This does **not** add `\begin{equation}`, numbering, or `\label` (the rest
of #1188).

## Type of change

- [x] New feature (non-breaking, adds functionality)
- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (lexer, marked parse/serialize/HTML, Enter convert, format cursor, quick-insert)
- [ ] Manually tested on: Linux (screenshots to follow)
  - [ ] `\[` / `\(` render in WYSIWYG and source mode
  - [ ] Save/reload keeps `\[`, does not convert to `$$`
  - [ ] Math inside inline/fenced code stays code
  - [ ] `$` / `$$` / GitLab ` ```math ` unchanged
  - [ ] Preference changes only newly inserted math

## Notes for reviewers

- Live lexer runs `tryLatexMath` **before** `tryBacklash`, otherwise CommonMark
  steals `\(` / `\[` as escaped punctuation.
- Block `\[...\]` only when the closer is last on the line; `foo \[x\] bar`
  stays a paragraph (inline display math).
- `$$` + Enter still prefix-matches; `\[` + Enter is **exact** `\[` so
  `\[ formula` is not wiped.
- Compatibility: a paragraph that is only `\[foo\]` becomes a math-block when
  math is on (already the default, already non-CommonMark because of `$`).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

Made with [Cursor](https://cursor.com)