### PR TITLE
fix(muya): make a code block a diagram when its language is a diagram language (#5060)

### DIFF
--- a/packages/muya/e2e/tests/blocks/diagram-fence-lang-5060.spec.ts
+++ b/packages/muya/e2e/tests/blocks/diagram-fence-lang-5060.spec.ts
@@ -1,0 +1,111 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../fixtures/muya';
+import { getMarkdown } from '../helpers/api';
+import { slowType } from '../helpers/keyboard';
+import { editor, floats } from '../helpers/selectors';
+
+// #5060: a fence whose language is a diagram language must become a diagram
+// block (with its live preview) however the language was entered — not only
+// when the paragraph reads exactly ```mermaid (#2177). Loading the same
+// markdown already yields a diagram, which is why a source-mode round-trip was
+// the only way to get the preview.
+
+const BODY = 'graph TD\nA-->B';
+
+interface IBlockState { name: string; text?: string; meta?: { type?: string; lang?: string } }
+
+function firstBlock(page: Page): Promise<IBlockState> {
+    return page.evaluate(() => window.muya!.getState()[0] as IBlockState);
+}
+
+function nextFrame(page: Page): Promise<void> {
+    return page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())));
+}
+
+// The `<pre>` intercepts pointer events over the language input, so place the
+// caret the way the engine does (see ui/code-block-language-selector.spec.ts).
+async function focusLanguageInput(page: Page): Promise<void> {
+    await page.evaluate(() => {
+        window.muya!.editor.scrollPage.firstChild.firstContentInDescendant().setCursor(0, 0, true);
+    });
+    await expect
+        .poll(() => page.evaluate(() => window.muya!.editor.activeContentBlock?.blockName))
+        .toBe('language-input');
+}
+
+async function expectMermaidDiagram(page: Page): Promise<void> {
+    await expect.poll(async () => (await firstBlock(page)).name).toBe('diagram');
+    expect((await firstBlock(page)).meta).toEqual({ type: 'mermaid', lang: 'yaml' });
+}
+
+async function expectRenderedBody(page: Page): Promise<void> {
+    await expect(page.locator(`${editor.diagramPreview} svg`).first()).toBeVisible({ timeout: 15_000 });
+    await expect.poll(() => getMarkdown(page)).toContain(`\`\`\`mermaid\n${BODY}\n\`\`\``);
+}
+
+test.describe('diagram language entered through the language picker or input (#5060)', () => {
+    test('accepting "mermaid" from the fence autocomplete with Enter creates a diagram', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '```mer');
+        await expect(page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="mermaid"]`)).toBeVisible();
+
+        await page.keyboard.press('Enter');
+
+        await expectMermaidDiagram(page);
+        await slowType(page, BODY);
+        await expectRenderedBody(page);
+    });
+
+    test('clicking "mermaid" in the fence autocomplete creates a diagram', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent(''));
+        await page.locator(editor.paragraph).first().click();
+        await slowType(page, '```mer');
+
+        await page.locator(`${floats.codeBlockLanguageSelector} li.item[data-label="mermaid"]`).click();
+
+        await expectMermaidDiagram(page);
+        await slowType(page, BODY);
+        await expectRenderedBody(page);
+    });
+
+    test('setting an existing code block\'s language to mermaid converts it and keeps the code', async ({ page }) => {
+        await page.evaluate(md => window.muya!.setContent(md), `\`\`\`\n${BODY}\n\`\`\`\n`);
+        await focusLanguageInput(page);
+        await slowType(page, 'mermaid');
+
+        await page.keyboard.press('Enter');
+
+        await expectMermaidDiagram(page);
+        expect((await firstBlock(page)).text).toBe(BODY);
+        await expectRenderedBody(page);
+    });
+
+    test('typing mermaid in the language input, then clicking into the code, converts it', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\n\n```\n'));
+        await focusLanguageInput(page);
+        await slowType(page, 'mermaid');
+
+        await page.locator(editor.codeContent).first().click();
+
+        await expectMermaidDiagram(page);
+        await slowType(page, BODY);
+        await expectRenderedBody(page);
+    });
+
+    test('a non-diagram language entered in the language input stays a code block', async ({ page }) => {
+        await page.evaluate(() => window.muya!.setContent('```\ncode\n```\n'));
+        await focusLanguageInput(page);
+        await slowType(page, 'python');
+
+        await page.keyboard.press('Enter');
+
+        await expect
+            .poll(() => page.evaluate(() => window.muya!.editor.activeContentBlock?.blockName))
+            .toBe('codeblock.content');
+        await nextFrame(page);
+        const block = await firstBlock(page);
+        expect(block.name).toBe('code-block');
+        expect(block.text).toBe('code');
+    });
+});

--- a/packages/muya/src/block/content/langInputContent/__tests__/diagramLanguage.spec.ts
+++ b/packages/muya/src/block/content/langInputContent/__tests__/diagramLanguage.spec.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import type Content from '../../../base/content';
+import type Parent from '../../../base/parent';
+import type LangInputContent from '../index';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../../../../muya';
+
+// #5060: leaving a code block's language input commits the language. A diagram
+// language turns the block into a diagram block — what loading its ```lang
+// fence produces — instead of leaving a code block with no preview.
+
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: string | undefined;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    document.getSelection()?.removeAllRanges();
+    if (hadVersion)
+        window.MUYA_VERSION = originalVersion as string;
+    else
+        delete (window as Partial<Window>).MUYA_VERSION;
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+function block(muya: Muya, index: number): Parent {
+    return muya.editor.scrollPage!.find(index) as Parent;
+}
+
+function typeLanguage(muya: Muya, lang: string): LangInputContent {
+    const langInput = block(muya, 0).firstContentInDescendant() as LangInputContent;
+    langInput.setCursor(0, 0, true);
+    langInput.updateLanguage(lang);
+    return langInput;
+}
+
+async function settle(): Promise<void> {
+    await Promise.resolve();
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+}
+
+describe('leaving the language input with a diagram language', () => {
+    it('turns the code block into a mermaid diagram that keeps the code', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n');
+        typeLanguage(muya, 'mermaid');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.getState()).toEqual([
+            { name: 'diagram', text: 'graph TD', meta: { type: 'mermaid', lang: 'yaml' } },
+        ]);
+    });
+
+    it('gives a vega-lite diagram json as its code language', async () => {
+        const muya = bootMuya('```\n{}\n```\n');
+        typeLanguage(muya, 'vega-lite');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.getState()[0]).toMatchObject({ name: 'diagram', meta: { type: 'vega-lite', lang: 'json' } });
+    });
+
+    it('keys off the first word of the info string, like loading the fence', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n');
+        typeLanguage(muya, 'mermaid title=x');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.getState()[0]).toMatchObject({ name: 'diagram', meta: { type: 'mermaid' } });
+    });
+
+    it('moves the caret into the diagram code when it went into the code block', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n');
+        typeLanguage(muya, 'mermaid');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.editor.activeContentBlock?.outMostBlock?.blockName).toBe('diagram');
+    });
+
+    it('leaves the caret in another block the user moved to', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n\nafter\n');
+        typeLanguage(muya, 'mermaid');
+        const after = block(muya, 1).firstContentInDescendant() as Content;
+
+        after.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.getState()[0].name).toBe('diagram');
+        expect(muya.editor.activeContentBlock).toBe(after);
+    });
+});
+
+describe('the language input does not convert', () => {
+    it('for a non-diagram language', async () => {
+        const muya = bootMuya('```\ncode\n```\n');
+        typeLanguage(muya, 'python');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        await settle();
+
+        expect(muya.getState()).toEqual([
+            { name: 'code-block', text: 'code', meta: { type: 'fenced', lang: 'python' } },
+        ]);
+    });
+
+    it('while the caret is still in the language input', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n');
+        typeLanguage(muya, 'mermaid');
+
+        await settle();
+
+        expect(muya.getState()[0].name).toBe('code-block');
+    });
+
+    it('when the document was replaced before the conversion ran', async () => {
+        const muya = bootMuya('```\ngraph TD\n```\n');
+        typeLanguage(muya, 'mermaid');
+
+        block(muya, 0).lastContentInDescendant()!.setCursor(0, 0, true);
+        muya.setContent('replaced\n');
+        await settle();
+
+        expect(muya.getState()).toEqual([{ name: 'paragraph', text: 'replaced' }]);
+    });
+});

--- a/packages/muya/src/block/content/langInputContent/index.ts
+++ b/packages/muya/src/block/content/langInputContent/index.ts
@@ -3,7 +3,10 @@ import type { IRenderCursor } from '../../../selection/types';
 import type { ICodeBlockState } from '../../../state/types';
 import type CodeBlock from '../../commonMark/codeBlock';
 import { CLASS_NAMES } from '../../../config';
+import { firstWordOfInfo } from '../../../utils';
+import { createDiagramState, diagramTypeOfLang } from '../../../utils/diagram/fence';
 import Content from '../../base/content';
+import { ScrollPage } from '../../scrollPage';
 import { escapeLangInputInnerHtml } from './escape';
 
 class LangInputContent extends Content {
@@ -67,6 +70,38 @@ class LangInputContent extends Content {
 
         const { parent } = this;
         parent!.lastContentInDescendant()?.setCursor(0, 0);
+    }
+
+    override blurHandler() {
+        super.blurHandler();
+        // Leaving the input commits the language. Deferred: blur runs inside
+        // the editor's active-block setter, which the replacement's setCursor
+        // would re-enter.
+        Promise.resolve().then(() => this._convertToDiagramIfNeeded());
+    }
+
+    // A diagram language makes the block a diagram, as loading its ```lang
+    // fence does (#5060).
+    private _convertToDiagramIfNeeded() {
+        const codeBlock = this.parent;
+        // Detached before the microtask ran, e.g. the document was replaced.
+        if (!codeBlock?.outMostBlock)
+            return;
+
+        const type = diagramTypeOfLang(firstWordOfInfo(codeBlock.lang));
+        if (!type)
+            return;
+
+        const code = codeBlock.lastContentInDescendant()!;
+        const caretInCode = this.muya.editor.activeContentBlock === code;
+        const diagramBlock = ScrollPage.loadBlock('diagram').create(
+            this.muya,
+            createDiagramState(type, code.text),
+        );
+        codeBlock.replaceWith(diagramBlock);
+
+        if (caretInCode)
+            diagramBlock.lastContentInDescendant()?.setCursor(0, 0, true);
     }
 
     override backspaceHandler(event: Event) {

--- a/packages/muya/src/ui/codeBlockLanguageSelector/index.ts
+++ b/packages/muya/src/ui/codeBlockLanguageSelector/index.ts
@@ -3,6 +3,7 @@ import type LangInputContent from '../../block/content/langInputContent';
 import type ParagraphContent from '../../block/content/paragraphContent';
 import type { Muya } from '../../index';
 import { ScrollPage } from '../../block/scrollPage';
+import { createDiagramState, diagramTypeOfLang } from '../../utils/diagram/fence';
 import { search } from '../../utils/prism';
 
 import { h, patch } from '../../utils/snabbdom';
@@ -21,30 +22,26 @@ const defaultOptions = {
     showArrow: false,
 };
 
-const DIAGRAM_LANGS = new Set(['mermaid', 'vega-lite', 'plantuml', 'flowchart', 'sequence']);
-
 // The language the user actually typed after the ``` fence. The selector's
 // fuzzy search may resolve a non-code language (e.g. `vega-lite`) to an
-// unrelated Prism language, so the diagram check keys off this raw text.
+// unrelated Prism language, so the diagram check tries this raw text before
+// the picked item.
 function typedFenceLang(text: string): string {
     return text.match(/`{3,}\s*([\w-]+)/)?.[1] ?? '';
 }
 
-// Build the state for the block a ```lang fence becomes. Diagram languages
-// (from the typed text) become a diagram block, mirroring markdownToState's
-// file-load path; GitLab math becomes a math-block; everything else a fenced
-// code block highlighted with the selector's matched language.
+// Build the state for the block a ```lang fence becomes. A diagram language,
+// typed in full or picked from a partial query (`mer` → mermaid, #5060),
+// becomes a diagram block, mirroring markdownToState's file-load path; GitLab
+// math becomes a math-block; everything else a fenced code block highlighted
+// with the selector's matched language.
 function newBlockStateForLang(typedLang: string, matchedLang: string, isGitlabMath: boolean) {
     if (isGitlabMath)
         return { name: 'math-block', meta: { mathStyle: 'gitlab' }, text: '' };
 
-    if (DIAGRAM_LANGS.has(typedLang)) {
-        return {
-            name: 'diagram',
-            meta: { type: typedLang, lang: typedLang === 'vega-lite' ? 'json' : 'yaml' },
-            text: '',
-        };
-    }
+    const diagramType = diagramTypeOfLang(typedLang) ?? diagramTypeOfLang(matchedLang);
+    if (diagramType)
+        return createDiagramState(diagramType);
 
     return { name: 'code-block', meta: { lang: matchedLang, type: 'fenced' }, text: '' };
 }

--- a/packages/muya/src/utils/diagram/fence.ts
+++ b/packages/muya/src/utils/diagram/fence.ts
@@ -1,0 +1,19 @@
+import type { IDiagramMeta, IDiagramState } from '../../state/types';
+
+const DIAGRAM_TYPES = ['mermaid', 'plantuml', 'vega-lite', 'flowchart', 'sequence'] as const;
+
+/**
+ * The diagram type a fence language renders as, or null for a code language.
+ * @param lang the first word of the fence info string
+ */
+export function diagramTypeOfLang(lang: string): IDiagramMeta['type'] | null {
+    return DIAGRAM_TYPES.find(type => type === lang) ?? null;
+}
+
+export function createDiagramState(type: IDiagramMeta['type'], text = ''): IDiagramState {
+    return {
+        name: 'diagram',
+        text,
+        meta: { type, lang: type === 'vega-lite' ? 'json' : 'yaml' },
+    };
+}


### PR DESCRIPTION
Closes #5060.

## Summary

Typing ```` ```mermaid ```` + Enter already creates a diagram block (#2177). Entering the same language any other way left a plain `code-block` with lang `mermaid` and no preview. The saved markdown was already ```` ```mermaid ````, so the preview only appeared after a source-mode round-trip re-parsed it. The two broken paths:

- **Picking "mermaid" from the fence autocomplete after a partial query** (```` ```mer ```` then Enter, or clicking the item). `newBlockStateForLang` only checked the typed text.
- **Setting an existing code block's language in its language input** (Enter, picking from the list, or clicking into the code). The language was stored, and nothing converted.

The fix:

- The picker decides on a diagram from the typed language first, then the picked item.
- Leaving a language input whose language is a diagram type now replaces the code block with a diagram block that keeps the code. The check uses the first word of the info string, and the result is the same one `markdownToState` gives on load. If the caret moved into that block, it goes to the start of the diagram code; otherwise it stays where it went.
- Both call sites use the diagram language list and state shape from the new `utils/diagram/fence.ts`.

## Reproduction

On develop (d19370f7), in Chrome through the muya e2e host:

| Steps | Before | After |
|---|---|---|
| ```` ```mermaid ```` + Enter | diagram | diagram |
| ```` ```mer ```` + Enter (autocomplete) | code block, no preview | diagram |
| ```` ```mer ```` + click "mermaid" | code block, no preview | diagram |
| ```` ``` ```` + Enter, type `mermaid` in the language input, Enter | code block, no preview | diagram |
| same, but click into the code instead of pressing Enter | code block, no preview | diagram |

The report is against 0.19.0, which ran the legacy muyajs engine; there the plain ```` ```mermaid ```` + Enter case failed too. @muyajs/core already handled that case (#4635, #4640).

## Notes for reviewers

- The conversion runs in a microtask queued from `blurHandler`. Blur fires inside the `Editor.activeContentBlock` setter, and the replacement's `setCursor` would re-enter it. The microtask checks `outMostBlock` first, so a code block that was removed or replaced in the meantime (for example by `setContent`) is left alone.
- It converts when the caret leaves the input, not while typing, so the input doesn't disappear mid-word.
- Not changed: ```` ``` mermaid ```` (a space before the language) + Enter still drops the language, because `CODE_BLOCK_REG` stops at the space. That affects every language, not only diagrams.
- The other copies of the diagram language list (`paragraphContent._enterConvert`, `markdownToState`, `blockTransforms`) are left alone to keep this PR focused.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] `packages/muya/src/block/content/langInputContent/__tests__/diagramLanguage.spec.ts` (happy-dom, real Muya). Converts, keeping the code: mermaid, vega-lite (code language `json`), and an info string whose first word is `mermaid`. The caret follows into the diagram, or stays in another block the user moved to. Doesn't convert: python, while the caret is still in the input, or after the document was replaced. The 5 conversion cases fail before the fix.
- [x] `packages/muya/e2e/tests/blocks/diagram-fence-lang-5060.spec.ts` (Chrome). Autocomplete with Enter, autocomplete click, language input + Enter on existing code, and language input + click into the code: each renders the mermaid SVG and round-trips to ```` ```mermaid ````. python stays a code block. The 4 conversion cases fail before the fix.
- [x] Full muya unit suite passes. The 7 export/CSS spec files that import CSS from outside a git worktree were run separately with `server.fs.allow`.
- [x] muya e2e CI job (bundled Chromium) passes on this PR. Run locally in system Chrome, the full suite had 15 failures, none of them in files this PR touches. For a baseline, I reran the 10 failing spec files with 1 worker after reverting this PR's two source files to develop (d19370f7). 13 of the failures also fail on develop there. `autopair.spec.ts:110` also fails in 2 of 3 repeats on develop. `plantuml.spec.ts:33`, which renders through plantuml.com, passed 3 of 3 reruns. `sequence-overflow-3560.spec.ts` only failed with 4 workers.
- [x] muya eslint, `tsc --noEmit`, `check-circular`.
- [ ] Manually tested on: macOS, muya e2e host in Chrome only; the desktop app was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vfFqHNk1Ao8EPhoQ3V3aZ
