### PR TITLE
feat(muya): preview link targets in the hover toolbar

### DIFF
--- a/packages/muya/e2e/tests/inline/link-tools.spec.ts
+++ b/packages/muya/e2e/tests/inline/link-tools.spec.ts
@@ -15,6 +15,13 @@ test.describe('link tools', () => {
         await expect(page.locator(floats.linkTools)).toBeVisible();
     });
 
+    test('shows the link title before the URL in the hover preview', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('[Docs](https://example.com "Reference")'));
+        await page.locator('span.mu-link').first().hover();
+
+        await expect(page.locator(`${floats.linkTools} .mu-link-preview`)).toHaveText('Reference');
+    });
+
     test('clicking the LinkTools jump button fires the jumpClick callback', async ({ page }) => {
         await page.evaluate(() => {
             window.muya!.setContent('Visit [Example](https://example.com) site.');

--- a/packages/muya/e2e/tests/inline/link-tools.spec.ts
+++ b/packages/muya/e2e/tests/inline/link-tools.spec.ts
@@ -22,6 +22,50 @@ test.describe('link tools', () => {
         await expect(page.locator(`${floats.linkTools} .mu-link-preview`)).toHaveText('Reference');
     });
 
+    test('lays out actions before a preview that grows to at most two lines', async ({ page }) => {
+        await page.setViewportSize({ width: 640, height: 480 });
+        const title = '王晗.W教师编制招聘考试培训机构营销策略研究[D].济南：山东师范大学，2025.这段补充文本用于验证悬浮预览最多显示两行。';
+        await page.evaluate((previewTitle) => {
+            window.muya!.setContent(`[Reference](https://example.com "${previewTitle}")`);
+        }, title);
+        await page.locator(editor.paragraph).first().click({ position: { x: 2, y: 2 } });
+        await page.locator('span.mu-link').first().hover();
+
+        const tools = page.locator(floats.linkTools);
+        const unlink = tools.locator('li.item.unlink');
+        const jump = tools.locator('li.item.jump');
+        const preview = tools.locator('.mu-link-preview');
+        await expect(preview).toHaveText(title);
+
+        const [toolsBox, unlinkBox, jumpBox, previewBox] = await Promise.all([
+            tools.boundingBox(),
+            unlink.boundingBox(),
+            jump.boundingBox(),
+            preview.boundingBox(),
+        ]);
+        expect(toolsBox).not.toBeNull();
+        expect(unlinkBox).not.toBeNull();
+        expect(jumpBox).not.toBeNull();
+        expect(previewBox).not.toBeNull();
+        expect(unlinkBox!.x).toBeLessThan(jumpBox!.x);
+        expect(jumpBox!.x + jumpBox!.width).toBeLessThanOrEqual(previewBox!.x);
+        expect(toolsBox!.width).toBeGreaterThan(toolsBox!.height * 5);
+        expect(toolsBox!.x).toBeGreaterThanOrEqual(8);
+        expect(toolsBox!.x + toolsBox!.width).toBeLessThanOrEqual(632);
+
+        const previewStyle = await preview.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+                lineClamp: style.getPropertyValue('-webkit-line-clamp'),
+                lineHeight: Number.parseFloat(style.lineHeight),
+                paddingBlock: Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom),
+            };
+        });
+        expect(previewStyle.lineClamp).toBe('2');
+        expect(previewBox!.height).toBeGreaterThan(previewStyle.lineHeight + previewStyle.paddingBlock);
+        expect(previewBox!.height).toBeLessThanOrEqual(previewStyle.lineHeight * 2 + previewStyle.paddingBlock + 1);
+    });
+
     test('clicking the LinkTools jump button fires the jumpClick callback', async ({ page }) => {
         await page.evaluate(() => {
             window.muya!.setContent('Visit [Example](https://example.com) site.');

--- a/packages/muya/src/ui/baseFloat/index.ts
+++ b/packages/muya/src/ui/baseFloat/index.ts
@@ -1,7 +1,7 @@
 import type { Placement, ReferenceElement } from '@floating-ui/dom';
 import type { Muya } from '../../index';
 import type { IBaseOptions } from '../types';
-import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
+import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
 import { EVENT_KEYS } from '../../config';
 
 import { isHTMLElement, isKeyboardEvent, noop } from '../../utils';
@@ -169,7 +169,7 @@ abstract class BaseFloat {
         const cleanup = autoUpdate(reference, floatBox, () => {
             computePosition(reference, floatBox, {
                 placement,
-                middleware: [offset(offsetOptions), flip()],
+                middleware: [offset(offsetOptions), flip(), shift({ padding: 8 })],
             }).then(({ x, y }) => {
                 // `computePosition` is async: a `hide()` (or a newer `show()`)
                 // can land before this resolves. Applying it then would set

--- a/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/muya/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -23,6 +23,7 @@ interface ILinkToolsView {
     _linkBlock: Format | null;
     _linkInfo: {
         href?: string | null;
+        title?: string | null;
         text?: string;
         raw?: string;
         range?: { start: number; end: number } | null;
@@ -177,5 +178,23 @@ describe('linkTools.render — jump visibility tracks linkInfo.href', () => {
 
         expect(tools.container!.querySelectorAll('li.item.jump').length).toBe(1);
         expect(tools.container!.querySelectorAll('li.item.unlink').length).toBe(1);
+    });
+
+    it('renders the action group before the preview text', () => {
+        const { tools } = bootLinkTools();
+        tools._linkInfo = {
+            href: 'https://example.com',
+            title: 'Reference preview',
+            text: 'Example',
+            raw: '[Example](https://example.com)',
+            range: { start: 0, end: 32 },
+        };
+
+        tools.render();
+
+        const content = tools.container!.firstElementChild;
+        expect(content?.firstElementChild?.tagName).toBe('UL');
+        expect(content?.lastElementChild?.classList.contains('mu-link-preview')).toBe(true);
+        expect(content?.lastElementChild?.getAttribute('title')).toBe('Reference preview');
     });
 });

--- a/packages/muya/src/ui/linkTools/index.css
+++ b/packages/muya/src/ui/linkTools/index.css
@@ -13,31 +13,46 @@
 .mu-link-tools {
     position: relative;
 
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    min-width: 100px;
-    max-width: 300px;
+    box-sizing: border-box;
+    width: max-content;
+    min-width: min(320px, calc(100vw - 24px));
+    max-width: min(560px, calc(100vw - 24px));
     height: auto;
     min-height: 34px;
 }
 
-.mu-link-preview {
-    box-sizing: border-box;
+.mu-link-tools > div {
+    display: grid;
+    grid-template-columns: 100px minmax(0, 1fr);
+    align-items: center;
     width: 100%;
+    min-width: 0;
+    min-height: 34px;
+}
 
-    max-height: 200px;
-    padding: 8px 12px 0;
-    overflow-y: auto;
+.mu-link-preview {
+    display: -webkit-box;
+    grid-column: 2;
+
+    box-sizing: border-box;
+    min-width: 0;
+
+    max-height: calc(2.8em + 16px);
+    padding: 8px 12px;
+    overflow: hidden;
 
     color: var(--editor-color);
     font-size: 12px;
     line-height: 1.4;
+    white-space: normal;
     overflow-wrap: anywhere;
 
     cursor: text;
 
     user-select: text;
+
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
 }
 
 .mu-link-tools ul,
@@ -49,6 +64,7 @@
 .mu-link-tools ul {
     display: flex;
     flex-shrink: 0;
+    grid-column: 1;
     align-items: center;
     justify-content: center;
     width: 100px;
@@ -74,7 +90,7 @@
     background: var(--float-hover-color);
 }
 
-.mu-link-tools li.item:last-of-type::before {
+.mu-link-tools li.item + li.item::before {
     position: absolute;
     top: 6px;
     left: -12px;

--- a/packages/muya/src/ui/linkTools/index.css
+++ b/packages/muya/src/ui/linkTools/index.css
@@ -13,8 +13,31 @@
 .mu-link-tools {
     position: relative;
 
-    width: 100px;
-    height: 34px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 100px;
+    max-width: 300px;
+    height: auto;
+    min-height: 34px;
+}
+
+.mu-link-preview {
+    box-sizing: border-box;
+    width: 100%;
+
+    max-height: 200px;
+    padding: 8px 12px 0;
+    overflow-y: auto;
+
+    color: var(--editor-color);
+    font-size: 12px;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+
+    cursor: text;
+
+    user-select: text;
 }
 
 .mu-link-tools ul,
@@ -25,10 +48,11 @@
 
 .mu-link-tools ul {
     display: flex;
+    flex-shrink: 0;
     align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 100%;
+    justify-content: center;
+    width: 100px;
+    height: 34px;
 }
 
 .mu-link-tools li.item {

--- a/packages/muya/src/ui/linkTools/index.ts
+++ b/packages/muya/src/ui/linkTools/index.ts
@@ -12,6 +12,7 @@ type LinkToolIcon = typeof iconsConfig[number];
 
 interface ILinkInfo {
     href?: string | null;
+    title?: string | null;
     text?: string;
     raw?: string;
     range?: { start: number; end: number } | null;
@@ -143,7 +144,53 @@ class LinkTools extends BaseFloat {
             );
         });
 
-        const vnode = h('ul', children);
+        const ulNode = h('ul', children);
+
+        const wrapperChildren: VNode[] = [];
+
+        let previewText = this._linkInfo?.title || this._linkInfo?.href;
+
+        if (this._linkInfo?.href?.startsWith('#')) {
+            const anchorId = this._linkInfo.href.slice(1);
+            if (anchorId) {
+                // If it's an internal reference, find the anchor element and display its paragraph text
+                const anchorElement = this.muya.domNode.querySelector<HTMLElement>(
+                    `#${CSS.escape(anchorId)}`,
+                );
+                if (anchorElement) {
+                    const blockElement = anchorElement.closest('.mu-paragraph, [data-role="paragraph"], .mu-block, .mu-html-block');
+                    let rawText = '';
+                    if (blockElement && blockElement.textContent) {
+                        rawText = blockElement.textContent;
+                    }
+                    else if (anchorElement.parentElement && anchorElement.parentElement.textContent) {
+                        rawText = anchorElement.parentElement.textContent;
+                    }
+
+                    if (rawText) {
+                        // Strip HTML tags and leading reference markers like [4]
+                        previewText = rawText
+                            .replace(/<[^>]+>/g, '')
+                            .replace(/^\[.*?\]\s*/, '')
+                            .trim();
+                    }
+                }
+            }
+        }
+
+        if (previewText) {
+            try {
+                previewText = decodeURI(previewText);
+            }
+            catch {
+                // ignore
+            }
+            wrapperChildren.push(h('div.mu-link-preview', previewText));
+        }
+
+        wrapperChildren.push(ulNode);
+
+        const vnode = h('div', wrapperChildren);
 
         if (oldVNode)
             patch(oldVNode, vnode);

--- a/packages/muya/src/ui/linkTools/index.ts
+++ b/packages/muya/src/ui/linkTools/index.ts
@@ -147,6 +147,7 @@ class LinkTools extends BaseFloat {
         const ulNode = h('ul', children);
 
         const wrapperChildren: VNode[] = [];
+        wrapperChildren.push(ulNode);
 
         let previewText = this._linkInfo?.title || this._linkInfo?.href;
 
@@ -185,10 +186,14 @@ class LinkTools extends BaseFloat {
             catch {
                 // ignore
             }
-            wrapperChildren.push(h('div.mu-link-preview', previewText));
+            wrapperChildren.push(
+                h(
+                    'div.mu-link-preview',
+                    { attrs: { title: previewText } },
+                    previewText,
+                ),
+            );
         }
-
-        wrapperChildren.push(ulNode);
 
         const vnode = h('div', wrapperChildren);
 

--- a/packages/muya/src/utils/__tests__/getLinkInfo.spec.ts
+++ b/packages/muya/src/utils/__tests__/getLinkInfo.spec.ts
@@ -43,6 +43,20 @@ describe('getLinkInfo — markdown `[text](href)` (rendered as span.mu-link)', (
         expect(info!.raw).toBe('[hello](https://x.com)');
         expect(info!.range).toEqual({ start: 0, end: 23 });
     });
+
+    it('extracts an optional title for the hover preview', () => {
+        const el = makeEl(
+            'span',
+            { start: '0', end: '34', raw: '[hello](https://x.com "Preview")' },
+            { title: 'Preview' },
+            { href: 'https://x.com' },
+        );
+
+        expect(getLinkInfo(el)).toMatchObject({
+            href: 'https://x.com',
+            title: 'Preview',
+        });
+    });
 });
 
 describe('getLinkInfo — reference link (rendered as a.mu-reference-link)', () => {

--- a/packages/muya/src/utils/getLinkInfo.ts
+++ b/packages/muya/src/utils/getLinkInfo.ts
@@ -10,6 +10,7 @@
 
 export interface IExtractedLinkInfo {
     href: string | null;
+    title: string | null;
     raw: string;
     text: string;
     range: { start: number; end: number } | null;
@@ -29,6 +30,13 @@ function readHref(el: HTMLElement): string | null {
     if (typeof prop === 'string' && prop)
         return prop;
 
+    return null;
+}
+
+function readTitle(el: HTMLElement): string | null {
+    const attr = el.getAttribute('title');
+    if (attr)
+        return attr;
     return null;
 }
 
@@ -56,6 +64,7 @@ export function getLinkInfo(el: HTMLElement): IExtractedLinkInfo | null {
 
     return {
         href: readHref(el),
+        title: readTitle(el),
         raw,
         text: el.textContent ?? '',
         range: parseRange(el.dataset.start, el.dataset.end),


### PR DESCRIPTION
Closes #5222

## Summary

- Add destination context to the existing link hover toolbar. A link title is preferred, then the URL; in-document fragments show the resolved block text when available.
- Present the two link actions before the preview in a compact horizontal bar.
- Keep short previews on one line, clamp long previews to two lines, and keep the floating bar inside the viewport.

## Problem

The existing toolbar exposes link actions but gives no context for similar links or internal anchors. Users must open the link or inspect Markdown source to identify the destination.

The initial stacked preview also used extra vertical space and a wide preview could place the action buttons outside a narrow viewport.

## Change

- Extend link metadata with the optional HTML or Markdown title.
- Show the title or URL after the existing unlink and jump actions.
- Resolve fragment previews inside the active editor only.
- Size the horizontal bar between 320 px and 560 px while respecting the viewport.
- Keep short values on one line and clamp long values to two lines; the full value remains available through the title attribute.
- Shift floating tools back inside the viewport with an 8 px boundary.
- Show the action divider only when a second action exists.
- Preserve existing jump, unlink, cursor, and keyboard behavior.
- Escape preview content by rendering it as text.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Demonstration

Manual Chromium validation on macOS covered both responsive states:

- At 1200 x 700, a short title rendered as a 378 x 34 px single-line bar with both actions before the text.
- At 640 x 480, a long citation rendered as a 560 x 49.6 px two-line bar at x = 8; both actions and all bar edges remained inside the viewport.
- Clicking the jump action still invoked the registered callback and closed the bar.
- No relevant browser console errors or warnings were observed.

## Test plan

- [x] New tests added
- [x] Manually tested on macOS with Chromium at 1200 x 700 and 640 x 480

Commands and results:

- `pnpm -C packages/muya test` — 212 files and 1,440 tests passed.
- `pnpm -C packages/muya/e2e exec playwright test tests/inline/link-tools.spec.ts --project=chromium` — 4 tests passed.
- `pnpm -C packages/muya lint:types` — passed.
- `pnpm -C packages/muya exec eslint src/ui/baseFloat/index.ts src/ui/linkTools/index.ts src/ui/linkTools/__tests__/linkTools.spec.ts` — passed.
- `pnpm -C packages/muya exec stylelint src/ui/linkTools/index.css` — passed.
- `pnpm -C packages/muya build` — passed.
- `pnpm -C packages/muya lint` — 0 errors; 8 existing warnings outside this change.

The package-wide CSS lint currently encounters an existing selector-order error in `src/assets/styles/blockSyntax.css`; the changed `linkTools/index.css` passes Stylelint directly.

## Notes for reviewers

The bar uses the existing LinkTools structure and Floating UI dependency. No new dependency or editor option is introduced.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
