### PR TITLE
fix(muya): ignore a quick-insert pick once its paragraph is gone (#5213)

### DIFF
--- a/packages/muya/e2e/tests/ui/quick-insert-detached-5213.spec.ts
+++ b/packages/muya/e2e/tests/ui/quick-insert-detached-5213.spec.ts
@@ -1,0 +1,39 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { floats, quickInsertItem } from '../helpers/selectors';
+
+function collectErrors(page: Page): string[] {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+    return errors;
+}
+
+async function openMenuInNewParagraph(page: Page): Promise<void> {
+    await page.evaluate(() => window.muya!.setContent('first\n'));
+    await page.evaluate(() => {
+        window.muya!.editor.scrollPage.firstContentInDescendant().setCursor(5, 5, true);
+    });
+    await page.waitForTimeout(150);
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('/');
+    await expect(page.locator(floats.quickInsert)).toBeVisible();
+}
+
+test.describe('quick-insert menu whose paragraph left the document (#5213)', () => {
+    test('picking an item after the paragraph was removed does not crash', async ({ page }) => {
+        const errors = collectErrors(page);
+        await openMenuInNewParagraph(page);
+
+        await page.evaluate(() => {
+            window.muya!.editor.activeContentBlock.parent.remove();
+        });
+        await page.locator(quickInsertItem('bullet-list')).click({ force: true });
+        await page.waitForTimeout(300);
+
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+        await expect.poll(() => page.evaluate(() =>
+            [...window.muya!.ui.shownFloat].some(float =>
+                (float.constructor as { pluginName?: string }).pluginName === 'quickInsert'),
+        )).toBe(false);
+    });
+});

--- a/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
+++ b/packages/muya/src/ui/paragraphQuickInsertMenu/index.ts
@@ -256,11 +256,13 @@ export class ParagraphQuickInsertMenu extends BaseScrollFloat {
 
     override selectItem({ label }: IQuickInsertMenuItem['children'][number]) {
         const { _block: block, muya } = this;
-        replaceBlockByLabel({
-            label,
-            block: block!.parent!,
-            muya,
-        });
+        if (block?.outMostBlock) {
+            replaceBlockByLabel({
+                label,
+                block: block.parent!,
+                muya,
+            });
+        }
         // delay hide to avoid dispatch enter handler
         setTimeout(this.hide.bind(this));
     }


### PR DESCRIPTION
## Summary

Fixes #5213

**Crash report (v0.20.0-rc.1):** `TypeError: Cannot destructure property 'path' of 'this.parent' as it is null.` The stack runs from a click on a quick-insert item: `ParagraphQuickInsertMenu.selectItem` → `replaceBlockByLabel` → `finishInsertedBlock` → `placeCaretInNewBlock` → `ParagraphContent.setCursor`.

**Cause:** the menu stores the paragraph where `/` was typed and never re-checks it in `selectItem`. If that paragraph has left the document while the menu is still open:
- `replaceBlockByLabel` calls `block.replaceWith(newBlock)`, which only logs a warning for a block without a parent, so the new block is never inserted.
- It then moves the caret into the orphaned new block, whose path cannot be resolved.

**Fix:** `selectItem` only replaces the block while it is still attached (`outMostBlock`), the same guard the code-block language selector got in #4677. The menu hides either way.

**About the test:** I could not find the user action that removes the paragraph while the menu stays open (undo with the menu open leaves it in place). The e2e test removes the paragraph directly, like the #4654 language-selector test.

## Test plan

- [x] e2e, Chromium (`e2e/tests/ui/quick-insert-detached-5213.spec.ts`): open the menu with `/`, remove the paragraph, click "Bullet List". Expected: no `pageerror`, and the menu hides. Before the fix: the TypeError above.
- [x] `e2e/tests/ui/slash-menu.spec.ts` still passes
- [x] `pnpm -C packages/muya test`, `pnpm -C packages/muya lint:types`, eslint on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
