### PR TITLE
fix(muya): end the paragraph on a Shift+Enter that would leave an empty line

### DIFF
--- a/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
+++ b/packages/muya/e2e/tests/typing/paragraph-and-headings.spec.ts
@@ -113,4 +113,55 @@ test.describe('paragraphs and headings', () => {
         await expect(page.locator(editor.paragraph)).toHaveCount(1);
         await expect(page.locator(editor.softLineBreak)).toHaveCount(0);
     });
+
+    // #5296: a paragraph cannot keep an empty line, so the second press ends it.
+    test('a second Shift+Enter breaks the paragraph', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        await slowType(page, 'a');
+        await page.keyboard.press('Shift+Enter');
+        await page.keyboard.press('Shift+Enter');
+        await slowType(page, 'b');
+
+        await expect(page.locator(editor.paragraph)).toHaveCount(2);
+        await expect(page.locator(editor.softLineBreak)).toHaveCount(0);
+        await page.waitForFunction(
+            () => window.muya!.getMarkdown() === 'a\n\nb\n',
+            undefined,
+            { timeout: 5000 },
+        );
+        expect(await getMarkdown(page)).toBe('a\n\nb\n');
+    });
+
+    test('undo after the paragraph break brings back the soft line break', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+
+        // History records edits once per frame: wait for each press to reach the
+        // document, or the presses and the undo collapse into one step.
+        await slowType(page, 'a');
+        await page.keyboard.press('Shift+Enter');
+        await page.waitForFunction(
+            () => window.muya!.getMarkdown() === 'a\n\n',
+            undefined,
+            { timeout: 5000 },
+        );
+        await page.keyboard.press('Shift+Enter');
+        await page.waitForFunction(
+            () => window.muya!.getState().length === 2,
+            undefined,
+            { timeout: 5000 },
+        );
+
+        await page.evaluate(() => window.muya!.undo());
+
+        await expect(page.locator(editor.paragraph)).toHaveCount(1);
+        await expect(page.locator(editor.softLineBreak)).toHaveCount(1);
+        await page.waitForFunction(
+            () => window.muya!.getMarkdown() === 'a\n\n',
+            undefined,
+            { timeout: 5000 },
+        );
+    });
 });

--- a/packages/muya/src/block/base/__tests__/shiftEnterParagraphBreak.spec.ts
+++ b/packages/muya/src/block/base/__tests__/shiftEnterParagraphBreak.spec.ts
@@ -1,0 +1,312 @@
+// @vitest-environment happy-dom
+
+import type Content from '../content';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Muya } from '../../../muya';
+
+// #5296 — a paragraph cannot hold an empty line: in Markdown a blank line ends the
+// paragraph, so a block edited into `abc\n\ndef` is saved as two paragraphs and
+// reopens as two. A Shift+Enter that would leave such a line behind breaks the
+// paragraph instead, exactly as Enter does at that position.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length)
+        bootedHosts.pop()!.remove();
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function contentByText(muya: Muya, text: string): Content {
+    let target: Content | null = null;
+    const visit = (block: {
+        text?: string;
+        constructor: { blockName?: string };
+        children?: { forEach: (cb: (b: unknown) => void) => void };
+    }) => {
+        if (block.constructor.blockName?.endsWith('.content') && block.text === text)
+            target = block as unknown as Content;
+        block.children?.forEach(b => visit(b as typeof block));
+    };
+    visit(muya.editor.scrollPage as unknown as Parameters<typeof visit>[0]);
+    if (!target)
+        throw new Error(`content block with text "${text}" not found`);
+    return target;
+}
+
+function placeCaret(muya: Muya, content: Content, start: number, end = start): void {
+    muya.editor.activeContentBlock = content;
+    content.setCursor(start, end, true);
+}
+
+function flush(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+async function pressShiftEnter(muya: Muya): Promise<void> {
+    muya.editor.activeContentBlock!.keydownHandler(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+    }));
+    await flush();
+}
+
+interface IBlockShape { name: string; text?: string; children?: IBlockShape[] }
+
+function blocks(muya: Muya): IBlockShape[] {
+    return JSON.parse(JSON.stringify(muya.getState(), ['name', 'text', 'children']));
+}
+
+function caret(muya: Muya): { text: string; offset: number } {
+    const active = muya.editor.activeContentBlock!;
+    return { text: active.text, offset: active.getCursor()!.start.offset };
+}
+
+describe('shift+Enter that would leave an empty line breaks the paragraph', () => {
+    it('turns a second Shift+Enter at the end into a new empty paragraph', async () => {
+        const muya = bootMuya('abc\n');
+        placeCaret(muya, contentByText(muya, 'abc'), 3);
+
+        await pressShiftEnter(muya);
+        expect(blocks(muya)).toEqual([{ name: 'paragraph', text: 'abc\n' }]);
+
+        await pressShiftEnter(muya);
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: '' },
+        ]);
+        expect(caret(muya)).toEqual({ text: '', offset: 0 });
+    });
+
+    it('moves the text after the caret into the new paragraph', async () => {
+        const muya = bootMuya('abc\ndef\n');
+        placeCaret(muya, contentByText(muya, 'abc\ndef'), 4);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: 'def' },
+        ]);
+        expect(caret(muya)).toEqual({ text: 'def', offset: 0 });
+    });
+
+    it('drops the line breaks on both sides of an empty line', async () => {
+        const muya = bootMuya('abc\n');
+        const content = contentByText(muya, 'abc');
+        content.text = 'abc\n\ndef';
+        placeCaret(muya, content, 4);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: 'def' },
+        ]);
+        expect(caret(muya)).toEqual({ text: 'def', offset: 0 });
+    });
+
+    it('treats a line holding only spaces and tabs as empty', async () => {
+        const muya = bootMuya('abc\n');
+        const content = contentByText(muya, 'abc');
+        content.text = 'abc\n \t';
+        placeCaret(muya, content, 6);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: '' },
+        ]);
+    });
+
+    it('removes a trailing-spaces hard break marker with the line break', async () => {
+        const muya = bootMuya('abc\n');
+        const content = contentByText(muya, 'abc');
+        content.text = 'abc  \n';
+        placeCaret(muya, content, 6);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: '' },
+        ]);
+    });
+
+    it('removes a backslash hard break marker with the line break', async () => {
+        const muya = bootMuya('abc\n');
+        const content = contentByText(muya, 'abc');
+        content.text = 'abc\\\n';
+        placeCaret(muya, content, 5);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: '' },
+        ]);
+    });
+
+    it('keeps an escaped backslash that ends the previous line', async () => {
+        const muya = bootMuya('abc\n');
+        const content = contentByText(muya, 'abc');
+        content.text = 'abc\\\\\n';
+        placeCaret(muya, content, 6);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc\\\\' },
+            { name: 'paragraph', text: '' },
+        ]);
+    });
+
+    it('deletes a selection that starts right after a soft break', async () => {
+        const muya = bootMuya('abc\ndef\n');
+        placeCaret(muya, contentByText(muya, 'abc\ndef'), 4, 6);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'paragraph', text: 'abc' },
+            { name: 'paragraph', text: 'f' },
+        ]);
+        expect(caret(muya)).toEqual({ text: 'f', offset: 0 });
+    });
+});
+
+describe('shift+Enter that leaves no empty line still inserts a soft break', () => {
+    it('inserts a line between two lines when the caret is before a soft break', async () => {
+        const muya = bootMuya('abc\ndef\n');
+        placeCaret(muya, contentByText(muya, 'abc\ndef'), 3);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([{ name: 'paragraph', text: 'abc\n\ndef' }]);
+        expect(caret(muya)).toEqual({ text: 'abc\n\ndef', offset: 4 });
+    });
+
+    it('inserts a soft break at the start of a paragraph', async () => {
+        const muya = bootMuya('abc\n');
+        placeCaret(muya, contentByText(muya, 'abc'), 0);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([{ name: 'paragraph', text: '\nabc' }]);
+    });
+});
+
+describe('the paragraph break matches Enter inside containers', () => {
+    it('starts a new list item from a list item holding one paragraph', async () => {
+        const muya = bootMuya('- abc\n');
+        placeCaret(muya, contentByText(muya, 'abc'), 3);
+
+        await pressShiftEnter(muya);
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([{
+            name: 'bullet-list',
+            children: [
+                { name: 'list-item', children: [{ name: 'paragraph', text: 'abc' }] },
+                { name: 'list-item', children: [{ name: 'paragraph', text: '' }] },
+            ],
+        }]);
+    });
+
+    it('adds a paragraph to a list item that already holds several', async () => {
+        const muya = bootMuya('- abc\n\n  def\n');
+        placeCaret(muya, contentByText(muya, 'def'), 3);
+
+        await pressShiftEnter(muya);
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([{
+            name: 'bullet-list',
+            children: [{
+                name: 'list-item',
+                children: [
+                    { name: 'paragraph', text: 'abc' },
+                    { name: 'paragraph', text: 'def' },
+                    { name: 'paragraph', text: '' },
+                ],
+            }],
+        }]);
+    });
+
+    it('adds a paragraph inside a block quote', async () => {
+        const muya = bootMuya('> abc\n');
+        placeCaret(muya, contentByText(muya, 'abc'), 3);
+
+        await pressShiftEnter(muya);
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([{
+            name: 'block-quote',
+            children: [
+                { name: 'paragraph', text: 'abc' },
+                { name: 'paragraph', text: '' },
+            ],
+        }]);
+    });
+
+    it('adds a paragraph after a setext heading', async () => {
+        const muya = bootMuya('Title\n===\n');
+        placeCaret(muya, contentByText(muya, 'Title'), 5);
+
+        await pressShiftEnter(muya);
+        await pressShiftEnter(muya);
+
+        expect(blocks(muya)).toEqual([
+            { name: 'setext-heading', text: 'Title' },
+            { name: 'paragraph', text: '' },
+        ]);
+    });
+});
+
+describe('the paragraph break survives undo and saving', () => {
+    it('undoes only the paragraph break, keeping the first soft break', async () => {
+        const muya = bootMuya('abc\n');
+        placeCaret(muya, contentByText(muya, 'abc'), 3);
+
+        await pressShiftEnter(muya);
+        await pressShiftEnter(muya);
+        muya.undo();
+
+        await vi.waitFor(() => {
+            expect(blocks(muya)).toEqual([{ name: 'paragraph', text: 'abc\n' }]);
+        });
+    });
+
+    it('reopens the saved markdown as the blocks shown in the editor', async () => {
+        const muya = bootMuya('abc\ndef\n');
+        placeCaret(muya, contentByText(muya, 'abc\ndef'), 4);
+
+        await pressShiftEnter(muya);
+
+        expect(blocks(bootMuya(muya.getMarkdown()))).toEqual(blocks(muya));
+    });
+});

--- a/packages/muya/src/block/base/format.ts
+++ b/packages/muya/src/block/base/format.ts
@@ -59,6 +59,16 @@ const INLINE_UPDATE_FRAGMENTS = [
 
 const INLINE_UPDATE_REG = new RegExp(INLINE_UPDATE_FRAGMENTS.join('|'), 'i');
 
+function stripHardBreakMarker(line: string): string {
+    const trimmed = line.replace(/[ \t]+$/, '');
+    if (trimmed !== line)
+        return trimmed;
+
+    const backslashes = /\\*$/.exec(line)![0].length;
+
+    return backslashes % 2 === 1 ? line.slice(0, -1) : line;
+}
+
 // Offset of the cursor relative to a symmetric/asymmetric marker pair
 // (strong/em/code/math/html_tag). `open`/`close` are the opening/closing
 // marker lengths; for the symmetric inline markers they are equal.
@@ -1525,6 +1535,26 @@ class Format extends Content {
         this.text
             = `${oldText.substring(0, start.offset)}\n${oldText.substring(end.offset)}`;
         this.setCursor(start.offset + 1, end.offset + 1, true);
+    }
+
+    // Markdown ends a paragraph at a blank line, so Shift+Enter must not leave an
+    // empty line in the block. When the caret's line is blank up to the caret,
+    // removes that line break and returns true: handle the key as Enter.
+    protected dropSoftBreakBeforeCursor(): boolean {
+        const { text } = this;
+        const { start, end } = this.getCursor()!;
+        const head = text.substring(0, start.offset);
+        const lineStart = head.lastIndexOf('\n');
+        if (lineStart === -1 || /[^ \t]/.test(head.substring(lineStart + 1)))
+            return false;
+
+        this.muya.editor.history.markInputBoundary('insertParagraph', '\n');
+        const before = stripHardBreakMarker(head.substring(0, lineStart));
+        const after = text.substring(end.offset).replace(/^[ \t]*\n/, '');
+        this.text = before + after;
+        this.setCursor(before.length, before.length, true);
+
+        return true;
     }
 
     override enterHandler(event: KeyboardEvent): void {

--- a/packages/muya/src/block/content/paragraphContent/index.ts
+++ b/packages/muya/src/block/content/paragraphContent/index.ts
@@ -550,7 +550,7 @@ class ParagraphContent extends Format {
         if (!isKeyboardEvent(event))
             return;
 
-        if (event.shiftKey)
+        if (event.shiftKey && !this.dropSoftBreakBeforeCursor())
             return this.shiftEnterHandler(event);
 
         // Any paragraph that would convert to a block (code fence, math block,

--- a/packages/muya/src/block/content/setextHeadingContent/index.ts
+++ b/packages/muya/src/block/content/setextHeadingContent/index.ts
@@ -31,7 +31,7 @@ class SetextHeadingContent extends Format {
         if (!isKeyboardEvent(event))
             return;
 
-        if (event.shiftKey) {
+        if (event.shiftKey && !this.dropSoftBreakBeforeCursor()) {
             event.preventDefault();
             event.stopPropagation();
 


### PR DESCRIPTION
Closes #5296

## Summary

Pressing Shift+Enter twice in a paragraph stacked a second `\n` into the block, so the editor showed one paragraph with an empty line in it. Markdown cannot hold that — a blank line ends a paragraph — and the saved file reopened with a different structure: `abc` ⇧↵ ⇧↵ `def` came back as two paragraphs, a trailing empty line vanished, and inside a list item the whole list turned loose.

A Shift+Enter that would leave an empty line behind now ends the paragraph instead, exactly as Enter does at that position (`|` is the caret):

- `abc\n|` → `abc` ¶ `|`
- `abc\n|def` → `abc` ¶ `|def`
- `abc|\ndef` → `abc\n|\ndef` as before, so a line can still be added between two lines; pressing it again on that empty line → `abc` ¶ `|def`

## Fix

`Format.dropSoftBreakBeforeCursor()` runs on Shift+Enter in the two blocks that take soft line breaks, paragraphs and setext headings. When only spaces or tabs sit between the previous `\n` and the caret, it removes that line break and returns `true`, and `enterHandler` carries on as a plain Enter. Containers therefore behave as they already do for Enter: a list item gets a new sibling item (or a new paragraph when it already holds several), a block quote gets a paragraph inside the quote, a setext heading gets a paragraph after it.

Along with the line break it removes:

- the rest of the caret's line when that is empty too, so the new paragraph does not start with a newline;
- a hard break marker ending the previous line — trailing spaces, or an unescaped `\`, which would otherwise end the paragraph and render literally. An escaped `\\` is kept.

A caret sitting *before* a soft break does not trigger it; otherwise Shift+Enter could never add a line between two existing lines.

It marks an input boundary before editing. `Format.enterHandler` does so itself, but the list-item Enter path does not, and without the boundary one undo took back the first soft break together with the paragraph break.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added
- [ ] Manually tested on: not in the desktop app — real key presses are covered by the Chromium e2e below

- `src/block/base/__tests__/shiftEnterParagraphBreak.spec.ts` (happy-dom, keys routed through `keydownHandler`): the cases above, whitespace-only lines, trailing-spaces / backslash / escaped-backslash markers, a selection, a list item with one and with several paragraphs, a block quote, a setext heading, undo, and that the saved Markdown reopens as the blocks shown in the editor. Without the fix 14 of the 16 fail; the other two guard the cases that must keep inserting a soft break (caret before a soft break, start of a paragraph).
- `e2e/tests/typing/paragraph-and-headings.spec.ts` (Chromium): real key presses give two paragraphs and `a\n\nb\n`; undo brings back the soft line break. Both fail without the fix.
- muya unit suite 1504/1504, `tsc --noEmit`, ESLint with no new warnings.

## Notes for reviewers

- History records edits once per animation frame (`JSONState._flushOperationCache`), so two presses — or a press and `undo()` — inside one frame are recorded as a single step. Real key presses never land that close, but Playwright's do, so the undo e2e waits for each press to reach `getMarkdown()` / `getState()` before the next action.
- Related, not fixed here: #5297 — a list item that gains a second paragraph keeps rendering tight until the file is reopened.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01649sL7gej6b8NoC6xr5HDv
