### PR TITLE
fix(muya): number empty lines in code blocks (#5294)

### DIFF
--- a/packages/muya/e2e/tests/blocks/codeblock-line-numbers-empty-line-5294.spec.ts
+++ b/packages/muya/e2e/tests/blocks/codeblock-line-numbers-empty-line-5294.spec.ts
@@ -1,0 +1,123 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { slowType } from '../helpers/keyboard';
+import { editor } from '../helpers/selectors';
+
+// #5294: with line numbers on, an empty code line's number was drawn above the
+// block, below it, or on another line's row.
+
+async function codeText(page: Page): Promise<string> {
+    return page.locator(editor.codeContent).first().evaluate(el => el.textContent ?? '');
+}
+
+// How far below the first code line each number sits, in lines (to 0.1).
+async function numberRows(page: Page): Promise<number[]> {
+    return page.locator(editor.codeBlock).first().evaluate((pre, selectors) => {
+        const code = pre.querySelector<HTMLElement>(selectors.codeContent)!;
+        const lineHeight = Number.parseFloat(getComputedStyle(code).lineHeight);
+        const codeTop = code.getBoundingClientRect().top;
+        return Array.from(
+            pre.querySelectorAll(selectors.lineNumber),
+            span => Math.round((span.getBoundingClientRect().top - codeTop) / lineHeight * 10) / 10 + 0,
+        );
+    }, { codeContent: editor.codeContent, lineNumber: editor.lineNumber });
+}
+
+async function visualRows(page: Page): Promise<number> {
+    return page.locator(editor.codeContent).first().evaluate(el =>
+        Math.round(el.getBoundingClientRect().height / Number.parseFloat(getComputedStyle(el).lineHeight)));
+}
+
+// A new code block re-renders on its first animation frame, which throws away
+// a caret that typing has already moved.
+async function settleCodeBlock(page: Page): Promise<void> {
+    await expect(page.locator(editor.codeContent)).toHaveCount(1);
+    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => setTimeout(resolve))));
+}
+
+async function openCodeBlock(page: Page): Promise<void> {
+    await page.evaluate(() => window.muya!.setContent(''));
+    await page.locator(editor.paragraph).first().click();
+    await page.keyboard.type('```');
+    await page.keyboard.press('Enter');
+    await settleCodeBlock(page);
+}
+
+test.describe('code block line numbers on empty lines', () => {
+    test('an empty line typed between two lines is numbered on its row', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'world');
+
+        await expect.poll(() => codeText(page)).toBe('hello\n\nworld');
+        await expect.poll(() => numberRows(page)).toEqual([0, 1, 2]);
+    });
+
+    test('empty lines typed at the end are numbered on their rows', async ({ page }) => {
+        await openCodeBlock(page);
+        await slowType(page, 'hello');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+
+        await expect.poll(() => codeText(page)).toBe('hello\n\n');
+        await expect.poll(() => numberRows(page)).toEqual([0, 1, 2]);
+    });
+
+    test('empty lines at the top of the block are numbered on their rows', async ({ page }) => {
+        await openCodeBlock(page);
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Enter');
+        await slowType(page, 'hello');
+
+        await expect.poll(() => codeText(page)).toBe('\n\nhello');
+        await expect.poll(() => numberRows(page)).toEqual([0, 1, 2]);
+    });
+
+    test('a syntax-highlighted block numbers its empty lines', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```js\nconst a = 1\n\n\nlet b = 2\n```\n'));
+        await expect.poll(() => page.locator(`${editor.codeContent} .token`).count()).toBeGreaterThan(0);
+
+        await expect.poll(() => numberRows(page)).toEqual([0, 1, 2, 3]);
+    });
+});
+
+test.describe('wrapped code block line numbers on empty lines', () => {
+    const longLine = 'word '.repeat(60).trim();
+
+    test.beforeEach(async ({ page }) => {
+        await page.evaluate(() => window.muya!.setOptions({ wrapCodeBlocks: true }));
+    });
+
+    // Rows are counted from the bottom of the block, so the expectations do
+    // not depend on how many rows the long line wraps into.
+    test('an empty line after a wrapped line is numbered on the row below it', async ({ page }) => {
+        await page.evaluate(md => window.muya!.setContent(md), `\`\`\`\n${longLine}\n\nend\n\`\`\`\n`);
+        await settleCodeBlock(page);
+        await expect.poll(() => visualRows(page)).toBeGreaterThan(3);
+
+        await expect.poll(async () => {
+            const rows = await visualRows(page);
+            const [first, ...rest] = await numberRows(page);
+            return [first, ...rest.map(row => rows - row)];
+        }).toEqual([0, 2, 1]);
+    });
+
+    test('an empty line typed after a wrapped line is numbered on its row', async ({ page }) => {
+        await page.evaluate(md => window.muya!.setContent(md), `\`\`\`\n${longLine}\n\`\`\`\n`);
+        await settleCodeBlock(page);
+        const box = (await page.locator(editor.codeContent).first().boundingBox())!;
+        await page.mouse.click(box.x + box.width - 2, box.y + box.height - 4);
+        await page.keyboard.press('End');
+        await page.keyboard.press('Enter');
+
+        await expect.poll(() => codeText(page)).toBe(`${longLine}\n`);
+        await expect.poll(() => visualRows(page)).toBeGreaterThan(2);
+        await expect.poll(async () => {
+            const rows = await visualRows(page);
+            const [first, ...rest] = await numberRows(page);
+            return [first, ...rest.map(row => rows - row)];
+        }).toEqual([0, 1]);
+    });
+});

--- a/packages/muya/e2e/tests/helpers/selectors.ts
+++ b/packages/muya/e2e/tests/helpers/selectors.ts
@@ -35,6 +35,9 @@ export const editor = {
     // Source of truth: packages/muya/src/block/content/codeBlockContent/index.ts
     // (classList pushes 'mu-codeblock-content').
     codeContent: '.mu-codeblock-content',
+    // One absolutely positioned span per code line when `codeBlockLineNumbers`
+    // is on; the number is its `::before` counter.
+    lineNumber: '.mu-line-numbers-rows > span',
     languageInput: '.mu-language-input',
     table: 'table',
     tableCell: '.mu-table-cell',

--- a/packages/muya/src/utils/codeBlockLineNumbers.ts
+++ b/packages/muya/src/utils/codeBlockLineNumbers.ts
@@ -1,3 +1,5 @@
+import { CLASS_NAMES } from '../config';
+
 // Visible line count for a code block, matching marktext `a028a7c2`:
 //   - each `\n` adds a row
 //   - a trailing `\n` still counts as the next visible (empty) row in
@@ -65,14 +67,26 @@ function measureLineTops(codeEl: HTMLElement): number[] {
         // A line start may be INSIDE this node (< nodeEnd); if it equals nodeEnd
         // it belongs to the next node and will be picked up on the next iteration.
         while (tops.length < lineStarts.length && lineStarts[tops.length] < nodeEnd) {
-            range.setStart(node, lineStarts[tops.length] - nodeStart);
-            range.collapse(true);
+            const offsetInNode = lineStarts[tops.length] - nodeStart;
+            range.setStart(node, offsetInNode);
+            // A caret position on an empty line has no client rect (#5294), so
+            // an empty line is measured by its own newline.
+            if (node.data.charCodeAt(offsetInNode) === LF)
+                range.setEnd(node, offsetInNode + 1);
+            else
+                range.collapse(true);
             tops.push(range.getBoundingClientRect().top);
         }
 
         nodeStart = nodeEnd;
         node = walker.nextNode() as Text | null;
     }
+
+    // The line after a final "\n" has no text of its own; CodeBlockContent
+    // renders a trailing break there to give it a line box.
+    const trailingBreak = codeEl.querySelector(`.${CLASS_NAMES.MU_TRAILING_BREAK}`);
+    if (trailingBreak !== null && tops.length === lineStarts.length - 1)
+        tops.push(trailingBreak.getBoundingClientRect().top);
 
     return tops;
 }
@@ -92,17 +106,16 @@ export function repositionLineNumberSpans(
 
     const tops = measureLineTops(codeEl);
     const measuredCount = Math.min(tops.length, spans.length);
-    // Origin = the measured top of the first logical line. A collapsed range's
-    // rect top sits at the text/caret box (below the line-box leading), so
-    // subtracting the wrapper top would offset every number down by that
-    // constant leading. Anchoring to the first line cancels it and keeps line 1
-    // flush with the gutter top, while preserving correct per-line deltas for
-    // wrap mode.
+    // Origin = the measured top of the first logical line. A measured top sits
+    // at the text box (below the line-box leading), so subtracting the wrapper
+    // top would offset every number down by that constant leading. Anchoring to
+    // the first line cancels it and keeps line 1 flush with the gutter top,
+    // while preserving correct per-line deltas for wrap mode.
     for (let i = 0; i < measuredCount; i++)
         spans[i].style.top = `${tops[i] - tops[0]}px`;
 
-    // Lines with no text node to measure from: the trailing empty line after a
-    // final "\n", or the single line of a wholly empty code block. The first
+    // Lines with nothing to measure: the single line of a wholly empty code
+    // block, or a final empty line rendered without a trailing break. The first
     // line is always flush with the top; later ones stack one line-height below
     // their predecessor.
     if (measuredCount < spans.length) {

--- a/packages/muya/src/utils/codeBlockLineNumbers.ts
+++ b/packages/muya/src/utils/codeBlockLineNumbers.ts
@@ -39,6 +39,44 @@ export function syncLineNumbersSpans(wrapper: HTMLElement, count: number): void 
     }
 }
 
+// Viewport tops of the logical lines in `codeEl`, in order. Lines at the end
+// with nothing to measure are left out.
+function measureLineTops(codeEl: HTMLElement): number[] {
+    const text = codeEl.textContent ?? '';
+
+    // Global character offsets where each logical line begins.
+    const lineStarts: number[] = [0];
+    for (let i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === LF)
+            lineStarts.push(i + 1);
+    }
+
+    // Walk all text nodes once, measuring each line where its start falls.
+    const walker = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
+    const range = document.createRange();
+    const tops: number[] = [];
+
+    let nodeStart = 0;
+    let node = walker.nextNode() as Text | null;
+
+    while (node !== null && tops.length < lineStarts.length) {
+        const nodeEnd = nodeStart + node.data.length;
+
+        // A line start may be INSIDE this node (< nodeEnd); if it equals nodeEnd
+        // it belongs to the next node and will be picked up on the next iteration.
+        while (tops.length < lineStarts.length && lineStarts[tops.length] < nodeEnd) {
+            range.setStart(node, lineStarts[tops.length] - nodeStart);
+            range.collapse(true);
+            tops.push(range.getBoundingClientRect().top);
+        }
+
+        nodeStart = nodeEnd;
+        node = walker.nextNode() as Text | null;
+    }
+
+    return tops;
+}
+
 // Measure the actual visual top of every logical line using Range API, then
 // set `top` on each span so line numbers align correctly in wrap mode (where
 // a single logical line can span multiple visual rows).
@@ -52,59 +90,24 @@ export function repositionLineNumberSpans(
     if (spans.length === 0)
         return;
 
-    const text = codeEl.textContent ?? '';
-
-    // Global character offsets where each logical line begins.
-    const lineStarts: number[] = [0];
-    for (let i = 0; i < text.length; i++) {
-        if (text.charCodeAt(i) === LF)
-            lineStarts.push(i + 1);
-    }
-
-    // Walk all text nodes once, positioning each span when we cross a line start.
-    const walker = document.createTreeWalker(codeEl, NodeFilter.SHOW_TEXT);
-    const range = document.createRange();
-
-    let nodeStart = 0;
-    let lineIdx = 0;
+    const tops = measureLineTops(codeEl);
+    const measuredCount = Math.min(tops.length, spans.length);
     // Origin = the measured top of the first logical line. A collapsed range's
     // rect top sits at the text/caret box (below the line-box leading), so
     // subtracting the wrapper top would offset every number down by that
     // constant leading. Anchoring to the first line cancels it and keeps line 1
     // flush with the gutter top, while preserving correct per-line deltas for
     // wrap mode.
-    let baseTop: number | null = null;
-    let node = walker.nextNode() as Text | null;
-
-    while (node !== null && lineIdx < lineStarts.length) {
-        const nodeLen = (node.textContent ?? '').length;
-        const nodeEnd = nodeStart + nodeLen;
-
-        // A line start may be INSIDE this node (< nodeEnd); if it equals nodeEnd
-        // it belongs to the next node and will be picked up on the next iteration.
-        while (lineIdx < lineStarts.length && lineStarts[lineIdx] < nodeEnd) {
-            const offsetInNode = lineStarts[lineIdx] - nodeStart;
-            range.setStart(node, offsetInNode);
-            range.collapse(true);
-            const measured = range.getBoundingClientRect().top;
-            if (baseTop === null)
-                baseTop = measured;
-            if (lineIdx < spans.length)
-                spans[lineIdx].style.top = `${measured - baseTop}px`;
-            lineIdx++;
-        }
-
-        nodeStart = nodeEnd;
-        node = walker.nextNode() as Text | null;
-    }
+    for (let i = 0; i < measuredCount; i++)
+        spans[i].style.top = `${tops[i] - tops[0]}px`;
 
     // Lines with no text node to measure from: the trailing empty line after a
     // final "\n", or the single line of a wholly empty code block. The first
     // line is always flush with the top; later ones stack one line-height below
     // their predecessor.
-    if (lineIdx < spans.length) {
+    if (measuredCount < spans.length) {
         const lineH = Number.parseFloat(getComputedStyle(wrapper).lineHeight) || 24;
-        for (let i = lineIdx; i < spans.length; i++) {
+        for (let i = measuredCount; i < spans.length; i++) {
             const prevTop = i > 0 ? Number.parseFloat(spans[i - 1].style.top || '0') : 0;
             spans[i].style.top = i > 0 ? `${prevTop + lineH}px` : '0px';
         }


### PR DESCRIPTION
## Summary

Fixes #5294.

With code block line numbers on, an empty code line's number was drawn above the block, below it, or on another line's row, so empty lines looked unnumbered.

## Root cause

`repositionLineNumberSpans` places each gutter number at the top of a collapsed Range at the start of its line. On an empty line that caret position has no client rects in Chromium, so `getBoundingClientRect()` is all zeros. The number then got `top = 0 - firstLineTop` (about −99px in the e2e host). When the first line itself was empty, the origin became 0 and the following numbers moved below the block.

The line after a final newline has no character to measure. It was stacked one line-height below the previous number, which puts it on the wrong row when the previous line wraps.

## Fix

- Measure an empty line with a range over its own `\n`. In Chromium that range has a real rect with the same top and height as a caret on a non-empty line, so the first-line origin still cancels the line-box leading.
- Measure the line after a final newline from the `.mu-trailing-break` that `CodeBlockContent` renders there since #5114. Line-height stacking now only covers lines with nothing to measure, such as an empty code block.
- A preceding refactor commit moves the measuring walk into `measureLineTops`, with no behavior change, so the fix keeps `repositionLineNumberSpans` under the ESLint complexity limit.

## Tests

- New e2e `blocks/codeblock-line-numbers-empty-line-5294.spec.ts` checks which row each number sits on. It covers an empty line between lines, empty lines at the end and at the top, a syntax-highlighted block, and wrapped code (an empty line after a wrapped line, loaded and typed). All 6 fail on develop and on the refactor commit with the same values, and pass with the fix.
- `codeblock-trailing-newline-5114`, `options/code-font` (gutter re-measure) and `codeblock-scroll-3191` e2e still pass. The `codeBlockLineNumbers` and `lineNumbersGutter` unit specs pass, and `tsc --noEmit`, ESLint and madge are clean.

Checked in Chromium only, which is what Electron and the muya e2e CI use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KtYifHmaETtxfX2ktbdYC
