### PR TITLE
fix(muya): keep IME input intact after a soft line break

### DIFF
--- a/packages/muya/e2e/tests/typing/ime-soft-line-break.spec.ts
+++ b/packages/muya/e2e/tests/typing/ime-soft-line-break.spec.ts
@@ -1,0 +1,57 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { editor } from '../helpers/selectors';
+
+// #5279 — a Shift+Enter soft line break was lost when the following text came
+// from a CJK IME. Chromium drops the trailing `\n` from the DOM the moment
+// anything is typed after it; `lineBreakAutoPair` puts it back, but the IME
+// commit never reached that repair, so both lines collapsed into one.
+//
+// Driven through CDP `Input.imeSetComposition` — the browser then runs its own
+// composition machinery and mutates the DOM itself. `ime.spec.ts` hand-builds
+// the event sequence instead, which cannot catch this class of bug: the DOM
+// state it stages is the one the test author expects, not the one Chromium
+// produces.
+
+test.describe('soft line break followed by an IME commit', () => {
+    test.skip(
+        ({ browserName }) => browserName !== 'chromium',
+        'Input.imeSetComposition is a Chrome DevTools Protocol command',
+    );
+
+    async function seedFirstLine(page: Page): Promise<void> {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await page.keyboard.insertText('第一行');
+        await page.keyboard.press('Shift+Enter');
+        await expect(page.locator(editor.softLineBreak)).toHaveCount(1);
+    }
+
+    test('keeps the soft line break when the IME commits the second line', async ({ page }) => {
+        await seedFirstLine(page);
+
+        const cdp = await page.context().newCDPSession(page);
+        await cdp.send('Input.imeSetComposition', {
+            text: 'dierhang',
+            selectionStart: 8,
+            selectionEnd: 8,
+        });
+        await cdp.send('Input.imeSetComposition', {
+            text: '第二行',
+            selectionStart: 3,
+            selectionEnd: 3,
+        });
+        await cdp.send('Input.insertText', { text: '第二行' });
+
+        await expect.poll(() => getMarkdown(page)).toBe('第一行\n第二行\n');
+    });
+
+    test('keeps the soft line break when the second line is typed without an IME', async ({ page }) => {
+        await seedFirstLine(page);
+
+        await page.keyboard.insertText('abc');
+
+        await expect.poll(() => getMarkdown(page)).toBe('第一行\nabc\n');
+    });
+});

--- a/packages/muya/e2e/tests/typing/ime-soft-line-break.spec.ts
+++ b/packages/muya/e2e/tests/typing/ime-soft-line-break.spec.ts
@@ -32,11 +32,31 @@ test.describe('soft line break followed by an IME commit', () => {
         await seedFirstLine(page);
 
         const cdp = await page.context().newCDPSession(page);
+        const compositionStarts: number[] = [];
+        await page.exposeFunction('__onCompositionStart', () => {
+            compositionStarts.push(1);
+        });
+        await page.evaluate(() => {
+            document
+                .querySelector('.mu-editor')!
+                .addEventListener('compositionstart', () => window.__onCompositionStart!(), true);
+        });
+
         await cdp.send('Input.imeSetComposition', {
             text: 'dierhang',
             selectionStart: 8,
             selectionEnd: 8,
         });
+
+        // Mid-composition, not just at the end. The commit is rebuilt from the
+        // model plus `event.data`, so it comes out right even when the browser
+        // has eaten the newline — only the live DOM shows whether the newline
+        // survived the composition, and only the newline surviving keeps the
+        // input method's own buffer intact (#3468).
+        await expect
+            .poll(() => page.evaluate(() => window.muya!.editor.activeContentBlock?.domNode?.textContent))
+            .toContain('第一行\n');
+
         await cdp.send('Input.imeSetComposition', {
             text: '第二行',
             selectionStart: 3,
@@ -45,6 +65,9 @@ test.describe('soft line break followed by an IME commit', () => {
         await cdp.send('Input.insertText', { text: '第二行' });
 
         await expect.poll(() => getMarkdown(page)).toBe('第一行\n第二行\n');
+        // A newline the browser overwrites takes the composition down with it,
+        // and the input method restarts — one composition means it never did.
+        expect(compositionStarts).toHaveLength(1);
     });
 
     test('keeps the soft line break when the second line is typed without an IME', async ({ page }) => {

--- a/packages/muya/e2e/types.d.ts
+++ b/packages/muya/e2e/types.d.ts
@@ -13,6 +13,10 @@ declare global {
         // exercise the static markdown → HTML pipeline.
         MarkdownToHtml?: typeof MarkdownToHtml;
 
+        // Installed per-spec by `page.exposeFunction` when a test needs to
+        // count DOM events the page fires on its own.
+        __onCompositionStart?: () => void;
+
         // Test-only globals exposed by host/main.ts. Aggregated under a single
         // namespace so the real Window surface stays clean.
         __e2e?: {

--- a/packages/muya/src/block/base/__tests__/autoPair.spec.ts
+++ b/packages/muya/src/block/base/__tests__/autoPair.spec.ts
@@ -217,10 +217,12 @@ describe('autoPair — 701fb9ae soft-line preservation (in-block branches)', () 
 describe('autoPair — 67e18176 soft-line completion on compositionend', () => {
     it('appends composed text after a trailing \\n when compositionend fires', () => {
         const fakeThis = makeFakeThis('a\n', 2);
-        // compositionend has no inputType; only event.type matches.
+        // No `inputType` key at all — a real CompositionEvent has none, and
+        // `autoPair`'s entry guard branches on exactly that. Stubbing one in
+        // (even as `''`) satisfies `isInputEvent`'s `'inputType' in event`
+        // and makes this test pass while the production path is dead (#5279).
         const event = {
             type: 'compositionend',
-            inputType: '',
             data: '你',
         } as unknown as Event;
 

--- a/packages/muya/src/block/base/__tests__/imeSoftLineBreak.spec.ts
+++ b/packages/muya/src/block/base/__tests__/imeSoftLineBreak.spec.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import type Format from '../format';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../muya';
+
+// #5279 — a Shift+Enter soft line break is lost when the next text is
+// committed by a CJK IME.
+//
+// Chromium drops the trailing `\n` from the DOM as soon as text is typed at
+// the end of a block that ends in one; `lineBreakAutoPair` re-attaches it.
+// The plain-typing path reaches that repair, the IME path did not, so the
+// paragraph collapsed onto a single line.
+//
+// The DOM mutation staged below is not invented — it is what Chromium 141
+// actually does, captured by driving a real composition through CDP
+// `Input.imeSetComposition` against the E2E host:
+//
+//   after Shift+Enter   <span class="mu-plain-text">第一行</span>
+//                       <span class="mu-soft-line-break mu-line-end">\n</span>
+//   mid-composition     <span class="mu-plain-text">第一行</span>
+//                       <span class="mu-soft-line-break mu-line-end">第二行</span>
+//
+// i.e. the composed text replaces the `\n` inside the soft-line-break span.
+//
+// Build the commit event with the real `CompositionEvent` constructor. An
+// object literal carrying a stub `inputType` would sail through
+// `isInputEvent` (`'inputType' in event`) and pass no matter what the
+// production guard does — which is exactly how this bug reached a release
+// with a green regression test. jsdom rather than happy-dom because only
+// jsdom carries `data` through the CompositionEvent constructor, and the
+// committed string is the whole point of the event.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion) {
+        window.MUYA_VERSION = originalVersion as string;
+    }
+    else {
+        delete (window as Partial<Window>).MUYA_VERSION;
+    }
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function firstBlock(muya: Muya): Format {
+    const content = muya.editor.scrollPage!.firstContentInDescendant() as unknown as Format;
+    muya.editor.activeContentBlock = content as never;
+    return content;
+}
+
+function pressShiftEnter(content: Format): void {
+    content.keydownHandler(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+    }));
+}
+
+/**
+ * Replay a CJK IME commit of `composed` at the end of the block, the way
+ * Chromium delivers it: the composed text overwrites the `\n` held by the
+ * soft-line-break span, then `compositionend` carries the committed string.
+ */
+function commitComposition(content: Format, composed: string): void {
+    content.composeHandler(new CompositionEvent('compositionstart', { data: '' }));
+
+    const lineBreak = content.domNode!.querySelector('.mu-soft-line-break')!;
+    const textNode = lineBreak.firstChild as Text;
+    textNode.data = composed;
+
+    const range = document.createRange();
+    range.setStart(textNode, composed.length);
+    range.collapse(true);
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    content.composeHandler(new CompositionEvent('compositionend', { data: composed }));
+}
+
+describe('soft line break followed by an IME commit', () => {
+    it('keeps the soft line break when the next text is committed by an IME', () => {
+        const muya = bootMuya('第一行\n');
+        const content = firstBlock(muya);
+        content.setCursor(3, 3);
+
+        pressShiftEnter(content);
+        expect(content.text).toBe('第一行\n');
+
+        commitComposition(content, '第二行');
+
+        expect(content.text).toBe('第一行\n第二行');
+    });
+
+    it('keeps the soft line break when the next text is typed without an IME', () => {
+        const muya = bootMuya('第一行\n');
+        const content = firstBlock(muya);
+        content.setCursor(3, 3);
+
+        pressShiftEnter(content);
+
+        // Same Chromium mutation, delivered as plain typing: the character
+        // overwrites the `\n` and arrives as an `insertText` InputEvent.
+        const lineBreak = content.domNode!.querySelector('.mu-soft-line-break')!;
+        const textNode = lineBreak.firstChild as Text;
+        textNode.data = 'x';
+        const range = document.createRange();
+        range.setStart(textNode, 1);
+        range.collapse(true);
+        const selection = document.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        content.inputHandler(new InputEvent('input', { inputType: 'insertText', data: 'x' }));
+
+        expect(content.text).toBe('第一行\nx');
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -7,7 +7,7 @@ import type Parent from './parent';
 import diff from 'fast-diff';
 import TreeNode from '../../block/base/treeNode';
 import { ScrollPage } from '../../block/scrollPage';
-import { BACK_HASH, BRACKET_HASH, EVENT_KEYS, isFirefox } from '../../config';
+import { BACK_HASH, BRACKET_HASH, EVENT_KEYS } from '../../config';
 import Selection from '../../selection';
 import {
     adjustOffset,
@@ -309,15 +309,17 @@ function lineBreakAutoPair(
     if (
         blockText.endsWith('\n')
         && start.offset === text.length
+        && typeof event.data === 'string'
         && (inputType === 'insertText' || event.type === 'compositionend')
     ) {
         text = blockText + event.data;
-        // I don't know why firefox don't need to offset++
+        // Re-anchor to the rebuilt text instead of nudging the DOM offset: how
+        // far the DOM drifted depends on whether the browser kept the trailing
+        // newline (Firefox does, Chromium overwrites it). The end of the
+        // rebuilt text is the one answer that holds either way.
         // For more info: https://github.com/marktext/muya/issues/130
-        if (!isFirefox) {
-            start.offset++;
-            end.offset++;
-        }
+        start.offset = text.length;
+        end.offset = text.length;
     }
     else if (
         blockText.length === oldStart.offset

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -12,6 +12,7 @@ import Selection from '../../selection';
 import {
     adjustOffset,
     diffToTextOp,
+    isCompositionEndEvent,
     isInputEvent,
     isKeyboardEvent,
     isMouseEvent,
@@ -295,18 +296,20 @@ function collapsedInputAutoPair(
 }
 
 function lineBreakAutoPair(
-    event: InputEvent,
+    event: InputEvent | CompositionEvent,
     text: string,
     start: INodeOffset,
     end: INodeOffset,
     oldStart: INodeOffset,
     blockText: string,
 ) {
+    const inputType = isInputEvent(event) ? event.inputType : '';
+
     // Just work for `Shift + Enter` to create a soft and hard line break.
     if (
         blockText.endsWith('\n')
         && start.offset === text.length
-        && (event.inputType === 'insertText' || event.type === 'compositionend')
+        && (inputType === 'insertText' || event.type === 'compositionend')
     ) {
         text = blockText + event.data;
         // I don't know why firefox don't need to offset++
@@ -319,7 +322,7 @@ function lineBreakAutoPair(
     else if (
         blockText.length === oldStart.offset
         && blockText[oldStart.offset - 2] === '\n'
-        && event.inputType === 'deleteContentBackward'
+        && inputType === 'deleteContentBackward'
     ) {
         text = blockText.substring(0, oldStart.offset - 1);
         start.offset = text.length;
@@ -628,11 +631,15 @@ class Content extends TreeNode {
         let needRender = false;
 
         // The event will not be input event, when click task list item input element.
-        if (!isInputEvent(event) || !oldStart)
+        // `compositionend` is let through as well: `composeHandler` forwards it
+        // straight into `inputHandler`, and it is the only signal an IME commit
+        // ever produces here — rejecting it left the soft-line-break repair
+        // below unreachable for CJK input (#5279).
+        if ((!isInputEvent(event) && !isCompositionEndEvent(event)) || !oldStart)
             return { text, needRender };
 
         if (this.text !== text) {
-            if (start.offset === end.offset && event.type === 'input') {
+            if (isInputEvent(event) && start.offset === end.offset && event.type === 'input') {
                 const collapsed = collapsedInputAutoPair(event, text, start, end, {
                     blockText: this.text,
                     options: this.muya.options,

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -7,7 +7,7 @@ import type Parent from './parent';
 import diff from 'fast-diff';
 import TreeNode from '../../block/base/treeNode';
 import { ScrollPage } from '../../block/scrollPage';
-import { BACK_HASH, BRACKET_HASH, EVENT_KEYS } from '../../config';
+import { BACK_HASH, BRACKET_HASH, CLASS_NAMES, EVENT_KEYS } from '../../config';
 import Selection from '../../selection';
 import {
     adjustOffset,
@@ -92,6 +92,22 @@ function extractWord(
         right,
         word: text.slice(left, right),
     };
+}
+
+/**
+ * Zero-width space an IME composes into instead of the block's trailing
+ * newline — see `Content._seedCompositionAnchor`.
+ */
+const COMPOSITION_ANCHOR = '\u200B';
+
+function countKeptBefore(text: string, offset: number): number {
+    let kept = 0;
+    for (let i = 0; i < offset; i++) {
+        if (text[i] !== COMPOSITION_ANCHOR)
+            kept++;
+    }
+
+    return kept;
 }
 
 function shouldRemoveClosingChar(
@@ -315,8 +331,9 @@ function lineBreakAutoPair(
         text = blockText + event.data;
         // Re-anchor to the rebuilt text instead of nudging the DOM offset: how
         // far the DOM drifted depends on whether the browser kept the trailing
-        // newline (Firefox does, Chromium overwrites it). The end of the
-        // rebuilt text is the one answer that holds either way.
+        // newline (Firefox does, Chromium overwrites it) and on whether the
+        // caret sat in a composition anchor. The end of the rebuilt text is the
+        // one answer that holds in every case.
         // For more info: https://github.com/marktext/muya/issues/130
         start.offset = text.length;
         end.offset = text.length;
@@ -337,6 +354,8 @@ function lineBreakAutoPair(
 class Content extends TreeNode {
     private _text: string;
     protected isComposed: boolean;
+    private _compositionAnchor: Nullable<Text> = null;
+    private _compositionLineEnd: Nullable<Element> = null;
 
     static override blockName = 'content';
 
@@ -606,12 +625,116 @@ class Content extends TreeNode {
     composeHandler(event: Event) {
         if (event.type === 'compositionstart') {
             this.isComposed = true;
+            this._seedCompositionAnchor();
         }
         else if (event.type === 'compositionend') {
             this.isComposed = false;
+            this._consumeCompositionAnchor();
             // Because the compose event will not cause `input` event, So need call `inputHandler` by ourself
             this.inputHandler(event);
         }
+    }
+
+    /**
+     * Give an IME its own text node to compose in when the caret sits at the
+     * end of a block whose text ends with `\n`.
+     *
+     * That newline is the last thing in the block's DOM, so the caret sits
+     * inside it, and Chromium will not sustain a composition there: it
+     * overwrites the newline and abandons the composition, which costs the
+     * input method the first keystroke of the word (#3468). An appended node
+     * takes the composition instead and the newline is left alone. The node
+     * has to carry a zero-width space — Chromium ignores an empty one.
+     *
+     * Seeded on `compositionstart` and stripped again on `compositionend`, so
+     * it exists only while `inputHandler` is short-circuited by `isComposed`
+     * and is never visible to the DOM ↔ text offset mapping.
+     */
+    private _seedCompositionAnchor() {
+        const { domNode } = this;
+        const cursor = this.getCursor();
+        if (
+            domNode == null
+            || cursor == null
+            || cursor.start.offset !== cursor.end.offset
+            || cursor.start.offset !== this.text.length
+            || !this.text.endsWith('\n')
+        ) {
+            return;
+        }
+
+        const anchor = document.createTextNode(COMPOSITION_ANCHOR);
+        domNode.appendChild(anchor);
+        this._compositionAnchor = anchor;
+
+        // `mu-line-end` makes the trailing newline a block of its own, because
+        // a newline with nothing after it renders no line at all. The anchor is
+        // now that something, so the newline renders on its own — and the class
+        // has to go, or the block keeps a line to itself and the composition
+        // lands one line below the caret.
+        const lineEnd = domNode.querySelector(`.${CLASS_NAMES.MU_LINE_END}`);
+        if (lineEnd != null) {
+            lineEnd.classList.remove(CLASS_NAMES.MU_LINE_END);
+            this._compositionLineEnd = lineEnd;
+        }
+
+        // In front of the zero-width space, not behind it: Chromium composes at
+        // the caret and leaves the caret where it was, so a trailing anchor
+        // keeps the caret on the far side of the text being composed and it
+        // draws to the left of the glyph the user is typing.
+        const range = document.createRange();
+        range.setStart(anchor, 0);
+        range.collapse(true);
+        const selection = document.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+    }
+
+    /**
+     * Strip the seeded anchor, keeping the text the IME committed into it and
+     * the caret where the user sees it, so the input handler that runs next
+     * reads an anchor-free block.
+     */
+    private _consumeCompositionAnchor() {
+        const anchor = this._compositionAnchor;
+        const lineEnd = this._compositionLineEnd;
+        this._compositionAnchor = null;
+        this._compositionLineEnd = null;
+        lineEnd?.classList.add(CLASS_NAMES.MU_LINE_END);
+        if (anchor == null)
+            return;
+
+        const selection = document.getSelection();
+        const text = anchor.textContent ?? '';
+        // Capture the caret before touching the node: assigning `textContent`
+        // replaces the text node's data and drops any selection inside it.
+        const caretOffset = selection?.anchorNode === anchor
+            ? countKeptBefore(text, selection.anchorOffset)
+            : null;
+        const stripped = text.split(COMPOSITION_ANCHOR).join('');
+
+        if (stripped === '') {
+            // Composition cancelled, or backspaced away character by character.
+            // The anchor goes with it, and the caret goes with the anchor — so
+            // put the caret back where it was before the composition started,
+            // at the end of the block's own text.
+            anchor.parentNode?.removeChild(anchor);
+            if (caretOffset != null)
+                this.setCursor(this.text.length, this.text.length);
+
+            return;
+        }
+
+        anchor.textContent = stripped;
+
+        if (caretOffset == null || selection == null)
+            return;
+
+        const range = document.createRange();
+        range.setStart(anchor, caretOffset);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
     }
 
     /**

--- a/packages/muya/src/utils/index.ts
+++ b/packages/muya/src/utils/index.ts
@@ -403,6 +403,14 @@ export function isInputEvent(event: Event): event is InputEvent {
     return 'inputType' in event;
 }
 
+// narrowing Event type to the `compositionend` CompositionEvent that
+// `Content.composeHandler` forwards into the input pipeline. It carries the
+// committed text on `data` but, unlike an InputEvent, has no `inputType` —
+// so `isInputEvent` rejects it.
+export function isCompositionEndEvent(event: Event): event is CompositionEvent {
+    return event.type === 'compositionend';
+}
+
 // narrowing Note type to Element.
 export function isElement(node: Node): node is Element {
     return node.nodeType === Node.ELEMENT_NODE;


### PR DESCRIPTION
Fixes #5279
Fixes #3468

Shift+Enter, then type the next line with a CJK IME. Two separate defects met there; both are fixed here, and the second turned out to be the older and the worse of the two.

## 1. The soft line break was lost (#5279 — a regression)

Chromium overwrites a block's trailing `\n` the moment anything is typed after it. `lineBreakAutoPair` puts it back, and it already carried a branch for the IME case:

```ts
&& (event.inputType === 'insertText' || event.type === 'compositionend')
```

That branch was unreachable. `composeHandler` forwards the raw `CompositionEvent` into `inputHandler`, but `autoPair` gates on `isInputEvent` — `'inputType' in event` — and a `CompositionEvent` has no `inputType`. Every IME commit returned before reaching the repair.

The old JS engine has no such gate (`packages/muyajs/lib/contentState/inputCtrl.js`, same repair, same `compositionend` condition), so this is a regression from the TypeScript rewrite. Letting `compositionend` past the guard restores the old engine's behaviour.

**Why it shipped with a green test:** the regression test pinning that branch built its event as an object literal carrying `inputType: ''` — the very key the guard looks for. The mock sailed past a guard that rejects every real `CompositionEvent`, so the test passed while the path it claimed to pin was dead code.

## 2. The IME lost the first keystroke of the word (#3468 — open since 2022)

With the newline preserved, a second defect became visible: typing `di'er'hang` for 第二行 produced `i 二行`.

A block whose text ends with `\n` renders that newline as the last thing in its DOM, so a caret at the end of the block sits *inside* the newline's own text node. Chromium will not sustain a composition there — it overwrites the newline and abandons the composition, and the input method never receives the keystroke that started the word. Captured from a real composition driven through CDP `Input.imeSetComposition`:

```
compositionstart   blockText="第一行\n"   domText="第一行\n"
input  d           domText="第一行d"        ← the newline is gone
compositionstart   ← again: the composition restarted, `d` is now plain text
input  i / ie / i'er'hang                   ← the IME's buffer no longer has the `d`
compositionend data="i 二行"
```

This is #3468 verbatim ("输入拼音，第一个字母会被吞掉，输入法中识别不到"), reported in 2022 against the old engine and reproducible there today — it was closed this June on the strength of the code the investigation above shows to be dead.

**Fix:** seed a zero-width space for the composition to live in on `compositionstart`, and strip it on `compositionend`. It exists only while `inputHandler` is short-circuited by `isComposed`, so it is never visible to the DOM ↔ text offset mapping. Two details the browser forces:

- An empty text node does not work — Chromium ignores it and goes back to the newline.
- `mu-line-end` gives the trailing newline a block box of its own, because a newline with nothing after it renders no line at all. The anchor is now that something, so the class is suspended while the anchor is parked; otherwise the composition renders one line below the caret.

Measured in real Chromium, mid-composition:

| | DOM during composition | at commit |
|---|---|---|
| before | `第一行dierhang` — newline gone | `第一行d第二行` |
| after | `第一行\ndierhang​` — newline intact | `第一行\n第二行` |

## 3. Offset compensation, unified

`lineBreakAutoPair` nudged the DOM offset by one and skipped the nudge on Firefox, under a comment admitting nobody knew why. The reason is that the browsers disagree about the text being rebuilt: Chromium overwrites the trailing newline, Firefox leaves it. Setting the offset to the end of the rebuilt text says that directly and holds for both, so the browser test goes away. `event.data` is now also required to be a string — a cancelled composition ends with `null`.

## Verified

Driven through CDP `Input.imeSetComposition` against the E2E host, and confirmed by hand with the WeChat IME on macOS:

| | |
|---|---|
| plain typing after a soft break | `第一行\nabc`, caret at 7 |
| IME commit | `第一行\n第二行`, caret at 7, one `compositionstart` |
| composition cancelled / backspaced away | caret returns to where it started |
| IME text then Backspace | steps down character by character, newline intact — matches the non-IME control |
| code block: Enter then IME | `第一行\n第二行` |
| lines shown while composing | 2, was 3 |

Unit suite 215 files / 1468 tests, `tsc --noEmit`, `eslint src test` (0 errors), `madge --circular`, `stylelint` all clean. The handful of E2E specs that fail locally (`cross-block-enter`, `search-replace`, `ime.spec` table cell) fail identically on unmodified `develop` in the same setup — the baseline failed 7, this branch 4.

## On the tests

No unit test for the anchor: jsdom does not reproduce Chromium's composition behaviour, so a unit test there would assert the implementation back at itself.

The E2E spec instead asserts the newline is still in the live DOM *while the composition is open*, and that only one `compositionstart` fired. The commit is rebuilt from the model plus `event.data`, so a markdown assertion alone comes out right even with the anchor removed — these two do not. Both were verified to fail with the anchor disabled while the non-IME control kept passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzDANHQnQyWY3pMWQVR4yB
