### PR TITLE
fix(muya): #4747 deep clone editor state without recursing

### DIFF
--- a/packages/muya/src/utils/__tests__/deepClone.spec.ts
+++ b/packages/muya/src/utils/__tests__/deepClone.spec.ts
@@ -1,0 +1,93 @@
+import type { TState } from '../../state/types';
+import { describe, expect, it } from 'vitest';
+import { deepClone } from '../index';
+
+// A bullet list nested `depth` levels deep, in the shape `markdownToState`
+// emits: every level adds a `bullet-list`, its `children` array, a
+// `list-item` and its `children` array, so 600 list levels are ~2400 nested
+// containers. `structuredClone` overflows the engine stack on this input
+// (#4747), and so would a recursive equality check, hence the iterative
+// walk below.
+function nestedBulletList(depth: number): TState[] {
+    let state: TState = { name: 'paragraph', text: 'leaf' };
+    for (let level = depth - 1; level >= 0; level--) {
+        state = {
+            name: 'bullet-list',
+            meta: { loose: false, marker: '-' },
+            children: [{ name: 'list-item', children: [{ name: 'paragraph', text: `item ${level}` }, state] }],
+        };
+    }
+    return [state];
+}
+
+// Descend through the nested lists and return the innermost paragraph plus
+// the number of list levels passed on the way.
+function innermostLeaf(state: TState[]): { leaf: TState; levels: number } {
+    let levels = 0;
+    let current = state[0];
+    while (current.name === 'bullet-list') {
+        levels++;
+        const item = current.children[0];
+        current = item.children[item.children.length - 1];
+    }
+    return { leaf: current, levels };
+}
+
+describe('deepClone', () => {
+    it('copies a 600-level nested list without exhausting the stack (#4747)', () => {
+        const state = nestedBulletList(600);
+
+        const copy = deepClone(state);
+
+        expect(copy).not.toBe(state);
+        expect(copy[0]).not.toBe(state[0]);
+        const source = innermostLeaf(state);
+        const cloned = innermostLeaf(copy);
+        expect(cloned.levels).toBe(600);
+        expect(cloned.levels).toBe(source.levels);
+        expect(cloned.leaf).toEqual({ name: 'paragraph', text: 'leaf' });
+        expect(cloned.leaf).not.toBe(source.leaf);
+    });
+
+    it('returns a structurally equal copy whose containers are all fresh', () => {
+        const state = nestedBulletList(3);
+
+        const copy = deepClone(state);
+
+        expect(copy).toEqual(state);
+        expect(copy[0]).not.toBe(state[0]);
+        const sourceList = state[0];
+        const copiedList = copy[0];
+        if (sourceList.name !== 'bullet-list' || copiedList.name !== 'bullet-list')
+            throw new Error('fixture root must be a bullet list');
+        expect(copiedList.meta).not.toBe(sourceList.meta);
+        expect(copiedList.children).not.toBe(sourceList.children);
+        copiedList.meta.loose = true;
+        expect(sourceList.meta.loose).toBe(false);
+    });
+
+    it('keeps references that are shared inside the source shared in the copy', () => {
+        const shared = { text: 'shared' };
+        const source = { a: shared, b: shared, list: [shared] };
+
+        const copy = deepClone(source);
+
+        expect(copy.a).not.toBe(shared);
+        expect(copy.a).toBe(copy.b);
+        expect(copy.list[0]).toBe(copy.a);
+    });
+
+    it('passes primitives through and still uses structuredClone for other object types', () => {
+        expect(deepClone(42)).toBe(42);
+        expect(deepClone('text')).toBe('text');
+        expect(deepClone(null)).toBeNull();
+        expect(deepClone(undefined)).toBeUndefined();
+
+        const date = new Date(0);
+        const copy = deepClone({ date, values: [1, 'two', null] });
+        expect(copy.date).toBeInstanceOf(Date);
+        expect(copy.date).not.toBe(date);
+        expect(copy.date.getTime()).toBe(0);
+        expect(copy.values).toEqual([1, 'two', null]);
+    });
+});

--- a/packages/muya/src/utils/index.ts
+++ b/packages/muya/src/utils/index.ts
@@ -139,8 +139,54 @@ export function throttle<TArgs extends unknown[], TReturn>(
     };
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null)
+        return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Deep copy of JSON-shaped data. Arrays and plain objects are walked with an
+ * explicit stack, so the nesting depth of the input never consumes engine
+ * stack: `structuredClone` recurses once per level and throws `RangeError`
+ * on a bullet list a few hundred levels deep, which is still ordinary
+ * Markdown (#4747). Shared references inside `value` stay shared in the
+ * copy. Values that are neither arrays nor plain objects (Date, Map, typed
+ * arrays, ...) are still copied with `structuredClone`, so they keep the
+ * semantics callers relied on before.
+ */
 export function deepClone<T>(value: T): T {
-    return structuredClone(value);
+    if (!Array.isArray(value) && !isPlainObject(value))
+        return structuredClone(value);
+
+    const copies = new Map<object, object>();
+    const stack: object[] = [];
+
+    const copyOf = (source: unknown): unknown => {
+        if (!Array.isArray(source) && !isPlainObject(source)) {
+            return typeof source === 'object' && source !== null
+                ? structuredClone(source)
+                : source;
+        }
+        let copy = copies.get(source);
+        if (copy === undefined) {
+            copy = Array.isArray(source) ? [] : {};
+            copies.set(source, copy);
+            stack.push(source);
+        }
+        return copy;
+    };
+
+    const root = copyOf(value) as T;
+    while (stack.length) {
+        const source = stack.pop() as Record<string, unknown>;
+        const target = copies.get(source) as Record<string, unknown>;
+        for (const key of Object.keys(source))
+            target[key] = copyOf(source[key]);
+    }
+
+    return root;
 }
 
 export function escapeHTML(str: string) {


### PR DESCRIPTION
Closes #4747

## Summary

`JSONState.getState()` copies the document with `structuredClone`, which recurses once per nesting level. A bullet list nested about 600 levels deep is roughly 2400 nested containers in the state tree (`bullet-list` → `children` → `list-item` → `children` per level), which exceeds the engine stack, so `Editor.init()` and `Editor.setContent()` throw `RangeError` before the document renders.

`deepClone` now walks arrays and plain objects with an explicit stack instead of recursing. Shared references inside the input stay shared in the copy (a source → copy map, which also rules out looping on cycles). Values that are neither arrays nor plain objects (`Date`, `Map`, typed arrays, ...) still go through `structuredClone`, so that behaviour is unchanged for callers that relied on it. Functions are the one input `structuredClone` rejected that the new walk does not: they are copied by reference. No caller passes them.

Muya playground (`packages/muya/examples`, Vite dev server) in Chrome 148 on Windows 11, `muya.setContent()` with the nested list from the issue's generator, then `muya.getMarkdown()`:

| levels | `develop` (89d69887) | this branch |
|---|---|---|
| 300 | ok, 702 ms, round-trip equal | ok, 484 ms, round-trip equal |
| 600 | `RangeError` at `deepClone` ← `JSONState.getState` ← `Editor.setContent` | ok, 1117 ms, round-trip equal, 600 `.mu-bullet-list` rendered |
| 1000 | `RangeError`, same stack | ok, 3109 ms, round-trip equal, 1000 `.mu-bullet-list` rendered, deepest `li` at depth 1000 |

`develop`, 600 levels:

```text
RangeError: Failed to execute 'structuredClone' on 'Window': Maximum call stack size exceeded
    at deepClone (packages/muya/src/utils/index.ts)
    at JSONState.getState (packages/muya/src/state/index.ts)
    at Editor.setContent (packages/muya/src/editor/index.ts)
```

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added: `packages/muya/src/utils/__tests__/deepClone.spec.ts`. The 600-level case fails on `develop` with the `RangeError` above; the other cases pin fresh containers in the copy, shared references staying shared, and the `structuredClone` fallback for non-plain values.
- [x] Manually tested on: Windows 11 (muya playground in Chrome 148, table above). The desktop app was not run on this machine: `ced` has no prebuilt binary and its `node-gyp` build needs Visual Studio Build Tools. The desktop path in the issue's stack (`Muya.setContent` → `Editor.setContent` → `JSONState.getState` → `deepClone`) is the same code the playground exercises.

```text
pnpm -C packages/muya test           214 files, 1466 tests passed
pnpm -C packages/muya lint           clean
pnpm -C packages/muya lint:types     clean
pnpm -C packages/muya check-circular no circular dependency found
```

## Notes for reviewers

- Only `deepClone` changes. `getState()` still returns a defensive copy, so the public `muya.getState()` contract is untouched. The alternatives the issue lists (a non-cloning accessor for editor-internal paths, a nesting-depth guard in `markdownToState`) are not part of this change.
- `JSON.stringify`, which `buildReplaceOp` uses to diff top-level blocks, also recurses and starts throwing at roughly 2000 list levels in V8, so lists that deep still fail further down the pipeline. The 600 to 1000 range the issue reports now loads.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
