### PR TITLE
fix(muya): flush pending edits before undo and redo

### DIFF
--- a/packages/muya/e2e/tests/editing/undo-pending-edit.spec.ts
+++ b/packages/muya/e2e/tests/editing/undo-pending-edit.spec.ts
@@ -1,0 +1,63 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+
+async function treeMatchesState(page: Page): Promise<boolean> {
+    return page.evaluate(() => {
+        const muya = window.muya!;
+        const blocks: unknown[] = [];
+        let node = muya.editor.scrollPage.children.head;
+        while (node) {
+            blocks.push(node.getState());
+            node = node.next;
+        }
+        return JSON.stringify(muya.getState()) === JSON.stringify(blocks);
+    });
+}
+
+async function typeAtEnd(page: Page, markdown: string, text: string): Promise<void> {
+    await page.evaluate(md => window.muya!.setContent(md), markdown);
+    await page.evaluate(() => {
+        const content = window.muya!.editor.scrollPage.lastContentInDescendant();
+        content.setCursor(content.text.length, content.text.length, true);
+    });
+    await page.waitForTimeout(100);
+    await page.keyboard.type(text, { delay: 20 });
+    await page.waitForTimeout(300);
+}
+
+// Keystrokes and Cmd/Ctrl+Z can land in the same animation frame, before the
+// queued text edit is flushed; drive that ordering directly.
+const sameFrameSequences = [
+    {
+        name: 'a text edit',
+        markdown: 'a\n\nb\n',
+        run: `const c = window.muya.editor.activeContentBlock; c.text = c.text + 'x'; window.muya.undo();`,
+    },
+    {
+        name: 'a text edit followed by Enter',
+        markdown: '- one\n- two\n',
+        run: `const c = window.muya.editor.activeContentBlock; c.text = c.text + 'x'; c.setCursor(c.text.length, c.text.length, true); c.enterHandler(new KeyboardEvent('keydown', { key: 'Enter' })); window.muya.undo();`,
+    },
+];
+
+for (const sequence of sameFrameSequences) {
+    test(`undo in the same frame as ${sequence.name} keeps the document consistent`, async ({ page }) => {
+        const errors: string[] = [];
+        page.on('pageerror', err => errors.push(String(err?.message || err)));
+
+        await typeAtEnd(page, sequence.markdown, ' more');
+        await page.evaluate((code) => {
+            // eslint-disable-next-line no-new-func
+            new Function(code)();
+        }, sequence.run);
+        await page.waitForTimeout(300);
+
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+        expect(await treeMatchesState(page)).toBe(true);
+
+        await page.keyboard.type('q', { delay: 20 });
+        await page.waitForTimeout(300);
+        expect(await treeMatchesState(page)).toBe(true);
+        expect(errors, `renderer pageerrors: ${errors.join(' | ')}`).toEqual([]);
+    });
+}

--- a/packages/muya/src/history/__tests__/undoPendingEdit.spec.ts
+++ b/packages/muya/src/history/__tests__/undoPendingEdit.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../muya';
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function holdPendingEdits() {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+}
+
+describe('undo and redo with an edit that has not been flushed yet', () => {
+    it('undo applies after the pending edit instead of corrupting the document', () => {
+        const muya = bootMuya('hello\n');
+        holdPendingEdits();
+        const content = muya.editor.scrollPage!.firstContentInDescendant()!;
+
+        content.text = 'hello world';
+        muya.flush();
+        muya.editor.history.cutoff();
+
+        content.text = 'hello world!';
+        expect(() => muya.undo()).not.toThrow();
+        expect(() => muya.flush()).not.toThrow();
+
+        expect(muya.getMarkdown()).toBe('hello world\n');
+        expect(muya.editor.scrollPage!.firstContentInDescendant()!.text).toBe('hello world');
+    });
+
+    it('redo is dropped by an edit that was still pending', () => {
+        const muya = bootMuya('hello\n');
+        holdPendingEdits();
+        const content = muya.editor.scrollPage!.firstContentInDescendant()!;
+
+        content.text = 'hello world';
+        muya.flush();
+        muya.undo();
+        expect(muya.getMarkdown()).toBe('hello\n');
+
+        muya.editor.scrollPage!.firstContentInDescendant()!.text = 'hello there';
+        expect(() => muya.redo()).not.toThrow();
+        expect(() => muya.flush()).not.toThrow();
+
+        expect(muya.getMarkdown()).toBe('hello there\n');
+    });
+});

--- a/packages/muya/src/history/index.ts
+++ b/packages/muya/src/history/index.ts
@@ -154,6 +154,8 @@ class History {
     }
 
     private _change(source: HistoryAction, dest: HistoryAction) {
+        this._muya.editor.jsonState.flush();
+
         if (this._stack[source].length === 0)
             return;
 


### PR DESCRIPTION
## Summary

Text edits reach the JSON state in a batch on the next animation frame (`JSONState._operationCache`). `History.undo()` / `redo()` did not wait for that batch: they applied their entry to the JSON state immediately.

If an edit was still queued when undo or redo ran (a keystroke and Cmd/Ctrl+Z landing in the same frame), the queued edit was built against the document before the undo but applied to the document after it. Depending on the edit, that throws:

- `The op is too long for this document` (ot-text-unicode), or
- an ot-json1 assertion in `drop`.

Either way, the block tree and the JSON state stay out of sync until the document is reloaded. Redo was affected the same way: a pending edit was merged with the redone text (`hello there` + redo → `hello there world`).

**Fix:** `History._change` now flushes the pending batch before touching the undo/redo stacks. The queued edit is recorded like any other edit:

- undo reverts it, and
- redo is correctly discarded by it.

## Possibly related crash reports

This is one concrete way the engine's JSON state and block tree get out of sync. The unresolved ot-json1 crash reports all come from a desync like this, but none has repro steps, and I could not reproduce their exact assertion messages. So this PR does not close them:

- #4944 (`Cannot use numerical key for object container`)
- #4903 (`Cannot insert into out of bounds index`)
- #5148 (`Cannot pick up or remove undefined`)

## Test plan

- [x] Unit (`src/history/__tests__/undoPendingEdit.spec.ts`, happy-dom with `requestAnimationFrame` held):
  - Undo with a queued edit no longer throws, and undoes that edit. Before the fix: `The op is too long for this document`.
  - A queued edit discards redo. Before the fix: `hello there world`.
- [x] e2e, Chromium (`e2e/tests/editing/undo-pending-edit.spec.ts`): undo in the same frame as a text edit, and as a text edit followed by Enter in a list:
  - no `pageerror`
  - the JSON state matches the block tree before and after further typing
  
  Before the fix: `The op is too long for this document`.
- [x] Existing `e2e/tests/editing/undo*` specs and `src/history` unit tests still pass.
- [x] `pnpm -C packages/muya test`, `pnpm -C packages/muya lint:types`, eslint on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPgRzXj7DDhJToWxHtkkR
