### PR TITLE
fix(muya): keep the image resize bar from crashing after its image is removed (#5216)

### DIFF
--- a/packages/muya/e2e/tests/drag/image-resize-bar-detached-5216.spec.ts
+++ b/packages/muya/e2e/tests/drag/image-resize-bar-detached-5216.spec.ts
@@ -1,0 +1,62 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { editor, floats } from '../helpers/selectors';
+
+const DATA_URI = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+
+function collectErrors(page: Page): string[] {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+    return errors;
+}
+
+async function loadImage(page: Page): Promise<Locator> {
+    await page.evaluate(uri => window.muya!.setContent(`before\n\n![alt](${uri})\n\nafter\n`), DATA_URI);
+    const image = page.locator(editor.image).first();
+    await expect.poll(() => image.evaluate(el => el.classList.contains('mu-image-success'))).toBe(true);
+    const innerImg = image.locator('img').first();
+    await expect(innerImg).toBeVisible();
+    return innerImg;
+}
+
+test.describe('ImageResizeBar after the image is deleted (#5216)', () => {
+    test('deleting the image before the bar renders does not crash', async ({ page }) => {
+        const errors = collectErrors(page);
+        const innerImg = await loadImage(page);
+
+        await innerImg.evaluate((img) => {
+            img.click();
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+        });
+        await page.waitForTimeout(200);
+
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+        await expect.poll(() => getMarkdown(page)).not.toContain('![alt]');
+        await expect(page.locator(floats.imageTransformerHandle)).toHaveCount(0);
+    });
+
+    test('deleting the image while dragging a resize handle does not crash', async ({ page }) => {
+        const errors = collectErrors(page);
+        const innerImg = await loadImage(page);
+
+        await innerImg.click();
+        const rightHandle = page.locator(`${floats.imageTransformer} .bar.right`);
+        await expect(rightHandle).toBeVisible();
+        const box = await rightHandle.boundingBox();
+        if (!box)
+            throw new Error('right handle has no bounding box');
+        const x = box.x + box.width / 2;
+        const y = box.y + box.height / 2;
+
+        await page.mouse.move(x, y);
+        await page.mouse.down();
+        await page.keyboard.press('Delete');
+        await expect.poll(() => getMarkdown(page)).not.toContain('![alt]');
+        await page.mouse.move(x + 40, y, { steps: 4 });
+        await page.mouse.up();
+        await page.waitForTimeout(200);
+
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+    });
+});

--- a/packages/muya/src/ui/imageResizeBar/__tests__/imageResizeBar.spec.ts
+++ b/packages/muya/src/ui/imageResizeBar/__tests__/imageResizeBar.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../muya';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ImageResizeBar } from '..';
+import EventCenter from '../../../event';
+
+const appendedNodes: ChildNode[] = [];
+
+function setup(): EventCenter {
+    const eventCenter = new EventCenter();
+    const domNode = document.createElement('div');
+    document.body.appendChild(domNode);
+    appendedNodes.push(domNode);
+    // eslint-disable-next-line no-new
+    new ImageResizeBar({ domNode, eventCenter } as unknown as Muya);
+    return eventCenter;
+}
+
+function imageContainer(): HTMLElement {
+    const container = document.createElement('span');
+    container.appendChild(document.createElement('img'));
+    container.getBoundingClientRect = () =>
+        ({ top: 0, left: 0, right: 10, bottom: 10, width: 10, height: 10, x: 0, y: 0, toJSON: () => '' }) as DOMRect;
+    document.body.appendChild(container);
+    appendedNodes.push(container);
+    return container;
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+    while (appendedNodes.length)
+        appendedNodes.pop()!.remove();
+    document.querySelectorAll('.mu-transformer').forEach(el => el.remove());
+});
+
+describe('image resize bar after its image is removed', () => {
+    it('skips the deferred render when the reference was cleared first (#5216)', () => {
+        vi.useFakeTimers();
+        const eventCenter = setup();
+
+        eventCenter.emit('muya-transformer', { block: {}, reference: imageContainer(), imageInfo: {} });
+        eventCenter.emit('muya-transformer', { reference: null });
+
+        expect(() => vi.runAllTimers()).not.toThrow();
+        expect(document.querySelectorAll('.mu-transformer .bar')).toHaveLength(0);
+    });
+
+    it('stops following the mouse when hidden in the middle of a drag', () => {
+        vi.useFakeTimers();
+        const eventCenter = setup();
+
+        eventCenter.emit('muya-transformer', { block: {}, reference: imageContainer(), imageInfo: {} });
+        vi.runAllTimers();
+        const handle = document.querySelector<HTMLElement>('.mu-transformer .bar.right')!;
+        handle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        eventCenter.emit('muya-transformer', { reference: null });
+
+        expect(eventCenter.events.some(e => e.target === document.body && e.event === 'mousemove')).toBe(false);
+
+        const listenerErrors: unknown[] = [];
+        const onError = (event: ErrorEvent) => listenerErrors.push(event.error ?? event.message);
+        window.addEventListener('error', onError);
+        try {
+            expect(() => document.body.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 40 }))).not.toThrow();
+        }
+        finally {
+            window.removeEventListener('error', onError);
+        }
+        expect(listenerErrors).toEqual([]);
+    });
+});

--- a/packages/muya/src/ui/imageResizeBar/index.ts
+++ b/packages/muya/src/ui/imageResizeBar/index.ts
@@ -68,7 +68,8 @@ export class ImageResizeBar {
                 this._block = block;
                 this._imageInfo = imageInfo;
                 setTimeout(() => {
-                    this._render();
+                    if (this._reference === reference)
+                        this._render();
                 });
             }
             else {

--- a/packages/muya/src/ui/imageResizeBar/index.ts
+++ b/packages/muya/src/ui/imageResizeBar/index.ts
@@ -189,13 +189,7 @@ export class ImageResizeBar {
 
     private _mouseUp = (event: Event) => {
         event.preventDefault();
-        const { eventCenter } = this.muya;
-        if (this._eventId.length) {
-            for (const id of this._eventId)
-                eventCenter.detachDOMEvent(id);
-
-            this._eventId = [];
-        }
+        this._detachResizeListeners();
 
         if (typeof this._width === 'number' && this._block && this._imageInfo) {
             this._block.updateImage(this._imageInfo, 'width', String(this._width));
@@ -207,10 +201,22 @@ export class ImageResizeBar {
         this._movingAnchor = null;
     };
 
+    private _detachResizeListeners() {
+        const { eventCenter } = this.muya;
+        for (const id of this._eventId)
+            eventCenter.detachDOMEvent(id);
+
+        this._eventId = [];
+    }
+
     hide() {
         const { eventCenter } = this.muya;
         this._cleanup?.();
         this._cleanup = null;
+        this._detachResizeListeners();
+        this._width = null;
+        this._resizing = false;
+        this._movingAnchor = null;
         const circles = this._container.querySelectorAll('.bar');
         Array.from(circles).forEach(c => c.remove());
         this._status = false;


### PR DESCRIPTION
## Summary

Fixes #5216
Fixes #4976
Fixes #4995
Fixes #5057

The image resize bar (`ImageResizeBar`) crashed when its image went away before it finished working with it. There were two separate races:

**1. Deferred render after the image is deleted (#5216, v0.20.0-rc.1)**
- Clicking an image emits `muya-transformer` with the image container and schedules `_render()` with `setTimeout`.
- Deleting the selected image right away (Delete, Backspace or Enter) emits `{ reference: null }` before the timer fires.
- The render then ran against a null reference: `TypeError: Cannot read properties of null (reading 'getBoundingClientRect')` in `ImageResizeBar._update`.
- Fix: the timer only renders if the reference is still the one that scheduled it.

**2. Mouse move after the bar hides mid-drag (#4976, #4995, #5057)**
- Those three reports come from the legacy image transformer in v0.19.x (`HTMLBodyElement.mouseMove`, null `getBoundingClientRect`/`querySelector`). `@muyajs/core` has the same bug.
- `hide()` removed the handles but left the drag's `mousemove`/`mouseup` listeners attached.
- Deleting the image while holding a handle clears the reference, so the next mouse move threw `Cannot read properties of null (reading 'querySelector')`.
- Fix: `hide()` detaches the drag listeners and resets the drag state (anchor, width, resizing flag), so a stale width also cannot leak into a later resize.

## Test plan

- [x] e2e, Chromium (`e2e/tests/drag/image-resize-bar-detached-5216.spec.ts`):
  - Clicking an image and deleting it in the same task: no `pageerror`, no handles left. Before: the `getBoundingClientRect` TypeError.
  - Pressing Delete while dragging a handle, then moving the mouse: no `pageerror`. Before: the `querySelector` TypeError, four times.
- [x] Existing `e2e/tests/drag/image-resize.spec.ts` and `image-resize-bar-reflow-2939.spec.ts` still pass.
- [x] Unit (`src/ui/imageResizeBar/__tests__/imageResizeBar.spec.ts`): both races, red before the fix.
- [x] `pnpm -C packages/muya test`, `pnpm -C packages/muya lint:types`, eslint on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
