### PR TITLE
fix(muya): give a code block's trailing empty line a line box

### DIFF
--- a/packages/muya/e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts
+++ b/packages/muya/e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts
@@ -160,6 +160,48 @@ test.describe('code block caret on the empty last line', () => {
     });
 });
 
+test.describe('code block arrow keys on empty lines', () => {
+    test('ArrowUp from the empty last line moves to the line above', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'world');
+        await page.keyboard.press('Enter');
+
+        await page.keyboard.press('ArrowUp');
+        await slowType(page, 'X');
+
+        await expect.poll(() => codeText(page)).toMatch(/^hello\n[^\n]*X[^\n]*\n$/);
+    });
+
+    test('ArrowDown from an empty line moves to the line below', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'world');
+
+        const { left, top, lineHeight } = await codeGeometry(page);
+        await page.mouse.click(left + 40, top + lineHeight * 1.5);
+        await page.keyboard.press('ArrowDown');
+        await slowType(page, 'Y');
+
+        await expect.poll(() => codeText(page)).toMatch(/^hello\n\n[^\n]*Y[^\n]*$/);
+    });
+
+    test('ArrowUp on the first line still leaves the code block', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'world');
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('ArrowUp');
+
+        await expect.poll(() => page.evaluate(() => window.muya!.editor.activeContentBlock?.blockName)).not.toBe('codeblock.content');
+        expect(await codeText(page)).toBe('hello\nworld');
+    });
+});
+
 test.describe('code block IME composition on the empty last line', () => {
     test.skip(
         ({ browserName }) => browserName !== 'chromium',

--- a/packages/muya/e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts
+++ b/packages/muya/e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts
@@ -1,0 +1,200 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #5114: Enter at the end of a code block whose text already ended in a newline
+// left the caret on the same visual line — the last line had no line box.
+
+interface ICodeGeometry {
+    left: number;
+    top: number;
+    lineHeight: number;
+    lines: number;
+}
+
+async function codeGeometry(page: Page): Promise<ICodeGeometry> {
+    return page.locator(editor.codeContent).first().evaluate((el) => {
+        const lineHeight = Number.parseFloat(getComputedStyle(el).lineHeight);
+        const { left, top, height } = el.getBoundingClientRect();
+        return { left, top, lineHeight, lines: Math.round(height / lineHeight) };
+    });
+}
+
+async function codeText(page: Page): Promise<string> {
+    return page.locator(editor.codeContent).first().evaluate(el => el.textContent ?? '');
+}
+
+// A collapsed range right after a newline has no client rects, so the painted
+// caret is located in a screenshot instead: glyphs hidden, caret pure red.
+async function caretLine(page: Page): Promise<number | null> {
+    const clip = (await page.locator(editor.codeContent).first().boundingBox())!;
+    const { top, lineHeight } = await codeGeometry(page);
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+        const png = await page.screenshot({ clip, caret: 'initial' });
+        const caretY = await page.evaluate(async (base64) => {
+            const image = new Image();
+            image.src = `data:image/png;base64,${base64}`;
+            await image.decode();
+            const canvas = document.createElement('canvas');
+            canvas.width = image.width;
+            canvas.height = image.height;
+            const context = canvas.getContext('2d')!;
+            context.drawImage(image, 0, 0);
+            const { data, width, height } = context.getImageData(0, 0, image.width, image.height);
+            const rows: number[] = [];
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const i = (y * width + x) * 4;
+                    if (data[i] > 200 && data[i + 1] < 60 && data[i + 2] < 60) {
+                        rows.push(y);
+                        break;
+                    }
+                }
+            }
+            return rows.length ? (rows[0] + rows[rows.length - 1]) / 2 : null;
+        }, png.toString('base64'));
+
+        if (caretY != null)
+            return Math.floor((clip.y + caretY - top) / lineHeight) + 1;
+        await page.waitForTimeout(100);
+    }
+
+    return null;
+}
+
+// A new code block re-renders on its first animation frame (the line-number
+// gutter seed in codeBlock/index.ts, and the language load), which throws away
+// a caret that typing has already moved.
+async function settleNewCodeBlock(page: Page): Promise<void> {
+    await expect(page.locator(editor.codeContent)).toHaveCount(1);
+    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => setTimeout(resolve))));
+}
+
+async function openCodeBlock(page: Page): Promise<void> {
+    await page.evaluate(() => window.muya!.setContent(''));
+    await page.locator(editor.paragraph).first().click();
+    await page.keyboard.type('```');
+    await page.keyboard.press('Enter');
+    await settleNewCodeBlock(page);
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.addStyleTag({
+        content: `${editor.codeContent}, ${editor.codeContent} * {
+            color: transparent !important;
+            caret-color: rgb(255, 0, 0) !important;
+            caret-animation: manual;
+        }`,
+    });
+});
+
+test.describe('code block Enter at a trailing newline', () => {
+    test('Enter twice after a line puts the caret on a third line', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+
+        await expect.poll(() => codeText(page)).toBe('hello\n\n');
+        expect((await codeGeometry(page)).lines).toBe(3);
+        expect(await caretLine(page)).toBe(3);
+
+        await slowType(page, 'x');
+        await expect.poll(() => codeText(page)).toBe('hello\n\nx');
+    });
+
+    test('Enter in an empty code block puts the caret on a second line', async ({ page }) => {
+        await openCodeBlock(page);
+        await page.keyboard.press('Enter');
+
+        await expect.poll(() => codeText(page)).toBe('\n');
+        expect((await codeGeometry(page)).lines).toBe(2);
+        expect(await caretLine(page)).toBe(2);
+    });
+
+    test('a syntax-highlighted block keeps its empty last line', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```js\nconst a = 1\n```\n'));
+        await settleNewCodeBlock(page);
+        await page.locator(editor.codeContent).first().click();
+        await page.keyboard.press('End');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+
+        await expect.poll(() => codeText(page)).toBe('const a = 1\n\n');
+        expect(await page.locator(`${editor.codeContent} .token`).count()).toBeGreaterThan(0);
+        expect((await codeGeometry(page)).lines).toBe(3);
+        expect(await caretLine(page)).toBe(3);
+    });
+});
+
+test.describe('code block caret on the empty last line', () => {
+    test('clicking the empty last line types at the end of the code', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+
+        const { left, top, lineHeight } = await codeGeometry(page);
+        await page.mouse.click(left + 40, top + lineHeight * 0.5);
+        await page.mouse.click(left + 40, top + lineHeight * 2.5);
+        await slowType(page, 'z');
+
+        await expect.poll(() => codeText(page)).toBe('hello\n\nz');
+    });
+
+    test('ArrowDown onto the empty last line types at the end of the code', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'abc');
+        await page.keyboard.press('Enter');
+
+        const { left, top, lineHeight } = await codeGeometry(page);
+        await page.mouse.click(left + 200, top + lineHeight * 1.5);
+        await page.keyboard.press('ArrowDown');
+        await slowType(page, 'q');
+
+        await expect.poll(() => codeText(page)).toBe('hello\nabc\nq');
+    });
+});
+
+test.describe('code block IME composition on the empty last line', () => {
+    test.skip(
+        ({ browserName }) => browserName !== 'chromium',
+        'Input.imeSetComposition is a Chrome DevTools Protocol command',
+    );
+
+    test('composes on the empty last line and commits at the end', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+
+        const cdp = await page.context().newCDPSession(page);
+        await cdp.send('Input.imeSetComposition', { text: 'ni', selectionStart: 2, selectionEnd: 2 });
+
+        const composedLine = await page.locator(editor.codeContent).first().evaluate((el) => {
+            const lineHeight = Number.parseFloat(getComputedStyle(el).lineHeight);
+            const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+            for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+                const index = node.textContent!.indexOf('ni');
+                if (index === -1)
+                    continue;
+                const range = document.createRange();
+                range.setStart(node, index);
+                range.setEnd(node, index + 2);
+                const { top, bottom } = range.getBoundingClientRect();
+                return Math.floor(((top + bottom) / 2 - el.getBoundingClientRect().top) / lineHeight) + 1;
+            }
+            return null;
+        });
+        expect(composedLine).toBe(3);
+
+        await cdp.send('Input.imeSetComposition', { text: '你', selectionStart: 1, selectionEnd: 1 });
+        await cdp.send('Input.insertText', { text: '你' });
+
+        await expect.poll(() => codeText(page)).toBe('hello\n\n你');
+    });
+});

--- a/packages/muya/src/block/base/content.ts
+++ b/packages/muya/src/block/base/content.ts
@@ -664,7 +664,9 @@ class Content extends TreeNode {
         }
 
         const anchor = document.createTextNode(COMPOSITION_ANCHOR);
-        domNode.appendChild(anchor);
+        // Ahead of a code block's trailing line break: past it, the composition
+        // would start a line below the caret.
+        domNode.insertBefore(anchor, domNode.querySelector(`:scope > .${CLASS_NAMES.MU_TRAILING_BREAK}`));
         this._compositionAnchor = anchor;
 
         // `mu-line-end` makes the trailing newline a block of its own, because

--- a/packages/muya/src/block/content/codeBlockContent/__tests__/arrowHandler.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/arrowHandler.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// happy-dom gives a collapsed caret no client rects — as Chromium does on an
+// empty line — so without a text-based answer Content.arrowHandler takes every
+// caret for the edge of the block.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function codeContentWithCaret(text: string, offset: number): { muya: Muya; content: Content } {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown: '```\nhello\n```\n' } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+
+    let content: Content | null = null;
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'codeblock.content')
+            content = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!content)
+        throw new Error('codeblock.content block not found');
+
+    const found: Content = content;
+    found.text = text;
+    found.setCursor(offset, offset, true);
+    return { muya, content: found };
+}
+
+function pressArrow(content: Content, key: 'ArrowUp' | 'ArrowDown'): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+    content.arrowHandler(event);
+    return event;
+}
+
+describe('codeBlockContent.arrowHandler', () => {
+    it('leaves ArrowUp on the empty last line to the browser', () => {
+        const { muya, content } = codeContentWithCaret('hello\nworld\n', 12);
+
+        expect(pressArrow(content, 'ArrowUp').defaultPrevented).toBe(false);
+        expect(muya.editor.activeContentBlock).toBe(content);
+    });
+
+    it('leaves ArrowDown on an empty middle line to the browser', () => {
+        const { muya, content } = codeContentWithCaret('hello\n\nworld', 6);
+
+        expect(pressArrow(content, 'ArrowDown').defaultPrevented).toBe(false);
+        expect(muya.editor.activeContentBlock).toBe(content);
+    });
+
+    it('still handles ArrowUp on the first line', () => {
+        const { content } = codeContentWithCaret('hello\nworld', 3);
+
+        expect(pressArrow(content, 'ArrowUp').defaultPrevented).toBe(true);
+    });
+
+    it('still handles ArrowDown on the last line', () => {
+        const { content } = codeContentWithCaret('hello\nworld', 11);
+
+        expect(pressArrow(content, 'ArrowDown').defaultPrevented).toBe(true);
+    });
+});

--- a/packages/muya/src/block/content/codeBlockContent/__tests__/trailingNewline.spec.ts
+++ b/packages/muya/src/block/content/codeBlockContent/__tests__/trailingNewline.spec.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import type Content from '../../../base/content';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../../../../config';
+import { Muya } from '../../../../muya';
+
+// #5114 — layout and caret placement are covered by
+// e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts; this pins the DOM
+// contract the fix relies on.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function codeContent(muya: Muya): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName === 'codeblock.content')
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error('codeblock.content block not found');
+    return target;
+}
+
+function trailingBreak(content: Content): Element | null {
+    return content.domNode!.querySelector(`:scope > .${CLASS_NAMES.MU_TRAILING_BREAK}`);
+}
+
+describe('codeBlockContent trailing newline', () => {
+    it('ends the rendered code with a line break when the text ends with a newline', () => {
+        const content = codeContent(bootMuya('```\nhello\n```\n'));
+        content.text = 'hello\n\n';
+        content.update();
+
+        const lineBreak = trailingBreak(content);
+        expect(lineBreak).not.toBeNull();
+        expect(content.domNode!.lastChild).toBe(lineBreak);
+        expect(lineBreak!.innerHTML).toBe('<br>');
+        expect(content.domNode!.textContent).toBe('hello\n\n');
+    });
+
+    it('renders no trailing line break when the text does not end with a newline', () => {
+        const content = codeContent(bootMuya('```\nhello\n```\n'));
+        content.text = 'hello\nworld';
+        content.update();
+
+        expect(trailingBreak(content)).toBeNull();
+        expect(content.domNode!.innerHTML).toBe('hello\nworld');
+    });
+
+    it('keeps the trailing line break on a syntax-highlighted block', () => {
+        const content = codeContent(bootMuya('```js\nconst a = 1\n```\n'));
+        content.text = 'const a = 1\n';
+        content.update();
+
+        expect(content.domNode!.querySelector('.token')).not.toBeNull();
+        expect(content.domNode!.lastChild).toBe(trailingBreak(content));
+        expect(content.domNode!.textContent).toBe('const a = 1\n');
+    });
+
+    it('seeds the IME composition anchor in front of the trailing line break', () => {
+        const content = codeContent(bootMuya('```\nhello\n```\n'));
+        content.text = 'hello\n\n';
+        content.setCursor(7, 7, true);
+
+        content.composeHandler(new CompositionEvent('compositionstart', { data: '' }));
+
+        const lineBreak = trailingBreak(content)!;
+        expect(content.domNode!.lastChild).toBe(lineBreak);
+        expect(lineBreak.previousSibling?.nodeType).toBe(Node.TEXT_NODE);
+        expect(lineBreak.previousSibling?.textContent).toBe(String.fromCharCode(0x200B));
+    });
+});

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -8,8 +8,8 @@ import type {
 } from '../../../state/types';
 import type Code from '../../commonMark/codeBlock/code';
 import type HTMLPreview from '../../commonMark/html/htmlPreview';
-import { CLASS_NAMES, HTML_TAGS, VOID_HTML_TAGS } from '../../../config';
-import { adjustOffset, escapeHTML, firstWordOfInfo } from '../../../utils';
+import { CLASS_NAMES, EVENT_KEYS, HTML_TAGS, VOID_HTML_TAGS } from '../../../config';
+import { adjustOffset, escapeHTML, firstWordOfInfo, isKeyboardEvent } from '../../../utils';
 import { computeLineCount, repositionLineNumberSpans, syncLineNumbersSpans } from '../../../utils/codeBlockLineNumbers';
 import { getHighlightHtml, MARKER_HASH } from '../../../utils/highlightHTML';
 import prism, { loadedLanguages, transformAliasToOrigin, walkTokens } from '../../../utils/prism/index';
@@ -317,6 +317,23 @@ class CodeBlockContent extends Content {
             offset += tabSize;
 
         this.setCursor(offset, offset, true);
+    }
+
+    // Content.arrowHandler measures the caret to tell whether it is on the
+    // block's first or last line, and a caret on an empty line has no rect to
+    // measure, so it left the block. A newline on the caret's side settles it.
+    override arrowHandler(event: Event): void {
+        if (isKeyboardEvent(event)) {
+            const { start, end } = this.getCursor()!;
+            if (
+                (event.key === EVENT_KEYS.ArrowUp && this.text.slice(0, start.offset).includes('\n'))
+                || (event.key === EVENT_KEYS.ArrowDown && this.text.slice(end.offset).includes('\n'))
+            ) {
+                return;
+            }
+        }
+
+        super.arrowHandler(event);
     }
 
     override tabHandler(event: KeyboardEvent): void {

--- a/packages/muya/src/block/content/codeBlockContent/index.ts
+++ b/packages/muya/src/block/content/codeBlockContent/index.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../state/types';
 import type Code from '../../commonMark/codeBlock/code';
 import type HTMLPreview from '../../commonMark/html/htmlPreview';
-import { HTML_TAGS, VOID_HTML_TAGS } from '../../../config';
+import { CLASS_NAMES, HTML_TAGS, VOID_HTML_TAGS } from '../../../config';
 import { adjustOffset, escapeHTML, firstWordOfInfo } from '../../../utils';
 import { computeLineCount, repositionLineNumberSpans, syncLineNumbersSpans } from '../../../utils/codeBlockLineNumbers';
 import { getHighlightHtml, MARKER_HASH } from '../../../utils/highlightHTML';
@@ -169,7 +169,7 @@ class CodeBlockContent extends Content {
         // transform alias to original language
         const fullLengthLang = transformAliasToOrigin([lang])[0];
         const domNode = this.domNode!;
-        const code = escapeHTML(getHighlightHtml(text, highlights, true, true))
+        const code = escapeHTML(getHighlightHtml(text, highlights, true))
             .replace(new RegExp(MARKER_HASH['<'], 'g'), '<')
             .replace(new RegExp(MARKER_HASH['>'], 'g'), '>')
             .replace(new RegExp(MARKER_HASH['"'], 'g'), '"')
@@ -189,6 +189,18 @@ class CodeBlockContent extends Content {
         }
         else {
             domNode.innerHTML = code;
+        }
+
+        // A final newline lays out no line of its own, so the caret after it had
+        // nowhere to sit (#5114). Added after highlighting: Prism's keep-markup
+        // drops empty elements. Wrapped: Chromium puts the caret just before the
+        // <br>, and (content, childIndex) would read back as text offset
+        // childIndex where (wrapper, 0) reads back as the text length.
+        if (text.endsWith('\n')) {
+            const trailingBreak = document.createElement('span');
+            trailingBreak.classList.add(CLASS_NAMES.MU_TRAILING_BREAK);
+            trailingBreak.appendChild(document.createElement('br'));
+            domNode.appendChild(trailingBreak);
         }
 
         this._updateLineNumbers(text);

--- a/packages/muya/src/config/index.ts
+++ b/packages/muya/src/config/index.ts
@@ -120,6 +120,7 @@ export const CLASS_NAMES = genUpper2LowerKeyHash([
     'MU_HARD_LINE_BREAK',
     'MU_HARD_LINE_BREAK_SPACE',
     'MU_LINE_END',
+    'MU_TRAILING_BREAK',
     'MU_HEADER_TIGHT_SPACE',
     'MU_HIDE',
     'MU_HIDE_SPELLING_MARKS',

--- a/packages/muya/src/utils/highlightHTML.ts
+++ b/packages/muya/src/utils/highlightHTML.ts
@@ -10,7 +10,7 @@ export const MARKER_HASH = {
     '\'': `%${getLongUniqueId()}%`,
 };
 
-export function getHighlightHtml(text: string, highlights: IHighlight[], escape = false, handleLineEnding = false) {
+export function getHighlightHtml(text: string, highlights: IHighlight[], escape = false) {
     let code = '';
     let pos = 0;
 
@@ -22,32 +22,12 @@ export function getHighlightHtml(text: string, highlights: IHighlight[], escape 
         const { start, end, active } = highlight;
         code += text.substring(pos, start);
         const className = active ? CLASS_NAMES.MU_HIGHLIGHT : CLASS_NAMES.MU_SELECTION;
-        let highlightContent = text.substring(start, end);
-        if (handleLineEnding && text.endsWith('\n') && end === text.length) {
-            highlightContent
-                = highlightContent.substring(start, end - 1)
-                    + (escape
-                        ? getEscapeHTML(CLASS_NAMES.MU_LINE_END, '\n')
-                        : `<span class="${CLASS_NAMES.MU_LINE_END}">\n</span>`);
-        }
+        const highlightContent = text.substring(start, end);
         code += escape
             ? getEscapeHTML(className, highlightContent)
             : `<span class="${className}">${highlightContent}</span>`;
         pos = end;
     }
 
-    if (pos !== text.length) {
-        if (handleLineEnding && text.endsWith('\n')) {
-            code
-                += text.substring(pos, text.length - 1)
-                    + (escape
-                        ? getEscapeHTML(CLASS_NAMES.MU_LINE_END, '\n')
-                        : `<span class="${CLASS_NAMES.MU_LINE_END}">\n</span>`);
-        }
-        else {
-            code += text.substring(pos);
-        }
-    }
-
-    return code;
+    return code + text.substring(pos);
 }


### PR DESCRIPTION
Fixes #5114

In a code block, type a line and press Enter twice: the caret should be on line 3, but it stays on line 2. While testing this branch a second defect on the same empty lines turned up — arrow keys there left the code block — and it is fixed here too.

## Root cause

A newline with nothing after it lays out no line. The code block compensated by wrapping its final `\n` in a `display: block` `mu-line-end` span (`getHighlightHtml(…, handleLineEnding)`), and that only works when the text before the newline does not end in one as well. Measured in Chromium:

| text | rendered | lines drawn | expected |
|---|---|---|---|
| `hello\n` | `hello<span.mu-line-end>\n</span>` | 2 | 2 |
| `hello\n\n` | `hello\n<span.mu-line-end>\n</span>` | **2** | 3 |
| `\n` (empty block + Enter) | `<span.mu-line-end>\n</span>` | **1** | 2 |

With no line box to sit on, the caret is drawn on the line above. The same gap made ArrowDown onto the empty last line type at the end of the previous line: `hello\nabc` + ArrowDown + `q` gave `hello\nabcq\n`.

## Fix

`CodeBlockContent.update()` appends `<span class="mu-trailing-break"><br></span>` whenever the text ends with a newline. The text node — and so `textContent` and every offset — is unchanged. Two constraints shape it:

- **Added after highlighting.** Prism's keep-markup plugin re-inserts preserved elements by text position and never matches a zero-width element at the very end of the text, so a `<br>` in the pre-highlight HTML is dropped.
- **Wrapped in a span.** Chromium puts the caret just before the `<br>`, inside its parent. For a bare `<br>` that is `(content, 1)`, which `TextSelection.getSelection` reads as text offset 1 — clicking the last line and typing produced `hzello`. Inside the wrapper the caret is at `(wrapper, 0)`, which resolves to the text length.

The IME composition anchor from #5281 is now seeded ahead of the trailing break; appended after it, the composition started a line below the caret.

`getHighlightHtml` loses its `handleLineEnding` path, which only the code block used.

### Measured and rejected

| approach | lines | caret |
|---|---|---|
| `mu-line-end` inline + `::after { content: '\200B' }` | ✓ | ✗ painted a line up |
| bare trailing `<br>` | ✓ | ✗ click / ArrowDown onto the last line resolve to offset 1 |

## Arrow keys on empty lines

In `hello\nworld\n` with the caret on the empty last line, ArrowUp left the code block for the language input instead of moving to `world`; from an empty middle line, ArrowDown left it the other way. This predates the branch.

`Content.arrowHandler` measures the caret to decide whether it is on the block's first or last line. A caret on an empty line has no client rect, and the failed measurement reads as both. In a code block a newline on the caret's side already answers the question, so `CodeBlockContent.arrowHandler` leaves those keys to the browser and defers to `Content.arrowHandler` otherwise — including a wrapped first or last line, which still needs the measurement.

## Tests

- `e2e/tests/blocks/codeblock-trailing-newline-5114.spec.ts` (Chromium)
  - lines drawn and the line the caret is painted on after Enter ×2, after Enter in an empty block, and in a Prism-highlighted block. A collapsed range right after a newline has no client rects, so the caret is found in a screenshot: glyphs transparent, caret painted red, `caret-animation: manual`;
  - click and ArrowDown onto the empty last line, then type;
  - ArrowUp from the empty last line and ArrowDown from an empty middle line stay in the block; ArrowUp on the first line still leaves it;
  - an IME composition on the empty last line via CDP `Input.imeSetComposition`.
- `codeBlockContent/__tests__/trailingNewline.spec.ts` (jsdom) — a trailing break only after a final newline, `textContent` unchanged, kept on highlighted blocks, the IME anchor seeded ahead of it.
- `codeBlockContent/__tests__/arrowHandler.spec.ts` (happy-dom, which like Chromium on an empty line gives the caret no rect) — which arrow keys are left to the browser and which still go through `Content.arrowHandler`.

## Verified

| | before | this branch |
|---|---|---|
| E2E, trailing-line cases (6) | `develop`: 4 fail | 6 pass; 48/48 at `--repeat-each=8 --workers=4` |
| E2E, arrow-key cases (3) | before the arrow fix: 2 fail | 3 pass; 24/24 at `--repeat-each=8 --workers=4` |
| unit, `trailingNewline.spec.ts` (4) | `develop`: 3 fail | 4 pass |
| unit, `arrowHandler.spec.ts` (4) | `Content.arrowHandler` prevents both empty-line moves | 4 pass |

Both IME guards fail with the anchor change reverted. `tsc --noEmit` and ESLint (0 errors) are clean, and the codeBlockContent / base arrow-navigation / table-cell arrow / HTML-block arrow unit suites pass. Locally the `blocks`, `diagrams`, `typing` and `options` E2E directories pass except `search-replace` ×2 and the `ime.spec` table-cell case — which fail identically on unmodified `develop` in the same setup — and the first two `options/autopair` cases, which type into a paragraph and never reach this code.

## Found along the way, not changed here

- **A new code block can drop the caret of the first keystroke.** With code-block line numbers enabled (off by default), a new code block re-renders on its first animation frame to fill the gutter (`codeBlock/index.ts`). A keystroke landing before that frame loses its caret to the start of the block, and the rest of the word is typed in front of it: `hello` becomes `elloh`. Seen only in automation under heavy parallel load (22 of 32 runs at 4 workers); not reproduced at typing speed, even with 20× CPU throttling. The E2E spec waits a frame after creating a block.
- **`TextSelection.getSelection` reads an element-level boundary `(content, n)` as text offset `n`** rather than the length of the text before child `n`. No normal editing path on `develop` is known to produce such a boundary — the bare `<br>` above did. To see it: in a code block containing `hello world`, set the selection to `(codeContent, 1)` (the end of the text), press Shift, then type `Z` — the result is `hZello world`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QodFHUNmHeC8NhrHSYeXk
