### PR TITLE
fix(muya): keep footnote reference ids intact for special identifiers (#5208)

### DIFF
--- a/packages/muya/e2e/tests/ui/footnote.spec.ts
+++ b/packages/muya/e2e/tests/ui/footnote.spec.ts
@@ -1,7 +1,51 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/muya';
 import { editor, floats } from '../helpers/selectors';
 
+const FOOTNOTE_BACKLINK = '.mu-footnote-backlink';
+
+function fillerParagraphs(count: number): string {
+    return Array.from({ length: count }, (_, i) => `Filler paragraph ${i + 1}.`).join('\n\n');
+}
+
+async function referenceInViewport(page: Page, identifier: string): Promise<boolean> {
+    return page.evaluate((id) => {
+        const reference = document.getElementById(`noteref-${id}`);
+        if (!reference)
+            return false;
+        const { top, bottom } = reference.getBoundingClientRect();
+        return top >= 0 && bottom <= window.innerHeight;
+    }, identifier);
+}
+
 test.describe('footnote tool', () => {
+    for (const identifier of ['锚点链接说明:1', 'a.b']) {
+        test(`backlink returns to the reference [^${identifier}] (#5208)`, async ({ page }) => {
+            const errors: string[] = [];
+            page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+
+            await page.evaluate((md) => {
+                window.muya!.setContent(md);
+            }, `See note[^${identifier}].\n\n${fillerParagraphs(60)}\n\n[^${identifier}]: footnote body\n`);
+
+            const backlink = page.locator(FOOTNOTE_BACKLINK);
+            await backlink.scrollIntoViewIfNeeded();
+            await expect.poll(() => referenceInViewport(page, identifier)).toBe(false);
+            await backlink.click();
+
+            await expect.poll(() => referenceInViewport(page, identifier)).toBe(true);
+            expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+        });
+    }
+
+    test('footnote tool previews a definition whose identifier contains a dot (#5208)', async ({ page }) => {
+        await page.evaluate(() => {
+            window.muya!.setContent('See note[^a.b].\n\n[^a.b]: dotted footnote body\n');
+        });
+        await page.locator(editor.inlineFootnoteIdentifier).first().click();
+        await expect(page.locator(floats.footnoteTool)).toContainText('dotted footnote body');
+    });
+
     test('footnote-tool float root is registered (option footnote: true)', async ({ page }) => {
         // host/main.ts wires `footnote: true`; the FootnoteTool plugin should
         // mount its baseFloat container at init.

--- a/packages/muya/src/block/extra/footnote/__tests__/footnote.spec.ts
+++ b/packages/muya/src/block/extra/footnote/__tests__/footnote.spec.ts
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
 import type { Muya } from '../../../../muya';
 import type { IFootnoteBlockState } from '../../../../state/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Footnote from '..';
+import { CLASS_NAMES } from '../../../../config';
 import { MarkdownToState } from '../../../../state/markdownToState';
 import ExportMarkdown from '../../../../state/stateToMarkdown';
 import { isFootnoteBlockState } from '../../../../state/types';
@@ -87,6 +88,26 @@ describe('footnote block — class API', () => {
 
         expect(parentDom.contains(block.domNode!)).toBe(false);
         expect(block.parent).toBeNull();
+    });
+});
+
+describe('footnote block — backlink', () => {
+    it.each(['a.b', '锚点链接说明:1'])('scrolls back to the inline reference [^%s] (#5208)', (identifier) => {
+        const block = Footnote.create(makeFakeMuya(), { ...baseState, meta: { identifier } });
+        const reference = document.createElement('sup');
+        reference.id = `noteref-${identifier}`;
+        const scrollIntoView = vi.fn();
+        reference.scrollIntoView = scrollIntoView;
+        document.body.append(reference, block.domNode!);
+
+        try {
+            block.domNode!.querySelector<HTMLElement>(`.${CLASS_NAMES.MU_FOOTNOTE_BACKLINK}`)!.click();
+            expect(scrollIntoView).toHaveBeenCalledOnce();
+        }
+        finally {
+            reference.remove();
+            block.domNode!.remove();
+        }
     });
 });
 

--- a/packages/muya/src/block/extra/footnote/index.ts
+++ b/packages/muya/src/block/extra/footnote/index.ts
@@ -37,9 +37,7 @@ class Footnote extends Parent {
         backlink.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
-            const target = document.querySelector(
-                `#noteref-${footnote.meta.identifier}`,
-            );
+            const target = document.getElementById(`noteref-${footnote.meta.identifier}`);
             target?.scrollIntoView({ behavior: 'smooth' });
         });
         footnote.domNode!.appendChild(backlink);

--- a/packages/muya/src/inlineRenderer/renderer/footnoteIdentifier.ts
+++ b/packages/muya/src/inlineRenderer/renderer/footnoteIdentifier.ts
@@ -34,7 +34,8 @@ export default function footnoteIdentifier(
 
     return [
         h(
-            `sup#noteref-${token.content}.${CLASS_NAMES.MU_INLINE_FOOTNOTE_IDENTIFIER}.${CLASS_NAMES.MU_INLINE_RULE}`,
+            `sup.${CLASS_NAMES.MU_INLINE_FOOTNOTE_IDENTIFIER}.${CLASS_NAMES.MU_INLINE_RULE}`,
+            { attrs: { id: `noteref-${token.content}` } },
             [
                 h(`span.${className}.${CLASS_NAMES.MU_REMOVE}`, startMarker),
                 h(


### PR DESCRIPTION
## Summary

Fixes #5208.

Footnote identifiers may contain characters that are special in CSS selectors, such as `[^a.b]` or `[^锚点链接说明:1]`. The report came from v0.19.1's footnote click handler, and `@muyajs/core` still used the identifier inside a selector in two places:

- **Inline reference id.** The `<sup>` got its id from the snabbdom selector string `sup#noteref-<identifier>.class`. With a `.` the id was truncated (`noteref-a`) and the rest became a class, so clicking the reference opened the footnote tool with "Can't find footnote with syntax [^a]".
- **Definition backlink (↩︎).** It called `document.querySelector('#noteref-<identifier>')`, which throws `SyntaxError: '#noteref-锚点链接说明:1' is not a valid selector` (the crash in #5208), and for `a.b` it found nothing to scroll to.

The id is now set through `attrs`, and the backlink resolves its target with `getElementById`; both take the identifier verbatim. The other `#id` lookups in muya use generated ids, so no other call site is affected.

## Test plan

- [x] Unit (`src/block/extra/footnote/__tests__/footnote.spec.ts`): the backlink scrolls to `[^a.b]` and `[^锚点链接说明:1]`. Before the fix: SyntaxError / no scroll.
- [x] e2e, Chromium (`e2e/tests/ui/footnote.spec.ts`):
  - The backlink returns to the reference for both identifiers, with no `pageerror`.
  - The footnote tool previews a `[^a.b]` definition. Before the fix it showed "Can't find footnote with syntax [^a]".
- [x] `pnpm -C packages/muya test` (1477 passed), `pnpm -C packages/muya lint:types`, eslint on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
