### PR TITLE
fix: math expression recognition and PDF/HTML export compatibility

### DIFF
--- a/packages/desktop/src/renderer/src/services/printService.ts
+++ b/packages/desktop/src/renderer/src/services/printService.ts
@@ -2,12 +2,22 @@ import { resolveLocalImageSrc } from '../util/resolveImageSrc'
 
 class MarkdownPrint {
   private container: HTMLElement | null = null
+  private injectedStyles: HTMLStyleElement[] = []
 
   /**
    * Prepare document export and append a hidden print container to the window.
    * Everything outside of this hidden print container will be hidden with display: none.
    *
-   * @param html HTML string
+   * `html` may be either a body-only HTML fragment (legacy callers) or a full
+   * `<!DOCTYPE html>` document produced by `exportStyledHTML`. When a full
+   * document is detected, the `<head>` stylesheets are extracted and injected
+   * into the current page's `<head>` so they apply during `printToPDF`, and
+   * only the `<body>` content is placed into the print container. This avoids
+   * the browser silently stripping `<html>`/`<head>`/`<body>` wrapper tags
+   * when assigned via `innerHTML`, which previously caused `<style>` elements
+   * to render as visible text and the markdown content to appear twice.
+   *
+   * @param html HTML string (fragment or full document)
    * @param renderStatic Render for static files like PDF documents
    * @param dir Text direction to mirror onto the container. `innerHTML` drops
    *   the exporter's outer `<html dir=…>` shell and the container is a sibling
@@ -22,7 +32,34 @@ class MarkdownPrint {
       printContainer.setAttribute('dir', dir)
     }
     this.container = printContainer
-    printContainer.innerHTML = html
+
+    // Detect whether `html` is a full HTML document or just a fragment.
+    // `exportStyledHTML` produces `<!DOCTYPE html>\n<html …>…</html>`.
+    const isFullDocument = /^\s*<!DOCTYPE\s/i.test(html)
+
+    if (isFullDocument) {
+      // Parse into a temporary DOM to safely extract <head> styles and <body>.
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(html, 'text/html')
+
+      // Extract all <style> elements from the parsed <head> and inject them
+      // into the live page so their rules apply to the print container during
+      // Chromium's `printToPDF` capture.
+      const headStyles = doc.head.querySelectorAll('style')
+      for (const style of Array.from(headStyles)) {
+        const liveStyle = document.createElement('style')
+        liveStyle.setAttribute('data-print-service', 'true')
+        liveStyle.textContent = style.textContent
+        document.head.appendChild(liveStyle)
+        this.injectedStyles.push(liveStyle)
+      }
+
+      // Use only the parsed <body> innerHTML — this is the article + any
+      // header/footer table wrapping, WITHOUT the document shell.
+      printContainer.innerHTML = doc.body.innerHTML
+    } else {
+      printContainer.innerHTML = html
+    }
 
     // Fix images when rendering for static files like PDF (GH#678).
     if (renderStatic) {
@@ -38,12 +75,18 @@ class MarkdownPrint {
   }
 
   /**
-   * Remove the print container from the window.
+   * Remove the print container and any injected styles from the window.
    */
   clearup(): void {
     if (this.container) {
       this.container.remove()
+      this.container = null
     }
+    // Remove all <style> elements we injected into <head> during renderMarkdown.
+    for (const style of this.injectedStyles) {
+      style.remove()
+    }
+    this.injectedStyles = []
   }
 }
 

--- a/packages/desktop/src/renderer/src/util/exportHtml.ts
+++ b/packages/desktop/src/renderer/src/util/exportHtml.ts
@@ -42,7 +42,7 @@ const HEADER_FOOTER_CSS = `
 table.page-container { width: 100%; border-collapse: collapse; }
 table.page-container > tbody,
 table.page-container > tbody > tr,
-table.page-container > tbody > tr > td { display: block; width: 100vw; }
+table.page-container > tbody > tr > td { display: block; width: 100%; }
 table.page-container > tbody > tr > td { overflow-wrap: anywhere; }
 table.page-container > thead,
 table.page-container > tfoot { display: table-header-group; }
@@ -208,9 +208,9 @@ export const exportStyledHTML = async(
   // back to a raw `[TOC]` if present.
   if (toc) {
     if (/<p>\s*\[TOC\]\s*<\/p>/i.test(article)) {
-      article = article.replace(/<p>\s*\[TOC\]\s*<\/p>/i, toc)
+      article = article.replace(/<p>\s*\[TOC\]\s*<\/p>/i, () => toc)
     } else if (TOC_REG.test(article)) {
-      article = article.replace(TOC_REG, toc)
+      article = article.replace(TOC_REG, () => toc)
     }
   }
 
@@ -230,5 +230,5 @@ export const exportStyledHTML = async(
   }
 
   // Re-emit the engine document shell with the (possibly augmented) body.
-  return fullDoc.replace(/<body>[\s\S]*<\/body>/, `<body>\n  ${bodyHtml}\n</body>`)
+  return fullDoc.replace(/<body>[\s\S]*<\/body>/, () => `<body>\n  ${bodyHtml}\n</body>`)
 }

--- a/packages/desktop/src/renderer/src/util/pdf.ts
+++ b/packages/desktop/src/renderer/src/util/pdf.ts
@@ -51,6 +51,10 @@ export const getCssForOptions = async(options: PdfCssOptions): Promise<string> =
     // Keep a heading with the content that follows it, so a page never breaks
     // immediately after a heading, and never split a multi-line heading (#3039).
     output += 'h1,h2,h3,h4,h5,h6{break-after:avoid;break-inside:avoid;}'
+    output += 'table,tr,figure,img,svg{break-inside:avoid;page-break-inside:avoid;}'
+    output += 'pre,blockquote{break-inside:avoid;page-break-inside:avoid;}'
+    output += '.katex-display,.mu-math-preview,pre.multiple-math{break-inside:avoid;page-break-inside:avoid;}'
+    output += 'div.plantuml,div.mermaid,div.vega-lite,div.flowchart,div.sequence{break-inside:avoid;page-break-inside:avoid;}'
   }
 
   // Auto numbering headings via CSS

--- a/packages/desktop/test/unit/specs/exportHtml.spec.ts
+++ b/packages/desktop/test/unit/specs/exportHtml.spec.ts
@@ -281,3 +281,31 @@ describe('exportStyledHTML — relative link paths (#1688)', () => {
     expect(out).not.toContain('file://')
   })
 })
+
+describe('exportStyledHTML — math expressions and dollar safety', () => {
+  it('renders single dollar $x = 1$ and double dollar $$x = 1$$ math in export', async() => {
+    const out = await exportStyledHTML(NO_MUYA, 'Inline $x = 1$ and double $$y = 2$$', {})
+
+    expect(out).toContain('katex')
+    expect(out).not.toContain('Inline $x = 1$')
+    expect(out).not.toContain('double $$y = 2$$')
+  })
+
+  it('renders math enclosed in parentheses ($x > 0$) and quotes "$x = 1$"', async() => {
+    const out = await exportStyledHTML(NO_MUYA, 'Parentheses ($x > 0$) and quotes "$x = 1$"', {})
+
+    expect(out).toContain('katex')
+    expect(out).not.toContain('($x > 0$)')
+    expect(out).not.toContain('"$x = 1$"')
+  })
+
+  it('safely preserves literal dollar amounts and math without regex corruption ($1, $&, $$)', async() => {
+    const out = await exportStyledHTML(NO_MUYA, 'Price: $100 and $200 with $$x = 1$$ and $1 in text', {
+      header: { type: 2, center: 'Header' }
+    })
+
+    expect(out).toContain('Price: $100 and $200 with')
+    expect(out).toContain('and $1 in text')
+    expect(out).toContain('katex')
+  })
+})

--- a/packages/desktop/test/unit/specs/pdf.spec.ts
+++ b/packages/desktop/test/unit/specs/pdf.spec.ts
@@ -34,23 +34,19 @@ const loadPdf = async() => {
 describe('getCssForOptions', () => {
   beforeEach(() => {
     vi.resetModules()
-    const w = globalThis as unknown as {
-      window: {
-        marktext: { paths: { userDataPath: string } }
-        fileUtils: { isFile: (p: string) => Promise<boolean>, readFile: (p: string) => Promise<unknown> }
-      }
-    }
-    w.window.marktext = { paths: { userDataPath: '/userData' } }
-    w.window.fileUtils = { isFile: async() => false, readFile: async() => '' }
+    const target = typeof window !== 'undefined' ? window : (globalThis as any).window
+    target.marktext = { paths: { userDataPath: '/userData' } }
+    target.fileUtils = { isFile: async() => false, readFile: async() => '' }
+    target.path = { sep: '/', join: (...parts: string[]) => parts.join('/') }
   })
 
   it('academic/liber take the inline-theme branch (no disk access required)', async() => {
     const { getCssForOptions } = await loadPdf()
     // Remove the disk surfaces entirely: if academic/liber tried a disk read
     // these would throw. They must not.
-    const w = globalThis as unknown as { window: Record<string, unknown> }
-    delete w.window.marktext
-    delete w.window.fileUtils
+    const target = typeof window !== 'undefined' ? window : (globalThis as any).window
+    delete (target as any).marktext
+    delete (target as any).fileUtils
 
     await expect(getCssForOptions({ theme: 'academic' })).resolves.toBeTypeOf('string')
     await expect(getCssForOptions({ theme: 'liber' })).resolves.toBeTypeOf('string')

--- a/packages/desktop/vitest.config.ts
+++ b/packages/desktop/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['test/unit/specs/**/*.spec.ts'],
-    globals: true
+    globals: true,
+    testTimeout: 15000
   },
   resolve: {
     alias: {

--- a/packages/muya/src/assets/styles/exportStyle.css
+++ b/packages/muya/src/assets/styles/exportStyle.css
@@ -20,6 +20,40 @@
     }
 }
 
+@media print {
+    .markdown-body {
+        padding: 0 !important;
+        background-color: transparent !important;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        break-after: avoid;
+        break-inside: avoid;
+        page-break-after: avoid;
+        page-break-inside: avoid;
+    }
+
+    table, tr, figure, img, svg {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    pre, blockquote {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    .katex-display, .mu-math-preview, pre.multiple-math {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    div.plantuml, div.mermaid, div.vega-lite, div.flowchart, div.sequence {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+}
+
 /* Table of contents injected at a `[TOC]` marker by the desktop export
    wrapper (getHtmlToc). Ported from legacy muyajs exportStyle.css so the
    exported TOC keeps the same look: body-colour links (not link-blue) and a

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -110,7 +110,9 @@ function getOffset(offset: number, token: Token) {
         case 'inline_code':
 
         case 'inline_math': {
-            const markerLen = type === 'strong' || type === 'del' ? 2 : 1;
+            const markerLen = 'marker' in token && typeof token.marker === 'string'
+                ? token.marker.length
+                : (type === 'strong' || type === 'del' ? 2 : 1);
             return markeredOffset(dis, len, markerLen, markerLen);
         }
 

--- a/packages/muya/src/inlineRenderer/__tests__/inlineMathEscape.spec.ts
+++ b/packages/muya/src/inlineRenderer/__tests__/inlineMathEscape.spec.ts
@@ -23,4 +23,20 @@ describe('inline math — escaped dollar (#4555)', () => {
     it('still tokenizes a plain $a+b$ unchanged', () => {
         expect(mathContent('$a+b$')).toBe('a+b');
     });
+
+    it('tokenizes double dollar $$x = 1$$', () => {
+        expect(mathContent('$$x = 1$$')).toBe('x = 1');
+    });
+
+    it('tokenizes double dollar with escaped \\$ $$y = \\$10000$$', () => {
+        expect(mathContent('$$y = \\$10000$$')).toBe('y = \\$10000');
+    });
+
+    it('sets correct marker for single and double dollar tokens', () => {
+        const singleToken = tokenizer('$x$').find(t => t.type === 'inline_math') as CodeEmojiMathToken;
+        expect(singleToken.marker).toBe('$');
+
+        const doubleToken = tokenizer('$$x$$').find(t => t.type === 'inline_math') as CodeEmojiMathToken;
+        expect(doubleToken.marker).toBe('$$');
+    });
 });

--- a/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
+++ b/packages/muya/src/inlineRenderer/renderer/inlineMath.ts
@@ -44,8 +44,8 @@ export default function inlineMath(this: Renderer, {
 
     const { loadMathMap } = this;
 
-    const displayMode = false;
-    const key = `${math}_${type}`;
+    const displayMode = marker.length === 2;
+    const key = `${math}_${type}_${displayMode}`;
     let mathVnode = null;
     let previewSelector = `span.${CLASS_NAMES.MU_MATH_RENDER}`;
     // Inline math errors stay compact to keep the surrounding text baseline
@@ -86,8 +86,8 @@ export default function inlineMath(this: Renderer, {
                         ? { contenteditable: 'false', title: errorTitle }
                         : { contenteditable: 'false' },
                     dataset: {
-                        start: String(start + 1), // '$'.length
-                        end: String(end - 1), // '$'.length
+                        start: String(start + marker.length),
+                        end: String(end - marker.length),
                     },
                 },
                 mathVnode,

--- a/packages/muya/src/inlineRenderer/rules.ts
+++ b/packages/muya/src/inlineRenderer/rules.ts
@@ -68,7 +68,7 @@ export type GfmRules = typeof gfmRules;
 // Markdown extensions (not belongs to GFM and Commonmark)
 export const inlineExtensionRules = {
     // eslint-disable-next-line regexp/no-super-linear-backtracking
-    inline_math: /^(\$)((?:[^$\\]|\\.)+)(\\*)\1(?!\1)/,
+    inline_math: /^(\${1,2})((?:[^$\\]|\\.)+)(\\*)\1(?!\$)/,
     // This is not the best regexp, because it not support `2^2\\^`.
     superscript: /^(\^)((?:[^^\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,
     subscript: /^(~)((?:[^~\s]|(?<=\\)\1|(?<=\\) )+?)(?<!\\)\1(?!\1)/,

--- a/packages/muya/src/state/__tests__/mathTrailingSpace.spec.ts
+++ b/packages/muya/src/state/__tests__/mathTrailingSpace.spec.ts
@@ -34,4 +34,22 @@ describe('block math — closing $$ with trailing whitespace (#1931)', () => {
         const states = parse('$$\nx = 1\n$$\n\nbar\n');
         expect(states.some(s => s.name === 'math-block')).toBe(true);
     });
+
+    it('parses a single-line math block $$x = 1$$', () => {
+        const states = parse('$$x = 1$$\n');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+        expect(states[0].text).toBe('x = 1');
+    });
+
+    it('parses a single-line math block with spaces $$ x = 1 $$', () => {
+        const states = parse('$$ x = 1 $$\n');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+        expect(states[0].text).toBe('x = 1');
+    });
+
+    it('parses a multi-line math block at the very start of input (index 0)', () => {
+        const states = parse('$$\nx = 1\n$$');
+        expect(states.some(s => s.name === 'math-block')).toBe(true);
+        expect(states[0].text).toBe('x = 1');
+    });
 });

--- a/packages/muya/src/utils/marked/extensions/math.ts
+++ b/packages/muya/src/utils/marked/extensions/math.ts
@@ -14,10 +14,10 @@ interface IOptions {
     useKatexRender?: boolean;
 }
 
-const inlineStartRule = /(\s|^)\${1,2}(?!\$)/;
+const inlineStartRule = /(?:^|[^\\])(\${1,2})(?!\$)/;
 const inlineRule
-    = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:]|$)/;
-const blockRule = /^(\${1,2})\n((?:\\[\s\S]|[^\\])+?)\n\1[ \t]*(?:\n|$)/;
+    = /^(\${1,2})(?!\$)((?:\\.|[^\\$\n])+?)\1(?![0-9$])/;
+const blockRule = /^(\${2})(?:\n((?:\\[\s\S]|[^\\])+?)\n|\s*([^\n]+?)\s*)\1[ \t]*(?:\n|$)/;
 
 const DEFAULT_OPTIONS = {
     throwOnError: false,
@@ -49,7 +49,7 @@ function createRenderer(options: IOptions, newlineAfter: boolean) {
         }
         else {
             return type === 'inlineMath'
-                ? `$${text}$`
+                ? (displayMode ? `$$${text}$$` : `$${text}$`)
                 : `<pre class="multiple-math" data-math-style="${mathStyle}">${text}</pre>\n`;
         }
     };
@@ -60,15 +60,17 @@ function inlineKatex(renderer: (token: IMathToken) => string) {
         name: 'inlineMath',
         level: 'inline' as const,
         start(src: string) {
-            const match = src.match(inlineStartRule);
-            if (!match)
-                return;
+            let match: RegExpExecArray | null;
+            const re = new RegExp(inlineStartRule.source, 'g');
+            while ((match = re.exec(src)) !== null) {
+                const index = match.index + (match[0].startsWith('$') ? 0 : 1);
+                const possibleKatex = src.substring(index);
 
-            const index = (match.index || 0) + match[1].length;
-            const possibleKatex = src.substring(index);
+                if (inlineRule.test(possibleKatex))
+                    return index;
 
-            if (inlineRule.test(possibleKatex))
-                return index;
+                re.lastIndex = match.index + 1;
+            }
         },
         tokenizer(src: string) {
             const match = src.match(inlineRule);
@@ -90,15 +92,26 @@ function blockKatex(renderer: (token: IMathToken) => string) {
         name: 'multiplemath',
         level: 'block' as const,
         start(src: string) {
-            return src.indexOf('\n$');
+            let match: RegExpExecArray | null;
+            const re = /(?:^|\n)\${2}/g;
+            while ((match = re.exec(src)) !== null) {
+                const index = match.index + (match[0].startsWith('\n') ? 1 : 0);
+                const possibleBlock = src.substring(index);
+
+                if (blockRule.test(possibleBlock))
+                    return index;
+
+                re.lastIndex = match.index + 1;
+            }
         },
         tokenizer(src: string) {
             const match = src.match(blockRule);
             if (match) {
+                const text = (match[2] ?? match[3] ?? '').trim();
                 return {
                     type: 'multiplemath',
                     raw: match[0],
-                    text: match[2].trim(),
+                    text,
                     displayMode: match[1].length === 2,
                     mathStyle: '',
                 };


### PR DESCRIPTION
# Pull Request: Fix math expression recognition and PDF/HTML export compatibility

**Branch:** `develop` → `origin/develop`  
**Commit:** `9aa81609`  
**Files changed:** 13 (193 insertions, 38 deletions)

---

## Summary

This PR fixes three interrelated bugs affecting how MarkText handles math expressions and exports documents to PDF/HTML:

1. **Double-dollar math (`$$ $$`) not recognised in the editor** — pasting or typing `$$x = 1$$` was rendered as literal text instead of a math block.
2. **Exported PDF repeating all content** — the PDF contained the markdown body twice, with raw CSS rules appearing as visible text before the actual content.
3. **Formatting quirks in PDF/HTML export** — inline math in parentheses/quotes/tables was silently dropped, dollar amounts (`$100`) were corrupted by JS regex replacement tokens, and elements like tables, code blocks, and diagrams were sliced across page boundaries.

---

## Root Causes & Fixes

### 1. Math Expression Recognition (Editor)

**Problem:** The inline math regex in `rules.ts` only matched single-dollar `$...$` delimiters. The Marked math extension's `start()` method evaluated only the first dollar sign candidate in a paragraph — if it was a literal currency amount (e.g. `$100`), it returned `undefined` and skipped all subsequent valid math expressions in the same block.

**Fix:**
- Updated `inline_math` regex in [`rules.ts`](packages/muya/src/inlineRenderer/rules.ts) to support both `$` and `$$` delimiters.
- Updated [`inlineMath.ts`](packages/muya/src/inlineRenderer/renderer/inlineMath.ts) renderer to use dynamic marker offsets and `displayMode` based on delimiter length.
- Updated [`format.ts`](packages/muya/src/block/base/format.ts) to read `token.marker.length` for correct cursor offset calculation.
- Made `inlineKatex.start()` and `blockKatex.start()` in [`math.ts`](packages/muya/src/utils/marked/extensions/math.ts) iterate through all regex candidates instead of bailing on the first non-match.
- Relaxed `inlineStartRule` and `inlineRule` boundaries so inline math works inside parentheses `($x$)`, quotes `"$x$"`, brackets `[$x$]`, table cells `| $x$ |`, and before CJK punctuation.

### 2. PDF Export Duplicating Content

**Problem:** `exportStyledHTML()` returns a full `<!DOCTYPE html>` document (with `<html>`, `<head>`, `<body>` and all `<style>` elements). `printService.renderMarkdown()` assigned this directly to `printContainer.innerHTML`. When a full HTML document is set as `innerHTML` of an `<article>`:
- The browser strips `<html>`, `<head>`, `<body>` wrapper tags
- `<style>`, `<meta>`, `<title>` elements from `<head>` become visible child nodes (CSS rules render as text)
- The actual article content appears after the style garbage — making it look like the markdown is repeated

**Fix:** Rewrote [`printService.ts`](packages/desktop/src/renderer/src/services/printService.ts) to:
- Detect full HTML documents via `<!DOCTYPE` prefix
- Parse with `DOMParser` to safely extract `<head>` styles and `<body>` content
- Inject `<style>` elements into the live page's `<head>` (tagged with `data-print-service="true"` for cleanup)
- Use only `doc.body.innerHTML` for the print container
- Remove all injected styles in `clearup()` after export completes

### 3. Export Formatting Quirks

**Problem (Dollar Corruption):** `exportHtml.ts` used `String.prototype.replace(regex, string)` where the replacement string contained user markdown. JS treats `$$` as literal `$`, `$1` as capture group 1, and `$&` as the matched text — corrupting math expressions and currency amounts.

**Fix:** Switched all `.replace()` calls in [`exportHtml.ts`](packages/desktop/src/renderer/src/util/exportHtml.ts) to functional replacers `.replace(regex, () => string)`.

**Problem (Page-Break Slicing):** Only headings had `break-after: avoid` rules. Tables, code blocks, math blocks, images, and diagrams were sliced across PDF page boundaries.

**Fix:** Added `break-inside: avoid; page-break-inside: avoid` for tables, code blocks, math, images, blockquotes, and diagram containers in both [`pdf.ts`](packages/desktop/src/renderer/src/util/pdf.ts) and [`exportStyle.css`](packages/muya/src/assets/styles/exportStyle.css).

**Problem (Viewport Overflow):** Header/footer table used `width: 100vw` which ignored `@page` margins, causing right-side clipping.

**Fix:** Changed to `width: 100%` in [`exportHtml.ts`](packages/desktop/src/renderer/src/util/exportHtml.ts).

---

## Files Changed

| File | Change |
|------|--------|
| `packages/muya/src/inlineRenderer/rules.ts` | `inline_math` regex → supports `$` and `$$` |
| `packages/muya/src/inlineRenderer/renderer/inlineMath.ts` | Dynamic marker offsets & displayMode |
| `packages/muya/src/block/base/format.ts` | Read `token.marker.length` for offset |
| `packages/muya/src/utils/marked/extensions/math.ts` | Iterative `start()`, relaxed inline boundaries |
| `packages/muya/src/assets/styles/exportStyle.css` | `@media print` break-inside rules |
| `packages/desktop/src/renderer/src/services/printService.ts` | DOMParser-based full-document handling |
| `packages/desktop/src/renderer/src/util/exportHtml.ts` | Functional replacers, `100vw` → `100%` |
| `packages/desktop/src/renderer/src/util/pdf.ts` | break-inside rules for PDF CSS |
| `packages/desktop/test/unit/specs/exportHtml.spec.ts` | Tests for math export & dollar safety |
| `packages/desktop/test/unit/specs/pdf.spec.ts` | Fixed mock restoration in beforeEach |
| `packages/desktop/vitest.config.ts` | `testTimeout: 15000` for jsdom imports |
| `packages/muya/src/inlineRenderer/__tests__/inlineMathEscape.spec.ts` | Tests for `$$` delimiter support |
| `packages/muya/src/state/__tests__/mathTrailingSpace.spec.ts` | Tests for math in various contexts |

---

## Testing

| Suite | Result |
|-------|--------|
| Muya unit tests | ✅ 212 files, 1444 tests passed |
| CommonMark & GFM spec conformance | ✅ 4 files, 1347 tests passed |
| Desktop unit tests | ✅ 50 files, 737 tests passed |
| Manual testing | ✅ Editor renders `$$...$$`, PDF export no longer duplicates |
