### PR TITLE
feat: add native TextPack document support

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,45 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream-textpack
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out TextPack branch
+        uses: actions/checkout@v4
+        with:
+          ref: textpack
+          fetch-depth: 0
+
+      - name: Rebase onto upstream develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/marktext/marktext.git
+          git fetch upstream develop
+          git rebase upstream/develop
+
+      - uses: ./.github/actions/setup
+
+      - name: Run ESLint
+        run: pnpm lint
+
+      - name: Run TypeScript typecheck
+        run: pnpm typecheck
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Update TextPack branch
+        run: git push --force-with-lease origin HEAD:textpack

--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 <h1 align="center">MarkText</h1>
 
+> [!IMPORTANT]
+> This is an unofficial fork of [MarkText](https://github.com/marktext/marktext).
+> It is independently maintained and is not an official MarkText release.
+
+## MarkText TextPack
+
+This fork adds native `.textpack` document support to MarkText while keeping
+the existing editing experience and limiting most integration changes to the
+document and filesystem layers.
+
+### Features
+
+- Open, edit, save, and restore `.textpack` documents.
+- Store pasted and dropped images in the package's `assets/` directory.
+- Convert Markdown documents to TextPack while embedding Base64 and local resources.
+- Export TextPack documents back to Markdown with their assets.
+- Preserve compatible metadata, existing assets, and unknown package files.
+- Detect unsafe archives and external file changes.
+
+### Current scope
+
+- `.textbundle` directories are not supported.
+- No generic attachment insertion UI is added.
+- Remote HTTP/HTTPS resources remain remote.
+- This fork follows MarkText's upstream `develop` branch.
+
+See [TextPack documentation](docs/textpack.md) for compatibility details and
+current limitations.
+
+The implementation was developed with AI assistance and manually reviewed and tested.
+
 <div align="center">
   <a href="https://twitter.com/intent/tweet?via=marktextme&url=https://github.com/marktext/marktext/&text=What%20do%20you%20want%20to%20say%20to%20app?&hashtags=happyMarkText">
     <img src="https://img.shields.io/twitter/url/https/github.com/marktext/marktext.svg?style=for-the-badge" alt="twitter">

--- a/docs/textpack.md
+++ b/docs/textpack.md
@@ -1,0 +1,27 @@
+# TextPack documents
+
+MarkText can open and edit compressed TextBundle documents with the `.textpack` extension. A TextPack remains one portable file while its Markdown text, images, other resources, and metadata are stored in an open ZIP-based layout.
+
+## Use
+
+- Open a `.textpack` from **File → Open**, the recent-files menu, the command line, a file association, or by dropping it on MarkText.
+- Edit it like any other Markdown document. Relative `assets/...` images resolve inside the bundle.
+- Pasted or dropped images are copied into the bundle's `assets/` directory. The Markdown keeps a portable POSIX-style `assets/...` reference.
+- **Save** rebuilds and validates a temporary archive, then replaces the original. External changes enter MarkText's existing file-change flow; a final source-revision check also prevents a changed archive from being overwritten during a race.
+- Saving a Markdown or untitled document as `.textpack` embeds Base64 image data, local absolute/file-URL images, and relative local link/image targets. Inline images, reference-style images, and HTML `<img src>` are supported. Source files are copied, never moved. Missing or invalid resources cancel conversion without replacing the destination.
+- Saving a TextPack as Markdown exports its complete `assets/` directory as `<document>.assets` and rewrites Markdown destinations accordingly.
+
+## Compatibility and safety
+
+MarkText accepts TextBundle versions 1 and 2 with a Markdown type (or no type), a lowercase root `info.json`, and exactly one root `text.*`. It preserves unknown metadata, unknown files, and unreferenced assets when saving back to TextPack. Text is decoded as strict UTF-8; a UTF-8 BOM is accepted.
+
+Archives containing traversal/absolute paths, backslashes, platform device names, duplicate case-folded names, symbolic links, encrypted entries, excessive entry counts/sizes, or suspicious compression ratios are rejected before a tab opens.
+
+## Current preview limitations
+
+- Relative resources in an untitled document have no known source directory. Save the Markdown beside its resources first; TextPack conversion deliberately does not guess a directory. Base64, absolute paths, and file URLs do not need a source directory.
+- HTTP/HTTPS and protocol-relative images remain remote links. The conversion implementation has an internal `remoteImages: 'preserve' | 'embed'` option, defaulting to `preserve`. `embed` is reserved and explicitly fails as unimplemented. No MarkText preference, settings UI, or package metadata field is added.
+- The source-position scanner is not a full CommonMark parser. Complex nested block syntax and HTML `srcset`/CSS images are not currently supported. Embedded image data must use a supported Base64 image MIME type; invalid or unsupported image data fails conversion explicitly.
+- TextPack does not add a generic non-image attachment insertion UI. Non-image drag-and-drop keeps MarkText's existing behavior, while arbitrary files already stored under `assets/` are preserved and relative local files referenced by Markdown links are collected during conversion.
+- Recovery reuses resource workspaces left by an abnormal exit, together with MarkText's existing buffered Markdown recovery. There is not yet a dedicated recovery-candidate picker.
+- External changes use the existing MarkText reload notification. MarkText stages the changed archive without disturbing local resources and switches the Markdown and complete resource workspace together only when the existing reload flow accepts the external version.

--- a/packages/desktop/build/windows/installer.nsh
+++ b/packages/desktop/build/windows/installer.nsh
@@ -5,7 +5,7 @@
 !macro customInstall
   ; Ask the user if they want to register file associations
   MessageBox MB_YESNO|MB_ICONQUESTION \
-  "Do you want to associate Markdown files (.md, .markdown, .mmd, .mdown, .mdtext, .mdx) with MarkText?" /SD IDNO IDNO SkipAssoc
+  "Do you want to associate Markdown and TextPack files (.md, .markdown, .mmd, .mdown, .mdtext, .mdx, .textpack) with MarkText?" /SD IDNO IDNO SkipAssoc
 
   ;— User clicked YES, perform the registry writes —
   WriteRegStr HKCU "Software\Classes\.md"       "" "MarkText.Document"
@@ -15,6 +15,7 @@
   WriteRegStr HKCU "Software\Classes\.mdtxt"    "" "MarkText.Document"
   WriteRegStr HKCU "Software\Classes\.mdtext"   "" "MarkText.Document"
   WriteRegStr HKCU "Software\Classes\.mdx"      "" "MarkText.Document"
+  WriteRegStr HKCU "Software\Classes\.textpack" "" "MarkText.Document"
 
   WriteRegStr HKCU "Software\Classes\MarkText.Document" \
     "" "MarkText Markdown Document"
@@ -46,6 +47,7 @@ SkipAssoc:
   DeleteRegKey HKCU "Software\Classes\.mdtxt"
   DeleteRegKey HKCU "Software\Classes\.mdtext"
   DeleteRegKey HKCU "Software\Classes\.mdx"
+  DeleteRegKey HKCU "Software\Classes\.textpack"
 
   MessageBox MB_YESNO "Do you want to delete user settings?" /SD IDNO IDNO SkipRemoval
     SetShellVarContext current

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -54,6 +54,12 @@ electronLanguages: # Avoid packaging all chromium locales since our app has in-b
 asarUnpack:
   - resources/**
 fileAssociations:
+  - ext: textpack
+    name: TextPack
+    description: TextPack document
+    mimeType: application/x-textpack
+    role: Editor
+    icon: icons/md.ico
   - ext: md
     name: Markdown
     description: Markdown document
@@ -137,6 +143,7 @@ linux:
   category: 'Office;TextEditor;Utility'
   mimeTypes:
     - 'text/markdown'
+    - 'application/x-textpack'
   icon: 'static/icon.png'
   desktop:
     entry:
@@ -149,6 +156,9 @@ linux:
     - rpm
     - tar.gz
   fileAssociations:
+    - ext: 'textpack'
+      name: 'TextPack'
+      description: 'TextPack document'
     - ext: 'md'
       name: 'Markdown'
       description: 'Markdown document'

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -108,7 +108,9 @@
     "vue-i18n": "^11.4.6",
     "vue-router": "^4.6.4",
     "webfontloader": "^1.6.28",
-    "write-file-atomic": "^7.0.1"
+    "write-file-atomic": "^7.0.1",
+    "yauzl": "^3.4.0",
+    "yazl": "^3.3.1"
   },
   "optionalDependencies": {
     "native-keymap": "^3.3.9"
@@ -128,6 +130,8 @@
     "@types/turndown": "^5.0.6",
     "@types/webfontloader": "^1.6.38",
     "@types/write-file-atomic": "^4.0.3",
+    "@types/yauzl": "^2.10.3",
+    "@types/yazl": "^3.3.0",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.9",
     "cross-env": "^10.1.0",

--- a/packages/desktop/src/common/filesystem/paths.ts
+++ b/packages/desktop/src/common/filesystem/paths.ts
@@ -23,6 +23,15 @@ export const MARKDOWN_INCLUSIONS: readonly string[] = Object.freeze(
   MARKDOWN_EXTENSIONS.map((x) => '*.' + x)
 )
 
+export const TEXTPACK_EXTENSION = 'textpack'
+export const DOCUMENT_EXTENSIONS: readonly string[] = Object.freeze([
+  ...MARKDOWN_EXTENSIONS,
+  TEXTPACK_EXTENSION
+])
+export const DOCUMENT_INCLUSIONS: readonly string[] = Object.freeze(
+  DOCUMENT_EXTENSIONS.map((x) => '*.' + x)
+)
+
 export const IMAGE_EXTENSIONS: readonly string[] = Object.freeze([
   'jpeg',
   'jpg',
@@ -108,6 +117,12 @@ export const hasMarkdownExtension = (filename: string): boolean => {
   return MARKDOWN_EXTENSIONS.some((ext) => filename.toLowerCase().endsWith(`.${ext}`))
 }
 
+export const hasTextPackExtension = (filename: string): boolean =>
+  typeof filename === 'string' && filename.toLowerCase().endsWith(`.${TEXTPACK_EXTENSION}`)
+
+export const hasDocumentExtension = (filename: string): boolean =>
+  hasMarkdownExtension(filename) || hasTextPackExtension(filename)
+
 /**
  * Returns true if the path is an image file.
  */
@@ -128,6 +143,12 @@ export const isMarkdownFile = (filepath: string): boolean => {
   }
   return hasMarkdownExtension(filepath)
 }
+
+export const isTextPackFile = (filepath: string): boolean =>
+  isFile2(filepath) && hasTextPackExtension(filepath)
+
+export const isDocumentFile = (filepath: string): boolean =>
+  isMarkdownFile(filepath) || isTextPackFile(filepath)
 
 /**
  * Check if the both paths point to the same file.

--- a/packages/desktop/src/main/app/index.ts
+++ b/packages/desktop/src/main/app/index.ts
@@ -10,7 +10,7 @@ import type { IUserPreferences } from '@shared/types/preferences'
 import { isLinux, isOsx, isWindows } from '../config'
 import parseArgs from '../cli/parser'
 import { normalizeAndResolvePath } from '../filesystem'
-import { normalizeMarkdownPath } from '../filesystem/markdown'
+import { normalizeDocumentPath } from '../filesystem/document'
 import { registerKeyboardListeners } from '../keyboard'
 import { selectTheme } from '../menu/actions/theme'
 import { dockMenu } from '../menu/templates'
@@ -83,7 +83,7 @@ class App {
           continue
         }
 
-        const info = normalizeMarkdownPath(path.resolve(workingDirectory, pathname))
+        const info = normalizeDocumentPath(path.resolve(workingDirectory, pathname))
         if (info) {
           buf.push(info as PathInfo)
         }
@@ -249,7 +249,7 @@ class App {
           continue
         }
 
-        const info = normalizeMarkdownPath(pathname)
+        const info = normalizeDocumentPath(pathname)
         if (info) {
           _openFilesCache.push(info as PathInfo)
         }
@@ -263,12 +263,12 @@ class App {
         // Restore based off the previous buffer
         isRestorePathway = true
       } else if (startUpAction === 'folder' && defaultDirectoryToOpen) {
-        const info = normalizeMarkdownPath(defaultDirectoryToOpen)
+        const info = normalizeDocumentPath(defaultDirectoryToOpen)
         if (info) {
           _openFilesCache.unshift(info as PathInfo)
         }
       } else if (startUpAction === 'openLastFolder' && lastOpenedFolder) {
-        const info = normalizeMarkdownPath(lastOpenedFolder)
+        const info = normalizeDocumentPath(lastOpenedFolder)
         if (info) {
           _openFilesCache.unshift(info as PathInfo)
         }
@@ -456,7 +456,7 @@ class App {
 
   openFile = (event: Electron.Event, pathname: string): void => {
     event.preventDefault()
-    const info = normalizeMarkdownPath(pathname)
+    const info = normalizeDocumentPath(pathname)
     if (info) {
       this._openFilesCache.push(info as PathInfo)
 
@@ -733,7 +733,7 @@ class App {
         if (editor) {
           editor.openTabsFromPaths(
             fileList
-              .map((p) => normalizeMarkdownPath(p))
+              .map((p) => normalizeDocumentPath(p))
               .filter((i): i is PathInfo => i !== null && !i.isDir)
               .map((i) => i.path)
           )

--- a/packages/desktop/src/main/app/windowManager.ts
+++ b/packages/desktop/src/main/app/windowManager.ts
@@ -12,6 +12,11 @@ import type Preference from '../preferences'
 import { WindowType } from '../windows/base'
 import type { WindowTypeValue } from '../windows/base'
 import type EditorWindow from '../windows/editor'
+import {
+  closeTextPackSession,
+  markTextPackResourcesDirty,
+  resolveTextPackReload
+} from '../filesystem/textpack'
 
 class WindowActivityList {
   // Oldest             Newest
@@ -405,8 +410,21 @@ class WindowManager extends TypedEmitter<WindowManagerEvents> {
       const editor = this.get(win.id) as EditorWindow | undefined
       if (editor) {
         editor.removeFromOpenedFiles(pathname)
+        closeTextPackSession(pathname).catch((error) =>
+          log.warn('Unable to close TextPack session:', error)
+        )
       }
     })
+
+    ipcMain.on('mt::textpack-resource-dirty', (_e, pathname: string) => {
+      markTextPackResourcesDirty(pathname)
+    })
+
+    ipcMain.handle(
+      'mt::resolve-textpack-reload',
+      (_e, pathname: string, token: string, accept: boolean) =>
+        resolveTextPackReload(pathname, token, accept)
+    )
 
     ipcMain.on('mt::window-toggle-always-on-top', (e) => {
       const win = BrowserWindow.fromWebContents(e.sender)

--- a/packages/desktop/src/main/filesystem/document.ts
+++ b/packages/desktop/src/main/filesystem/document.ts
@@ -1,0 +1,111 @@
+import path from 'path'
+import { isDirectory2 } from 'common/filesystem'
+import { hasTextPackExtension, isDocumentFile } from 'common/filesystem/paths'
+import type { LineEnding, MarkdownDocument, SaveOptions } from '@shared/types/files'
+import { normalizeAndResolvePath } from '.'
+import { loadMarkdownFile, writeMarkdownFile } from './markdown'
+import {
+  exportTextPackToMarkdown,
+  loadTextPackFile,
+  prepareTextPackReload,
+  writeTextPackFile
+} from './textpack'
+
+export const normalizeDocumentPath = (
+  pathname: string
+): { isDir: boolean; path: string } | null => {
+  const isDir = isDirectory2(pathname)
+  if (!isDir && !isDocumentFile(pathname)) return null
+  const resolved = normalizeAndResolvePath(pathname)
+  return resolved ? { isDir, path: resolved } : null
+}
+
+export const loadDocumentFile = async(
+  pathname: string,
+  preferredEol: LineEnding,
+  autoGuessEncoding = true,
+  trimTrailingNewline = 2,
+  autoNormalizeLineEndings = false
+): Promise<MarkdownDocument> => {
+  if (hasTextPackExtension(pathname)) {
+    return loadTextPackFile(
+      pathname,
+      preferredEol,
+      autoGuessEncoding,
+      trimTrailingNewline,
+      autoNormalizeLineEndings
+    )
+  }
+  const doc = await loadMarkdownFile(
+    pathname,
+    preferredEol,
+    autoGuessEncoding,
+    trimTrailingNewline,
+    autoNormalizeLineEndings
+  )
+  return {
+    ...doc,
+    encoding: { encoding: doc.encoding.encoding, isBom: !!doc.encoding.isBom },
+    documentKind: 'markdown',
+    resourcePath: path.dirname(pathname)
+  }
+}
+
+export const inspectDocumentFile = async(
+  pathname: string,
+  preferredEol: LineEnding,
+  autoGuessEncoding = true,
+  trimTrailingNewline = 2,
+  autoNormalizeLineEndings = false,
+  prepareReload = false
+): Promise<MarkdownDocument> => {
+  if (hasTextPackExtension(pathname)) {
+    if (prepareReload) {
+      return prepareTextPackReload(
+        pathname,
+        preferredEol,
+        trimTrailingNewline,
+        autoNormalizeLineEndings
+      )
+    }
+    return loadTextPackFile(
+      pathname,
+      preferredEol,
+      autoGuessEncoding,
+      trimTrailingNewline,
+      autoNormalizeLineEndings,
+      false
+    )
+  }
+  return loadDocumentFile(
+    pathname,
+    preferredEol,
+    autoGuessEncoding,
+    trimTrailingNewline,
+    autoNormalizeLineEndings
+  )
+}
+
+export const writeDocumentFile = async(
+  pathname: string,
+  markdown: string,
+  options: SaveOptions,
+  sourcePath?: string
+): Promise<{
+  documentKind: 'markdown' | 'textpack'
+  resourcePath: string
+  markdown?: string
+}> => {
+  if (hasTextPackExtension(pathname)) {
+    return writeTextPackFile(pathname, markdown, options, sourcePath)
+  }
+  if (sourcePath && hasTextPackExtension(sourcePath)) {
+    return exportTextPackToMarkdown(sourcePath, pathname, markdown, options)
+  }
+  // The IPC `SaveOptions` has every field optional, but writeMarkdownFile
+  // requires the strict `MarkdownDocumentOptions` shape — the renderer always
+  // populates every field for the unsaved-file dialog payload, so the cast
+  // is safe at this seam.
+  await writeMarkdownFile(pathname, markdown, options as Parameters<typeof writeMarkdownFile>[2])
+  return { documentKind: 'markdown', resourcePath: path.dirname(pathname) }
+}

--- a/packages/desktop/src/main/filesystem/textpack.ts
+++ b/packages/desktop/src/main/filesystem/textpack.ts
@@ -1,0 +1,1029 @@
+import { createHash, randomUUID } from 'crypto'
+import { fileURLToPath } from 'url'
+import fs from 'fs'
+import fsPromises from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { pipeline } from 'stream/promises'
+import yauzl, { type Entry, type ZipFile } from 'yauzl'
+import yazl from 'yazl'
+import type { LineEnding, MarkdownDocument, SaveOptions } from '@shared/types/files'
+import { loadMarkdownFile, writeMarkdownFile } from './markdown'
+
+export const TEXTPACK_LIMITS = Object.freeze({
+  entries: 10_000,
+  entryBytes: 512 * 1024 * 1024,
+  totalBytes: 2 * 1024 * 1024 * 1024,
+  infoBytes: 1024 * 1024,
+  textBytes: 64 * 1024 * 1024,
+  compressionRatio: 1000
+})
+
+const MARKDOWN_TYPE = 'net.daringfireball.markdown'
+const SESSION_ROOT = path.join(os.tmpdir(), 'marktext-textpack-sessions')
+const WINDOWS_DEVICE_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i
+
+export interface TextPackConversionOptions {
+  /** Internal policy only; embed is reserved and intentionally not implemented. */
+  remoteImages: 'preserve' | 'embed'
+}
+
+const DEFAULT_CONVERSION_OPTIONS: Readonly<TextPackConversionOptions> = Object.freeze({
+  remoteImages: 'preserve'
+})
+
+interface TextPackSession {
+  physicalPath: string
+  workspacePath: string
+  textEntryName: string
+  sourceRevision: { size: number; mtimeMs: number } | null
+  references: number
+  dirtyResources: boolean
+}
+
+interface TextPackManifest {
+  version: 1
+  physicalPath: string
+  textEntryName: string
+  sourceRevision: { size: number; mtimeMs: number } | null
+  pid: number
+  dirtyResources: boolean
+  updatedAt: string
+}
+
+interface PendingTextPackReload {
+  token: string
+  key: string
+  physicalPath: string
+  workspacePath: string
+  textEntryName: string
+  sourceRevision: { size: number; mtimeMs: number }
+  baseWorkspacePath: string
+}
+
+interface MarkdownDestination {
+  start: number
+  end: number
+  value: string
+  image?: boolean
+  html?: boolean
+}
+
+const sessions = new Map<string, TextPackSession>()
+const saveQueues = new Map<string, Promise<void>>()
+const pendingReloads = new Map<string, PendingTextPackReload>()
+
+const findClosingBracket = (text: string, start: number): number => {
+  let depth = 1
+  for (let index = start; index < text.length; index++) {
+    if (text[index] === '\\') {
+      index++
+    } else if (text[index] === '[') {
+      depth++
+    } else if (text[index] === ']' && --depth === 0) {
+      return index
+    }
+  }
+  return -1
+}
+
+const readDestination = (
+  text: string,
+  start: number,
+  lineEnd: number
+): MarkdownDestination | null => {
+  while (start < lineEnd && /\s/.test(text[start])) start++
+  if (start >= lineEnd) return null
+  if (text[start] === '<') {
+    const end = text.indexOf('>', start + 1)
+    return end >= 0 && end < lineEnd
+      ? { start: start + 1, end, value: text.slice(start + 1, end) }
+      : null
+  }
+  let depth = 0
+  for (let index = start; index < lineEnd; index++) {
+    const char = text[index]
+    if (char === '\\') {
+      index++
+    } else if (char === '(') {
+      depth++
+    } else if (char === ')') {
+      if (depth === 0) return { start, end: index, value: text.slice(start, index) }
+      depth--
+    } else if (/\s/.test(char) && depth === 0) {
+      return { start, end: index, value: text.slice(start, index) }
+    }
+  }
+  return start < lineEnd ? { start, end: lineEnd, value: text.slice(start, lineEnd) } : null
+}
+
+export const findMarkdownDestinations = (markdown: string): MarkdownDestination[] => {
+  // Keep source offsets while excluding non-rendered HTML contents.
+  markdown = markdown.replace(/<!--[\s\S]*?(?:-->|$)|<(script|style|pre|code)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, (value) => value.replace(/[^\r\n]/g, ' '))
+  const destinations: MarkdownDestination[] = []
+  const imageReferences = new Set<string>()
+  const definitions = new Map<number, string>()
+  const normalizeLabel = (label: string): string => label.trim().replace(/\s+/g, ' ').toLowerCase()
+  let inFence = false
+  let fenceMarker = ''
+  let offset = 0
+  let skipUntil = 0
+  for (const lineWithEnding of markdown.match(/.*(?:\r?\n|$)/g) ?? []) {
+    if (!lineWithEnding) continue
+    const line = lineWithEnding.replace(/\r?\n$/, '')
+    const marker = /^ {0,3}(`{3,}|~{3,})/.exec(line)?.[1] ?? ''
+    if (marker) {
+      if (!inFence) {
+        inFence = true
+        fenceMarker = marker
+      } else if (marker[0] === fenceMarker[0] && marker.length >= fenceMarker.length && line.trim() === marker) {
+        inFence = false
+      }
+      offset += lineWithEnding.length
+      continue
+    }
+    if (!inFence) {
+      let index = Math.max(0, skipUntil - offset)
+      const definition = index === 0 ? /^ {0,3}\[[^\]]+\]:\s*/.exec(line) : null
+      if (definition) {
+        const destination = readDestination(line, definition[0].length, line.length)
+        if (destination) {
+          definitions.set(offset + destination.start, normalizeLabel(definition[0].slice(definition[0].indexOf('[') + 1, definition[0].lastIndexOf(']'))))
+          destinations.push({
+            ...destination,
+            start: offset + destination.start,
+            end: offset + destination.end
+          })
+        }
+      }
+      while (index < line.length) {
+        if (line[index] === '\\') {
+          index += 2
+          continue
+        }
+        if (line[index] === '<') {
+          const tag = /^<img\b(?:[^>"']|"[^"]*"|'[^']*')*>/i.exec(markdown.slice(offset + index))
+          if (tag) {
+            const src = [...tag[0].matchAll(/\s+([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g)].find((attribute) => attribute[1].toLowerCase() === 'src')
+            if (src) {
+              const value = src[2] ?? src[3] ?? src[4] ?? ''
+              const start = offset + index + src.index + src[0].indexOf('=') + 1
+              const prefix = /^\s*["']?/.exec(markdown.slice(start))?.[0].length ?? 0
+              destinations.push({ start: start + prefix, end: start + prefix + value.length, value, image: true, html: true })
+            }
+            skipUntil = offset + index + tag[0].length
+            index += tag[0].length
+            continue
+          }
+        }
+        if (line[index] === '`') {
+          const ticks = /^`+/.exec(line.slice(index))?.[0] ?? '`'
+          const end = line.indexOf(ticks, index + ticks.length)
+          index = end < 0 ? index + ticks.length : end + ticks.length
+          continue
+        }
+        const bracket =
+          line[index] === '['
+            ? index
+            : line[index] === '!' && line[index + 1] === '['
+              ? index + 1
+              : -1
+        if (bracket < 0) {
+          index++
+          continue
+        }
+        const close = findClosingBracket(line, bracket + 1)
+        if (close < 0) break
+        let open = close + 1
+        while (open < line.length && /\s/.test(line[open])) open++
+        if (line[open] === '(') {
+          const destination = readDestination(line, open + 1, line.length)
+          if (destination) {
+            destinations.push({
+              ...destination,
+              image: line[index] === '!',
+              start: offset + destination.start,
+              end: offset + destination.end
+            })
+          }
+        } else if (line[index] === '!') {
+          const reference = /^\[([^\]]*)\]/.exec(line.slice(open))
+          imageReferences.add(normalizeLabel(reference?.[1] || line.slice(bracket + 1, close)))
+        }
+        index = close + 1
+      }
+    }
+    offset += lineWithEnding.length
+  }
+  for (const destination of destinations) {
+    const label = definitions.get(destination.start)
+    if (label && imageReferences.has(label)) destination.image = true
+  }
+  return destinations.filter(
+    (item, index, all) => all.findIndex((other) => other.start === item.start) === index
+  )
+}
+
+const rewriteDestinations = async(
+  markdown: string,
+  rewrite: (value: string, destination: MarkdownDestination) => Promise<string | null>
+): Promise<string> => {
+  const replacements: Array<MarkdownDestination & { replacement: string }> = []
+  for (const destination of findMarkdownDestinations(markdown)) {
+    const replacement = await rewrite(destination.value, destination)
+    if (replacement && replacement !== destination.value) { replacements.push({ ...destination, replacement }) }
+  }
+  for (const item of replacements.sort((a, b) => b.start - a.start)) {
+    markdown = markdown.slice(0, item.start) + item.replacement + markdown.slice(item.end)
+  }
+  return markdown
+}
+
+const isExternalDestination = (value: string): boolean =>
+  !value || value.startsWith('#') || /^[a-z][a-z\d+.-]*:/i.test(value) || value.startsWith('//')
+
+const packageLocalResources = async(
+  markdown: string,
+  sourceDirectory: string | undefined,
+  workspacePath: string
+): Promise<string> => {
+  const copied = new Map<string, string>()
+  const usedNames = new Set((await fsPromises.readdir(path.join(workspacePath, 'assets'))).map((name) => name.toLowerCase()))
+  const missing: string[] = []
+  const rewritten = await rewriteDestinations(markdown, async(rawValue, destination) => {
+    const value = destination.html
+      ? rawValue.replace(/&(?:amp|quot|apos|lt|gt|#\d+|#x[\da-f]+);/gi, (entity) => {
+        const named: Record<string, string> = { '&amp;': '&', '&quot;': '"', '&apos;': "'", '&lt;': '<', '&gt;': '>' }
+        if (named[entity.toLowerCase()]) return named[entity.toLowerCase()]
+        const code = entity.toLowerCase().startsWith('&#x') ? parseInt(entity.slice(3, -1), 16) : parseInt(entity.slice(2, -1), 10)
+        return code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : entity
+      })
+      : rawValue.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~\\])/g, '$1')
+    if (destination.image && /^data:/i.test(value)) {
+      const match = /^data:image\/(png|jpe?g|gif|webp|svg\+xml|bmp|avif|x-icon);base64,([\s\S]+)$/i.exec(value)
+      if (!match) throw new Error('Unsupported or invalid embedded image data URL.')
+      const encoded = match[2].replace(/\s/g, '')
+      if (encoded.length > Math.ceil(TEXTPACK_LIMITS.entryBytes / 3) * 4) throw new Error('Embedded image exceeds the TextPack resource size limit.')
+      if (!/^[A-Za-z0-9+/]+={0,2}$/.test(encoded) || encoded.length % 4 === 1) throw new Error('Invalid Base64 image data.')
+      const bytes = Buffer.from(encoded, 'base64')
+      if (!bytes.length || bytes.toString('base64').replace(/=+$/, '') !== encoded.replace(/=+$/, '')) throw new Error('Invalid Base64 image data.')
+      const ext = ({ jpeg: 'jpg', 'svg+xml': 'svg', 'x-icon': 'ico' } as Record<string, string>)[match[1].toLowerCase()] ?? match[1].toLowerCase()
+      const name = `${createHash('sha256').update(bytes).digest('hex')}.${ext}`
+      const target = path.join(workspacePath, 'assets', name)
+      if (usedNames.has(name.toLowerCase())) {
+        const existing = await fsPromises.readFile(target)
+        if (!existing.equals(bytes)) throw new Error('Embedded image resource name collision.')
+      } else {
+        await fsPromises.writeFile(target, bytes, { flag: 'wx' })
+        usedNames.add(name.toLowerCase())
+      }
+      return `assets/${name}`
+    }
+    // Never turn a normal save into a network request (including //host URLs).
+    if (/^https?:\/\//i.test(value) || value.startsWith('//')) return null
+    const absoluteImage = destination.image && (path.isAbsolute(value) || /^file:/i.test(value))
+    if (!absoluteImage && isExternalDestination(value)) return null
+    let decoded: string
+    try {
+      decoded = /^file:/i.test(value) ? fileURLToPath(value) : decodeURIComponent(value.split(/[?#]/)[0])
+    } catch {
+      throw new Error('Invalid local resource path in TextPack conversion.')
+    }
+    if (path.isAbsolute(decoded) && !destination.image) return null
+    if (!path.isAbsolute(decoded) && !sourceDirectory) throw new Error('Cannot resolve a relative resource in an untitled document. Save the Markdown beside its resources first.')
+    const source = path.isAbsolute(decoded) ? path.resolve(decoded) : path.resolve(sourceDirectory as string, decoded)
+    const sourceKey = process.platform === 'win32' ? source.toLowerCase() : source
+    const suffixMatch = /^file:/i.test(value) ? new URL(value).hash : value.match(/[?#].*$/)?.[0] ?? ''
+    const known = copied.get(sourceKey)
+    if (known) return known + suffixMatch
+    let filename = [...path.basename(source)]
+      .map((char) => (char.charCodeAt(0) < 32 || /[<>:"/\\|?*\s]/.test(char) ? '-' : char))
+      .join('')
+    if (!filename) filename = 'resource'
+    const extension = path.extname(filename)
+    const stem = path.basename(filename, extension)
+    let suffix = 2
+    while (usedNames.has(filename.toLowerCase())) filename = `${stem}-${suffix++}${extension}`
+    try {
+      const stat = await fsPromises.stat(source)
+      if (!stat.isFile() || stat.size > TEXTPACK_LIMITS.entryBytes) throw new Error('Invalid or oversized resource')
+      await fsPromises.copyFile(source, path.join(workspacePath, 'assets', filename))
+    } catch {
+      missing.push(value)
+      return null
+    }
+    const packaged = `assets/${filename}`
+    copied.set(sourceKey, packaged)
+    usedNames.add(filename.toLowerCase())
+    return packaged + suffixMatch
+  })
+  if (missing.length) {
+    throw new Error(
+      `Cannot create TextPack because local resources are missing: ${missing.join(', ')}`
+    )
+  }
+  return rewritten
+}
+
+const sessionKey = (pathname: string): string => {
+  const resolved = path.resolve(pathname)
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+}
+
+const manifestPath = (workspacePath: string): string =>
+  path.join(path.dirname(workspacePath), 'manifest.json')
+
+const writeManifest = async(session: TextPackSession): Promise<void> => {
+  const manifest: TextPackManifest = {
+    version: 1,
+    physicalPath: session.physicalPath,
+    textEntryName: session.textEntryName,
+    sourceRevision: session.sourceRevision,
+    pid: process.pid,
+    dirtyResources: session.dirtyResources,
+    updatedAt: new Date().toISOString()
+  }
+  await fsPromises.writeFile(
+    manifestPath(session.workspacePath),
+    JSON.stringify(manifest, null, 2),
+    'utf8'
+  )
+}
+
+const isProcessRunning = (pid: number): boolean => {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const findRecoverySession = async(physicalPath: string): Promise<TextPackSession | null> => {
+  const directories = await fsPromises
+    .readdir(SESSION_ROOT, { withFileTypes: true })
+    .catch(() => [])
+  for (const directory of directories) {
+    if (!directory.isDirectory()) continue
+    const workspacePath = path.join(SESSION_ROOT, directory.name, 'content')
+    try {
+      const manifest = JSON.parse(
+        await fsPromises.readFile(manifestPath(workspacePath), 'utf8')
+      ) as Partial<TextPackManifest>
+      if (
+        manifest.version !== 1 ||
+        typeof manifest.physicalPath !== 'string' ||
+        sessionKey(manifest.physicalPath) !== sessionKey(physicalPath) ||
+        typeof manifest.textEntryName !== 'string' ||
+        isProcessRunning(Number(manifest.pid))
+      ) { continue }
+      validateTextPackEntryName(manifest.textEntryName)
+      await fsPromises.access(path.join(workspacePath, manifest.textEntryName))
+      const session: TextPackSession = {
+        physicalPath: path.resolve(physicalPath),
+        workspacePath,
+        textEntryName: manifest.textEntryName,
+        sourceRevision: manifest.sourceRevision ?? null,
+        references: 1,
+        dirtyResources: !!manifest.dirtyResources
+      }
+      await writeManifest(session)
+      return session
+    } catch {
+      // Ignore incomplete or corrupt recovery candidates.
+    }
+  }
+  return null
+}
+
+const openZip = (pathname: string): Promise<ZipFile> =>
+  new Promise((resolve, reject) => {
+    yauzl.open(
+      pathname,
+      { lazyEntries: true, autoClose: false, decodeStrings: true, strictFileNames: true },
+      (error, zipfile) =>
+        error || !zipfile ? reject(error ?? new Error('Invalid ZIP archive.')) : resolve(zipfile)
+    )
+  })
+
+const openEntryStream = (zipfile: ZipFile, entry: Entry): Promise<NodeJS.ReadableStream> =>
+  new Promise((resolve, reject) => {
+    zipfile.openReadStream(entry, (error, stream) =>
+      error || !stream ? reject(error ?? new Error('Unable to read ZIP entry.')) : resolve(stream)
+    )
+  })
+
+export const validateTextPackEntryName = (name: string): string => {
+  if (
+    !name ||
+    name.includes('\0') ||
+    name.includes('\\') ||
+    name.startsWith('/') ||
+    /^[a-z]:/i.test(name)
+  ) {
+    throw new Error(`Unsafe TextPack entry path: ${JSON.stringify(name)}.`)
+  }
+  const isDirectory = name.endsWith('/')
+  const parts = name
+    .split('/')
+    .filter((part, index, all) => (!(isDirectory && index === all.length - 1)))
+  const invalidPart = (part: string): boolean =>
+    !part ||
+    part === '.' ||
+    part === '..' ||
+    WINDOWS_DEVICE_NAME.test(part) ||
+    /[<>:"|?*]/.test(part) ||
+    /[ .]$/.test(part)
+  if (!parts.length || parts.some(invalidPart)) {
+    throw new Error(`Unsafe TextPack entry path: ${JSON.stringify(name)}.`)
+  }
+  return parts.join('/') + (isDirectory ? '/' : '')
+}
+
+const isSymbolicLinkEntry = (entry: Entry): boolean => {
+  const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff
+  return (unixMode & 0xf000) === 0xa000
+}
+
+const extractArchive = async(archivePath: string, workspacePath: string): Promise<string> => {
+  const zipfile = await openZip(archivePath)
+  const names = new Set<string>()
+  const rootTextEntries: string[] = []
+  let infoEntry = ''
+  let entryCount = 0
+  let totalBytes = 0
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const fail = (error: unknown): void => {
+        zipfile.close()
+        reject(error)
+      }
+      zipfile.once('error', fail)
+      zipfile.once('end', resolve)
+      zipfile.on('entry', (entry: Entry) => {
+        ;(async() => {
+          const name = validateTextPackEntryName(entry.fileName)
+          const foldedName = name.normalize('NFC').toLocaleLowerCase('en-US')
+          if (names.has(foldedName)) throw new Error(`Duplicate TextPack entry: ${name}.`)
+          names.add(foldedName)
+          if (++entryCount > TEXTPACK_LIMITS.entries) { throw new Error('TextPack entry limit exceeded.') }
+          if ((entry.generalPurposeBitFlag & 1) !== 0) { throw new Error(`Encrypted TextPack entries are not supported: ${name}.`) }
+          if (isSymbolicLinkEntry(entry)) { throw new Error(`TextPack links are not supported: ${name}.`) }
+          if (entry.uncompressedSize > TEXTPACK_LIMITS.entryBytes) { throw new Error(`TextPack entry is too large: ${name}.`) }
+          totalBytes += entry.uncompressedSize
+          if (totalBytes > TEXTPACK_LIMITS.totalBytes) { throw new Error('TextPack expanded-size limit exceeded.') }
+          if (
+            entry.compressedSize > 0 &&
+            entry.uncompressedSize / entry.compressedSize > TEXTPACK_LIMITS.compressionRatio
+          ) {
+            throw new Error(`Suspicious TextPack compression ratio: ${name}.`)
+          }
+          if (name.toLowerCase() === 'info.json') {
+            if (entry.uncompressedSize > TEXTPACK_LIMITS.infoBytes) { throw new Error('TextPack info.json is too large.') }
+            infoEntry = name
+          } else if (!name.includes('/') && /^text\.[^./]+$/i.test(name)) {
+            if (entry.uncompressedSize > TEXTPACK_LIMITS.textBytes) { throw new Error('TextPack document text is too large.') }
+            rootTextEntries.push(name)
+          }
+
+          const destination = path.resolve(workspacePath, ...name.replace(/\/$/, '').split('/'))
+          const relative = path.relative(workspacePath, destination)
+          if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+            throw new Error(`TextPack entry escapes its workspace: ${name}.`)
+          }
+          if (name.endsWith('/')) {
+            await fsPromises.mkdir(destination, { recursive: true })
+          } else {
+            await fsPromises.mkdir(path.dirname(destination), { recursive: true })
+            const source = await openEntryStream(zipfile, entry)
+            await pipeline(source, fs.createWriteStream(destination, { flags: 'wx' }))
+          }
+          zipfile.readEntry()
+        })().catch(fail)
+      })
+      zipfile.readEntry()
+    })
+  } finally {
+    zipfile.close()
+  }
+
+  if (!infoEntry || infoEntry !== 'info.json') { throw new Error('TextPack must contain lowercase info.json at its root.') }
+  if (rootTextEntries.length !== 1) { throw new Error('TextPack must contain exactly one text.* file at its root.') }
+
+  const metadataText = await fsPromises.readFile(path.join(workspacePath, infoEntry), 'utf8')
+  let metadata: unknown
+  try {
+    metadata = JSON.parse(metadataText.replace(/^\uFEFF/, ''))
+  } catch {
+    throw new Error('TextPack info.json is not valid JSON.')
+  }
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) { throw new Error('TextPack info.json must contain an object.') }
+  const info = metadata as Record<string, unknown>
+  if (info.version !== 1 && info.version !== 2) { throw new Error(`Unsupported TextPack version: ${String(info.version)}.`) }
+  if (info.type !== undefined && info.type !== MARKDOWN_TYPE) { throw new Error(`Unsupported TextPack document type: ${String(info.type)}.`) }
+
+  const textBytes = await fsPromises.readFile(path.join(workspacePath, rootTextEntries[0]))
+  new TextDecoder('utf-8', { fatal: true }).decode(textBytes)
+  return rootTextEntries[0]
+}
+
+const removeWorkspace = async(workspacePath: string): Promise<void> => {
+  const relative = path.relative(SESSION_ROOT, workspacePath)
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return
+  await fsPromises.rm(path.dirname(workspacePath), { recursive: true, force: true })
+}
+
+const retireWorkspace = async(workspacePath: string): Promise<void> => {
+  // Stop this superseded workspace from becoming a recovery candidate immediately,
+  // but leave its assets alive briefly while the renderer switches resource roots.
+  await fsPromises.rm(manifestPath(workspacePath), { force: true })
+  const timer = setTimeout(() => {
+    removeWorkspace(workspacePath).catch(() => undefined)
+  }, 10_000)
+  timer.unref()
+}
+
+const revisionsMatch = (
+  left: { size: number; mtimeMs: number } | null,
+  right: { size: number; mtimeMs: number } | null
+): boolean => !!left && !!right && left.size === right.size && left.mtimeMs === right.mtimeMs
+
+const discardPendingReloads = async(key: string, exceptToken?: string): Promise<void> => {
+  const removals: Promise<void>[] = []
+  for (const [token, candidate] of pendingReloads) {
+    if (candidate.key === key && token !== exceptToken) {
+      pendingReloads.delete(token)
+      removals.push(removeWorkspace(candidate.workspacePath))
+    }
+  }
+  await Promise.all(removals)
+}
+
+export const prepareTextPackReload = async(
+  pathname: string,
+  preferredEol: LineEnding,
+  trimTrailingNewline = 2,
+  autoNormalizeLineEndings = false
+): Promise<MarkdownDocument> => {
+  const physicalPath = path.resolve(pathname)
+  const key = sessionKey(physicalPath)
+  const activeSession = sessions.get(key)
+  if (!activeSession) {
+    return loadTextPackFile(
+      physicalPath,
+      preferredEol,
+      false,
+      trimTrailingNewline,
+      autoNormalizeLineEndings,
+      false
+    )
+  }
+
+  await discardPendingReloads(key)
+  const workspacePath = path.join(SESSION_ROOT, randomUUID(), 'content')
+  await fsPromises.mkdir(workspacePath, { recursive: true })
+  try {
+    const before = await fsPromises.stat(physicalPath)
+    const textEntryName = await extractArchive(physicalPath, workspacePath)
+    const after = await fsPromises.stat(physicalPath)
+    const sourceRevision = { size: after.size, mtimeMs: after.mtimeMs }
+    if (!revisionsMatch({ size: before.size, mtimeMs: before.mtimeMs }, sourceRevision)) {
+      throw new Error('The TextPack changed again while MarkText was reading it.')
+    }
+    const doc = await loadMarkdownFile(
+      path.join(workspacePath, textEntryName),
+      preferredEol,
+      false,
+      trimTrailingNewline,
+      autoNormalizeLineEndings
+    )
+    const token = randomUUID()
+    pendingReloads.set(token, {
+      token,
+      key,
+      physicalPath,
+      workspacePath,
+      textEntryName,
+      sourceRevision,
+      baseWorkspacePath: activeSession.workspacePath
+    })
+    return {
+      ...doc,
+      filename: path.basename(physicalPath),
+      pathname: physicalPath,
+      encoding: { encoding: 'utf8', isBom: false },
+      documentKind: 'textpack',
+      resourcePath: workspacePath,
+      reloadToken: token
+    }
+  } catch (error) {
+    await removeWorkspace(workspacePath)
+    throw error
+  }
+}
+
+export const resolveTextPackReload = async(
+  pathname: string,
+  token: string,
+  accept: boolean
+): Promise<{ accepted: boolean; resourcePath?: string }> => {
+  const key = sessionKey(pathname)
+  const candidate = pendingReloads.get(token)
+  if (!candidate || candidate.key !== key) {
+    throw new Error('The pending TextPack reload is no longer available.')
+  }
+  pendingReloads.delete(token)
+  if (!accept) {
+    await removeWorkspace(candidate.workspacePath)
+    return { accepted: false }
+  }
+
+  const activeSession = sessions.get(key)
+  if (!activeSession) {
+    await removeWorkspace(candidate.workspacePath)
+    throw new Error('The TextPack session is no longer available.')
+  }
+  if (activeSession.workspacePath !== candidate.baseWorkspacePath) {
+    if (revisionsMatch(activeSession.sourceRevision, candidate.sourceRevision)) {
+      await removeWorkspace(candidate.workspacePath)
+      return { accepted: true, resourcePath: activeSession.workspacePath }
+    }
+    await removeWorkspace(candidate.workspacePath)
+    throw new Error('A newer TextPack version has already been loaded.')
+  }
+
+  const currentStat = await fsPromises.stat(candidate.physicalPath)
+  if (
+    !revisionsMatch(
+      { size: currentStat.size, mtimeMs: currentStat.mtimeMs },
+      candidate.sourceRevision
+    )
+  ) {
+    await removeWorkspace(candidate.workspacePath)
+    throw new Error('The TextPack changed again before it could be reloaded.')
+  }
+
+  const replacement: TextPackSession = {
+    physicalPath: candidate.physicalPath,
+    workspacePath: candidate.workspacePath,
+    textEntryName: candidate.textEntryName,
+    sourceRevision: candidate.sourceRevision,
+    references: activeSession.references,
+    dirtyResources: false
+  }
+  sessions.set(key, replacement)
+  await writeManifest(replacement)
+  await retireWorkspace(activeSession.workspacePath)
+  await discardPendingReloads(key)
+  return { accepted: true, resourcePath: replacement.workspacePath }
+}
+
+export const loadTextPackFile = async(
+  pathname: string,
+  preferredEol: LineEnding,
+  _autoGuessEncoding = true,
+  trimTrailingNewline = 2,
+  autoNormalizeLineEndings = false,
+  establishSession = true
+): Promise<MarkdownDocument> => {
+  const physicalPath = path.resolve(pathname)
+  const activeSession = sessions.get(sessionKey(physicalPath))
+  if (establishSession && activeSession) {
+    activeSession.references++
+    const doc = await loadMarkdownFile(
+      path.join(activeSession.workspacePath, activeSession.textEntryName),
+      preferredEol,
+      false,
+      trimTrailingNewline,
+      autoNormalizeLineEndings
+    )
+    return {
+      ...doc,
+      filename: path.basename(physicalPath),
+      pathname: physicalPath,
+      encoding: { encoding: 'utf8', isBom: false },
+      documentKind: 'textpack',
+      resourcePath: activeSession.workspacePath
+    }
+  }
+  if (establishSession) {
+    const recovered = await findRecoverySession(physicalPath)
+    if (recovered) {
+      sessions.set(sessionKey(physicalPath), recovered)
+      const doc = await loadMarkdownFile(
+        path.join(recovered.workspacePath, recovered.textEntryName),
+        preferredEol,
+        false,
+        trimTrailingNewline,
+        autoNormalizeLineEndings
+      )
+      return {
+        ...doc,
+        filename: path.basename(physicalPath),
+        pathname: physicalPath,
+        encoding: { encoding: 'utf8', isBom: false },
+        documentKind: 'textpack',
+        resourcePath: recovered.workspacePath
+      }
+    }
+  }
+  const workspacePath = path.join(SESSION_ROOT, randomUUID(), 'content')
+  await fsPromises.mkdir(workspacePath, { recursive: true })
+  let textEntryName: string
+  try {
+    textEntryName = await extractArchive(physicalPath, workspacePath)
+  } catch (error) {
+    await removeWorkspace(workspacePath)
+    throw error
+  }
+  const previous = sessions.get(sessionKey(physicalPath))
+  try {
+    const doc = await loadMarkdownFile(
+      path.join(workspacePath, textEntryName),
+      preferredEol,
+      false,
+      trimTrailingNewline,
+      autoNormalizeLineEndings
+    )
+    if (establishSession) {
+      const stat = await fsPromises.stat(physicalPath)
+      const session: TextPackSession = {
+        physicalPath,
+        workspacePath,
+        textEntryName,
+        sourceRevision: { size: stat.size, mtimeMs: stat.mtimeMs },
+        references: 1,
+        dirtyResources: false
+      }
+      sessions.set(sessionKey(physicalPath), session)
+      await writeManifest(session)
+      if (previous) await removeWorkspace(previous.workspacePath)
+    }
+    return {
+      ...doc,
+      filename: path.basename(physicalPath),
+      pathname: physicalPath,
+      encoding: { encoding: 'utf8', isBom: false },
+      documentKind: 'textpack',
+      resourcePath: establishSession ? workspacePath : (previous?.workspacePath ?? '')
+    }
+  } finally {
+    if (!establishSession) await removeWorkspace(workspacePath)
+  }
+}
+
+const listWorkspaceFiles = async(root: string, current = root): Promise<string[]> => {
+  const files: string[] = []
+  for (const item of await fsPromises.readdir(current, { withFileTypes: true })) {
+    const absolute = path.join(current, item.name)
+    if (item.isSymbolicLink()) throw new Error(`TextPack workspace contains a link: ${item.name}.`)
+    if (item.isDirectory()) files.push(...(await listWorkspaceFiles(root, absolute)))
+    else if (item.isFile()) files.push(path.relative(root, absolute).split(path.sep).join('/'))
+  }
+  return files.sort()
+}
+
+const buildArchive = async(workspacePath: string, outputPath: string): Promise<void> => {
+  const zipfile = new yazl.ZipFile()
+  for (const relative of await listWorkspaceFiles(workspacePath)) {
+    zipfile.addFile(path.join(workspacePath, ...relative.split('/')), relative, { compress: true })
+  }
+  const output = fs.createWriteStream(outputPath, { flags: 'wx' })
+  zipfile.end()
+  await pipeline(zipfile.outputStream, output)
+  const handle = await fsPromises.open(outputPath, 'r+')
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+const createTextPackSession = async(targetPath: string): Promise<TextPackSession> => {
+  const workspacePath = path.join(SESSION_ROOT, randomUUID(), 'content')
+  await fsPromises.mkdir(path.join(workspacePath, 'assets'), { recursive: true })
+  await fsPromises.writeFile(
+    path.join(workspacePath, 'info.json'),
+    JSON.stringify(
+      {
+        version: 2,
+        type: MARKDOWN_TYPE,
+        transient: false,
+        creatorIdentifier: 'com.github.marktext.marktext'
+      },
+      null,
+      2
+    ) + '\n',
+    'utf8'
+  )
+  return {
+    physicalPath: path.resolve(targetPath),
+    workspacePath,
+    textEntryName: 'text.md',
+    sourceRevision: null,
+    references: 1,
+    dirtyResources: false
+  }
+}
+
+const replaceArchive = async(tempPath: string, targetPath: string): Promise<void> => {
+  await fsPromises.rename(tempPath, targetPath)
+}
+
+const queueSave = (key: string, task: () => Promise<void>): Promise<void> => {
+  const pending = (saveQueues.get(key) ?? Promise.resolve()).catch(() => undefined).then(task)
+  saveQueues.set(key, pending)
+  return pending.finally(() => {
+    if (saveQueues.get(key) === pending) saveQueues.delete(key)
+  })
+}
+
+export const writeTextPackFile = async(
+  targetPath: string,
+  markdown: string,
+  _options: SaveOptions,
+  sourcePath?: string,
+  conversionOptions: TextPackConversionOptions = DEFAULT_CONVERSION_OPTIONS
+): Promise<{ documentKind: 'textpack'; resourcePath: string; markdown: string }> => {
+  if (conversionOptions.remoteImages !== 'preserve') {
+    throw new Error('TextPack remote image embedding is not implemented. Use the preserve policy.')
+  }
+  const resolvedTarget = path.resolve(targetPath)
+  const targetKey = sessionKey(resolvedTarget)
+  const sourceKey = sourcePath ? sessionKey(sourcePath) : targetKey
+  let session = sessions.get(sourceKey)
+  let savedMarkdown = markdown
+  if (!session) {
+    session = await createTextPackSession(resolvedTarget)
+    try {
+      if (!sourcePath || !sourcePath.toLowerCase().endsWith('.textpack')) {
+        savedMarkdown = await packageLocalResources(
+          markdown,
+          sourcePath ? path.dirname(sourcePath) : undefined,
+          session.workspacePath
+        )
+      }
+    } catch (error) {
+      await removeWorkspace(session.workspacePath)
+      throw error
+    }
+  }
+
+  await queueSave(targetKey, async() => {
+    if (sourceKey === targetKey && session!.sourceRevision) {
+      const stat = await fsPromises.stat(resolvedTarget)
+      if (
+        stat.size !== session!.sourceRevision.size ||
+        stat.mtimeMs !== session!.sourceRevision.mtimeMs
+      ) {
+        throw new Error(
+          'The TextPack changed on disk. Reload it or use Save As to keep both versions.'
+        )
+      }
+    }
+    await fsPromises.writeFile(
+      path.join(session!.workspacePath, session!.textEntryName),
+      savedMarkdown,
+      'utf8'
+    )
+    const tempPath = path.join(
+      path.dirname(resolvedTarget),
+      `.${path.basename(resolvedTarget)}.${randomUUID()}.tmp`
+    )
+    try {
+      await buildArchive(session!.workspacePath, tempPath)
+      const validationPath = path.join(SESSION_ROOT, randomUUID(), 'content')
+      await fsPromises.mkdir(validationPath, { recursive: true })
+      try {
+        await extractArchive(tempPath, validationPath)
+      } finally {
+        await removeWorkspace(validationPath)
+      }
+      await replaceArchive(tempPath, resolvedTarget)
+      const stat = await fsPromises.stat(resolvedTarget)
+      session!.sourceRevision = { size: stat.size, mtimeMs: stat.mtimeMs }
+      session!.dirtyResources = false
+      await writeManifest(session!)
+    } finally {
+      await fsPromises.rm(tempPath, { force: true })
+    }
+  })
+
+  if (sourceKey !== targetKey) sessions.delete(sourceKey)
+  session.physicalPath = resolvedTarget
+  sessions.set(targetKey, session)
+  await writeManifest(session)
+  return { documentKind: 'textpack', resourcePath: session.workspacePath, markdown: savedMarkdown }
+}
+
+export const exportTextPackToMarkdown = async(
+  sourcePath: string,
+  targetPath: string,
+  markdown: string,
+  options: SaveOptions
+): Promise<{ documentKind: 'markdown'; resourcePath: string; markdown: string }> => {
+  const session = sessions.get(sessionKey(sourcePath))
+  if (!session) {
+    throw new Error(
+      'The TextPack session is no longer available. Reopen the document and try again.'
+    )
+  }
+  const targetDirectory = path.dirname(targetPath)
+  const assetFolderName = `${path.basename(targetPath, path.extname(targetPath))}.assets`
+  const targetAssets = path.join(targetDirectory, assetFolderName)
+  const sourceAssets = path.join(session.workspacePath, 'assets')
+  let exportedAssets = false
+  try {
+    const sourceStat = await fsPromises.stat(sourceAssets).catch(() => null)
+    if (sourceStat?.isDirectory()) {
+      try {
+        await fsPromises.access(targetAssets)
+        throw new Error(`The resource folder already exists: ${targetAssets}`)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+      await fsPromises.cp(sourceAssets, targetAssets, { recursive: true, errorOnExist: true })
+      exportedAssets = true
+    }
+    const exportedMarkdown = await rewriteDestinations(markdown, async(value) => {
+      const normalized = value.replace(/\\/g, '/')
+      return normalized.startsWith('assets/') ? `${assetFolderName}/${normalized.slice(7)}` : null
+    })
+    await writeMarkdownFile(
+      targetPath,
+      exportedMarkdown,
+      options as Parameters<typeof writeMarkdownFile>[2]
+    )
+    return { documentKind: 'markdown', resourcePath: targetDirectory, markdown: exportedMarkdown }
+  } catch (error) {
+    if (exportedAssets) await fsPromises.rm(targetAssets, { recursive: true, force: true })
+    throw error
+  }
+}
+
+export const closeTextPackSession = async(pathname: string): Promise<void> => {
+  const key = sessionKey(pathname)
+  const session = sessions.get(key)
+  if (!session) {
+    await discardPendingReloads(key)
+    return
+  }
+  session.references--
+  if (session.references > 0) return
+  sessions.delete(key)
+  await discardPendingReloads(key)
+  await removeWorkspace(session.workspacePath)
+}
+
+export const moveTextPackSession = (oldPathname: string, newPathname: string): void => {
+  const oldKey = sessionKey(oldPathname)
+  const session = sessions.get(oldKey)
+  if (!session) return
+  sessions.delete(oldKey)
+  session.physicalPath = path.resolve(newPathname)
+  sessions.set(sessionKey(newPathname), session)
+  writeManifest(session).catch(() => undefined)
+}
+
+export const markTextPackResourcesDirty = (pathname: string): void => {
+  const session = sessions.get(sessionKey(pathname))
+  if (!session) return
+  session.dirtyResources = true
+  writeManifest(session).catch(() => undefined)
+}
+
+export const cleanupStaleTextPackSessions = async(
+  now = Date.now(),
+  cleanMaxAgeMs = 7 * 24 * 60 * 60 * 1000
+): Promise<void> => {
+  const directories = await fsPromises
+    .readdir(SESSION_ROOT, { withFileTypes: true })
+    .catch(() => [])
+  for (const directory of directories) {
+    if (!directory.isDirectory()) continue
+    const sessionPath = path.join(SESSION_ROOT, directory.name)
+    try {
+      const workspacePath = path.join(sessionPath, 'content')
+      const manifest = JSON.parse(
+        await fsPromises.readFile(manifestPath(workspacePath), 'utf8')
+      ) as Partial<TextPackManifest>
+      const updatedAt = Date.parse(String(manifest.updatedAt))
+      if (
+        manifest.version === 1 &&
+        !manifest.dirtyResources &&
+        !isProcessRunning(Number(manifest.pid)) &&
+        Number.isFinite(updatedAt) &&
+        now - updatedAt > cleanMaxAgeMs
+      ) {
+        await fsPromises.rm(sessionPath, { recursive: true, force: true })
+      }
+    } catch {
+      const stat = await fsPromises.stat(sessionPath).catch(() => null)
+      if (stat && now - stat.mtimeMs > cleanMaxAgeMs) {
+        await fsPromises.rm(sessionPath, { recursive: true, force: true })
+      }
+    }
+  }
+}

--- a/packages/desktop/src/main/filesystem/watcher.ts
+++ b/packages/desktop/src/main/filesystem/watcher.ts
@@ -3,9 +3,9 @@ import fsPromises from 'fs/promises'
 import log from 'electron-log'
 import chokidar, { type FSWatcher } from 'chokidar'
 import { exists } from 'common/filesystem'
-import { hasMarkdownExtension, checkPathExcludePattern } from 'common/filesystem/paths'
+import { hasDocumentExtension, checkPathExcludePattern } from 'common/filesystem/paths'
 import { getUniqueId } from '../utils'
-import { loadMarkdownFile } from '../filesystem/markdown'
+import { inspectDocumentFile } from '../filesystem/document'
 import { isLinux, isOsx } from '../config'
 import type { BrowserWindow } from 'electron'
 import type { LineEnding } from '@shared/types/files'
@@ -53,7 +53,7 @@ const add = async(
   const stats = await fsPromises.stat(pathname)
   const birthTime = stats.birthtime
   const mtimeMs = stats.mtimeMs
-  const isMarkdown = hasMarkdownExtension(pathname)
+  const isMarkdown = hasDocumentExtension(pathname)
   const file: {
     pathname: string
     name: string
@@ -62,7 +62,7 @@ const add = async(
     birthTime: Date
     mtimeMs: number
     isMarkdown: boolean
-    data?: Awaited<ReturnType<typeof loadMarkdownFile>>
+    data?: Awaited<ReturnType<typeof inspectDocumentFile>>
   } = {
     pathname,
     name: path.basename(pathname),
@@ -75,7 +75,7 @@ const add = async(
   if (isMarkdown) {
     // HACK: But this should be removed completely in #1034/#1035.
     try {
-      const data = await loadMarkdownFile(
+      const data = await inspectDocumentFile(
         pathname,
         endOfLine,
         autoGuessEncoding,
@@ -132,11 +132,18 @@ const change = async(
     return
   }
 
-  const isMarkdown = hasMarkdownExtension(pathname)
+  const isMarkdown = hasDocumentExtension(pathname)
   if (isMarkdown) {
     try {
       const [data, stats] = await Promise.all([
-        loadMarkdownFile(pathname, endOfLine, autoGuessEncoding, trimTrailingNewline, autoNormalizeLineEndings),
+        inspectDocumentFile(
+          pathname,
+          endOfLine,
+          autoGuessEncoding,
+          trimTrailingNewline,
+          autoNormalizeLineEndings,
+          true
+        ),
         fsPromises.stat(pathname)
       ])
       const file = { pathname, data, mtimeMs: stats.mtimeMs }
@@ -225,7 +232,7 @@ class Watcher {
         if (fileInfo.isDirectory()) {
           return false
         }
-        return !hasMarkdownExtension(pathname)
+        return !hasDocumentExtension(pathname)
       },
       ignoreInitial: type === 'file',
       persistent: true,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import Accessor from './app/accessor'
 import App from './app'
 import { t } from './i18n'
 import { registerSandboxIpcHandlers } from './ipc'
+import { cleanupStaleTextPackSessions } from './filesystem/textpack'
 
 // Set version strings into global and process.versions
 process.env.MARKTEXT_VERSION = MARKTEXT_VERSION
@@ -113,6 +114,9 @@ try {
 }
 const appController = new App(accessor, args as unknown as { _: string[] })
 appController.init()
+cleanupStaleTextPackSessions().catch((error) =>
+  log.warn('Unable to clean TextPack sessions:', error)
+)
 
 // Quit when all windows are closed (except on macOS)
 app.on('window-all-closed', () => {

--- a/packages/desktop/src/main/menu/actions/file.ts
+++ b/packages/desktop/src/main/menu/actions/file.ts
@@ -11,14 +11,20 @@ import {
 } from 'electron'
 import log from 'electron-log'
 import { isDirectory, isFile, exists } from 'common/filesystem'
-import { MARKDOWN_EXTENSIONS, isDangerousExecutableFile, isMarkdownFile } from 'common/filesystem/paths'
+import {
+  DOCUMENT_EXTENSIONS,
+  MARKDOWN_EXTENSIONS,
+  isDangerousExecutableFile,
+  isDocumentFile
+} from 'common/filesystem/paths'
 import { checkUpdates, userSetting } from './marktext'
 import { showTabBar } from './view'
 import { COMMANDS } from '../../commands'
 import type { CommandManager } from '../../commands'
 import { EXTENSION_HASN, PANDOC_EXTENSIONS, URL_REG } from '../../config'
 import { normalizeAndResolvePath, writeFile } from '../../filesystem'
-import { writeMarkdownFile } from '../../filesystem/markdown'
+import { writeDocumentFile } from '../../filesystem/document'
+import { moveTextPackSession } from '../../filesystem/textpack'
 import { getPath, getRecommendTitleFromMarkdownString } from '../../utils'
 import pandoc from '../../utils/pandoc'
 import { t } from '../../i18n'
@@ -181,7 +187,11 @@ const handleResponseForSave = async(
 
   if (!filePath) {
     const { filePath: dialogPath, canceled } = await dialog.showSaveDialog(win, {
-      defaultPath: path.join(defaultPath || getPath('documents'), `${recommendFilename}.md`)
+      defaultPath: path.join(defaultPath || getPath('documents'), `${recommendFilename}.md`),
+      filters: [
+        { name: 'Markdown document', extensions: [...MARKDOWN_EXTENSIONS] },
+        { name: 'TextPack document', extensions: ['textpack'] }
+      ]
     })
 
     if (dialogPath && !canceled) {
@@ -199,18 +209,20 @@ const handleResponseForSave = async(
   filePath = !filePath.endsWith(extension) ? (filePath += extension) : filePath
   // The original JS passed `win` here; writeMarkdownFile only takes 3 args
   // (the 4th was silently ignored). Drop it explicitly under strict mode.
-  // The IPC `SaveOptions` has every field optional, but writeMarkdownFile
-  // requires the strict `MarkdownDocumentOptions` shape — the renderer always
-  // populates every field for the unsaved-file dialog payload, so the cast
-  // is safe at this seam.
-  return writeMarkdownFile(filePath, markdown, options as Parameters<typeof writeMarkdownFile>[2])
-    .then(() => {
+  // The Markdown-only SaveOptions cast is now handled by writeDocumentFile.
+  return writeDocumentFile(filePath, markdown, options, pathname)
+    .then((descriptor) => {
       if (!alreadyExistOnDisk) {
         ipcMain.emit('window-add-file-path', win.id, filePath)
         ipcMain.emit('menu-add-recently-used', filePath)
 
         const newFilename = path.basename(filePath!)
-        win.webContents.send('mt::set-pathname', { id, pathname: filePath, filename: newFilename })
+        win.webContents.send('mt::set-pathname', {
+          id,
+          pathname: filePath,
+          filename: newFilename,
+          ...descriptor
+        })
       } else {
         ipcMain.emit('window-file-saved', win.id, filePath)
         win.webContents.send('mt::tab-saved', id)
@@ -363,13 +375,17 @@ ipcMain.on(
 
     let { filePath, canceled } = await dialog.showSaveDialog(win, {
       defaultPath:
-        pathname || path.join(defaultPath || getPath('documents'), `${recommendFilename}.md`)
+        pathname || path.join(defaultPath || getPath('documents'), `${recommendFilename}.md`),
+      filters: [
+        { name: 'Markdown document', extensions: [...MARKDOWN_EXTENSIONS] },
+        { name: 'TextPack document', extensions: ['textpack'] }
+      ]
     })
 
     if (filePath && !canceled) {
       filePath = path.resolve(filePath)
-      writeMarkdownFile(filePath, markdown, options as Parameters<typeof writeMarkdownFile>[2])
-        .then(() => {
+      writeDocumentFile(filePath, markdown, options, pathname)
+        .then((descriptor) => {
           if (!alreadyExistOnDisk) {
             ipcMain.emit('window-add-file-path', win.id, filePath)
             ipcMain.emit('menu-add-recently-used', filePath)
@@ -378,7 +394,8 @@ ipcMain.on(
             win.webContents.send('mt::set-pathname', {
               id,
               pathname: filePath,
-              filename: newFilename
+              filename: newFilename,
+              ...descriptor
             })
           } else if (pathname !== filePath) {
             // Update window file list and watcher.
@@ -388,7 +405,8 @@ ipcMain.on(
             win.webContents.send('mt::set-pathname', {
               id,
               pathname: filePath,
-              filename: newFilename
+              filename: newFilename,
+              ...descriptor
             })
           } else {
             ipcMain.emit('window-file-saved', win.id, filePath)
@@ -467,7 +485,7 @@ ipcMain.on('mt::window::drop', async(e, fileList: string[]) => {
     return
   }
   for (const file of fileList) {
-    if (isMarkdownFile(file)) {
+    if (isDocumentFile(file)) {
       openFileOrFolder(win, file)
       continue
     }
@@ -506,6 +524,7 @@ ipcMain.on('mt::rename', async(e, { id, pathname, newPathname }: RenamePayload) 
       }
 
       ipcMain.emit('window-change-file-path', win.id, newPathname, pathname)
+      moveTextPackSession(pathname, newPathname)
       e.sender.send('mt::set-pathname', {
         id,
         pathname: newPathname,
@@ -553,6 +572,7 @@ ipcMain.on(
         }
 
         ipcMain.emit('window-change-file-path', win.id, filePath, pathname)
+        moveTextPackSession(pathname, filePath)
         e.sender.send('mt::set-pathname', {
           id,
           pathname: filePath,
@@ -623,7 +643,7 @@ ipcMain.on('mt::format-link-click', async(e, { data, dirname }: FormatLinkPayloa
   if (pathname) {
     // decodeURIComponent() CommonMark #503, allow percent encoded path names to open files. https://github.com/marktext/marktext/issues/57
     pathname = path.normalize(decodeURIComponent(pathname))
-    if (isMarkdownFile(pathname)) {
+    if (isDocumentFile(pathname)) {
       const innerWin = BrowserWindow.fromWebContents(e.sender)
       if (innerWin) {
         openFileOrFolder(innerWin, pathname)
@@ -729,8 +749,8 @@ export const openFile = async(win: BrowserWindow | null): Promise<void> => {
     properties: ['openFile', 'multiSelections'],
     filters: [
       {
-        name: 'Markdown document',
-        extensions: [...MARKDOWN_EXTENSIONS]
+        name: 'Markdown or TextPack document',
+        extensions: [...DOCUMENT_EXTENSIONS]
       }
     ]
   })

--- a/packages/desktop/src/main/windows/editor.ts
+++ b/packages/desktop/src/main/windows/editor.ts
@@ -9,11 +9,11 @@ import type Accessor from '../app/accessor'
 import { ensureWindowPosition, zoomIn, zoomOut } from './utils'
 import { TITLE_BAR_HEIGHT, editorWinOptions, isLinux, isOsx } from '../config'
 import { showEditorContextMenu } from '../contextMenu/editor'
-import { loadMarkdownFile } from '../filesystem/markdown'
+import { loadDocumentFile } from '../filesystem/document'
 import { switchLanguage } from '../spellchecker'
 import fs from 'fs'
 
-type RawMarkdownDocument = Awaited<ReturnType<typeof loadMarkdownFile>>
+type RawMarkdownDocument = Awaited<ReturnType<typeof loadDocumentFile>>
 
 // The deferred file/markdown to open before the window finishes loading.
 interface PendingFile {
@@ -334,7 +334,7 @@ class EditorWindow extends BaseWindow {
         browserWindow!.webContents.send('mt::switch-tab-by-file_path', filePath)
         continue
       }
-      loadMarkdownFile(
+      loadDocumentFile(
         filePath,
         eol,
         autoGuessEncoding,
@@ -531,6 +531,7 @@ class EditorWindow extends BaseWindow {
     const { _accessor, _openedFiles, browserWindow } = this
     const { menu: appMenu } = _accessor
     const { pathname } = rawDocument
+    if (!pathname) return
 
     // Listen for file changed.
     ipcMain.emit('watcher-watch-file', browserWindow, pathname)
@@ -590,7 +591,7 @@ class EditorWindow extends BaseWindow {
         }
 
         fileOpenRequests.push(
-          loadMarkdownFile(
+          loadDocumentFile(
             tab.pathname,
             eol,
             autoGuessEncoding,
@@ -598,6 +599,8 @@ class EditorWindow extends BaseWindow {
             autoNormalizeLineEndings
           )
             .then((rawDocument) => {
+              tab.documentKind = rawDocument.documentKind
+              tab.resourcePath = rawDocument.resourcePath
               if (rawDocument.markdown !== tab.markdown) {
                 // File has changed since it was last opened, if it is not saved, we should NOT override the buffer
                 if (tab.isSaved) {

--- a/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
+++ b/packages/desktop/src/renderer/src/components/editorWithTabs/editor.vue
@@ -882,6 +882,23 @@ const imageAction = async (
     if (file) image = file
   }
 
+  if (currentFile.value.documentKind === 'textpack' && currentFile.value.resourcePath) {
+    const workspaceTextPath = window.path.join(currentFile.value.resourcePath, 'text.md')
+    const result = await moveImageToFolder(
+      currentPathname,
+      image,
+      window.path.join(currentFile.value.resourcePath, 'assets'),
+      true,
+      workspaceTextPath
+    )
+    const destImagePath = result.split(window.path.sep).join('/')
+    window.electron.ipcRenderer.send('mt::textpack-resource-dirty', currentPathname)
+    if (id && sourceCode.value) {
+      bus.emit('image-action', { id, result: destImagePath, alt })
+    }
+    return destImagePath
+  }
+
   // Figure out the current working directory.
   // Save an image relative to the file, otherwise use the project root when available.
   const isTabSavedOnDisk = !!currentPathname

--- a/packages/desktop/src/renderer/src/store/editor.ts
+++ b/packages/desktop/src/renderer/src/store/editor.ts
@@ -72,6 +72,9 @@ interface FileChangePayload {
     encoding?: IFileState['encoding']
     markdown: string
     filename: string
+    documentKind?: IFileState['documentKind']
+    resourcePath?: string
+    reloadToken?: string
   }
 }
 
@@ -146,6 +149,11 @@ export interface EditorState {
 
 const autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
+const getDocumentResourcePath = (file: IFileState | null | undefined): string => {
+  if (!file) return ''
+  return file.resourcePath || (file.pathname ? window.path.dirname(file.pathname) : '')
+}
+
 export const useEditorStore = defineStore('editor', {
   state: (): EditorState => ({
     currentFile: null,
@@ -202,7 +210,7 @@ export const useEditorStore = defineStore('editor', {
       })
 
       this.updateTabIdToIndex()
-      window.DIRNAME = currentFile?.pathname ? window.path.dirname(currentFile.pathname) : ''
+      window.DIRNAME = getDocumentResourcePath(currentFile)
       this.UPDATE_LINE_ENDING_MENU()
 
       for (const warning of bufferedEditorState.restoreWarnings) {
@@ -300,9 +308,31 @@ export const useEditorStore = defineStore('editor', {
       })
     },
 
-    loadChange(change: FileChangePayload): void {
+    async loadChange(change: FileChangePayload): Promise<void> {
       const { tabs, currentFile } = this
-      const { data, pathname } = change
+      const { pathname } = change
+      let { data } = change
+      if (data.reloadToken && data.documentKind === 'textpack') {
+        try {
+          const resolved = await window.electron.ipcRenderer.invoke(
+            'mt::resolve-textpack-reload',
+            pathname,
+            data.reloadToken,
+            true
+          )
+          if (!resolved.accepted || !resolved.resourcePath) return
+          data = { ...data, resourcePath: resolved.resourcePath, reloadToken: undefined }
+        } catch (error) {
+          notice.notify({
+            title: t('store.editor.errorLoadingTabTitle'),
+            message: error instanceof Error ? error.message : String(error),
+            type: 'error',
+            time: 20000,
+            showConfirm: false
+          })
+          return
+        }
+      }
       const {
         isMixedLineEndings,
         lineEnding,
@@ -310,7 +340,9 @@ export const useEditorStore = defineStore('editor', {
         trimTrailingNewline,
         encoding,
         markdown,
-        filename
+        filename,
+        documentKind,
+        resourcePath
       } = data
       // Create a new document and update few entires later.
       const newFileState = createDocumentState({
@@ -320,7 +352,9 @@ export const useEditorStore = defineStore('editor', {
         encoding,
         lineEnding,
         adjustLineEndingOnSave,
-        trimTrailingNewline
+        trimTrailingNewline,
+        documentKind,
+        resourcePath
       })
 
       const tab = tabs.find((t) => window.fileUtils.isSamePathSync(t.pathname, pathname))
@@ -385,6 +419,7 @@ export const useEditorStore = defineStore('editor', {
       if (currentFile && pathname === currentFile.pathname) {
         // save current state first
         this.currentFile = tab
+        window.DIRNAME = getDocumentResourcePath(tab)
         const { id, cursor, history, scrollTop, muyaIndexCursor } = tab // Should not use blocks history as this is loaded from disk
         bus.emit('file-changed', {
           id,
@@ -590,12 +625,24 @@ export const useEditorStore = defineStore('editor', {
         }
 
         // SET_PATHNAME
-        const { filename } = fileInfo
-        if (id === this.currentFile?.id && pathname) {
-          window.DIRNAME = window.path.dirname(pathname)
-        }
+        const { filename, documentKind, resourcePath, markdown } = fileInfo
         if (tab) {
-          Object.assign(tab, { filename, pathname, isSaved: true })
+          Object.assign(tab, { filename, pathname, isSaved: true, documentKind, resourcePath })
+          if (typeof markdown === 'string') tab.markdown = markdown
+          if (id === this.currentFile?.id && pathname) {
+            window.DIRNAME = getDocumentResourcePath(tab)
+            if (typeof markdown === 'string') {
+              bus.emit('file-changed', {
+                id,
+                markdown,
+                cursor: tab.cursor,
+                muyaIndexCursor: tab.muyaIndexCursor,
+                renderCursor: true,
+                history: tab.history,
+                scrollTop: tab.scrollTop
+              })
+            }
+          }
           debouncedSendBufferedState()
         }
       })
@@ -805,13 +852,14 @@ export const useEditorStore = defineStore('editor', {
         if (tab.pathname === src) {
           tab.pathname = dest
           tab.filename = window.path.basename(dest)
+          if (tab.documentKind === 'markdown') tab.resourcePath = window.path.dirname(dest)
         }
       })
       // Keep DIRNAME in sync when the active tab is the one being renamed,
       // so link resolution / dirname-based lookups don't keep using the old
       // folder until the user switches tabs.
       if (this.currentFile != null && this.currentFile.pathname === dest) {
-        window.DIRNAME = window.path.dirname(dest)
+        window.DIRNAME = getDocumentResourcePath(this.currentFile)
       }
       debouncedSendBufferedState()
     },
@@ -820,14 +868,13 @@ export const useEditorStore = defineStore('editor', {
       const oldCurrentFile = this.currentFile
       let didUpdateCurrentFile = false
       if (oldCurrentFile == null || oldCurrentFile.id !== currentFile.id) {
-        const { id, markdown, cursor, history, pathname, scrollTop, blocks, muyaIndexCursor } =
-          currentFile
+        const { id, markdown, cursor, history, scrollTop, blocks, muyaIndexCursor } = currentFile
         // Must run while `currentFile` still points at the outgoing tab, so its
         // flushed edit is attributed to that tab and not lost on switch (#2938).
         if (oldCurrentFile) {
           this.flushActiveEditor()
         }
-        window.DIRNAME = pathname ? window.path.dirname(pathname) : ''
+        window.DIRNAME = getDocumentResourcePath(currentFile)
         this.currentFile = currentFile
         didUpdateCurrentFile = true
 
@@ -1020,9 +1067,8 @@ export const useEditorStore = defineStore('editor', {
           this.tabs[index] ?? this.tabs[index - 1] ?? this.tabs[0] ?? null
         this.currentFile = fileState
         if (fileState && typeof fileState.markdown === 'string') {
-          const { id, markdown, cursor, history, pathname, scrollTop, blocks, muyaIndexCursor } =
-            fileState
-          window.DIRNAME = pathname ? window.path.dirname(pathname) : ''
+          const { id, markdown, cursor, history, scrollTop, blocks, muyaIndexCursor } = fileState
+          window.DIRNAME = getDocumentResourcePath(fileState)
           bus.emit('file-changed', {
             id,
             markdown,
@@ -1111,9 +1157,9 @@ export const useEditorStore = defineStore('editor', {
         this.currentFile =
           this.tabs[tabIndex] ?? this.tabs[tabIndex - 1] ?? this.tabs[0] ?? null
         if (this.currentFile && typeof this.currentFile.markdown === 'string') {
-          const { id, markdown, cursor, history, pathname, scrollTop, blocks, muyaIndexCursor } =
+          const { id, markdown, cursor, history, scrollTop, blocks, muyaIndexCursor } =
             this.currentFile
-          window.DIRNAME = pathname ? window.path.dirname(pathname) : ''
+          window.DIRNAME = getDocumentResourcePath(this.currentFile)
           bus.emit('file-changed', {
             id,
             markdown,
@@ -1675,7 +1721,12 @@ export const useEditorStore = defineStore('editor', {
               // that left the content byte-identical) — there is nothing to
               // reload and no reason to warn the user (#1861).
               const newMarkdown = (change as unknown as FileChangePayload).data?.markdown
-              if (typeof newMarkdown === 'string' && newMarkdown === tab.markdown) {
+              const reloadToken = (change as unknown as FileChangePayload).data?.reloadToken
+              if (
+                typeof newMarkdown === 'string' &&
+                newMarkdown === tab.markdown &&
+                !reloadToken
+              ) {
                 break
               }
 
@@ -1688,7 +1739,7 @@ export const useEditorStore = defineStore('editor', {
                 }
 
                 if (isSaved) {
-                  this.loadChange(change as unknown as FileChangePayload)
+                  this.loadChange(change as unknown as FileChangePayload).catch(console.error)
                   return
                 }
               }
@@ -1701,7 +1752,11 @@ export const useEditorStore = defineStore('editor', {
                 exclusiveType: 'file_changed',
                 action: (status) => {
                   if (status) {
-                    this.loadChange(change as unknown as FileChangePayload)
+                    this.loadChange(change as unknown as FileChangePayload).catch(console.error)
+                  } else if (reloadToken) {
+                    window.electron.ipcRenderer
+                      .invoke('mt::resolve-textpack-reload', pathname, reloadToken, false)
+                      .catch(console.error)
                   }
                 }
               })
@@ -2008,6 +2063,8 @@ function toSerializableValue<T>(value: T | null | undefined, fallback: T | null 
 interface BufferedTabState {
   id: string
   pathname: string
+  documentKind: IFileState['documentKind']
+  resourcePath: string
   filename: string
   markdown: string
   isSaved: boolean
@@ -2025,6 +2082,10 @@ const createBufferedTabState = (tab: Partial<IFileState> & { id: string }): Buff
   return {
     id: tab.id,
     pathname: tab.pathname ?? defaultFileState.pathname,
+    // Main supplies a fresh TextPack workspace during restore. Do not strip
+    // this descriptor while normalizing the incoming mt::load-state payload.
+    documentKind: tab.documentKind ?? defaultFileState.documentKind,
+    resourcePath: tab.resourcePath ?? defaultFileState.resourcePath,
     filename: tab.filename ?? defaultFileState.filename,
     markdown: typeof tab.markdown === 'string' ? tab.markdown : defaultFileState.markdown,
     isSaved: tab.isSaved ?? defaultFileState.isSaved,

--- a/packages/desktop/src/renderer/src/store/help.ts
+++ b/packages/desktop/src/renderer/src/store/help.ts
@@ -20,6 +20,8 @@ const defaultFileStateWithoutId = {
   pathname: '',
   filename: 'Untitled-1',
   markdown: '',
+  documentKind: 'markdown',
+  resourcePath: '',
   encoding: {
     encoding: 'utf8',
     isBom: false
@@ -73,6 +75,8 @@ const documentStateKeys = [
   'pathname',
   'filename',
   'markdown',
+  'documentKind',
+  'resourcePath',
   'encoding',
   'lineEnding',
   'trimTrailingNewline',

--- a/packages/desktop/src/shared/types/files.ts
+++ b/packages/desktop/src/shared/types/files.ts
@@ -5,6 +5,7 @@
 // imperfect surface than a placeholder that's wrong.
 
 export type LineEnding = 'lf' | 'crlf'
+export type DocumentKind = 'markdown' | 'textpack'
 
 export interface SerializedStat {
   size: number
@@ -18,11 +19,15 @@ export interface MarkdownDocument {
   markdown: string
   filename: string
   pathname: string | null
-  encoding?: string
+  encoding?: FileEncoding | string
   lineEnding?: LineEnding
   adjustLineEndingOnSave?: boolean
   trimTrailingNewline?: number
   isMixedLineEndings?: boolean
+  documentKind?: DocumentKind
+  resourcePath?: string
+  /** Opaque main-process token for a staged external TextPack reload. */
+  reloadToken?: string
 }
 
 export interface FileHistory {
@@ -72,6 +77,8 @@ export interface IFileState {
   // missing entirely. Always a string at runtime now.
   pathname: string
   markdown: string
+  documentKind: DocumentKind
+  resourcePath: string
   isSaved: boolean
   encoding: FileEncoding
   lineEnding: LineEnding | string

--- a/packages/desktop/src/shared/types/ipc.ts
+++ b/packages/desktop/src/shared/types/ipc.ts
@@ -69,6 +69,10 @@ export interface IpcInvokeChannels {
   }
   'mt::keybinding-save-user-keybindings': { args: [bindings: unknown]; ret: boolean }
   'mt::paths::is-image': { args: [path: string]; ret: boolean }
+  'mt::resolve-textpack-reload': {
+    args: [pathname: string, token: string, accept: boolean]
+    ret: { accepted: boolean; resourcePath?: string }
+  }
   'mt::rg::start': { args: [req: unknown]; ret: { searchId: string } }
   'mt::shell::open-external': { args: [url: string]; ret: void }
   'mt::shell::open-path': { args: [fullPath: string]; ret: string }
@@ -183,6 +187,7 @@ export interface IpcSendChannels {
   'mt::window-add-file-path': [windowId: number, filePath: string]
   'mt::window-initialized': []
   'mt::window-tab-closed': [pathname: string]
+  'mt::textpack-resource-dirty': [pathname: string]
   'mt::window-toggle-always-on-top': []
   'mt::window::drop': [payload: unknown]
   'screen-capture': [payload: unknown]
@@ -261,7 +266,16 @@ export interface IpcMainEventChannels {
   'mt::rg::progress': [payload: unknown]
   'mt::screenshot-captured': [filePath: string]
   'mt::set-line-ending': [lineEnding: LineEnding]
-  'mt::set-pathname': [payload: { id: string; pathname: string; filename: string }]
+  'mt::set-pathname': [
+    payload: {
+      id: string
+      pathname: string
+      filename: string
+      documentKind?: 'markdown' | 'textpack'
+      resourcePath?: string
+      markdown?: string
+    }
+  ]
   'mt::set-view-layout': [layout: unknown]
   'mt::show-command-palette': []
   'mt::show-export-dialog': [type: ExportType]

--- a/packages/desktop/test/unit/specs/textpack-restore.spec.ts
+++ b/packages/desktop/test/unit/specs/textpack-restore.spec.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import ts from 'typescript'
+
+// Exercise the real buffer normalizer without importing the renderer's editor,
+// Electron and Vue component dependencies. This follows the source-loading
+// approach used by the source-code-image-action regression tests.
+const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../../src/renderer/src/store/editor.ts'), 'utf8')
+const helpers = source.slice(source.indexOf('interface BufferedTabState'))
+const compiled = ts.transpileModule(helpers, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 }
+}).outputText
+const defaults = {
+  pathname: '',
+  filename: 'Untitled',
+  markdown: '',
+  isSaved: true,
+  documentKind: 'markdown',
+  resourcePath: '',
+  encoding: { encoding: 'utf8', isBom: false },
+  lineEnding: 'lf',
+  trimTrailingNewline: 2,
+  adjustLineEndingOnSave: false,
+  cursor: null,
+  wordCount: {},
+  muyaIndexCursor: null,
+  scrollTop: 0
+}
+// eslint-disable-next-line no-new-func
+const normalize = new Function('defaultFileState', 'toSerializableValue', `${compiled}\nreturn createBufferedEditorState`)(
+  defaults,
+  (value: unknown, fallback: unknown) => JSON.parse(JSON.stringify(value ?? fallback))
+) as (state: unknown) => { currentFileId: string; tabs: Array<Record<string, unknown>> }
+
+describe('TextPack buffered tab restoration', () => {
+  it('retains the document kind and fresh resource directory supplied by main', () => {
+    const restored = normalize({
+      currentFileId: 'pack',
+      tabs: [{
+        id: 'pack',
+        pathname: 'C:/notes/note.textpack',
+        documentKind: 'textpack',
+        resourcePath: 'C:/Temp/new-session/content',
+        markdown: '![](assets/photo.png)',
+        isSaved: true
+      }]
+    })
+    expect(restored.currentFileId).toBe('pack')
+    expect(restored.tabs[0]).toMatchObject({
+      documentKind: 'textpack',
+      resourcePath: 'C:/Temp/new-session/content',
+      pathname: 'C:/notes/note.textpack',
+      markdown: '![](assets/photo.png)'
+    })
+  })
+
+  it('preserves the descriptor through buffer serialization and restoration with dirty text', () => {
+    const state = {
+      currentFileId: 'pack',
+      tabs: [{
+        id: 'pack',
+        documentKind: 'textpack',
+        resourcePath: 'C:/Temp/old-session/content',
+        pathname: 'C:/notes/note.textpack',
+        markdown: '# Unsaved',
+        isSaved: false
+      }]
+    }
+    const serialized = JSON.parse(JSON.stringify(normalize(state)))
+    // Main recreates the workspace before sending mt::load-state.
+    serialized.tabs[0].resourcePath = 'C:/Temp/recreated-session/content'
+    expect(normalize(serialized).tabs[0]).toMatchObject({
+      documentKind: 'textpack',
+      resourcePath: 'C:/Temp/recreated-session/content',
+      markdown: '# Unsaved',
+      isSaved: false
+    })
+  })
+
+  it('keeps old Markdown buffers compatible when the new fields are absent', () => {
+    const restored = normalize({ tabs: [{ id: 'md', pathname: 'C:/notes/note.md' }] })
+    expect(restored.tabs[0]).toMatchObject({ documentKind: 'markdown', resourcePath: '' })
+  })
+})

--- a/packages/desktop/test/unit/specs/textpack.spec.ts
+++ b/packages/desktop/test/unit/specs/textpack.spec.ts
@@ -1,0 +1,391 @@
+import fs from 'fs'
+import fsPromises from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { pipeline } from 'stream/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import yauzl, { type Entry } from 'yauzl'
+import yazl from 'yazl'
+import {
+  closeTextPackSession,
+  exportTextPackToMarkdown,
+  findMarkdownDestinations,
+  loadTextPackFile,
+  markTextPackResourcesDirty,
+  prepareTextPackReload,
+  resolveTextPackReload,
+  validateTextPackEntryName,
+  writeTextPackFile
+} from '../../../src/main/filesystem/textpack'
+
+vi.mock('ced', () => ({ default: () => 'utf8' }))
+
+const temporaryDirectories: string[] = []
+const openedTextPacks: string[] = []
+
+const makeDirectory = async(): Promise<string> => {
+  const directory = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'marktext-textpack-test-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+const createArchive = async(
+  pathname: string,
+  entries: Array<{ name: string; content: string | Buffer }>
+): Promise<void> => {
+  const archive = new yazl.ZipFile()
+  for (const entry of entries) archive.addBuffer(Buffer.from(entry.content), entry.name)
+  archive.end()
+  await pipeline(archive.outputStream, fs.createWriteStream(pathname))
+}
+
+const readArchive = (pathname: string): Promise<Map<string, Buffer>> =>
+  new Promise((resolve, reject) => {
+    yauzl.open(pathname, { lazyEntries: true }, (error, zipfile) => {
+      if (error || !zipfile) return reject(error)
+      const entries = new Map<string, Buffer>()
+      zipfile.on('error', reject)
+      zipfile.on('end', () => resolve(entries))
+      zipfile.on('entry', (entry: Entry) => {
+        zipfile.openReadStream(entry, (streamError, stream) => {
+          if (streamError || !stream) return reject(streamError)
+          const chunks: Buffer[] = []
+          stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+          stream.on('error', reject)
+          stream.on('end', () => {
+            entries.set(entry.fileName, Buffer.concat(chunks))
+            zipfile.readEntry()
+          })
+        })
+      })
+      zipfile.readEntry()
+    })
+  })
+
+afterEach(async() => {
+  await Promise.all(openedTextPacks.splice(0).map(closeTextPackSession))
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fsPromises.rm(directory, { recursive: true, force: true }))
+  )
+})
+
+describe('TextPack codec', () => {
+  it('reserves remote embedding without silently falling back or writing a file', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'remote.textpack')
+    await expect(writeTextPackFile(pathname, '![remote](https://example.invalid/a.png)', {}, undefined, {
+      remoteImages: 'embed'
+    })).rejects.toThrow(/not implemented/)
+    await expect(fsPromises.access(pathname)).rejects.toThrow()
+  })
+  it('embeds Base64 images on the first save of an untitled document and deduplicates them', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'untitled.textpack')
+    const bytes = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
+    const data = `data:image/png;base64,${bytes.toString('base64')}`
+    const saved = await writeTextPackFile(pathname, `![one](${data})\n<img src="${data}" width="80">`, {})
+    openedTextPacks.push(pathname)
+    expect(saved.markdown).not.toContain('data:image')
+    expect(saved.markdown).toContain('width="80"')
+    const entries = await readArchive(pathname)
+    const assets = [...entries.keys()].filter((name) => name.startsWith('assets/'))
+    expect(assets).toHaveLength(1)
+    expect(entries.get(assets[0])).toEqual(bytes)
+    expect(entries.get('text.md')?.toString()).toBe(saved.markdown)
+  })
+
+  it('embeds absolute, file URL, reference and HTML images without copying absolute attachment links', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'images.textpack')
+    const image = path.join(directory, 'photo one.png')
+    const bytes = Buffer.from('image bytes')
+    await fsPromises.writeFile(image, bytes)
+    const absolute = image.split(path.sep).join('/')
+    const fileUrl = pathToFileURL(image).href
+    const markdown = [
+      `![inline](<${absolute}>)`,
+      '![reference][photo]',
+      `[photo]: <${fileUrl}>`,
+      `<img alt='literal src="ignored.png"'\n src="${fileUrl}" width="100">`,
+      `[attachment](<${absolute}>)`,
+      '![remote](https://example.invalid/image.png)',
+      '![remote](//example.invalid/image.png)'
+    ].join('\n')
+    const saved = await writeTextPackFile(pathname, markdown, {})
+    openedTextPacks.push(pathname)
+    expect(saved.markdown).toContain('![inline](<assets/photo-one.png>)')
+    expect(saved.markdown).toContain('[photo]: <assets/photo-one.png>')
+    expect(saved.markdown).toContain('src="assets/photo-one.png" width="100"')
+    expect(saved.markdown).toContain(`[attachment](<${absolute}>)`)
+    expect(saved.markdown).toContain('https://example.invalid/image.png')
+    expect(saved.markdown).toContain('//example.invalid/image.png')
+    const entries = await readArchive(pathname)
+    expect(entries.get('assets/photo-one.png')).toEqual(bytes)
+    expect(await fsPromises.readFile(image)).toEqual(bytes)
+    const exported = await exportTextPackToMarkdown(pathname, path.join(directory, 'out.md'), saved.markdown, {
+      encoding: { encoding: 'utf8', isBom: false }, lineEnding: 'lf'
+    })
+    expect(exported.markdown).toContain('src="out.assets/photo-one.png"')
+    expect(exported.markdown).toContain('[photo]: <out.assets/photo-one.png>')
+  })
+
+  it('leaves image examples in code and comments unchanged', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'examples.textpack')
+    const markdown = [
+      '``![example](missing.png)``',
+      '```html',
+      '<img src="missing.png">',
+      '```',
+      '<!-- <img src="missing.png"> -->'
+    ].join('\n')
+    const saved = await writeTextPackFile(pathname, markdown, {})
+    openedTextPacks.push(pathname)
+    expect(saved.markdown).toBe(markdown)
+  })
+
+  it.each([
+    '![broken](data:image/png;base64,not!base64)',
+    '![broken](data:image/png;base64,AB==)',
+    '![relative](unknown.png)'
+  ])('rejects invalid or unresolved images before replacing the destination: %s', async(markdown) => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'unchanged.textpack')
+    const original = Buffer.from('existing destination')
+    await fsPromises.writeFile(pathname, original)
+    await expect(writeTextPackFile(pathname, markdown, {})).rejects.toThrow()
+    expect(await fsPromises.readFile(pathname)).toEqual(original)
+  })
+
+  it('opens and round-trips Markdown while preserving unknown data', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'sample.textpack')
+    const metadata = {
+      version: 2,
+      type: 'net.daringfireball.markdown',
+      transient: false,
+      thirdParty: { nested: ['kept', 42] }
+    }
+    const asset = Buffer.from([0, 1, 2, 250, 255])
+    await createArchive(pathname, [
+      { name: 'info.json', content: JSON.stringify(metadata) },
+      { name: 'text.markdown', content: '\uFEFF# Before\n\n![](assets/picture.bin)\n' },
+      { name: 'assets/picture.bin', content: asset },
+      { name: 'vendor/private.dat', content: 'opaque' }
+    ])
+
+    const opened = await loadTextPackFile(pathname, 'lf')
+    openedTextPacks.push(pathname)
+    expect(opened.markdown).toBe('# Before\n\n![](assets/picture.bin)\n')
+    expect(opened.documentKind).toBe('textpack')
+    expect(opened.resourcePath).toBeTruthy()
+
+    await writeTextPackFile(pathname, '# After\n', {
+      encoding: { encoding: 'utf8', isBom: false },
+      lineEnding: 'lf',
+      adjustLineEndingOnSave: false,
+      trimTrailingNewline: 1
+    })
+
+    const contents = await readArchive(pathname)
+    expect(contents.get('text.markdown')?.toString()).toBe('# After\n')
+    expect(contents.get('assets/picture.bin')).toEqual(asset)
+    expect(contents.get('vendor/private.dat')?.toString()).toBe('opaque')
+    expect(JSON.parse(contents.get('info.json')!.toString())).toEqual(metadata)
+  })
+
+  it('rejects traversal, absolute, backslash, NUL, and device paths', () => {
+    for (const name of [
+      '../escape',
+      '/absolute',
+      'C:/drive',
+      'assets\\escape',
+      'a\0b',
+      'assets/CON'
+    ]) {
+      expect(() => validateTextPackEntryName(name)).toThrow(/Unsafe TextPack entry path/)
+    }
+  })
+
+  it('rejects ambiguous case-folded entries', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'duplicate.textpack')
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":2}' },
+      { name: 'text.md', content: '# Test' },
+      { name: 'assets/A.txt', content: 'one' },
+      { name: 'assets/a.txt', content: 'two' }
+    ])
+    await expect(loadTextPackFile(pathname, 'lf')).rejects.toThrow(/Duplicate TextPack entry/)
+  })
+
+  it('rejects unsupported metadata and ambiguous text entries', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'invalid.textpack')
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":3}' },
+      { name: 'text.md', content: 'one' },
+      { name: 'text.txt', content: 'two' }
+    ])
+    await expect(loadTextPackFile(pathname, 'lf')).rejects.toThrow(/exactly one text/)
+  })
+
+  it('does not overwrite a TextPack changed by another process', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'conflict.textpack')
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":2}' },
+      { name: 'text.md', content: '# Original' }
+    ])
+    await loadTextPackFile(pathname, 'lf')
+    openedTextPacks.push(pathname)
+    const externalBytes = Buffer.from('external replacement')
+    await fsPromises.writeFile(pathname, externalBytes)
+
+    await expect(
+      writeTextPackFile(pathname, '# Local edit', {
+        encoding: { encoding: 'utf8', isBom: false },
+        lineEnding: 'lf'
+      })
+    ).rejects.toThrow(/changed on disk/)
+    expect(await fsPromises.readFile(pathname)).toEqual(externalBytes)
+  })
+
+  it('finds inline and reference destinations without treating code as links', () => {
+    const markdown = [
+      '![inline](images/a.png "title")',
+      '[attachment](docs/file(1).pdf)',
+      '[ref]: <images/ref image.png>',
+      '`![code](ignored.png)`',
+      '```md',
+      '![fenced](ignored-too.png)',
+      '```'
+    ].join('\n')
+    expect(findMarkdownDestinations(markdown).map((item) => item.value)).toEqual([
+      'images/a.png',
+      'docs/file(1).pdf',
+      'images/ref image.png'
+    ])
+  })
+
+  it('packages local resources and exports assets beside Markdown', async() => {
+    const directory = await makeDirectory()
+    await fsPromises.mkdir(path.join(directory, 'images'))
+    await fsPromises.writeFile(
+      path.join(directory, 'images', 'photo one.png'),
+      Buffer.from([1, 2, 3])
+    )
+    const sourcePath = path.join(directory, 'source.md')
+    const targetPack = path.join(directory, 'portable.textpack')
+    const sourceMarkdown = '# Portable\n\n![](images/photo%20one.png)\n'
+    await fsPromises.writeFile(sourcePath, sourceMarkdown)
+    await fsPromises.mkdir(path.join(directory, 'docs'))
+    await fsPromises.writeFile(path.join(directory, 'docs', 'report.pdf'), Buffer.from('PDF'))
+    const markdownWithAttachment = `${sourceMarkdown}\n[Report](docs/report.pdf)\n`
+    const saved = await writeTextPackFile(
+      targetPack,
+      markdownWithAttachment,
+      { lineEnding: 'lf' },
+      sourcePath
+    )
+    openedTextPacks.push(targetPack)
+    expect(saved.markdown).toMatch(/!\[\]\(assets\/photo-one\.png\)/)
+    expect(saved.markdown).toContain('[Report](assets/report.pdf)')
+
+    const entries = await readArchive(targetPack)
+    expect(entries.get('assets/photo-one.png')).toEqual(Buffer.from([1, 2, 3]))
+    expect(entries.get('assets/report.pdf')?.toString()).toBe('PDF')
+
+    const targetMarkdown = path.join(directory, 'exported.md')
+    const exported = await exportTextPackToMarkdown(targetPack, targetMarkdown, saved.markdown, {
+      encoding: { encoding: 'utf8', isBom: false },
+      lineEnding: 'lf',
+      adjustLineEndingOnSave: false,
+      trimTrailingNewline: 1
+    })
+    expect(exported.markdown).toContain('exported.assets/photo-one.png')
+    expect(
+      await fsPromises.readFile(path.join(directory, 'exported.assets', 'photo-one.png'))
+    ).toEqual(Buffer.from([1, 2, 3]))
+    expect(
+      await fsPromises.readFile(path.join(directory, 'exported.assets', 'report.pdf'), 'utf8')
+    ).toBe('PDF')
+  })
+
+  it('stages external changes until reload is accepted and then swaps all resources', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'reload.textpack')
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":2}' },
+      { name: 'text.md', content: '# Original' },
+      { name: 'assets/report.pdf', content: 'old resource' }
+    ])
+    const opened = await loadTextPackFile(pathname, 'lf')
+    openedTextPacks.push(pathname)
+    markTextPackResourcesDirty(pathname)
+
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":2}' },
+      { name: 'text.md', content: '# External' },
+      { name: 'assets/report.pdf', content: 'new resource' },
+      { name: 'assets/data.csv', content: 'a,b' }
+    ])
+    const staged = await prepareTextPackReload(pathname, 'lf')
+    expect(staged.reloadToken).toBeTruthy()
+    expect(
+      await fsPromises.readFile(path.join(opened.resourcePath!, 'assets', 'report.pdf'), 'utf8')
+    ).toBe('old resource')
+    expect(
+      await fsPromises.readFile(path.join(staged.resourcePath!, 'assets', 'report.pdf'), 'utf8')
+    ).toBe('new resource')
+
+    expect(await resolveTextPackReload(pathname, staged.reloadToken!, false)).toEqual({
+      accepted: false
+    })
+    expect(
+      await fsPromises.readFile(path.join(opened.resourcePath!, 'assets', 'report.pdf'), 'utf8')
+    ).toBe('old resource')
+
+    const accepted = await prepareTextPackReload(pathname, 'lf')
+    const resolved = await resolveTextPackReload(pathname, accepted.reloadToken!, true)
+    expect(resolved).toMatchObject({ accepted: true, resourcePath: accepted.resourcePath })
+    expect(
+      await fsPromises.readFile(path.join(resolved.resourcePath!, 'assets', 'data.csv'), 'utf8')
+    ).toBe('a,b')
+    expect(
+      await fsPromises.readFile(path.join(opened.resourcePath!, 'assets', 'report.pdf'), 'utf8')
+    ).toBe('old resource')
+
+    await writeTextPackFile(pathname, '# Reloaded\n', { lineEnding: 'lf' })
+    const entries = await readArchive(pathname)
+    expect(entries.get('assets/report.pdf')?.toString()).toBe('new resource')
+    expect(entries.get('assets/data.csv')?.toString()).toBe('a,b')
+  })
+
+  it('records recoverable resource changes in the private session manifest', async() => {
+    const directory = await makeDirectory()
+    const pathname = path.join(directory, 'recovery.textpack')
+    await createArchive(pathname, [
+      { name: 'info.json', content: '{"version":2}' },
+      { name: 'text.md', content: '# Recovery' }
+    ])
+    const opened = await loadTextPackFile(pathname, 'lf')
+    openedTextPacks.push(pathname)
+    markTextPackResourcesDirty(pathname)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const manifest = JSON.parse(
+      await fsPromises.readFile(
+        path.join(path.dirname(opened.resourcePath!), 'manifest.json'),
+        'utf8'
+      )
+    )
+    expect(manifest).toMatchObject({
+      version: 1,
+      physicalPath: pathname,
+      dirtyResources: true
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,12 @@ importers:
       write-file-atomic:
         specifier: ^7.0.1
         version: 7.0.1
+      yauzl:
+        specifier: ^3.4.0
+        version: 3.4.0
+      yazl:
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.4
@@ -270,6 +276,12 @@ importers:
       '@types/write-file-atomic':
         specifier: ^4.0.3
         version: 4.0.3
+      '@types/yauzl':
+        specifier: ^2.10.3
+        version: 2.10.3
+      '@types/yazl':
+        specifier: ^3.3.0
+        version: 3.3.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -5386,6 +5398,12 @@ packages:
         integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
       }
 
+  '@types/yazl@3.3.1':
+    resolution:
+      {
+        integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==
+      }
+
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution:
       {
@@ -6694,6 +6712,13 @@ packages:
       {
         integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
       }
+
+  buffer-crc32@1.0.0:
+    resolution:
+      {
+        integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==
+      }
+    engines: { node: '>=8.0.0' }
 
   buffer-from@1.1.2:
     resolution:
@@ -15731,6 +15756,19 @@ packages:
         integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
       }
 
+  yauzl@3.4.0:
+    resolution:
+      {
+        integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
+      }
+    engines: { node: '>=12' }
+
+  yazl@3.3.1:
+    resolution:
+      {
+        integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==
+      }
+
   yocto-queue@0.1.0:
     resolution:
       {
@@ -18745,7 +18783,10 @@ snapshots:
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 22.20.0
-    optional: true
+
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -19756,6 +19797,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -26317,6 +26360,14 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
<!-- Link the issue(s) this PR addresses. "Closes #NNN" auto-closes on merge. -->

Closes #5261
Summary

## Summary

This adds native support for opening, editing, and saving `.textpack` documents.

Markdown documents with local images are currently difficult to move or share without preserving a separate directory structure. TextPack provides single-file portability while allowing MarkText to continue editing ordinary Markdown.

The implementation treats TextPack as a document storage format and keeps format-specific behavior mainly in the file-reading and file-writing layer. It supports:

- native open, save, Save As, recent-file, file-association, and startup-restoration flows;
- displaying bundled images and storing newly pasted or inserted images in `assets/`;
- converting Markdown or an untitled document to TextPack, including Base64 and referenced local images;
- exporting TextPack to Markdown with its assets;
- preserving unknown metadata and resources;
- validated extraction, atomic saves, external-change protection, and crash recovery.

Ordinary Markdown behavior is unchanged. The change adds no settings or generic non-image attachment UI. It intentionally supports `.textpack` only because the goal is single-file portability; `.textbundle` directory support remains out of scope.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Documentation update

## Test plan

- [x] New tests added: 19 focused tests cover format validation, round trips, conversion, conflicts, recovery, and startup restoration.
- [x] Manually tested on Windows 10 x64: open, edit, image paste, save, reopen, and startup restoration.
- [x] Desktop TypeScript/Vue typecheck.
- [x] Windows x64 production build and packaging.
- [x] Full repository lint executed against the rebased branch: 0 errors (existing warnings remain).
- [x] Full unit suite executed against the rebased branch: 787 passed, 1 skipped, and 15 failed in five unrelated existing Windows/locale/PDF suites; both TextPack suites passed.
- [ ] Confirm clean CI results.

## Demonstration

<!-- Attach a short screen recording or screenshots showing: open a TextPack with a bundled image, paste another image, save, close and reopen, then restart MarkText and restore the document. -->

## Notes for reviewers

- ZIP processing stays in the Electron main process. The renderer receives only the document kind and resource base.
- Archive paths and expansion are validated and bounded. Saves are serialized, validated, and protected against overwriting an externally changed source.
- `yauzl` and `yazl` are added as desktop runtime dependencies for streaming ZIP reads and writes.
- Remote images remain remote links; saving does not introduce network requests.

### AI assistance disclosure

The implementation, tests, documentation, and this pull request description were developed with assistance from OpenAI Codex. The contributor reviewed and manually tested the resulting changes and takes responsibility for the submission.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).
