### PR TITLE
fix(desktop): ignore line-ending menu updates for a closed window (#4923)

### DIFF
--- a/packages/desktop/src/main/menu/index.ts
+++ b/packages/desktop/src/main/menu/index.ts
@@ -474,6 +474,7 @@ class AppMenu {
       this.addRecentlyUsedDocument(pathname)
     })
     ipcMain.on('mt::update-line-ending-menu', (_e, windowId: number, lineEnding: string) => {
+      if (!this.has(windowId)) return
       this.updateLineEndingMenu(windowId, lineEnding)
     })
     ipcMain.on(

--- a/packages/desktop/test/unit/specs/line-ending-menu-closed-window.spec.ts
+++ b/packages/desktop/test/unit/specs/line-ending-menu-closed-window.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// A renderer can queue `mt::update-line-ending-menu` (e.g. from a tab switch)
+// in the moment between sending `mt::close-window` and main destroying the
+// window. Main removes the window menu first, so the late message must be
+// ignored instead of throwing "Cannot find window menu for id N" (#4923).
+
+const { ipcOn, crlfItem, lfItem } = vi.hoisted(() => ({
+  ipcOn: vi.fn(),
+  crlfItem: { checked: false },
+  lfItem: { checked: false }
+}))
+
+vi.mock('electron', () => ({
+  app: { addRecentDocument: vi.fn(), clearRecentDocuments: vi.fn() },
+  ipcMain: { on: ipcOn, handle: vi.fn(), emit: vi.fn() },
+  Menu: {
+    buildFromTemplate: vi.fn(() => ({
+      getMenuItemById: (id: string) =>
+        id === 'crlfLineEndingMenuEntry' ? crlfItem : id === 'lfLineEndingMenuEntry' ? lfItem : null
+    })),
+    setApplicationMenu: vi.fn(),
+    getApplicationMenu: vi.fn()
+  }
+}))
+
+vi.mock('common/filesystem', () => ({
+  ensureDirSync: vi.fn(),
+  isDirectory2: () => false,
+  isFile2: () => false
+}))
+
+vi.mock('main_renderer/config', () => ({ isLinux: false, isOsx: true, isWindows: false }))
+vi.mock('main_renderer/menu/actions/edit', () => ({ updateSidebarMenu: vi.fn() }))
+vi.mock('main_renderer/menu/actions/format', () => ({ updateFormatMenu: vi.fn() }))
+vi.mock('main_renderer/menu/actions/paragraph', () => ({ updateSelectionMenus: vi.fn() }))
+vi.mock('main_renderer/menu/actions/view', () => ({ viewLayoutChanged: vi.fn() }))
+vi.mock('main_renderer/utils/internalIpc', () => ({ onInternalChannel: vi.fn() }))
+vi.mock('main_renderer/i18n.js', () => ({ setLanguage: vi.fn() }))
+vi.mock('main_renderer/menu/templates', () => ({
+  default: vi.fn(() => []),
+  configSettingMenu: vi.fn(() => [])
+}))
+
+import AppMenu from 'main_renderer/menu'
+import type Preference from 'main_renderer/preferences'
+import type Keybindings from 'main_renderer/keyboard/shortcutHandler'
+
+type LineEndingListener = (event: unknown, windowId: number, lineEnding: string) => void
+
+const setup = () => {
+  ipcOn.mockClear()
+  const preferences = { getItem: () => 'en' } as unknown as Preference
+  const keybindings = { registerEditorKeyHandlers: vi.fn() } as unknown as Keybindings
+  const appMenu = new AppMenu(preferences, keybindings, '/tmp/mt-test')
+  const call = ipcOn.mock.calls.find(([channel]) => channel === 'mt::update-line-ending-menu')
+  if (!call) throw new Error('mt::update-line-ending-menu listener was not registered')
+  return { appMenu, onLineEnding: call[1] as LineEndingListener }
+}
+
+describe('mt::update-line-ending-menu (#4923)', () => {
+  beforeEach(() => {
+    crlfItem.checked = false
+    lfItem.checked = false
+  })
+
+  it('checks the line ending of a window that still has its menu', () => {
+    const { appMenu, onLineEnding } = setup()
+    appMenu.addEditorMenu({ id: 1 } as never)
+
+    onLineEnding({}, 1, 'crlf')
+
+    expect(crlfItem.checked).toBe(true)
+  })
+
+  it('ignores a late update for a window whose menu was already removed', () => {
+    const { appMenu, onLineEnding } = setup()
+    appMenu.addEditorMenu({ id: 1 } as never)
+    appMenu.removeWindowMenu(1)
+
+    expect(() => onLineEnding({}, 1, 'crlf')).not.toThrow()
+    expect(crlfItem.checked).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #4923

## Summary

`Error: Cannot find window menu for id 1` is thrown in the main process by the `mt::update-line-ending-menu` listener in `AppMenu`.

When an editor window closes, the renderer sends `mt::close-window` and main runs `forceClose`, which removes the window's menu and then destroys the window. Any renderer IPC that was already queued behind `mt::close-window` (for example `UPDATE_LINE_ENDING_MENU` from a tab switch) is still delivered after the menu is gone, and `updateLineEndingMenu` → `getWindowMenuById` throws. The other per-window menu channels (`mt::update-format-menu`, `mt::update-sidebar-menu`, `mt::view-layout-changed`, `mt::editor-selection-changed`, `mt::set-editor-format-menus-enabled`) already skip windows without a menu (#1437); this listener was the one left without the guard.

The fix adds the same `has(windowId)` guard.

## Type of change

- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Breaking change (causes existing functionality to change)
- [ ] Documentation update

## Test plan

- [x] New tests added — `test/unit/specs/line-ending-menu-closed-window.spec.ts` drives the registered listener: it still checks the line-ending item for a live window, and ignores a window whose menu was removed. The second case fails on `develop` with `Error: Cannot find window menu for id 1.`
- [x] Manually tested on: macOS — in the built app (Playwright + Electron), the renderer sent `mt::update-line-ending-menu` for its own window in a tight loop while the window was being closed. On `develop` the late messages reached main after `forceClose` and threw the exact error from the report 21 times; with this change there were none.

## Notes for reviewers [optional]

The race window is small (the messages must already be queued when main processes `mt::close-window`), which matches this being a rare report. In the built-app repro, messages sent even 1 ms later via `setTimeout` were no longer delivered, so the reproduction needs the renderer to be sending right as the window closes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGKDSxyPk9WxU2h5DgPcWn
