### PR TITLE
fix(muya): restore the caret when undoing the first edit after a load

### DIFF
--- a/packages/muya/e2e/tests/editing/first-undo-caret.spec.ts
+++ b/packages/muya/e2e/tests/editing/first-undo-caret.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { editor } from '../helpers/selectors';
+
+test('the first undo after loading restores the caret in the edited paragraph', async ({ page }) => {
+    await page.evaluate(() => window.muya!.setContent('first\n\nsecond\n'));
+    await page.locator(editor.paragraph).nth(1).click();
+    await page.keyboard.press('End');
+    await page.keyboard.press('ArrowLeft');
+    await expect.poll(() => page.evaluate(() => {
+        const selection = window.muya!.editor.selection.getSelection();
+        return { path: selection?.anchor.path, offset: selection?.anchor.offset };
+    })).toEqual({ path: [1, 'text'], offset: 5 });
+
+    await page.keyboard.type('X');
+    await expect.poll(() => getMarkdown(page)).toBe('first\n\nseconXd\n');
+    await expect.poll(() => page.evaluate(() => window.muya!.getHistory().stack.undo.length)).toBe(1);
+    await page.evaluate(() => window.muya!.undo());
+
+    await expect.poll(() => getMarkdown(page)).toBe('first\n\nsecond\n');
+    await expect.poll(() => page.evaluate(() => {
+        const selection = window.muya!.editor.selection.getSelection();
+        return {
+            anchor: selection && { path: selection.anchor.path, offset: selection.anchor.offset },
+            focus: selection && { path: selection.focus.path, offset: selection.focus.offset },
+        };
+    })).toEqual({
+        anchor: { path: [1, 'text'], offset: 5 },
+        focus: { path: [1, 'text'], offset: 5 },
+    });
+    await page.keyboard.type('Y');
+    await expect.poll(() => getMarkdown(page)).toBe('first\n\nseconYd\n');
+});

--- a/packages/muya/src/history/__tests__/firstEntrySelection.spec.ts
+++ b/packages/muya/src/history/__tests__/firstEntrySelection.spec.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+
+import type Format from '../../block/base/format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+const editors: Muya[] = [];
+
+beforeEach(() => {
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (editors.length)
+        editors.pop()!.destroy();
+    vi.useRealTimers();
+    delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    editors.push(muya);
+    return muya;
+}
+
+function contentAt(muya: Muya, index: number): Format {
+    const contents: Format[] = [];
+    let content = muya.editor.scrollPage!.firstContentInDescendant();
+    while (content) {
+        contents.push(content as unknown as Format);
+        content = (content as unknown as { nextContentInContext: () => typeof content })
+            .nextContentInContext();
+    }
+    return contents[index];
+}
+
+function firstContent(muya: Muya): Format {
+    return muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+}
+
+function undoStack(muya: Muya) {
+    return muya.getHistory().stack.undo;
+}
+
+async function editContent(content: Format, text: string, muya: Muya): Promise<void> {
+    const target = content as unknown as { text: string; checkInlineUpdate: () => void };
+    target.text = text;
+    content.setCursor(text.length, text.length, true);
+    target.checkInlineUpdate();
+    await vi.waitFor(() => {
+        expect(muya.getMarkdown()).toContain(text);
+    });
+}
+
+describe('selection recorded on the first history entry after a load', () => {
+    it('captures the caret as it was immediately before the first edit', async () => {
+        const muya = bootMuya('seed\n');
+        // setContent clears both the undo stack and the selection baseline, which
+        // is the state the app leaves the editor in for every opened document.
+        muya.setContent('fresh\n');
+
+        // Two caret moves before any edit: the entry must describe the second.
+        // Seeding only the first would record a caret the user has since left.
+        firstContent(muya).setCursor(1, 1, true);
+        firstContent(muya).setCursor(5, 5, true);
+
+        await editContent(firstContent(muya), 'freshly', muya);
+
+        expect(undoStack(muya)).toHaveLength(1);
+        expect(undoStack(muya)[0].selection).not.toBeNull();
+        expect(undoStack(muya)[0].selection!.anchor.offset).toBe(5);
+    });
+
+    it('ignores the caret move an edit makes on its own behalf', async () => {
+        const muya = bootMuya('seed\n');
+        muya.setContent('fresh\n');
+        const content = firstContent(muya);
+        content.setCursor(2, 2, true);
+
+        // Mirror the order Format.inputHandler works in: assigning `text` queues
+        // the operation, and the caret is moved past the inserted text before that
+        // batch flushes. The seed must stay the caret from before the edit.
+        const target = content as unknown as { text: string; checkInlineUpdate: () => void };
+        target.text = 'freshly';
+        content.setCursor(7, 7, true);
+        target.checkInlineUpdate();
+        await vi.waitFor(() => {
+            expect(muya.getMarkdown()).toContain('freshly');
+        });
+
+        expect(undoStack(muya)[0].selection!.anchor.offset).toBe(2);
+    });
+
+    it('ignores a selection that resolves to no caret', async () => {
+        const muya = bootMuya('seed\n');
+        muya.setContent('fresh\n');
+        firstContent(muya).setCursor(3, 3, true);
+
+        // An image selection clears the DOM range, so getSelection() reports null.
+        // That must not claim the baseline and lock out the real caret.
+        document.getSelection()!.removeAllRanges();
+        muya.eventCenter.emit('selection-change', null);
+
+        await editContent(firstContent(muya), 'freshly', muya);
+
+        expect(undoStack(muya)[0].selection).not.toBeNull();
+        expect(undoStack(muya)[0].selection!.anchor.offset).toBe(3);
+    });
+
+    it('restores the caret to the right block when that entry is undone', async () => {
+        const muya = bootMuya('seed\n');
+        // Two blocks, so the fallback in _restoreSelection (which focuses the
+        // first content block) cannot be mistaken for a real restore.
+        muya.setContent('first\n\nsecond\n');
+        contentAt(muya, 1).setCursor(6, 6, true);
+
+        await editContent(contentAt(muya, 1), 'secondly', muya);
+        muya.undo();
+
+        const selection = muya.editor.selection.getSelection();
+        expect(selection).not.toBeNull();
+        expect(selection!.anchor.block).toBe(contentAt(muya, 1));
+        expect(selection!.anchor.offset).toBe(6);
+    });
+
+    it('leaves later entries reporting the caret before their own edit', async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const muya = bootMuya('seed\n');
+        muya.setContent('fresh\n');
+        firstContent(muya).setCursor(5, 5, true);
+
+        await editContent(firstContent(muya), 'freshly', muya);
+
+        // Past History's coalescing delay, so the next edit starts its own entry.
+        vi.advanceTimersByTime(2000);
+        firstContent(muya).setCursor(7, 7, true);
+        await editContent(firstContent(muya), 'freshly typed', muya);
+
+        expect(undoStack(muya)).toHaveLength(2);
+        // The oldest entry still describes the caret before the FIRST edit, and
+        // the newer one comes from the ordinary previous-entry path rather than
+        // from the seeding added for the first.
+        expect(undoStack(muya)[0].selection!.anchor.offset).toBe(5);
+        expect(undoStack(muya)[1].selection!.anchor.offset).toBe(7);
+        muya.undo();
+        expect(muya.getMarkdown()).toBe('freshly\n');
+        expect(muya.editor.selection.getSelection()!.anchor.offset).toBe(7);
+    });
+});

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -151,6 +151,22 @@ class History {
                     this._transform(op);
             },
         );
+
+        // The first undo entry needs a selection from before the edit.
+        // Input queues its operation before moving the caret, so pending edits
+        // must not replace this baseline with their post-edit selection.
+        this._muya.eventCenter.on('selection-change', () => {
+            if (this._selectionStack.length > 1)
+                return;
+            if (this._muya.editor.jsonState.hasPendingOperations)
+                return;
+
+            const selection = this._selection.getSelection();
+            if (selection == null)
+                return;
+
+            this._selectionStack[0] = selection;
+        });
     }
 
     private _change(source: HistoryAction, dest: HistoryAction) {

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -156,6 +156,9 @@ class History {
         // Input queues its operation before moving the caret, so pending edits
         // must not replace this baseline with their post-edit selection.
         this._muya.eventCenter.on('selection-change', () => {
+            // Only the first entry needs a seeded baseline; `_record` maintains the
+            // window after that. Leaving early also keeps `getSelection()`, which
+            // rebuilds the selection from the DOM, off every later caret move.
             if (this._selectionStack.length > 1)
                 return;
             if (this._muya.editor.jsonState.hasPendingOperations)

--- a/packages/muya/src/state/index.ts
+++ b/packages/muya/src/state/index.ts
@@ -242,6 +242,11 @@ class JSONState {
         return mdGenerator.generate(state);
     }
 
+    /** Whether edits are queued for the next animation frame. */
+    get hasPendingOperations() {
+        return this._rafId !== null;
+    }
+
     private _emitStateChange() {
         if (this._rafId !== null)
             return;


### PR DESCRIPTION
This PR was developed with Codex using GPT-6 Astra and went through several rounds of automated review. It resolves a real issue that I encountered while using this library.

## Summary

This PR retains the pre-edit selection for the first undo entry after loading content. Undo restores the caret in the edited paragraph, so subsequent typing continues at the original position. Pending edits cannot overwrite that baseline with their post-edit selection.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue).
- [ ] New feature (non-breaking, adds functionality).
- [ ] Breaking change (causes existing functionality to change).
- [ ] Documentation update.

## Test plan

- [x] New tests added.
- [ ] Manually tested on: Not performed.

From `packages/muya`, `pnpm test --maxWorkers=2` passes 1,467 tests and `pnpm test:spec --maxWorkers=2` passes 1,347 checks. `pnpm lint:types`, `pnpm lint` and `pnpm check-circular` pass, with eight existing lint warnings. All five new unit tests fail without the fix.

The headless Chromium and WebKit regression loads two paragraphs, moves the caret, types, undoes and types again. It passes with the fix and fails without it in Chromium. The optional e2e TypeScript check reports the same existing errors on unchanged upstream code.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).


---

Edit: Closes #5258.
