### PR TITLE
feat(desktop): open a right-clicked image in the associated viewer (#2461)

### DIFF
--- a/packages/desktop/src/main/contextMenu/editor/index.ts
+++ b/packages/desktop/src/main/contextMenu/editor/index.ts
@@ -10,6 +10,7 @@ import {
   getInsertBefore,
   getInsertAfter
 } from './menuItems'
+import { localImagePathFromSrc, openImageExternally } from './openImage'
 import spellcheckMenuBuilder from './spellcheck'
 import { t } from '../../i18n'
 
@@ -18,6 +19,9 @@ import { t } from '../../i18n'
 interface ContextMenuParams {
   isEditable: boolean
   hasImageContents?: boolean
+  // The right-clicked image's URL, when `hasImageContents` is set. For a local
+  // image this is a `file:` URL.
+  srcURL?: string
   selectionText: string
   inputFieldType?: string
   editFlags: {
@@ -60,6 +64,16 @@ const isInsideEditor = (params: ContextMenuParams): boolean => {
   const { isEditable, editFlags, inputFieldType } = params
   // WORKAROUND for Electron#32102: `params.spellcheckEnabled` is always false. Try to detect the editor container via other information.
   return isEditable && !inputFieldType && !!editFlags.canEditRichly
+}
+
+// An inline image is rendered `contenteditable="false"` (muya's
+// inlineRenderer/renderer/image.ts), so Electron reports `isEditable: false` for
+// it and `isInsideEditor` — which requires an editable target — never matches.
+// Gate on the image signals instead: `canEditRichly` still ties the event to the
+// editor, and `inputFieldType` rules out a real <input>.
+const isEditorImage = (params: ContextMenuParams): boolean => {
+  const { hasImageContents, inputFieldType, editFlags } = params
+  return !!hasImageContents && !inputFieldType && !!editFlags.canEditRichly
 }
 
 export const showEditorContextMenu = (
@@ -121,5 +135,27 @@ export const showEditorContextMenu = (
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     event
     menu.popup({ window: win, x: params.x, y: params.y })
+  }
+
+  // Right-clicking an image yields no menu at all: the guard above excludes
+  // `hasImageContents` and nothing replaced it (#2461). Offer the one action
+  // that has a system counterpart — hand the file to the associated viewer.
+  if (isEditorImage(params)) {
+    const pathname = localImagePathFromSrc(params.srcURL ?? '')
+    // A remote or data: image has no file for the OS to open, so leave that case
+    // menuless as it is today rather than showing an item that cannot work.
+    if (pathname) {
+      const menu = new Menu()
+      menu.append(
+        new MenuItem({
+          label: t('contextMenu.openImage'),
+          id: 'openImageMenuItem',
+          click: async() => {
+            await openImageExternally(pathname)
+          }
+        })
+      )
+      menu.popup({ window: win, x: params.x, y: params.y })
+    }
   }
 }

--- a/packages/desktop/src/main/contextMenu/editor/openImage.ts
+++ b/packages/desktop/src/main/contextMenu/editor/openImage.ts
@@ -1,0 +1,40 @@
+import { fileURLToPath } from 'url'
+import { shell } from 'electron'
+import log from 'electron-log'
+import { isImageFile } from 'common/filesystem/paths'
+
+/**
+ * Resolve the `srcURL` Electron reports for a right-clicked image to a path the
+ * OS can open, or null when there is nothing to open.
+ *
+ * Remote (`http:`) and `data:` images have no filesystem path. The extension
+ * whitelist in `isImageFile` is what keeps a crafted document from turning
+ * "Open Image" into `shell.openPath` on a co-located script or executable, the
+ * hole #3575 closed for markdown links.
+ */
+export const localImagePathFromSrc = (srcURL: string): string | null => {
+  if (!srcURL || !/^file:/i.test(srcURL)) return null
+
+  let pathname: string
+  try {
+    pathname = fileURLToPath(srcURL)
+  } catch {
+    return null
+  }
+
+  return isImageFile(pathname) ? pathname : null
+}
+
+/**
+ * Hand a local image to the application the OS associates with its format.
+ * `shell.openPath` resolves with an error string rather than rejecting when no
+ * application is registered, so both outcomes are reported through the log.
+ */
+export const openImageExternally = async(pathname: string): Promise<void> => {
+  try {
+    const error = await shell.openPath(pathname)
+    if (error) log.error('Opening the image failed:', error)
+  } catch (err) {
+    log.error('Opening the image failed:', err)
+  }
+}

--- a/packages/desktop/static/locales/de.json
+++ b/packages/desktop/static/locales/de.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Sprache ändern...",
     "addToDictionary": "Zum Wörterbuch hinzufügen",
     "editDictionary": "Wörterbuch bearbeiten...",
+    "openImage": "Bild öffnen",
     "sideBar": {
       "newFile": "Neue Datei",
       "newDirectory": "Neuer Ordner",

--- a/packages/desktop/static/locales/en.json
+++ b/packages/desktop/static/locales/en.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Change Language...",
     "addToDictionary": "Add to Dictionary",
     "editDictionary": "Edit Dictionary...",
+    "openImage": "Open Image",
     "sideBar": {
       "newFile": "New File",
       "newDirectory": "New Directory",

--- a/packages/desktop/static/locales/es.json
+++ b/packages/desktop/static/locales/es.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Cambiar Idioma...",
     "addToDictionary": "Agregar al Diccionario",
     "editDictionary": "Editar Diccionario...",
+    "openImage": "Abrir Imagen",
     "sideBar": {
       "newFile": "Nuevo Archivo",
       "newDirectory": "Nuevo Directorio",

--- a/packages/desktop/static/locales/fr.json
+++ b/packages/desktop/static/locales/fr.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Changer de langue...",
     "addToDictionary": "Ajouter au dictionnaire",
     "editDictionary": "Modifier le dictionnaire...",
+    "openImage": "Ouvrir l'image",
     "sideBar": {
       "newFile": "Nouveau fichier",
       "newDirectory": "Nouveau dossier",

--- a/packages/desktop/static/locales/ja.json
+++ b/packages/desktop/static/locales/ja.json
@@ -191,6 +191,7 @@
     "changeLanguage": "言語の変更...",
     "addToDictionary": "辞書に追加",
     "editDictionary": "辞書の編集...",
+    "openImage": "画像を開く",
     "sideBar": {
       "newFile": "新しいファイル",
       "newDirectory": "新しいフォルダー",

--- a/packages/desktop/static/locales/ko.json
+++ b/packages/desktop/static/locales/ko.json
@@ -191,6 +191,7 @@
     "changeLanguage": "언어 변경...",
     "addToDictionary": "사전에 추가",
     "editDictionary": "사전 편집...",
+    "openImage": "이미지 열기",
     "sideBar": {
       "newFile": "새 파일",
       "newDirectory": "새 디렉터리",

--- a/packages/desktop/static/locales/nl.json
+++ b/packages/desktop/static/locales/nl.json
@@ -190,6 +190,7 @@
     "changeLanguage": "Taal wijzigen...",
     "addToDictionary": "Toevoegen aan woordenboek",
     "editDictionary": "Woordenboek bewerken...",
+    "openImage": "Afbeelding openen",
     "sideBar": {
       "newFile": "Nieuw bestand",
       "newDirectory": "Nieuwe map",

--- a/packages/desktop/static/locales/pt.json
+++ b/packages/desktop/static/locales/pt.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Alterar Idioma...",
     "addToDictionary": "Adicionar ao Dicionário",
     "editDictionary": "Editar Dicionário...",
+    "openImage": "Abrir Imagem",
     "sideBar": {
       "newFile": "Novo Arquivo",
       "newDirectory": "Nova Pasta",

--- a/packages/desktop/static/locales/tr.json
+++ b/packages/desktop/static/locales/tr.json
@@ -191,6 +191,7 @@
     "changeLanguage": "Dili Değiştir...",
     "addToDictionary": "Sözlüğe Ekle",
     "editDictionary": "Sözlüğü Düzenle...",
+    "openImage": "Görseli Aç",
     "sideBar": {
       "newFile": "Yeni Dosya",
       "newDirectory": "Yeni Klasör",

--- a/packages/desktop/static/locales/zh-CN.json
+++ b/packages/desktop/static/locales/zh-CN.json
@@ -191,6 +191,7 @@
     "changeLanguage": "更改语言…",
     "addToDictionary": "添加到词典",
     "editDictionary": "编辑词典…",
+    "openImage": "打开图片",
     "sideBar": {
       "newFile": "新建文件",
       "newDirectory": "新建目录",

--- a/packages/desktop/static/locales/zh-TW.json
+++ b/packages/desktop/static/locales/zh-TW.json
@@ -191,6 +191,7 @@
     "changeLanguage": "變更語言…",
     "addToDictionary": "加入字典",
     "editDictionary": "編輯字典…",
+    "openImage": "開啟圖片",
     "sideBar": {
       "newFile": "新建檔案",
       "newDirectory": "新建資料夾",

--- a/packages/desktop/test/e2e/image-open-external.spec.ts
+++ b/packages/desktop/test/e2e/image-open-external.spec.ts
@@ -1,0 +1,152 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { expect, test } from '@playwright/test'
+import type { ElectronApplication, Page } from 'playwright'
+import {
+  launchElectron,
+  waitForEditor,
+  waitForMenuReady,
+  expectNoRendererErrors
+} from './helpers'
+
+// #2461 — right-clicking an image produced no menu at all: the editor context
+// menu required `isEditable`, and muya renders inline images
+// `contenteditable="false"` (inlineRenderer/renderer/image.ts), so Electron
+// reports `isEditable: false` for them. The image branch therefore gates on
+// `hasImageContents` instead, and offers the one action with a system
+// counterpart — hand the file to the OS's associated image viewer.
+//
+// `Menu.popup` and `shell.openPath` are stubbed in the main process: popping a
+// real OS menu would take focus from the renderer, and really opening the file
+// would launch the platform's image viewer under CI. The raw Menu instances are
+// kept on a main-process global so the item's real click handler can be invoked
+// there — MenuItem objects cannot cross the CDP boundary.
+
+const SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80">' +
+  '<rect width="120" height="80" fill="#33aa77"/></svg>'
+const DATA_URI = `data:image/svg+xml;base64,${Buffer.from(SVG).toString('base64')}`
+
+type MenuSummary = Array<{ id?: string, label?: string }>
+
+test.describe('Open Image in the associated viewer (#2461)', () => {
+  let app: ElectronApplication
+  let page: Page
+  let dir: string
+  let imagePath: string
+
+  test.beforeAll(async() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mt-open-image-e2e-'))
+    imagePath = path.join(dir, 'photo.svg')
+    fs.writeFileSync(imagePath, SVG, 'utf8')
+    const md = path.join(dir, 'note.md')
+    fs.writeFileSync(md, `# open external\n\n![local](./photo.svg)\n\n![inline](${DATA_URI})\n`, 'utf8')
+
+    const launched = await launchElectron([md], { suppressErrorDialog: true })
+    app = launched.app
+    page = launched.page
+    await waitForEditor(page)
+    await waitForMenuReady(app)
+
+    await app.evaluate(({ Menu, shell }) => {
+      const g = globalThis as unknown as {
+        __menus: Electron.Menu[]
+        __opened: string[]
+        __openPathPatched: boolean
+      }
+      g.__menus = []
+      g.__opened = []
+      Menu.prototype.popup = function(this: Electron.Menu) {
+        g.__menus.push(this)
+      }
+      shell.openPath = async(target: string) => {
+        g.__opened.push(target)
+        return ''
+      }
+      g.__openPathPatched = true
+    })
+
+    await page.waitForSelector('.editor-component .mu-inline-image.mu-image-success img', {
+      state: 'attached',
+      timeout: 20000
+    })
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  const menuSummary = (): Promise<MenuSummary[]> =>
+    app.evaluate(() => {
+      const g = globalThis as unknown as { __menus: Electron.Menu[] }
+      return g.__menus.map((m) => m.items.map((i) => ({ id: i.id, label: i.label })))
+    })
+
+  const clickLastMenuItem = (): Promise<void> =>
+    app.evaluate(({ BrowserWindow }) => {
+      const g = globalThis as unknown as { __menus: Electron.Menu[] }
+      const menu = g.__menus[g.__menus.length - 1]
+      const win = BrowserWindow.getAllWindows()[0]
+      const item = menu.items[0]
+      item.click(undefined, win, win.webContents)
+    })
+
+  const openedPaths = (): Promise<string[]> =>
+    app.evaluate(() => (globalThis as unknown as { __opened: string[] }).__opened)
+
+  const rightClickImage = async(index: number) => {
+    const img = page
+      .locator('.editor-component .mu-inline-image .mu-image-container img')
+      .nth(index)
+    await img.waitFor({ state: 'attached', timeout: 15000 })
+    await img.click({ button: 'right', timeout: 8000 })
+    await page.waitForTimeout(500)
+  }
+
+  test('the stubs are in place before asserting on them', async() => {
+    const patched = await app.evaluate(
+      () => (globalThis as unknown as { __openPathPatched?: boolean }).__openPathPatched === true
+    )
+    expect(patched).toBe(true)
+  })
+
+  test('right-clicking a local image offers "Open Image" and opens that file', async() => {
+    const before = (await menuSummary()).length
+    const openedBefore = (await openedPaths()).length
+    await rightClickImage(0)
+
+    const menus = await menuSummary()
+    expect(menus.length).toBe(before + 1)
+    const items = menus[menus.length - 1]
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe('openImageMenuItem')
+    // The label must be a resolved translation. `getTranslation` returns the key
+    // itself when the locale file cannot be loaded, so a bare truthiness check
+    // would pass while the user is shown a raw "contextMenu.openImage".
+    expect(items[0].label).toBeTruthy()
+    expect(items[0].label).not.toContain('contextMenu.')
+    // Building the menu must not open anything yet.
+    expect((await openedPaths()).length).toBe(openedBefore)
+
+    await clickLastMenuItem()
+    // The engine renders `photo.svg?mucache=mu-N`; the query must be gone by the
+    // time the path reaches the OS, or the open fails.
+    const opened = await openedPaths()
+    expect(opened.slice(openedBefore)).toEqual([imagePath])
+
+    await expectNoRendererErrors(app)
+  })
+
+  test('right-clicking a data: image stays menuless, as it has no file to open', async() => {
+    const before = (await menuSummary()).length
+    const openedBefore = (await openedPaths()).length
+    await rightClickImage(1)
+
+    expect((await menuSummary()).length).toBe(before)
+    expect((await openedPaths()).length).toBe(openedBefore)
+
+    await expectNoRendererErrors(app)
+  })
+})

--- a/packages/desktop/test/unit/specs/open-image-external.spec.ts
+++ b/packages/desktop/test/unit/specs/open-image-external.spec.ts
@@ -1,0 +1,182 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { localImagePathFromSrc, openImageExternally } from 'main_renderer/contextMenu/editor/openImage'
+import { showEditorContextMenu } from 'main_renderer/contextMenu/editor'
+
+// #2461 — right-clicking an image offered no way to open it outside MarkText;
+// `showEditorContextMenu` required `!hasImageContents`, so images got no menu at
+// all. The new item hands a LOCAL image to the OS's associated viewer. The src
+// comes from an untrusted document, so `isImageFile`'s extension whitelist is
+// what stops "Open Image" from becoming `shell.openPath` on a co-located script
+// or executable — the hole #3575 closed for markdown links.
+
+const { openPath, appended, popups, logError } = vi.hoisted(() => ({
+  openPath: vi.fn(async() => ''),
+  appended: [] as Record<string, unknown>[],
+  popups: [] as Record<string, unknown>[],
+  logError: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  shell: { openPath },
+  Menu: class {
+    append(item: Record<string, unknown>) {
+      appended.push(item)
+    }
+
+    popup(options: Record<string, unknown>) {
+      popups.push(options)
+    }
+  },
+  MenuItem: class {
+    constructor(options: Record<string, unknown>) {
+      Object.assign(this, options)
+    }
+  }
+}))
+vi.mock('electron-log', () => ({ default: { error: logError, info: vi.fn() } }))
+vi.mock('main_renderer/i18n', () => ({ t: (key: string) => key }))
+vi.mock('main_renderer/contextMenu/editor/spellcheck', () => ({ default: () => [] }))
+
+let dir: string
+let pngPath: string
+let scriptPath: string
+
+const fileUrl = (p: string): string => pathToFileURL(p).href
+
+const editorParams = (over: Record<string, unknown> = {}) => ({
+  isEditable: true,
+  selectionText: '',
+  inputFieldType: undefined,
+  editFlags: { canCut: true, canCopy: true, canPaste: true, canEditRichly: true },
+  x: 10,
+  y: 20,
+  ...over
+})
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'mt-open-image-'))
+  pngPath = join(dir, 'photo.png')
+  scriptPath = join(dir, 'payload.js')
+  writeFileSync(pngPath, 'not really a png')
+  writeFileSync(scriptPath, 'console.log("pwned")')
+  writeFileSync(join(dir, 'note.md'), '# note')
+})
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  openPath.mockClear()
+  logError.mockClear()
+  appended.length = 0
+  popups.length = 0
+})
+
+describe('#2461 — localImagePathFromSrc', () => {
+  it('resolves a file: URL to an existing image path', () => {
+    expect(localImagePathFromSrc(fileUrl(pngPath))).toBe(pngPath)
+  })
+
+  it('ignores the cache-buster muya appends to the rendered src', () => {
+    // The engine renders `photo.png?mucache=mu-4` so "Reload Images" can bypass
+    // the cache; the query has to be dropped before the extension check, or it
+    // would see `.png?mucache=mu-4` and refuse a perfectly good image.
+    expect(localImagePathFromSrc(`${fileUrl(pngPath)}?mucache=mu-4`)).toBe(pngPath)
+  })
+
+  it('rejects a file: URL whose extension is not an image', () => {
+    // The #3575 case: a document could point an image src at a co-located
+    // script, which the OS would execute rather than display.
+    expect(localImagePathFromSrc(fileUrl(scriptPath))).toBeNull()
+    expect(localImagePathFromSrc(fileUrl(join(dir, 'note.md')))).toBeNull()
+  })
+
+  it('rejects an image extension that does not exist on disk', () => {
+    expect(localImagePathFromSrc(fileUrl(join(dir, 'missing.png')))).toBeNull()
+  })
+
+  it('rejects remote, data: and malformed sources', () => {
+    expect(localImagePathFromSrc('https://example.com/pic.png')).toBeNull()
+    expect(localImagePathFromSrc('http://example.com/pic.png')).toBeNull()
+    expect(
+      localImagePathFromSrc('data:image/png;base64,iVBORw0KGgo=')
+    ).toBeNull()
+    expect(localImagePathFromSrc('')).toBeNull()
+    expect(localImagePathFromSrc('file://')).toBeNull()
+    expect(localImagePathFromSrc('photo.png')).toBeNull()
+  })
+})
+
+describe('#2461 — openImageExternally', () => {
+  it('hands the path to the OS', async() => {
+    await openImageExternally(pngPath)
+    expect(openPath).toHaveBeenCalledWith(pngPath)
+    expect(logError).not.toHaveBeenCalled()
+  })
+
+  it('logs when the OS reports no application for the format', async() => {
+    openPath.mockResolvedValueOnce('No application is registered to handle this file type.')
+    await openImageExternally(pngPath)
+    expect(logError).toHaveBeenCalled()
+  })
+})
+
+describe('#2461 — editor context menu on an image', () => {
+  const show = (params: Record<string, unknown>) =>
+    showEditorContextMenu(
+      {} as never,
+      {} as never,
+      params as never,
+      false
+    )
+
+  it('offers "Open Image" for a local image and opens it on click', async() => {
+    // Measured in-app: muya renders the image `contenteditable="false"`, so
+    // Electron reports isEditable false here. The gate must not require it, or
+    // the item never appears.
+    show(
+      editorParams({
+        isEditable: false,
+        hasImageContents: true,
+        mediaType: 'image',
+        srcURL: `${fileUrl(pngPath)}?mucache=mu-4`
+      })
+    )
+
+    expect(popups).toHaveLength(1)
+    expect(appended).toHaveLength(1)
+    expect(appended[0].label).toBe('contextMenu.openImage')
+    expect(openPath).not.toHaveBeenCalled()
+
+    await (appended[0].click as () => Promise<void>)()
+    expect(openPath).toHaveBeenCalledWith(pngPath)
+  })
+
+  it('stays menuless for a remote image, which has no file to open', () => {
+    show(
+      editorParams({
+        isEditable: false,
+        hasImageContents: true,
+        srcURL: 'https://example.com/pic.png'
+      })
+    )
+
+    expect(popups).toHaveLength(0)
+    expect(appended).toHaveLength(0)
+    expect(openPath).not.toHaveBeenCalled()
+  })
+
+  it('does not offer "Open Image" for text, and still shows the text menu', () => {
+    show(editorParams({ isEditable: true, hasImageContents: false, srcURL: '' }))
+
+    expect(popups).toHaveLength(1)
+    expect(appended.map((i) => i.label)).not.toContain('contextMenu.openImage')
+    expect(appended.length).toBeGreaterThan(1)
+  })
+})


### PR DESCRIPTION
Closes #2461

## Summary

#2461 asks for a way to open an image in the system's associated viewer, *"Maybe via right-click or simply by double-clicking."* Today right-clicking an image in the editor produces **no menu at all**.

The cause is not a missing menu item — it is the gate. `showEditorContextMenu` only builds a menu when `isInsideEditor(params)`, which requires `params.isEditable`, and the existing branch is additionally guarded by `!hasImageContents`. muya renders inline images `contenteditable="false"` (`inlineRenderer/renderer/image.ts`), so Electron reports `isEditable: false` for them and that gate can never match an image. Measured in the built app rather than assumed:

| right-click target | `isEditable` | `hasImageContents` | `mediaType` | `srcURL` |
| --- | --- | --- | --- | --- |
| inline image | `false` | `true` | `image` | `file:///…/photo.png?mucache=mu-4` |
| paragraph text | `true` | `false` | `none` | `""` |
| tab bar (non-editor UI) | `true` | `false` | `none` | `""` |

So this adds an image branch gated on the image signals instead (`hasImageContents`, no `inputFieldType`, `canEditRichly`), offering a single **Open Image** item that hands the file to the OS. Double-click is deliberately *not* used: #3202 asks for double-click to open the in-app preview, and one gesture can only go to one destination — see #5246.

Two details worth calling out:

- **The src comes from an untrusted document**, so the path is whitelisted through the existing `isImageFile` (a known image extension *and* an existing regular file) before it reaches `shell.openPath`, rather than relying on the #3575 dangerous-extension blacklist. Blacklists are what let `update.js.` through in the first place.
- **The engine renders `photo.png?mucache=mu-N`** so "Reload Images" can bypass the cache. `fileURLToPath` drops the query, so the extension check still sees `.png` — but only just, and it is easy to break, so it has its own test.

Remote (`http:`) and `data:` images have no file for the OS to open, so they stay menuless exactly as they are today instead of gaining an item that cannot work.

Adds `contextMenu.openImage` to all 11 files under `static/locales/`, since `locale-validation.spec.ts` asserts key parity with `en.json`.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
  - `test/unit/specs/open-image-external.spec.ts` (10 cases): resolves a `file:` URL to the real path; ignores the `?mucache=` suffix; rejects a non-image extension (the #3575 case — a `.js`/`.md` next to the document); rejects an image extension that does not exist; rejects `http:`/`data:`/empty/malformed input; `openImageExternally` calls `shell.openPath` and logs when the OS reports no handler; the menu offers the item for a local image and opens it on click; stays menuless for a remote image; text still gets the unchanged text menu.
  - `test/e2e/image-open-external.spec.ts` (3 cases): drives a **real right-click** in the built Electron app, with `Menu.popup` and `shell.openPath` stubbed in the main process (a real OS menu would take focus, and really opening the file would launch the platform's viewer under CI). Asserts the menu is built with id `openImageMenuItem`, that its label is a *resolved* translation rather than a raw key, and that clicking it calls `shell.openPath` with the exact on-disk path — query stripped. Also asserts a `data:` image stays menuless.
- [x] `pnpm -C packages/desktop exec playwright test test/e2e/image-open-external.spec.ts` → 3 passed.
- [x] `pnpm run lint` → 0 errors, warning count unchanged from `develop`. `pnpm run typecheck` → clean.
- [x] Manually tested on: Windows — right-click a local image → **Open Image** → the file opens in the associated viewer; right-click paragraph text → the unchanged Cut/Copy/Paste menu.

## Notes for reviewers [optional]

- `pnpm run test:unit` currently fails one test on `develop` that is unrelated to this change: `locale-validation.spec.ts > nl.json has the same keys as en.json`, because `1135cc8` added `menu.window.resetZoom` to ten locales and skipped `nl.json`. One-line fix in #5245; merging that first will make this PR's CI green.
- No icon is needed (this is a native menu, not a floating toolbar), which is why the entry point is right-click rather than the image toolbar.
- The `ContextMenuParams` interface in this file is deliberately narrow; only `srcURL` was added to it.

<!-- screenshot: right-click menu showing "Open Image" -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
