### PR TITLE
fix(muya): load relative images from folders named with #, ? or % (#5302)

### DIFF
--- a/packages/desktop/test/e2e/image-relative-path.spec.ts
+++ b/packages/desktop/test/e2e/image-relative-path.spec.ts
@@ -22,9 +22,10 @@ const ONE_BY_ONE_PNG_BASE64 =
 
 const createdDirs: string[] = []
 
-const writeDocWithRelativeImage = (): { docPath: string; docDir: string } => {
-  const docDir = fs.mkdtempSync(path.join(os.tmpdir(), 'marktext-e2e-relimg-'))
-  createdDirs.push(docDir)
+const writeDocWithRelativeImage = (folderName = ''): { docPath: string; docDir: string } => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'marktext-e2e-relimg-'))
+  createdDirs.push(tempDir)
+  const docDir = path.join(tempDir, folderName)
   const assetsDir = path.join(docDir, 'assets')
   fs.mkdirSync(assetsDir, { recursive: true })
   fs.writeFileSync(path.join(assetsDir, 'cat.png'), Buffer.from(ONE_BY_ONE_PNG_BASE64, 'base64'))
@@ -32,6 +33,16 @@ const writeDocWithRelativeImage = (): { docPath: string; docDir: string } => {
   fs.writeFileSync(docPath, '![a cat](assets/cat.png)\n', 'utf-8')
   return { docPath, docDir }
 }
+
+test.afterAll(() => {
+  for (const dir of createdDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  }
+})
 
 test.describe('Relative-path image resolves to a DIRNAME-anchored file:// URL', () => {
   let app: ElectronApplication | null = null
@@ -50,13 +61,6 @@ test.describe('Relative-path image resolves to a DIRNAME-anchored file:// URL', 
 
   test.afterAll(async() => {
     if (app) await app.close()
-    for (const dir of createdDirs) {
-      try {
-        fs.rmSync(dir, { recursive: true, force: true })
-      } catch {
-        /* ignore */
-      }
-    }
   })
 
   test('window.DIRNAME tracks the opened document directory', async() => {
@@ -114,5 +118,45 @@ test.describe('Relative-path image resolves to a DIRNAME-anchored file:// URL', 
     const onDiskPath = withoutQuery.replace(/^file:\/\//, '')
     expect(fs.existsSync(onDiskPath)).toBe(true)
     expect(onDiskPath).toBe(path.join(docDir, 'assets', 'cat.png').replace(/\\/g, '/'))
+  })
+})
+
+test.describe('Relative-path image in a directory named with URL delimiters (#5212)', () => {
+  let app: ElectronApplication | null = null
+  let page: Page
+  let docDir: string
+
+  test.beforeAll(async() => {
+    // `?` cannot appear in a Windows file name.
+    const folderName = process.platform === 'win32' ? 'C# 100%25' : 'C# 100%25 what?'
+    const written = writeDocWithRelativeImage(folderName)
+    docDir = written.docDir
+    const launched = await launchElectron([written.docPath])
+    app = launched.app
+    page = launched.page
+    await waitForEditor(page)
+    await waitForMenuReady(app)
+  })
+
+  test.afterAll(async() => {
+    if (app) await app.close()
+  })
+
+  test('loads the image from the file next to the document', async() => {
+    await expect
+      .poll(async() => page.locator('.editor-component .mu-inline-image.mu-image-success').count(), {
+        timeout: 10000
+      })
+      .toBeGreaterThanOrEqual(1)
+
+    const src = await page
+      .locator('.editor-component .mu-image-container img')
+      .first()
+      .getAttribute('src')
+    expect(src).not.toBeNull()
+    const url = new URL(src as string)
+    expect(decodeURIComponent(url.pathname)).toBe(
+      path.join(docDir, 'assets', 'cat.png').replace(/\\/g, '/')
+    )
   })
 })

--- a/packages/muya/src/utils/__tests__/image.spec.ts
+++ b/packages/muya/src/utils/__tests__/image.spec.ts
@@ -183,6 +183,29 @@ describe('getImageSrc — relative local image paths anchored to window.DIRNAME'
     });
 });
 
+describe('getImageSrc — document directory containing URL-significant characters (#5212)', () => {
+    it.each([
+        ['/home/user/C# notes'],
+        ['/home/user/what? notes'],
+        ['/home/user/50%25 off'],
+    ])('loads the image from the real file under %s', (dirname) => {
+        withDirname(dirname, () => {
+            const url = new URL(getImageSrc('assets/image.jpg').src);
+            expect(url.hash).toBe('');
+            expect(url.search).toBe('');
+            expect(decodeURIComponent(url.pathname)).toBe(`${dirname}/assets/image.jpg`);
+        });
+    });
+
+    it('does not re-encode the already URL-encoded markdown path', () => {
+        withDirname('/home/user/C# notes', () => {
+            expect(getImageSrc('assets/my%20image.jpg').src).toBe(
+                'file:///home/user/C%23 notes/assets/my%20image.jpg',
+            );
+        });
+    });
+});
+
 describe('getImageSrc — non-relative sources are left unchanged', () => {
     it('leaves an absolute POSIX local path as a single `file://`', () => {
         withDirname(DIRNAME, () => {

--- a/packages/muya/src/utils/image.ts
+++ b/packages/muya/src/utils/image.ts
@@ -67,6 +67,16 @@ function resolveRelativePath(base: string, relative: string): string {
     return tail ? `${root}/${tail}` : root;
 }
 
+// `window.DIRNAME` is a raw filesystem path, whereas a markdown image path is
+// already URL-encoded, so only the directory gets its `%`, `?` and `#` escaped:
+// raw, they would read as an escape, a query or a fragment (#5212).
+function encodeDirnameForUrl(dirname: string): string {
+    return dirname
+        .replace(/%/g, '%25')
+        .replace(/\?/g, '%3F')
+        .replace(/#/g, '%23');
+}
+
 function localPathToFileUrl(src: string): string {
     const normalized = src.replace(/\\/g, '/');
 
@@ -107,7 +117,7 @@ export function getImageSrc(src: string) {
         else if (!isAbsoluteLocal && baseUrl) {
             return {
                 isUnknownType: false,
-                src: localPathToFileUrl(resolveRelativePath(baseUrl, src)),
+                src: localPathToFileUrl(resolveRelativePath(encodeDirnameForUrl(baseUrl), src)),
             };
         }
         else {


### PR DESCRIPTION
Fixes #5302.

## Summary

- A relative-path image failed to load ("Load image failed") when the document's folder name contained `#` or `?`, e.g. `C# notes/note.md` with `![](assets/image.jpg)`. `getImageSrc` joined the raw `window.DIRNAME` into a `file://` URL, so Chromium read the rest of the path as a fragment or query. A literal `%xx` in the folder name was percent-decoded the same way.
- `getImageSrc` now percent-encodes `%`, `?` and `#` in the directory only. The markdown path is left as written: it is already URL-form (`my%20image.jpg`) and would otherwise be double-encoded.

## Relation to #5212

Related to #5212. The steps there (`![](assets/image.jpg)  ` next to `assets/image.jpg`) do not reproduce on the published v0.20.0-rc.1 macOS arm64 build. Tested: launching with the file as an argument, cold start through Finder (`open`), opening into a running window, and folders named with spaces, CJK characters and `%`. The one failure found for that setup is a folder name containing `#` or `?`, filed as #5302 and fixed here. It is not an rc regression: legacy muyajs built the URL as `'file://' + path.resolve(DIRNAME, src)` too.

## Not changed

- `packages/desktop/src/renderer/src/util/resolveImageSrc.ts` (HTML/PDF export) and `resolveLinkHref.ts` build `file://` URLs from `DIRNAME` the same way; left for a follow-up.
- Absolute image paths keep going through the unchanged absolute branch.

## Test plan

- [x] `packages/muya/src/utils/__tests__/image.spec.ts`: `#`, `?` and `%25` in the directory (the URL's path decodes back to the file, with no hash or query), and no re-encoding of the markdown path. All 4 fail before the fix and pass after.
- [x] `packages/desktop/test/e2e/image-relative-path.spec.ts`: new real-app case opening a document in `C# 100%25 what?/`. Fails on the unfixed build (the image never reaches `.mu-image-success`), passes with the fix.
- [x] muya unit suites for utils, inlineRenderer, selection, clipboard, editor and imageEditTool: 484 passed.
- [x] muya eslint + `tsc --noEmit`; desktop eslint + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn9MCAxQ8NDX7trUiCvMTH
