### PR TITLE
docs: fix the macOS alias path in the CLI docs

### DIFF
--- a/packages/website/content/docs/end-user/CLI.md
+++ b/packages/website/content/docs/end-user/CLI.md
@@ -19,5 +19,5 @@ Usage: marktext [commands] [path ...]
 `marktext` should point to your installation of MarkText. The exact location will vary from platform to platform. On macOS, you can create a convenient alias like:
 
 ```sh
-alias marktext="/Applications/Mark\ Text.app/Contents/MacOS/Mark\ Text"
+alias marktext="/Applications/marktext.app/Contents/MacOS/marktext"
 ```


### PR DESCRIPTION
Related to #5119. Found while triaging it; that issue is about Windows and is not addressed here.

## Summary

The CLI docs suggested `alias marktext="/Applications/Mark\ Text.app/Contents/MacOS/Mark\ Text"`, but the macOS app bundle is now `/Applications/marktext.app` with a `marktext` executable, so the alias pointed at a path that no longer exists. This updates the alias to the current path.

## Type of change

- [ ] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [x] Documentation update

## Test plan

- [x] New tests added (or explain why not needed): docs-only change
- [x] Manually tested on: macOS. `/Applications/marktext.app/Contents/MacOS/marktext --version` prints `MarkText: v0.19.1`

## Notes for reviewers [optional]

`public/docs-index.json` strips code blocks, so it does not contain the alias and needs no regeneration.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jhhQfVDnBRL2jGsPjzWep
