### PR TITLE
fix(muya): don't restore a drag selection onto removed blocks (#4981, #5256)

### DIFF
--- a/packages/muya/e2e/tests/editing/drag-select-detached-4981.spec.ts
+++ b/packages/muya/e2e/tests/editing/drag-select-detached-4981.spec.ts
@@ -1,0 +1,58 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+async function paragraphPoint(page: Page, index: number, edge: 'start' | 'end'): Promise<{ x: number; y: number }> {
+    const box = await page.locator(editor.paragraph).nth(index).boundingBox();
+    if (!box)
+        throw new Error(`paragraph ${index} has no bounding box`);
+    return {
+        x: edge === 'start' ? box.x + 1 : box.x + box.width - 2,
+        y: box.y + box.height / 2,
+    };
+}
+
+interface IScenario {
+    name: string;
+    from: [number, 'start' | 'end'];
+    to: [number, 'start' | 'end'];
+    whileDragging: (page: Page) => Promise<void>;
+}
+
+const scenarios: IScenario[] = [
+    {
+        name: 'Backspace over bbb..ccc (backward)',
+        from: [2, 'end'],
+        to: [1, 'start'],
+        whileDragging: page => page.keyboard.press('Backspace'),
+    },
+    {
+        name: 'Backspace over bbb..ccc (forward)',
+        from: [1, 'start'],
+        to: [2, 'end'],
+        whileDragging: page => page.keyboard.press('Backspace'),
+    },
+];
+
+for (const scenario of scenarios) {
+    test(`#4981 releasing a cross-block drag after ${scenario.name} does not crash`, async ({ page }) => {
+        const errors: string[] = [];
+        page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+
+        await page.evaluate(() => window.muya!.setContent('aaa\n\nbbb\n\nccc\n'));
+        await expect(page.locator(editor.paragraph)).toHaveCount(3);
+
+        const from = await paragraphPoint(page, ...scenario.from);
+        const to = await paragraphPoint(page, ...scenario.to);
+
+        await page.mouse.move(from.x, from.y);
+        await page.mouse.down();
+        await page.mouse.move(to.x, to.y, { steps: 8 });
+        await scenario.whileDragging(page);
+        await page.waitForTimeout(200);
+        await page.mouse.up();
+        await page.waitForTimeout(300);
+
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+    });
+}

--- a/packages/muya/src/selection/TextSelection.ts
+++ b/packages/muya/src/selection/TextSelection.ts
@@ -273,8 +273,9 @@ class TextSelection {
         };
 
         const handleMouseupOrLeave = () => {
-            if (this._selectInfo.selection)
-                this.setSelection(this._selectInfo.selection.anchor, this._selectInfo.selection.focus);
+            const { selection } = this._selectInfo;
+            if (selection?.anchor.block.outMostBlock && selection.focus.block.outMostBlock)
+                this.setSelection(selection.anchor, selection.focus);
 
             this._selectInfo = {
                 isSelect: false,


### PR DESCRIPTION
## Summary

Fixes #4981
Fixes #5256

**Crash reports (v0.20.0-rc.1, macOS):** `InvalidStateError: Failed to execute 'extend' on 'Selection': This Selection object doesn't have any Ranges.`, raised at `TextSelection._setFocus` ← `_updateSelection` ← `setSelection` ← `handleMouseupOrLeave`.

**Cause:**
- While the mouse is held across blocks, `TextSelection` remembers the anchor and focus blocks. On `mouseup`/`mouseleave` it restores that selection.
- If a keystroke removes those blocks mid-drag, the restore selects a detached DOM node. For example: drag backward from the end of `ccc` to the start of `bbb`, then press Backspace before releasing.
- Chromium ignores `addRange` for a range outside the document, so the selection is left with no ranges, and `Selection.extend` throws.

**Fix:** only restore the remembered selection while both endpoint blocks are still in the document (`outMostBlock`).

## Test plan

- [x] e2e, Chromium (`e2e/tests/editing/drag-select-detached-4981.spec.ts`):
  - Drag backward and forward over two of three paragraphs, press Backspace while holding the mouse, then release.
  - Expected: no `pageerror`.
  - Before the fix: the backward drag throws the `InvalidStateError` above.
- [x] Existing selection and drag specs still pass: `editing/text-selection-no-expand`, `editing/table-cell-selection`, `editing/table-rect-clipboard`, `drag/paragraph-reorder`.
- [x] `pnpm -C packages/muya test`, `pnpm -C packages/muya lint:types`, eslint on the changed file.

No unit test: happy-dom's `Selection.extend` does not throw without a range, so it cannot reproduce this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
