### PR TITLE
fix(muya): skip search matches whose block left the document (#5163, #5215)

### DIFF
--- a/packages/muya/e2e/tests/editing/search-stale-match-5163.spec.ts
+++ b/packages/muya/e2e/tests/editing/search-stale-match-5163.spec.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+
+// The desktop find bar closes with `muya.search('', { selectHighlight: true })`,
+// which drops the caret back onto the last active match.
+async function closeSearch(page: Page): Promise<string | null> {
+    return page.evaluate(() => {
+        try {
+            window.muya!.search('', { selectHighlight: true });
+            return null;
+        }
+        catch (error) {
+            return String(error);
+        }
+    });
+}
+
+test('#5163 closing search after the matched heading was turned into a paragraph does not crash', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+
+    await page.evaluate(() => window.muya!.setContent('# foo\n\nbar\n'));
+    await page.evaluate(() => window.muya!.search('foo'));
+    await page.evaluate(() => {
+        window.muya!.editor.scrollPage.firstContentInDescendant().setCursor(0, 0, true);
+    });
+    await page.waitForTimeout(150);
+    await page.keyboard.press('Backspace');
+    await expect.poll(() => getMarkdown(page)).toBe('foo\n\nbar\n');
+
+    expect(await closeSearch(page)).toBeNull();
+
+    await page.keyboard.type('x', { delay: 30 });
+    await expect.poll(() => getMarkdown(page)).toContain('x');
+    expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+});

--- a/packages/muya/src/search/__tests__/searchStaleMatch.spec.ts
+++ b/packages/muya/src/search/__tests__/searchStaleMatch.spec.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('search with matches whose blocks left the document (#5163)', () => {
+    it('closing the search with selectHighlight skips a detached active match', () => {
+        const muya = bootMuya('# foo\n\nbar\n');
+        const search = muya.editor.searchModule;
+        search.search('foo');
+        expect(search.matches.length).toBe(1);
+
+        search.matches[0].block.parent!.remove();
+
+        expect(() => search.search('', { selectHighlight: true })).not.toThrow();
+        expect(search.matches).toEqual([]);
+    });
+});

--- a/packages/muya/src/search/index.ts
+++ b/packages/muya/src/search/index.ts
@@ -51,6 +51,9 @@ export class Search {
         }
 
         for (const [block, highlights] of matchesMap.entries()) {
+            if (!block.outMostBlock)
+                continue;
+
             const isActive = highlights.some(h => h.active);
 
             block.update(undefined, isClear ? [] : highlights);
@@ -208,7 +211,7 @@ export class Search {
         // cursor where the highlight was so the user can keep typing there.
         if (selectHighlight) {
             const activeMatch = matches[index] ?? prevActiveMatch;
-            if (activeMatch) {
+            if (activeMatch?.block.outMostBlock) {
                 const { block, start, end } = activeMatch;
                 block.setCursor(start, end, true);
             }


### PR DESCRIPTION
## Summary

Fixes #5163
Fixes #5215

Both crash reports (v0.20.0-rc.1) show `TypeError: Cannot destructure property 'path' of 'this.parent' as it is null.`:

- #5163: `AtxHeadingContent.setCursor` ← `Search.search` ← `emptySearch`
- #5215: `CodeBlockContent.setCursor` ← `Search.search`

`Search` stores live block references in its matches. When an edit replaces the matched block while the find bar is open (a heading turned into a paragraph, or a code block rebuilt), the matches still point at the old block. Closing the find bar calls `muya.search('', { selectHighlight: true })`, which puts the cursor back on the previous active match. That block is no longer in the document, so `setCursor` cannot resolve its path and throws.

The fix only restores the cursor onto a match whose block is still attached (`block.outMostBlock`), and skips detached blocks when clearing or repainting highlights.

## Test plan

- [x] e2e, Chromium (`e2e/tests/editing/search-stale-match-5163.spec.ts`): search `foo` in `# foo`, press Backspace at the heading start, close the search the way the desktop find bar does, then keep typing. Before the fix: the TypeError above.
- [x] Unit (`src/search/__tests__/searchStaleMatch.spec.ts`): closing a search whose active match was detached does not throw. Before the fix: the same TypeError.
- [x] `pnpm -C packages/muya test` (1476 passed), `pnpm -C packages/muya lint:types`, eslint on the changed files

`e2e/tests/editing/search-replace.spec.ts` (`#single` / `#all`) also fails locally on unmodified `develop` for me: it reads markdown before the next animation frame flushes the edit. That spec is unchanged here and passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
