### PR TITLE
fix(muya): preserve tight mixed bullet and task lists

### DIFF
--- a/packages/muya/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/muya/src/state/__tests__/listSerialization.spec.ts
@@ -612,3 +612,27 @@ describe('stateToMarkdown — ordered list start + delimiter', () => {
         expect(serialize(states)).toBe('5) one\n6) two\n');
     });
 });
+
+describe('stateToMarkdown — a task item beside a bullet item', () => {
+    // A bullet item and a task item written as one list are two blocks in Muya's state, and
+    // separating them on the way out turns a tight list into a loose one.
+    it.each([
+        '- containing a bullet\n- [ ] and a task\n',
+        '- [x] a task\n- followed by a bullet\n',
+        '- a bullet\n- [ ] a task\n- another bullet\n- [x] another task\n',
+    ])('keeps adjacent bullet and task runs tight: %j', (md) => {
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it('keeps the pair tight inside an ordered item', () => {
+        const md = '1. An ordered item\n   - containing a bullet\n   - [ ] and a task\n2. Another ordered item\n';
+        expect(roundTrip(md)).toBe(md);
+    });
+
+    it.each([
+        '- a bullet item\n\n- [ ] a task item\n',
+        '- [x] a task item\n\n- a bullet item\n',
+    ])('preserves authored loose spacing: %j', (md) => {
+        expect(roundTrip(md)).toBe(md);
+    });
+});

--- a/packages/muya/src/state/stateToMarkdown.ts
+++ b/packages/muya/src/state/stateToMarkdown.ts
@@ -226,6 +226,10 @@ export default class ExportMarkdown {
 
         if (lastListBullet && lastListBullet !== bulletMarkerOrDelimiter)
             insertNewLine = false;
+        // Bullet and task runs share one Markdown list. Separating tight runs
+        // with a blank line would make the whole list loose.
+        else if (lastListBullet && 'loose' in meta && !meta.loose)
+            insertNewLine = false;
 
         if (insertNewLine)
             this._insertLineBreak(result, indent);


### PR DESCRIPTION
This PR was developed with Codex using GPT-6 Astra and went through several rounds of automated review. It resolves a real issue that I encountered while using this library.

## Summary

Muya stores adjacent bullet and task runs as separate blocks. This PR prevents serialization from inserting a blank line between tight runs while retaining authored loose spacing.

This input now round-trips unchanged:

```markdown
- A bullet
- [ ] A task
```

## Type of change

- [x] Bug fix (non-breaking, fixes an issue).
- [ ] New feature (non-breaking, adds functionality).
- [ ] Breaking change (causes existing functionality to change).
- [ ] Documentation update.

## Test plan

- [x] New tests added.
- [ ] Manually tested on: Not performed.

From `packages/muya`, `pnpm test --maxWorkers=2` passes 1,468 tests and `pnpm test:spec --maxWorkers=2` passes 1,347 checks. `pnpm lint:types`, `pnpm lint` and `pnpm check-circular` pass, with eight existing lint warnings. Four tight-list regressions fail without the fix; loose-list controls pass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).


---

Edit: Closes #5257.
