### PR TITLE
fix(muya): drop an image selection whose block left the document (#5055)

### DIFF
--- a/packages/muya/e2e/tests/editing/image-selection-detached-5055.spec.ts
+++ b/packages/muya/e2e/tests/editing/image-selection-detached-5055.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '../fixtures/muya';
+import { editor } from '../helpers/selectors';
+
+const DATA_URI = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+
+test('#5055 Backspace after the selected image\'s paragraph was removed does not crash', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', err => errors.push(String(err?.message ?? err)));
+
+    await page.evaluate(uri => window.muya!.setContent(`first\n\n![alt](${uri})\n`), DATA_URI);
+    const image = page.locator(editor.image).first();
+    await expect.poll(() => image.evaluate(el => el.classList.contains('mu-image-success'))).toBe(true);
+    await image.locator('img').first().click();
+
+    await page.evaluate(() => {
+        window.muya!.editor.scrollPage.lastChild.remove();
+    });
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(300);
+
+    expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+});

--- a/packages/muya/src/selection/ImageSelection.ts
+++ b/packages/muya/src/selection/ImageSelection.ts
@@ -48,6 +48,11 @@ class ImageSelection {
         if (!selected)
             return;
 
+        if (!selected.block.outMostBlock) {
+            this.selected = null;
+            return;
+        }
+
         if (key === ' ') {
             event.preventDefault();
             this._previewSelectedImage(selected);


### PR DESCRIPTION
## Summary

Fixes #5055

**Crash report (0.20.0-dev build):** `TypeError: Cannot destructure property 'path' of 'this.parent' as it is null.` The stack runs `set text` ← `ParagraphContent.deleteImage` ← `HTMLDocument._handleKeydown` (in `ImageSelection`).

**Cause:** `ImageSelection` remembers the clicked image, including its block, until the next click. Its document-level keydown handler deletes that image on Backspace, Delete or Enter. If the block was removed or replaced in the meantime, `deleteImage` wrote `text` on a detached block, and that block's OT path cannot be resolved.

**Fix:** the keydown handler now drops a selection whose block is no longer in the document (`outMostBlock`) and lets the key through.

**Test limitation:** as with #5213, I couldn't find the user action that replaces the paragraph while the image stays selected, so the e2e test removes the paragraph directly.

## Test plan

- [x] e2e, Chromium (`e2e/tests/editing/image-selection-detached-5055.spec.ts`): click an image, remove its paragraph, press Backspace. Expect no `pageerror`. Before the fix: the TypeError above.
- [x] `e2e/tests/drag/image-resize.spec.ts` still passes
- [x] `pnpm -C packages/muya test`, `pnpm -C packages/muya lint:types`, eslint on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
