### PR TITLE
test(desktop): wait for TOC scrolls to settle in the toc-scroll e2e

### DIFF
--- a/packages/desktop/test/e2e/toc-scroll.spec.ts
+++ b/packages/desktop/test/e2e/toc-scroll.spec.ts
@@ -74,6 +74,14 @@ const headingOffsetFromViewportTop = (page: Page, index: number): Promise<number
     )
   }, index)
 
+// `scrollToHeader` animates for ~300ms, so a heading passes through the
+// viewport before it stops. Poll until it rests at the 24px TOC gap (within
+// ±4px) instead of reading its offset once.
+const expectHeadingAtTocGap = (page: Page, index: number): Promise<void> =>
+  expect
+    .poll(() => headingOffsetFromViewportTop(page, index), { timeout: 8000 })
+    .toBeCloseTo(24, -1)
+
 // Locate a TOC tree node label by its EXACT text. Exact matching avoids the
 // substring trap where "Heading Number 1" also matches "Heading Number 18".
 const tocLabel = (page: Page, text: string) =>
@@ -162,10 +170,7 @@ test.describe('TOC sidebar click scrolls the live editor', () => {
     await expect
       .poll(() => isHeadingInViewport(page, targetIndex), { timeout: 8000 })
       .toBe(true)
-    await expect
-      .poll(() => headingOffsetFromViewportTop(page, targetIndex), { timeout: 8000 })
-      .toBeGreaterThanOrEqual(20)
-    expect(await headingOffsetFromViewportTop(page, targetIndex)).toBeLessThanOrEqual(28)
+    await expectHeadingAtTocGap(page, targetIndex)
   })
 
   test('clicking an earlier heading scrolls back up toward it', async() => {
@@ -196,9 +201,7 @@ test.describe('TOC sidebar click scrolls the live editor', () => {
 
     const label = tocLabel(page, targetText)
     await label.click()
-    await expect
-      .poll(() => isHeadingInViewport(page, targetIndex), { timeout: 8000 })
-      .toBe(true)
+    await expectHeadingAtTocGap(page, targetIndex)
     const firstScroll = await getScrollTop(page)
 
     // Click again — should land on (essentially) the same scroll position.

--- a/packages/desktop/test/e2e/toc-scroll.spec.ts
+++ b/packages/desktop/test/e2e/toc-scroll.spec.ts
@@ -174,9 +174,13 @@ test.describe('TOC sidebar click scrolls the live editor', () => {
   })
 
   test('clicking an earlier heading scrolls back up toward it', async() => {
-    // After the previous test the editor is scrolled down near heading 18.
+    // Start at the bottom so the click must scroll UP to reveal heading 3.
+    await page.evaluate(() => {
+      const el = document.querySelector('.editor-component') as HTMLElement | null
+      if (el) el.scrollTop = el.scrollHeight
+    })
+    await expect.poll(() => getScrollTop(page)).toBeGreaterThan(0)
     const fromTop = await getScrollTop(page)
-    expect(fromTop).toBeGreaterThan(0)
 
     const targetText = 'Heading Number 3'
     const targetIndex = await headingIndexByText(page, targetText)


### PR DESCRIPTION
## Summary

`toc-scroll.spec.ts` failed on the v0.20.0-rc.2 release gate (PR #4664, [run 34548584272](https://github.com/marktext/marktext/actions/runs/34548584272)). Heading 18 was 690px below the viewport top instead of at the 24px TOC gap, and the next test saw `scrollTop` 0. A rerun on the same commit passed. This is a race in the test, not a bug in the app.

- **Wait for the scroll to settle.** `scrollToHeader` animates over ~300 ms of animation frames. The deep-outline test polled until the offset was ≥ 20, then read it once. A stalled frame let that single read see a position mid-animation; CI runs two Electron workers on one xvfb display. The double-click test had the same race when reading `firstScroll`. Both tests now poll until the heading rests at the 24px gap (±4px).
- **Make the scroll-up test independent.** It relied on the previous test leaving the editor near heading 18. After a failure, Playwright restarts the worker and `beforeAll` relaunches the app at `scrollTop` 0, so one flake was reported as two failures. The test now scrolls to the bottom itself.

The single offset read was added in #5153.

## Verification

I reproduced the CI failure locally by holding back one `animateScroll` frame for 500 ms late in each animation, while the heading is inside the viewport but not yet settled:

| | deep outline | scroll up | double click |
|---|---|---|---|
| before | fails: offset 332 (expected ≤ 28) | fails: `scrollTop` 0 | fails: 192px apart (expected ≤ 5) |
| after | passes | passes | passes |

- With the stall, 3 repeats: 9/9 pass. Without it, 3 repeats: 9/9 pass. The scroll-up test also passes when run alone.
- `pnpm run lint`: 0 errors, and no warnings from this file.
- Only the test file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6E1aHfEJFTQBrHj9mRMoQ
