### PR TITLE
fix: skip website preview deploy on fork PRs

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -78,7 +78,7 @@ jobs:
       # notice on the PR rather than failing the build.
       - name: Deploy preview
         id: preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         working-directory: packages/website
         run: |
           set +e
@@ -122,6 +122,13 @@ jobs:
             echo "Could not parse a preview URL or version ID from wrangler output" >&2
             exit 1
           fi
+
+      # Fork PRs cannot access repository secrets, so the wrangler upload above
+      # is skipped for them. Report why via a notice (which needs no PR-write
+      # token) instead of leaving the run looking silently incomplete.
+      - name: Note preview skipped for forks
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Website preview deploy skipped for fork PRs — Cloudflare deploy secrets are not exposed to pull requests from forks. The build, lint, and type-check steps above still validate this change."
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request' && steps.preview.outputs.result == 'ok'


### PR DESCRIPTION
## Summary

The **Deploy website** check fails on every pull request opened from a fork (most recently #4937 by an external contributor). The website build itself is fine — `Lint`, `Type-check`, `Next build`, and `OpenNext Cloudflare build` all pass. Only the **Deploy preview** step fails:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

## Root cause

GitHub Actions does not expose repository secrets to `pull_request` runs that originate from a fork (a deliberate security measure). So `secrets.CLOUDFLARE_API_TOKEN` / `secrets.CLOUDFLARE_ACCOUNT_ID` (injected at the job level) resolve to empty strings, and `wrangler versions upload` aborts. The step only handles the "Could not route to" (not-bootstrapped) error, so the empty-token failure falls through to `exit $upload_status` and turns the whole job red. This affects **every** fork PR, not this PR's code.

## Fix

Guard the `Deploy preview` step with the same fork check the repo already uses in `build.yml` (`github.event.pull_request.head.repo.full_name == github.repository`), so fork PRs skip the wrangler upload. A `::notice::` explains why (annotations need no PR-write token, which fork runs also lack).

- Same-repo PRs: unchanged — preview deploys and comments exactly as before.
- Production deploy (`push` to `develop`): unchanged.
- Fork PRs: build/lint/type-check still validate the change; the deploy step is skipped and the job goes green.

Note: because `pull_request` uses the workflow definition from the PR head branch, existing fork PRs (like #4937) need a rebase onto `develop` after this merges to pick up the fix.