### PR TITLE
feat: open the image preview on double click (#3202)

### DIFF
--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -8,18 +8,25 @@
       ref="editorRef"
       class="editor-component"
     />
-    <div
-      v-show="imageViewerVisible"
-      class="image-viewer"
-    >
-      <span
-        class="icon-close"
-        @click="setImageViewerVisible(false)"
+    <!-- Teleported out of `.editor-wrapper`: that element carries
+         `isolation: isolate`, which traps this overlay's z-index inside the
+         editor's own stacking context, so muya's body-level floats (z-index
+         10000) painted over the full-screen preview even though `.image-viewer`
+         is 10001. -->
+    <Teleport to="body">
+      <div
+        v-show="imageViewerVisible"
+        class="image-viewer"
       >
-        <CloseIcon />
-      </span>
-      <div ref="imageViewerRef" />
-    </div>
+        <span
+          class="icon-close"
+          @click="setImageViewerVisible(false)"
+        >
+          <CloseIcon />
+        </span>
+        <div ref="imageViewerRef" />
+      </div>
+    </Teleport>
     <el-dialog
       v-model="dialogTableVisible"
       :show-close="isShowClose"

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -457,6 +457,7 @@ class SimpleImageViewer {
   _onMousedown!: (e: MouseEvent) => void
   _onMousemove!: (e: MouseEvent) => void
   _onMouseup!: () => void
+  _onDblClick!: () => void
 
   constructor (container: HTMLElement, { url }: { url: string }) {
     this.container = container
@@ -488,7 +489,19 @@ class SimpleImageViewer {
     this._onWheel = (e: WheelEvent) => {
       e.preventDefault()
       const factor = e.deltaY < 0 ? 1.1 : 0.9
-      this.scale = Math.max(0.1, Math.min(10, this.scale * factor))
+      const next = Math.max(0.1, Math.min(10, this.scale * factor))
+      if (next === this.scale) return
+      // Zoom about the cursor, not the image centre, so the detail under the
+      // pointer stays under it. The rect is already the transformed box, and
+      // `translate(...) scale(...)` with a centre origin keeps that box's centre
+      // where the untransformed centre lands, so the cursor offset divided by the
+      // current scale is the point in untransformed image space.
+      const rect = this.img.getBoundingClientRect()
+      const offsetX = (e.clientX - (rect.left + rect.width / 2)) / this.scale
+      const offsetY = (e.clientY - (rect.top + rect.height / 2)) / this.scale
+      this.translateX += (this.scale - next) * offsetX
+      this.translateY += (this.scale - next) * offsetY
+      this.scale = next
       this._updateTransform()
     }
     this._onMousedown = (e: MouseEvent) => {
@@ -509,8 +522,17 @@ class SimpleImageViewer {
       this.isDragging = false
       this.container.style.cursor = 'grab'
     }
+    // scale 1 is the fitted view: the img is constrained to 90vw/90vh, so a
+    // double click (the same gesture that opens the preview) returns to it.
+    this._onDblClick = () => {
+      this.scale = 1
+      this.translateX = 0
+      this.translateY = 0
+      this._updateTransform()
+    }
     this.container.addEventListener('wheel', this._onWheel, { passive: false })
     this.container.addEventListener('mousedown', this._onMousedown)
+    this.container.addEventListener('dblclick', this._onDblClick)
     document.addEventListener('mousemove', this._onMousemove)
     document.addEventListener('mouseup', this._onMouseup)
   }
@@ -518,6 +540,7 @@ class SimpleImageViewer {
   destroy () {
     this.container.removeEventListener('wheel', this._onWheel)
     this.container.removeEventListener('mousedown', this._onMousedown)
+    this.container.removeEventListener('dblclick', this._onDblClick)
     document.removeEventListener('mousemove', this._onMousemove)
     document.removeEventListener('mouseup', this._onMouseup)
     this.container.innerHTML = ''

--- a/packages/desktop/test/e2e/image-viewer.spec.ts
+++ b/packages/desktop/test/e2e/image-viewer.spec.ts
@@ -10,9 +10,10 @@ import {
 // Item 124 — Space on a selected image opens the desktop SimpleImageViewer;
 // Esc closes it (desktop e2e).
 //
-// The engine half (the `preview-image` emit on Space, and `format-click` on a
-// Cmd/Ctrl-click) is unit-covered in:
+// The engine half (the `preview-image` emit on Space and on a double click, and
+// `format-click` on a Cmd/Ctrl-click) is unit-covered in:
 //   packages/muya/src/selection/__tests__/parityPreviewImage.spec.ts
+//   packages/muya/src/selection/__tests__/dblClickImagePreview.spec.ts
 //   packages/muya/src/__tests__/formatClickEvents.spec.ts
 // The UNTESTED half is the desktop SimpleImageViewer wired up in
 // editor.vue: the `.image-viewer` overlay container (template line 20), the
@@ -25,8 +26,9 @@ import {
 // `<img>` mounted, press Escape, assert it is hidden and the viewer DOM is
 // destroyed. We also assert Space did NOT insert a literal space into the
 // markdown (the engine `preventDefault`s the Space keydown for a selected
-// image), and exercise the Cmd/Ctrl-click path (item 130) that opens the same
-// viewer.
+// image), and exercise the Cmd/Ctrl-click path (item 130) and the double-click
+// path (#3202) that open the same viewer, plus the viewer's cursor-anchored
+// wheel zoom and its double-click-to-reset.
 
 // 1x1 red SVG, base64-encoded. `getImageSrc` (packages/muya/src/utils/image.ts)
 // recognises this via DATA_URL_REG so the preview path resolves a real src.
@@ -48,6 +50,21 @@ const viewerVisible = (page: Page): Promise<boolean> =>
 const viewerImgCount = (page: Page): Promise<number> =>
   page.locator('.image-viewer img').count()
 
+// Parse SimpleImageViewer's `translate(Xpx,Ypx) scale(S)`. Chromium serialises
+// the value back with a space after the comma, which the source template does
+// not write, so the separator has to tolerate it. Before the first wheel or drag
+// the transform is never written, which is the identity state.
+const viewerTransform = (page: Page): Promise<{ x: number, y: number, scale: number }> =>
+  page.evaluate(() => {
+    const img = document.querySelector('.image-viewer img') as HTMLElement | null
+    const m = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)\s*scale\(([-\d.]+)\)/.exec(
+      img?.style.transform ?? ''
+    )
+    return m
+      ? { x: Number(m[1]), y: Number(m[2]), scale: Number(m[3]) }
+      : { x: 0, y: 0, scale: 1 }
+  })
+
 // Click the rendered inline image to populate the engine's selected-image
 // state (ImageSelection._handleClick → selectImage). Returns the clicked
 // element handle so the caller can keep driving it.
@@ -57,7 +74,7 @@ const selectImage = async(page: Page): Promise<void> => {
   await img.click({ timeout: 5000 })
 }
 
-test.describe('SimpleImageViewer (Space-to-preview + Esc close)', () => {
+test.describe('SimpleImageViewer (Space / double-click to preview, Esc close)', () => {
   let app: ElectronApplication
   let page: Page
 
@@ -180,6 +197,97 @@ test.describe('SimpleImageViewer (Space-to-preview + Esc close)', () => {
     await page.locator('.image-viewer .icon-close').click({ timeout: 5000 })
     await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(false)
     await expect.poll(() => viewerImgCount(page), { timeout: 5000 }).toBe(0)
+
+    await expectNoRendererErrors(app)
+  })
+
+  // #3202 — a double click opens the same viewer. The engine cannot listen for
+  // dblclick: `_handleClickInlineImage` preventDefaults the click, and Blink
+  // suppresses dblclick when a click's default is prevented, so ImageSelection
+  // reads the double click off the click event's own detail count and emits
+  // `preview-image`. Playwright's dblclick drives real input, so this also
+  // proves the detail count survives the engine's re-render of the image block.
+  test('double-click on an image opens the same viewer (#3202)', async() => {
+    const img = page
+      .locator('.editor-component .mu-inline-image .mu-image-container img')
+      .first()
+    await img.waitFor({ state: 'attached', timeout: 15000 })
+    await img.dblclick({ timeout: 5000 })
+
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(true)
+    await expect.poll(() => viewerImgCount(page), { timeout: 5000 }).toBeGreaterThanOrEqual(1)
+
+    const overlaySrc = await page.locator('.image-viewer img').first().getAttribute('src')
+    expect(overlaySrc).toBe(SVG_DATA_URI)
+
+    await page.keyboard.press('Escape')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(false)
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('wheel zoom anchors at the cursor rather than the image centre', async() => {
+    await selectImage(page)
+    await page.keyboard.press('Space')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(true)
+    await expect.poll(() => viewerImgCount(page), { timeout: 5000 }).toBeGreaterThanOrEqual(1)
+
+    const box = await page.locator('.image-viewer img').first().boundingBox()
+    if (!box) throw new Error('the viewer image has no bounding box')
+    // The wheel listener is on the full-overlay container, so zooming at a point
+    // away from the (1x1, centred) image is what separates cursor-anchored zoom
+    // from centre-anchored: the latter leaves the translation at zero regardless
+    // of where the cursor is, pushing the area of interest off screen.
+    const px = box.x + box.width / 2 + 150
+    const py = box.y + box.height / 2 + 100
+
+    await page.mouse.move(px, py)
+    await page.mouse.wheel(0, -300)
+
+    await expect
+      .poll(async() => (await viewerTransform(page)).scale, { timeout: 5000 })
+      .toBeGreaterThan(1)
+
+    const settled = await viewerTransform(page)
+    expect(settled.x).not.toBe(0)
+    expect(settled.y).not.toBe(0)
+
+    await page.keyboard.press('Escape')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(false)
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('double-click inside the viewer resets to the fitted view', async() => {
+    await selectImage(page)
+    await page.keyboard.press('Space')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(true)
+    await expect.poll(() => viewerImgCount(page), { timeout: 5000 }).toBeGreaterThanOrEqual(1)
+
+    const box = await page.locator('.image-viewer img').first().boundingBox()
+    if (!box) throw new Error('the viewer image has no bounding box')
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await page.mouse.move(cx + 150, cy + 100)
+    await page.mouse.wheel(0, -300)
+    await expect
+      .poll(async() => (await viewerTransform(page)).scale, { timeout: 5000 })
+      .toBeGreaterThan(1)
+
+    await page.mouse.dblclick(cx, cy)
+
+    await expect
+      .poll(async() => (await viewerTransform(page)).scale, { timeout: 5000 })
+      .toBe(1)
+    const reset = await viewerTransform(page)
+    expect(reset.x).toBe(0)
+    expect(reset.y).toBe(0)
+    // Resetting is not dismissing: the overlay stays open.
+    expect(await viewerVisible(page)).toBe(true)
+
+    await page.keyboard.press('Escape')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(false)
 
     await expectNoRendererErrors(app)
   })

--- a/packages/desktop/test/e2e/image-viewer.spec.ts
+++ b/packages/desktop/test/e2e/image-viewer.spec.ts
@@ -291,4 +291,37 @@ test.describe('SimpleImageViewer (Space / double-click to preview, Esc close)', 
 
     await expectNoRendererErrors(app)
   })
+
+  // Selecting an image floats muya's image toolbar, which baseFloat appends to
+  // document.body at z-index 10000. `.image-viewer` is 10001 but lived inside
+  // `.editor-wrapper`, whose `isolation: isolate` traps that z-index in the
+  // editor's own stacking context, so the toolbar painted over the full-screen
+  // preview. The overlay is teleported to the body to escape it.
+  test('the preview overlay paints above the editor image toolbar', async() => {
+    await selectImage(page)
+    await page.keyboard.press('Space')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(true)
+    await expect.poll(() => viewerImgCount(page), { timeout: 5000 }).toBeGreaterThanOrEqual(1)
+
+    const toolbarCentre = await page.evaluate(() => {
+      const toolbar = document.querySelector('.mu-image-toolbar')
+      if (!toolbar) return null
+      const r = toolbar.getBoundingClientRect()
+      return r.width && r.height ? { x: r.x + r.width / 2, y: r.y + r.height / 2 } : null
+    })
+    // Guard against a vacuous pass: the overlap is only exercised while the
+    // toolbar is actually on screen.
+    if (!toolbarCentre) throw new Error('the image toolbar is not on screen')
+
+    const viewerOnTop = await page.evaluate(
+      ([x, y]) => !!document.elementFromPoint(x, y)?.closest('.image-viewer'),
+      [toolbarCentre.x, toolbarCentre.y] as [number, number]
+    )
+    expect(viewerOnTop).toBe(true)
+
+    await page.keyboard.press('Escape')
+    await expect.poll(() => viewerVisible(page), { timeout: 5000 }).toBe(false)
+
+    await expectNoRendererErrors(app)
+  })
 })

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -1,5 +1,6 @@
 import type Format from '../block/base/format';
 import type { Muya } from '../muya';
+import type { IImageInfo } from '../utils/image';
 import type Selection from './index';
 import type { IImageSelectionData } from './types';
 import { BLOCK_DOM_PROPERTY, CLASS_NAMES } from '../config';
@@ -78,6 +79,26 @@ class ImageSelection {
         }
     }
 
+    // `_handleClickInlineImage` preventDefaults the click, and Blink suppresses
+    // the dblclick event when a click's default is prevented, so no dblclick
+    // listener can fire on an image. Read the double click off the click's own
+    // detail count instead and reuse the `preview-image` event the host already
+    // subscribes to for Space-on-a-selected-image (#3202). Modifier-clicks are
+    // skipped: they already open the viewer through the format-click emit.
+    private _emitDblClickPreview(
+        event: MouseEvent,
+        img: HTMLElement,
+        imageInfo: IImageInfo,
+    ): void {
+        if (event.detail !== 2 || event.metaKey || event.ctrlKey)
+            return;
+
+        const tokenSrc = imageInfo.token.src || imageInfo.token.attrs.src || '';
+        const src = getImageSrc(tokenSrc).src || img.getAttribute('src') || '';
+        if (src)
+            this._muya.eventCenter.emit('preview-image', { data: src });
+    }
+
     private _handleClickInlineImage(event: Event, imageWrapper: HTMLElement) {
         event.preventDefault();
         event.stopPropagation();
@@ -124,6 +145,9 @@ class ImageSelection {
                     });
                 }
             }
+
+            if (event instanceof MouseEvent)
+                this._emitDblClickPreview(event, target, imageInfo);
 
             const rect = imageWrapper
                 .querySelector(`.${CLASS_NAMES.MU_IMAGE_CONTAINER}`)

--- a/packages/muya/src/selection/__tests__/dblClickImagePreview.spec.ts
+++ b/packages/muya/src/selection/__tests__/dblClickImagePreview.spec.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLASS_NAMES } from '../../config';
+import { Muya } from '../../muya';
+
+// #3202: a double click on an image should open the host's full-size preview.
+// `_handleClickInlineImage` calls `preventDefault()` before anything else, and
+// Blink suppresses the `dblclick` event when the click's default is prevented,
+// so the double click is recognised from the click event's own `detail` count
+// and routed to the existing `preview-image` event (the one Space-on-a-selected
+// -image already emits, and the one the desktop renderer already subscribes to).
+
+const bootedMuyas: Muya[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedMuyas.length)
+        bootedMuyas.pop()!.destroy();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function boot(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedMuyas.push(muya);
+    return muya;
+}
+
+// The async image load never resolves under happy-dom, so inject the <img> the
+// loaded path would have produced.
+function injectImg(muya: Muya, src: string): HTMLImageElement {
+    const wrapper = muya.domNode.querySelector<HTMLElement>(
+        `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+    )!;
+    const container = wrapper.querySelector<HTMLElement>(
+        `.${CLASS_NAMES.MU_IMAGE_CONTAINER}`,
+    )!;
+    const img = document.createElement('img');
+    img.setAttribute('src', src);
+    container.appendChild(img);
+    return img;
+}
+
+function click(img: HTMLImageElement, detail: number, init: MouseEventInit = {}): void {
+    img.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true, detail, ...init }),
+    );
+}
+
+// A real double click arrives as two clicks with detail 1 then 2. The first
+// click selects the image and re-renders the block; under happy-dom the async
+// image load never resolves, so the injected <img> is detached and not
+// re-created. Inject it again before the second click to stand in for the
+// loaded image a real browser would have.
+function dblClick(muya: Muya, src: string, init: MouseEventInit = {}): void {
+    click(injectImg(muya, src), 1, init);
+    click(injectImg(muya, src), 2, init);
+}
+
+function capturePreviews(muya: Muya): unknown[] {
+    const payloads: unknown[] = [];
+    muya.on('preview-image', (payload: unknown) => payloads.push(payload));
+    return payloads;
+}
+
+function captureFormatClickTypes(muya: Muya): string[] {
+    const types: string[] = [];
+    muya.eventCenter.on('format-click', (payload: { formatType?: string }) => {
+        if (payload && payload.formatType)
+            types.push(payload.formatType);
+    });
+    return types;
+}
+
+describe('double click previews an image (#3202)', () => {
+    it('emits preview-image once, carrying the image src', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`![alt](${src})`);
+        const previews = capturePreviews(muya);
+
+        dblClick(muya, src);
+
+        expect(previews).toHaveLength(1);
+        expect(JSON.stringify(previews[0])).toContain(src);
+    });
+
+    it('does not emit preview-image for the first click of the pair', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`![alt](${src})`);
+        const img = injectImg(muya, src);
+        const previews = capturePreviews(muya);
+
+        click(img, 1);
+
+        expect(previews).toHaveLength(0);
+    });
+
+    it('leaves the modifier-click path as the single preview trigger', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`![alt](${src})`);
+        const previews = capturePreviews(muya);
+        const types = captureFormatClickTypes(muya);
+
+        dblClick(muya, src, { ctrlKey: true });
+
+        // Ctrl/Cmd-click already opens the viewer through format-click; emitting
+        // preview-image as well would make the host tear down and rebuild it.
+        expect(previews).toHaveLength(0);
+        expect(types).toContain('image');
+    });
+
+    it('previews a linked image, whose navigation needs a modifier', () => {
+        const src = 'https://example.com/pic.png';
+        const muya = boot(`[![alt](${src})](https://link.example.com)`);
+
+        const wrapper = muya.domNode.querySelector<HTMLElement>(
+            `span.${CLASS_NAMES.MU_INLINE_IMAGE}`,
+        )!;
+        expect(wrapper.closest(`.${CLASS_NAMES.MU_LINK}`)).not.toBeNull();
+
+        const previews = capturePreviews(muya);
+        const onFormatClick = vi.fn();
+        muya.eventCenter.on('format-click', onFormatClick);
+
+        dblClick(muya, src);
+
+        // The #3835 guard only suppresses the preview for a *modifier*-click,
+        // where the link is actually being followed. A plain double click does
+        // not navigate, so there is nothing to conflict with.
+        expect(previews).toHaveLength(1);
+        expect(onFormatClick).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #3202

## Summary

#3202 asks for *"Double click on an image to open a preview that lets you zoom in and out."*

The viewer itself already exists — `SimpleImageViewer` in `editor.vue`, reachable by pressing <kbd>Space</kbd> on a selected image or by <kbd>Cmd/Ctrl</kbd>-clicking one, with wheel zoom (0.1×–10×) and drag-pan. What was missing was the double-click entry point the issue asks for, plus two defects that undercut "zoom in and out". Three separable commits:

**1. `feat(muya)` — the double-click trigger.**
The engine cannot use a `dblclick` listener. `_handleClickInlineImage` calls `preventDefault()` before anything else, and Blink suppresses the `dblclick` event when a click's default is prevented. Measured in-app to be sure: double-clicking a paragraph fires `dblclick` normally, while on an image only `click` with `detail === 2` ever arrives. So the handler reads the double click off `detail` and emits the existing `preview-image` event — the same one <kbd>Space</kbd> uses — which the desktop already subscribes to. **No host change is needed for the trigger.**

Modifier-clicks are excluded (they already reach the viewer through `format-click`, so emitting both would make the host tear the viewer down and rebuild it), and the #3835 linked-image guard is left untouched: a *plain* double click does not follow a link, so there is nothing to conflict with.

**2. `fix(desktop)` — zoom anchored at the cursor.**
Wheel zoom scaled about the image centre, so zooming into a corner drifted the area of interest off screen. It now compensates the translation by the scale change times the cursor's offset from the transformed box centre, keeping the point under the cursor under it. A double click inside the viewer also resets to the fitted view, mirroring the gesture that opens it.

**3. `fix(desktop)` — the overlay was painted *under* the editor's image toolbar.**
`.image-viewer` is `z-index: 10001` and muya's floats are `10000`, but the overlay lived inside `.editor-wrapper`, whose `isolation: isolate` confines that z-index to the editor's own stacking context. `baseFloat` appends its wrappers to `document.body`, so the toolbar painted over the full-screen preview. Verified rather than assumed: with the viewer open, `document.elementFromPoint()` at the toolbar's centre returned the toolbar's own `<li>`. This affected the existing <kbd>Space</kbd> and <kbd>Cmd/Ctrl</kbd>-click paths too, not just the new one. The overlay is now teleported to the body, which is what the `isolation` rule was added to allow for modals.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
  - `packages/muya/src/selection/__tests__/dblClickImagePreview.spec.ts` (4 cases): double click emits `preview-image` with the src; the first click of the pair does not; a modifier double-click stays on the `format-click` path; a linked image still previews (its navigation needs a modifier).
  - `packages/desktop/test/e2e/image-viewer.spec.ts` (+4 cases, suite now 9/9): double click opens the viewer in the real Electron app; wheel zoom off-centre moves the translation (centre-anchored zoom cannot); double click inside the viewer resets; the overlay hit-tests above the image toolbar. The pre-existing 5 cases still pass.
- [x] `pnpm -C packages/muya test` for the selection specs, `pnpm -C packages/desktop exec playwright test test/e2e/image-viewer.spec.ts` → 9 passed.
- [x] `pnpm run lint` → 0 errors, warning count unchanged from `develop`. `pnpm run typecheck` → clean. `pnpm -C packages/muya lint` / `lint:types` → clean.
- [x] Manually tested on: Windows

## Notes for reviewers [optional]

- The three commits are deliberately independent. If you would rather land the double-click trigger alone, commits 2 and 3 can be split into their own PRs — commit 3 in particular fixes a pre-existing defect and stands on its own.
- `packages/muya` is 4-space/antfu; the new method was extracted out of `_handleClickInlineImage` specifically to keep that method under the package's `complexity: 20` lint limit rather than adding a 9th warning.
- Related: #2461 also suggests double-clicking, but for opening the image in the *system* viewer. One gesture can only go to one destination, so that issue is handled by right-click in a separate PR.

<!-- screenshots: 01-editor.png / 02-viewer-fitted.png / 03-viewer-zoomed.png / 04-viewer-reset.png -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
