### PR TITLE
chore: run only eslint --fix on staged desktop TS/Vue files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,10 @@
   },
   "lint-staged": {
     "packages/desktop/src/**/*.{ts,vue}": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix"
     ],
     "packages/desktop/test/**/*.ts": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix"
     ],
     "*.{json,md,yaml}": [
       "prettier --write"


### PR DESCRIPTION
Follow-up to #4999 (issue #4998).

## Summary

The pre-commit hook ran `prettier --write` after `eslint --fix` on staged desktop TS/Vue files. The desktop ESLint config (neostandard `@stylistic`) and Prettier disagree, and CI only runs ESLint (`pnpm lint`), so the Prettier step undid what ESLint requires:

- Prettier always prints `async (x) =>`, while `@stylistic/space-before-function-paren: never` requires `async(x) =>`. Committing any TS file with an async arrow through the hook made `pnpm lint` fail in CI, so the only way to land such a change was `--no-verify`.
- Most desktop files aren't Prettier-formatted, so the hook also reflowed unrelated lines in every touched file (e.g. a one-line fix in `src/main/menu/index.ts` came out with a rewrapped constructor signature and a lint-breaking `async (`).

This PR drops the Prettier step for `packages/desktop/src/**/*.{ts,vue}` and `packages/desktop/test/**/*.ts`, so the hook enforces exactly what CI enforces. `*.{json,md,yaml}` keep `prettier --write`.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] Simulated the hook with the ESLint and Prettier Node APIs over all 351 tracked desktop TS/Vue files:

  | Hook steps | Files failing ESLint afterwards | Files reformatted |
  |---|---|---|
  | `eslint --fix` → `prettier --write` (before) | 136 (769 `space-before-function-paren`, 47 `@stylistic/indent`, 1 `curly`) | 200 |
  | `prettier --write` → `eslint --fix` | 0 | 91 |
  | `eslint --fix` (this PR) | 0 | 0 |

- [x] Ran `pnpm exec lint-staged` with the new config on a staged one-line change to `src/main/menu/index.ts`: the diff stays one line and ESLint reports no errors (with the old config the same change failed ESLint).
- [x] Manually tested on: macOS

## Notes for reviewers [optional]

Making Prettier the source of truth instead would mean disabling the conflicting `@stylistic` rules and reformatting the whole desktop package; that's a much larger change and not needed for the hook to match CI.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKDSxyPk9WxU2h5DgPcWn
