### PR TITLE
fix(i18n): add the missing Dutch resetZoom label

### DIFF
--- a/packages/desktop/static/locales/nl.json
+++ b/packages/desktop/static/locales/nl.json
@@ -80,6 +80,7 @@
       "minimize": "Minimaliseren",
       "zoomIn": "Inzoomen",
       "zoomOut": "Uitzoomen",
+      "resetZoom": "Zoom herstellen",
       "fullScreen": "Volledig scherm",
       "bringAllToFront": "Alles naar voren",
       "alwaysOnTop": "Altijd bovenaan"


### PR DESCRIPTION
No issue — found while running the unit suite on `develop`.

## Summary

`1135cc8` (*feat(desktop): add reset zoom*, #5185) added `menu.window.resetZoom` to ten locale files but skipped `nl.json`. `test/unit/specs/locale-validation.spec.ts` asserts key parity with `en.json`, so `pnpm run test:unit` has been red on `develop` since that commit:

```
FAIL  test/unit/specs/locale-validation.spec.ts
      > desktop locale validation > key parity with en.json
      > nl.json has the same keys as en.json
```

This adds the one missing key. The wording follows the neighbouring entries in that file (`Inzoomen` / `Uitzoomen`); a native speaker may prefer *Zoomniveau herstellen* — happy to change it.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added (or explain why not needed) — not needed: `locale-validation.spec.ts` already asserts key parity and was the test that caught this.
- [x] `pnpm -C packages/desktop exec vitest run test/unit/specs/locale-validation.spec.ts` → 35/35 pass (was 34/35).
- [x] Verified the flattened key sets of all 11 files under `static/locales/` are now identical to `en.json`.
- [ ] Manually tested on: n/a — a single label, no behaviour change.

## Notes for reviewers [optional]

One-line diff. `nl.json` is the only locale missing the key; `de/es/fr/ja/ko/pt/tr/zh-CN/zh-TW/en` all received it in `1135cc8`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
