### PR TITLE
fix(desktop): ignore revoked output pipe errors on macOS

### DIFF
--- a/packages/desktop/src/main/exceptionHandler.ts
+++ b/packages/desktop/src/main/exceptionHandler.ts
@@ -108,12 +108,13 @@ Operating system: ${getOSInformation()}`
 }
 
 const setupExceptionHandler = (): void => {
-  // Suppress EPIPE errors when electron-log writes to a closed pipe.
-  const ignoreEpipe = (err: NodeJS.ErrnoException): void => {
-    if (err.code !== 'EPIPE') throw err
+  // macOS reports EIO for revoked terminal descriptors; other platforms
+  // commonly report EPIPE for the same closed-output condition.
+  const ignoreBrokenOutputPipe = (err: NodeJS.ErrnoException): void => {
+    if (err.code !== 'EPIPE' && err.code !== 'EIO') throw err
   }
-  process.stdout.on('error', ignoreEpipe)
-  process.stderr.on('error', ignoreEpipe)
+  process.stdout.on('error', ignoreBrokenOutputPipe)
+  process.stderr.on('error', ignoreBrokenOutputPipe)
 
   // main process error handler
   process.on('uncaughtException', (error: Error) => {

--- a/packages/desktop/test/unit/specs/exception-handler-output.spec.ts
+++ b/packages/desktop/test/unit/specs/exception-handler-output.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(), isReady: vi.fn() },
+  clipboard: { writeText: vi.fn() },
+  crashReporter: { start: vi.fn() },
+  dialog: { showErrorBox: vi.fn(), showMessageBox: vi.fn() },
+  ipcMain: { on: vi.fn() }
+}))
+
+vi.mock('electron-log', () => ({
+  default: { error: vi.fn() }
+}))
+
+vi.mock('../../../src/main/i18n', () => ({
+  t: (key: string) => key
+}))
+
+vi.mock('../../../src/main/utils/createGitHubIssue', () => ({
+  createAndOpenGitHubIssueUrl: vi.fn()
+}))
+
+import setupExceptionHandler from '../../../src/main/exceptionHandler'
+
+type OutputErrorHandler = (error: NodeJS.ErrnoException) => void
+
+describe('main process output error handling', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('ignores revoked-pipe EIO errors without hiding unrelated output failures', () => {
+    let stdoutHandler: OutputErrorHandler | undefined
+
+    vi.spyOn(process.stdout, 'on').mockImplementation(((event: string, listener: OutputErrorHandler) => {
+      if (event === 'error') stdoutHandler = listener
+      return process.stdout
+    }) as typeof process.stdout.on)
+    vi.spyOn(process.stderr, 'on').mockImplementation((() => process.stderr) as typeof process.stderr.on)
+    vi.spyOn(process, 'on').mockImplementation((() => process) as typeof process.on)
+
+    setupExceptionHandler()
+    if (!stdoutHandler) throw new Error('stdout error handler was not registered')
+    const handleOutputError = stdoutHandler
+
+    const eio = Object.assign(new Error('write EIO'), { code: 'EIO' })
+    const enospc = Object.assign(new Error('write ENOSPC'), { code: 'ENOSPC' })
+    expect(() => handleOutputError(eio)).not.toThrow()
+    expect(() => handleOutputError(enospc)).toThrow(enospc)
+  })
+})


### PR DESCRIPTION
Closes #5221

## Summary

On macOS, a revoked terminal or launcher output descriptor can report EIO. Treat it as the same closed-output condition already handled for EPIPE, while continuing to rethrow unrelated output errors.

## Problem

The main-process exception handler only ignored EPIPE. macOS can report EIO for the equivalent revoked-output case, turning a logging failure into an uncaught exception.

## Change

- Ignore EIO and EPIPE for stdout/stderr output handlers.
- Keep unrelated errors such as ENOSPC visible.
- Add a focused unit regression test around the registered stdout handler.

## Demonstration

The regression test constructs an EIO output error and verifies that it is ignored, then constructs ENOSPC and verifies that it is rethrown.

## Test plan

- pnpm -C packages/desktop exec vitest run test/unit/specs/exception-handler-output.spec.ts passed.
- No renderer, parser, or user-document behavior is changed.